### PR TITLE
Make hosted clinic texting operationally ready

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -15,6 +15,10 @@ import {
 import { trpc } from "@/lib/trpc";
 import { EmptyState } from "@/components/common/empty-state";
 import { PageLoading } from "@/components/common/loading";
+import { SmsRecoveryConsole } from "@/components/admin/sms-recovery-console";
+
+const EMPTY_UUID = "00000000-0000-4000-8000-000000000000";
+const MESSAGING_HISTORY_LIMIT = 50;
 
 function formatUsd(n: number) {
   return new Intl.NumberFormat("en-US", {
@@ -53,6 +57,12 @@ function formatAgeMinutes(minutes: number | null) {
   return `${Math.round(minutes / (24 * 60))}d`;
 }
 
+function formatDateTime(value: Date | string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}
+
 const statusStyles: Record<string, string> = {
   active: "bg-green-100 text-green-700",
   trialing: "bg-blue-100 text-blue-700",
@@ -74,10 +84,16 @@ function recoveryLabel(value: string) {
 
 export default function AdminPage() {
   const utils = trpc.useUtils();
-  const { data, isLoading, error, refetch } =
-    trpc.admin.overview.useQuery(undefined, {
+  const [messagingHistorySelection, setMessagingHistorySelection] = useState<{
+    practiceId: string;
+    practiceName: string;
+  } | null>(null);
+  const { data, isLoading, error, refetch } = trpc.admin.overview.useQuery(
+    undefined,
+    {
       retry: false,
-    });
+    },
+  );
   const { data: funnel, error: funnelError } =
     trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false });
   const { data: recoveryQueue, error: recoveryError } =
@@ -86,6 +102,17 @@ export default function AdminPage() {
     trpc.admin.journeyFunnel.useQuery({ days: 30 }, { retry: false });
   const { data: messagingQueue, error: messagingQueueError } =
     trpc.admin.messagingRegistrationQueue.useQuery(undefined, { retry: false });
+  const {
+    data: messagingHistory,
+    error: messagingHistoryError,
+    isFetching: messagingHistoryFetching,
+  } = trpc.admin.messagingRegistrationHistory.useQuery(
+    {
+      practiceId: messagingHistorySelection?.practiceId ?? EMPTY_UUID,
+      limit: MESSAGING_HISTORY_LIMIT,
+    },
+    { enabled: Boolean(messagingHistorySelection), retry: false },
+  );
   const { data: smsOperations, error: smsOperationsError } =
     trpc.admin.smsOperationsHealth.useQuery(undefined, { retry: false });
   const [extendTrialError, setExtendTrialError] = useState<string | null>(null);
@@ -215,11 +242,27 @@ export default function AdminPage() {
   }
 
   const kpis = [
-    { label: "Practices", value: String(data.totals.practices), icon: Building2 },
-    { label: "Est. MRR", value: formatUsd(data.totals.estimatedMrr), icon: DollarSign },
-    { label: "Active trials", value: String(data.totals.activeTrials), icon: Clock },
+    {
+      label: "Practices",
+      value: String(data.totals.practices),
+      icon: Building2,
+    },
+    {
+      label: "Est. MRR",
+      value: formatUsd(data.totals.estimatedMrr),
+      icon: DollarSign,
+    },
+    {
+      label: "Active trials",
+      value: String(data.totals.activeTrials),
+      icon: Clock,
+    },
     { label: "Active", value: String(data.totals.active), icon: CheckCircle },
-    { label: "Past due", value: String(data.totals.pastDue), icon: AlertTriangle },
+    {
+      label: "Past due",
+      value: String(data.totals.pastDue),
+      icon: AlertTriangle,
+    },
   ];
 
   return (
@@ -236,7 +279,10 @@ export default function AdminPage() {
         {kpis.map((k) => {
           const Icon = k.icon;
           return (
-            <div key={k.label} className="rounded-lg border border-border bg-card p-5">
+            <div
+              key={k.label}
+              className="rounded-lg border border-border bg-card p-5"
+            >
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Icon className="h-4 w-4" />
                 <span className="text-sm">{k.label}</span>
@@ -281,7 +327,11 @@ export default function AdminPage() {
               {[
                 ["Critical", smsOperations.counts.critical, "text-red-700"],
                 ["Attention", smsOperations.counts.attention, "text-amber-700"],
-                ["Send exceptions", smsOperations.counts.sendAttempts, "text-foreground"],
+                [
+                  "Send exceptions",
+                  smsOperations.counts.sendAttempts,
+                  "text-foreground",
+                ],
                 [
                   "Delivery exceptions",
                   smsOperations.counts.deliveryEvents +
@@ -289,9 +339,14 @@ export default function AdminPage() {
                   "text-foreground",
                 ],
               ].map(([label, value, tone]) => (
-                <div key={String(label)} className="rounded-md border border-border p-3">
+                <div
+                  key={String(label)}
+                  className="rounded-md border border-border p-3"
+                >
                   <p className="text-xs text-muted-foreground">{label}</p>
-                  <p className={`mt-1 text-xl font-semibold tabular-nums ${tone}`}>
+                  <p
+                    className={`mt-1 text-xl font-semibold tabular-nums ${tone}`}
+                  >
                     {value}
                   </p>
                 </div>
@@ -309,7 +364,9 @@ export default function AdminPage() {
                   <thead>
                     <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
                       <th className="px-3 py-2 font-medium">Priority</th>
-                      <th className="px-3 py-2 font-medium">Clinic / location</th>
+                      <th className="px-3 py-2 font-medium">
+                        Clinic / location
+                      </th>
                       <th className="px-3 py-2 font-medium">Category</th>
                       <th className="px-3 py-2 font-medium">Age</th>
                       <th className="px-3 py-2 font-medium">Reason</th>
@@ -346,7 +403,9 @@ export default function AdminPage() {
                           {formatAgeMinutes(item.ageMinutes)}
                         </td>
                         <td className="px-3 py-2">{item.reason}</td>
-                        <td className="px-3 py-2 font-medium">{item.nextAction}</td>
+                        <td className="px-3 py-2 font-medium">
+                          {item.nextAction}
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -372,6 +431,8 @@ export default function AdminPage() {
           </p>
         )}
       </div>
+
+      <SmsRecoveryConsole />
 
       {/* Activation recovery queue */}
       <div className="mt-6 rounded-lg border border-border bg-card p-5">
@@ -399,13 +460,17 @@ export default function AdminPage() {
               </thead>
               <tbody className="divide-y divide-border">
                 {recoveryQueue.map((clinic) => (
-                  <tr key={clinic.practiceId} className="align-top hover:bg-muted/20">
+                  <tr
+                    key={clinic.practiceId}
+                    className="align-top hover:bg-muted/20"
+                  >
                     <td className="px-3 py-2 font-medium tabular-nums">
                       {clinic.queueRank}
                     </td>
                     <td className="px-3 py-2">
                       <p className="font-medium">{clinic.practiceName}</p>
-                      {clinic.verifiedAdminEmail && clinic.verifiedAdminEmailAt ? (
+                      {clinic.verifiedAdminEmail &&
+                      clinic.verifiedAdminEmailAt ? (
                         <a
                           href={`mailto:${clinic.verifiedAdminEmail}`}
                           className="mt-0.5 block text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
@@ -440,9 +505,10 @@ export default function AdminPage() {
                       <p>{clinic.setupStage}</p>
                       {clinic.setupHelpRequestedAt ? (
                         <p className="mt-0.5 text-xs font-medium text-emerald-700">
-                          Help requested {formatDate(
+                          Help requested{" "}
+                          {formatDate(
                             clinic.setupHelpRequestedAt,
-                            clinic.timezone
+                            clinic.timezone,
                           )}
                         </p>
                       ) : null}
@@ -453,10 +519,12 @@ export default function AdminPage() {
                         {clinic.realAppointmentCount} visits
                       </p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
-                        Last {formatDate(
+                        Last{" "}
+                        {formatDate(
                           clinic.lastMeaningfulActivityAt,
-                          clinic.timezone
-                        )} · stalled {clinic.stallAgeDays}d
+                          clinic.timezone,
+                        )}{" "}
+                        · stalled {clinic.stallAgeDays}d
                       </p>
                     </td>
                     <td className="px-3 py-2 capitalize text-muted-foreground">
@@ -472,7 +540,10 @@ export default function AdminPage() {
                 ))}
                 {recoveryQueue.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="px-3 py-6 text-center text-muted-foreground">
+                    <td
+                      colSpan={7}
+                      className="px-3 py-6 text-center text-muted-foreground"
+                    >
                       No clinic workspaces need activation recovery.
                     </td>
                   </tr>
@@ -566,7 +637,11 @@ export default function AdminPage() {
                           : registration.senders
                               .map(
                                 (sender) =>
-                                  `${sender.senderE164 ?? "—"} (${sender.registrationStatus}; ${
+                                  `${
+                                    sender.senderLast4
+                                      ? `Number ••••${sender.senderLast4}`
+                                      : "Number not assigned"
+                                  } (${sender.registrationStatus}; ${
                                     sender.providerProfileReady
                                       ? "provider ready"
                                       : "provider not verified"
@@ -574,12 +649,24 @@ export default function AdminPage() {
                                     sender.registrationDetail
                                       ? ` — ${sender.registrationDetail}`
                                       : ""
-                                  }`
+                                  }`,
                               )
                               .join(", ")}
                       </td>
                       <td className="px-3 py-2">
                         <div className="flex flex-wrap gap-1.5">
+                          <button
+                            type="button"
+                            className="rounded border border-border px-2 py-1 text-xs font-medium hover:bg-muted"
+                            onClick={() =>
+                              setMessagingHistorySelection({
+                                practiceId: registration.practiceId,
+                                practiceName: registration.practiceName,
+                              })
+                            }
+                          >
+                            History
+                          </button>
                           {!registration.providerBrandId ? (
                             <button
                               type="button"
@@ -590,14 +677,14 @@ export default function AdminPage() {
                                   window.confirm(
                                     registration.lastError
                                       ? `Retry ${registration.practiceName}'s brand only after confirming in the Telnyx portal that no brand was created. This can incur another non-refundable charge. Continue?`
-                                      : `Submit ${registration.practiceName}'s legal brand to Telnyx? This incurs a non-refundable provider charge.`
+                                      : `Submit ${registration.practiceName}'s legal brand to Telnyx? This incurs a non-refundable provider charge.`,
                                   )
                                 ) {
                                   submitMessagingBrand.mutate({
                                     practiceId: registration.practiceId,
                                     confirmProviderCharges: true,
                                     retryAfterProviderReview: Boolean(
-                                      registration.lastError
+                                      registration.lastError,
                                     ),
                                   });
                                 }
@@ -619,14 +706,14 @@ export default function AdminPage() {
                                   window.confirm(
                                     registration.lastError
                                       ? `Retry ${registration.practiceName}'s campaign only after confirming in the Telnyx portal that no matching campaign exists. This can incur another non-refundable charge. Continue?`
-                                      : `Submit ${registration.practiceName}'s campaign to Telnyx? This incurs non-refundable provider charges.`
+                                      : `Submit ${registration.practiceName}'s campaign to Telnyx? This incurs non-refundable provider charges.`,
                                   )
                                 ) {
                                   submitMessagingCampaign.mutate({
                                     practiceId: registration.practiceId,
                                     confirmProviderCharges: true,
                                     retryAfterProviderReview: Boolean(
-                                      registration.lastError
+                                      registration.lastError,
                                     ),
                                   });
                                 }
@@ -645,7 +732,7 @@ export default function AdminPage() {
                               onClick={() => {
                                 if (
                                   window.confirm(
-                                    `Assign ${registration.practiceName}'s texting numbers to its approved campaign? Sending will remain disabled.`
+                                    `Assign ${registration.practiceName}'s texting numbers to its approved campaign? Sending will remain disabled.`,
                                   )
                                 ) {
                                   assignMessagingNumbers.mutate({
@@ -691,8 +778,7 @@ export default function AdminPage() {
                                         )
                                       ) {
                                         setMessagingProfileEnabled.mutate({
-                                          practiceId:
-                                            registration.practiceId,
+                                          practiceId: registration.practiceId,
                                           locationId: sender.locationId,
                                           enabled: true,
                                           confirmProviderMutation: true,
@@ -750,11 +836,11 @@ export default function AdminPage() {
                                 className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
                                 onClick={() => {
                                   const brandId = window.prompt(
-                                    "After reviewing the Telnyx portal, enter the existing brand ID. Cancel if no provider object exists."
+                                    "After reviewing the Telnyx portal, enter the existing brand ID. Cancel if no provider object exists.",
                                   );
                                   if (!brandId) return;
                                   const campaignId = window.prompt(
-                                    "Optional: enter the existing campaign ID, or leave blank."
+                                    "Optional: enter the existing campaign ID, or leave blank.",
                                   );
                                   attachMessagingProviderIds.mutate({
                                     practiceId: registration.practiceId,
@@ -783,7 +869,7 @@ export default function AdminPage() {
                                       : "brand";
                                   if (
                                     window.confirm(
-                                      `I reviewed the Telnyx portal and confirmed NO matching ${providerObject} exists. Clear the stale lock and keep all sending disabled?`
+                                      `I reviewed the Telnyx portal and confirmed NO matching ${providerObject} exists. Clear the stale lock and keep all sending disabled?`,
                                     )
                                   ) {
                                     clearStaleMessagingSubmissionLock.mutate({
@@ -827,6 +913,117 @@ export default function AdminPage() {
         )}
       </div>
 
+      {/* Messaging carrier history */}
+      {messagingHistorySelection ? (
+        <div className="mt-4 rounded-lg border border-border bg-card p-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold">Carrier lifecycle history</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {messagingHistorySelection.practiceName} · newest first · at
+                most {MESSAGING_HISTORY_LIMIT} redacted operational events
+              </p>
+            </div>
+            <button
+              type="button"
+              className="rounded border border-border px-2 py-1 text-xs font-medium hover:bg-muted"
+              onClick={() => setMessagingHistorySelection(null)}
+            >
+              Close history
+            </button>
+          </div>
+          {messagingHistoryError ? (
+            <p className="mt-3 text-sm text-destructive">
+              Could not load carrier lifecycle history.
+            </p>
+          ) : messagingHistory ? (
+            <>
+              <div className="mt-4 overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Recorded</th>
+                      <th className="px-3 py-2 font-medium">Lifecycle event</th>
+                      <th className="px-3 py-2 font-medium">Status</th>
+                      <th className="px-3 py-2 font-medium">
+                        Operational evidence
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {messagingHistory.events.map((event) => (
+                      <tr key={event.id} className="align-top">
+                        <td className="px-3 py-2">
+                          {formatDateTime(event.createdAt)}
+                        </td>
+                        <td className="px-3 py-2 capitalize">
+                          <p>{recoveryLabel(event.eventType)}</p>
+                          <p className="mt-1 text-muted-foreground">
+                            {recoveryLabel(event.operation)} · {event.provider}
+                          </p>
+                        </td>
+                        <td className="px-3 py-2 capitalize">
+                          <p>
+                            {recoveryLabel(
+                              event.statusBefore ?? "not recorded",
+                            )}{" "}
+                            →{" "}
+                            {recoveryLabel(event.statusAfter ?? "not recorded")}
+                          </p>
+                          <p className="mt-1 text-muted-foreground">
+                            Brand {event.providerBrandStatus ?? "—"} · campaign{" "}
+                            {event.providerCampaignStatus ?? "—"}
+                          </p>
+                        </td>
+                        <td className="px-3 py-2 font-mono text-[11px]">
+                          <p className="break-all">event {event.id}</p>
+                          <p className="mt-1 break-all text-muted-foreground">
+                            operation {event.operationId}
+                          </p>
+                          <p className="mt-1 break-all text-muted-foreground">
+                            registration {event.registrationId} · location{" "}
+                            {event.locationId ?? "—"}
+                          </p>
+                          <p className="mt-1 capitalize text-muted-foreground">
+                            reason {recoveryLabel(event.reasonCode)}
+                          </p>
+                          <p className="mt-1 text-muted-foreground">
+                            actor {event.actorLabel}
+                          </p>
+                        </td>
+                      </tr>
+                    ))}
+                    {messagingHistory.events.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={4}
+                          className="px-3 py-6 text-center text-muted-foreground"
+                        >
+                          No carrier lifecycle evidence has been recorded.
+                        </td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+              {messagingHistory.truncated ? (
+                <p className="mt-2 text-xs font-medium text-amber-700">
+                  History is truncated at {MESSAGING_HISTORY_LIMIT} events.
+                  Review the newest evidence before taking any separate operator
+                  action.
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">
+              {messagingHistoryFetching
+                ? "Loading redacted carrier history…"
+                : "Select History again to load carrier evidence."}
+            </p>
+          )}
+        </div>
+      ) : null}
+
       {/* Trial funnel */}
       <div className="mt-6 rounded-lg border border-border bg-card p-5">
         <div className="flex items-center gap-2 text-muted-foreground">
@@ -839,8 +1036,16 @@ export default function AdminPage() {
               {[
                 ["Visit", journey.totals.visitors, null],
                 ["Demo", journey.totals.demos, journey.totals.demoRate],
-                ["Registered", journey.totals.registrations, journey.totals.registrationRate],
-                ["Activated", journey.totals.activated, journey.totals.activationRate],
+                [
+                  "Registered",
+                  journey.totals.registrations,
+                  journey.totals.registrationRate,
+                ],
+                [
+                  "Activated",
+                  journey.totals.activated,
+                  journey.totals.activationRate,
+                ],
                 [
                   "Payment method",
                   journey.totals.paymentMethodCollected,
@@ -869,8 +1074,12 @@ export default function AdminPage() {
             <div className="mt-5 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 xl:grid-cols-6">
               <p>Left before trying (7d+): {journey.totals.leftBeforeTrying}</p>
               <p>Demo without signup (7d+): {journey.totals.demoAbandoned}</p>
-              <p>Signup stalled (7d+): {journey.totals.registrationAbandoned}</p>
-              <p>Activation stalled (7d+): {journey.totals.activationAbandoned}</p>
+              <p>
+                Signup stalled (7d+): {journey.totals.registrationAbandoned}
+              </p>
+              <p>
+                Activation stalled (7d+): {journey.totals.activationAbandoned}
+              </p>
               <p>
                 Payment method without positive payment after trial (7d+):{" "}
                 {journey.totals.paymentAbandoned}
@@ -894,11 +1103,19 @@ export default function AdminPage() {
                 <tbody className="divide-y divide-border">
                   {journey.weeks.map((week) => (
                     <tr key={week.weekStart}>
-                      <td className="px-3 py-2 font-medium">{week.weekStart}</td>
-                      <td className="px-3 py-2 tabular-nums">{week.visitors}</td>
+                      <td className="px-3 py-2 font-medium">
+                        {week.weekStart}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {week.visitors}
+                      </td>
                       <td className="px-3 py-2 tabular-nums">{week.demos}</td>
-                      <td className="px-3 py-2 tabular-nums">{week.registrations}</td>
-                      <td className="px-3 py-2 tabular-nums">{week.activated}</td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {week.registrations}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {week.activated}
+                      </td>
                       <td className="px-3 py-2 tabular-nums">
                         {week.paymentMethodCollected}
                       </td>
@@ -909,7 +1126,10 @@ export default function AdminPage() {
                   ))}
                   {journey.weeks.length === 0 ? (
                     <tr>
-                      <td colSpan={7} className="px-3 py-6 text-center text-muted-foreground">
+                      <td
+                        colSpan={7}
+                        className="px-3 py-6 text-center text-muted-foreground"
+                      >
                         No first-party journey cohorts recorded yet.
                       </td>
                     </tr>
@@ -918,10 +1138,10 @@ export default function AdminPage() {
               </table>
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
-              Anonymous first touch is carried across openvpm.com, demo, and signup.
-              Rates are visit-to-step for demo and registration, then step-to-step.{" "}
-              Stalls require seven full days; an active trial with a collected
-              payment method is not treated as payment-abandoned.
+              Anonymous first touch is carried across openvpm.com, demo, and
+              signup. Rates are visit-to-step for demo and registration, then
+              step-to-step. Stalls require seven full days; an active trial with
+              a collected payment method is not treated as payment-abandoned.
               {journey.totals.historicalUnattributedRegistrations > 0
                 ? ` ${journey.totals.historicalUnattributedRegistrations} historical registration(s) have no captured journey ID and remain explicitly unknown.`
                 : ""}
@@ -932,7 +1152,9 @@ export default function AdminPage() {
           </>
         ) : (
           <p className="mt-3 text-sm text-muted-foreground">
-            {journeyError ? "Could not load journey cohorts." : "Loading journey cohorts..."}
+            {journeyError
+              ? "Could not load journey cohorts."
+              : "Loading journey cohorts..."}
           </p>
         )}
       </div>
@@ -979,7 +1201,9 @@ export default function AdminPage() {
                 </p>
               </div>
               <div>
-                <p className="text-sm text-muted-foreground">First visit done</p>
+                <p className="text-sm text-muted-foreground">
+                  First visit done
+                </p>
                 <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
                   {funnel.totals.firstVisitCompleted}
                   <span className="ml-2 text-sm font-normal text-muted-foreground">
@@ -997,7 +1221,9 @@ export default function AdminPage() {
                 </p>
               </div>
               <div>
-                <p className="text-sm text-muted-foreground">First positive payment</p>
+                <p className="text-sm text-muted-foreground">
+                  First positive payment
+                </p>
                 <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
                   {funnel.totals.firstPositivePayment}
                   <span className="ml-2 text-sm font-normal text-muted-foreground">
@@ -1006,7 +1232,9 @@ export default function AdminPage() {
                 </p>
               </div>
               <div>
-                <p className="text-sm text-muted-foreground">Currently active</p>
+                <p className="text-sm text-muted-foreground">
+                  Currently active
+                </p>
                 <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
                   {funnel.totals.currentlyActive}
                   <span className="ml-2 text-sm font-normal text-muted-foreground">
@@ -1016,28 +1244,37 @@ export default function AdminPage() {
               </div>
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
-              Setup progress comes from the guided clinic setup. Activated = added a
-              real client and booked a real visit. First visit done requires a
-              completed clinical and billing closeout; its rate is measured from
-              activated clinics. Payment method = a signed subscription Checkout
-              completed with collection required. First positive payment = a signed,
-              positive subscription invoice payment. Currently active is current
-              billing state, not a historical conversion milestone.
+              Setup progress comes from the guided clinic setup. Activated =
+              added a real client and booked a real visit. First visit done
+              requires a completed clinical and billing closeout; its rate is
+              measured from activated clinics. Payment method = a signed
+              subscription Checkout completed with collection required. First
+              positive payment = a signed, positive subscription invoice
+              payment. Currently active is current billing state, not a
+              historical conversion milestone.
             </p>
             <div className="mt-4 rounded-md border border-amber-300/60 bg-amber-50/50 p-3 text-xs text-muted-foreground dark:bg-amber-950/10">
-              <p className="font-medium text-foreground">Conversion evidence quality</p>
+              <p className="font-medium text-foreground">
+                Conversion evidence quality
+              </p>
               <p className="mt-1">
-                Legacy business-stage rows are excluded; unknown evidence is never
-                counted as zero or assigned a synthetic date.
+                Legacy business-stage rows are excluded; unknown evidence is
+                never counted as zero or assigned a synthetic date.
               </p>
               <p className="mt-2">
-                Legacy rows: {funnel.dataQuality.legacyBusinessStageRows} · Unknown
-                payment method: {funnel.dataQuality.unknownPaymentMethodPractices} ·{" "}
-                Unknown positive payment: {funnel.dataQuality.unknownPositivePaymentPractices}
-                {" · "}Missing registrations: {funnel.dataQuality.missingRegistrationMilestones}
-                {" · "}Missing activations: {funnel.dataQuality.missingActivationMilestones}
-                {" · "}Unprojected Stripe evidence: {funnel.dataQuality.unprojectedStripeEvidence}
-                {" · "}Unmapped Stripe evidence: {funnel.dataQuality.unmappedStripeEvidence}
+                Legacy rows: {funnel.dataQuality.legacyBusinessStageRows} ·
+                Unknown payment method:{" "}
+                {funnel.dataQuality.unknownPaymentMethodPractices} · Unknown
+                positive payment:{" "}
+                {funnel.dataQuality.unknownPositivePaymentPractices}
+                {" · "}Missing registrations:{" "}
+                {funnel.dataQuality.missingRegistrationMilestones}
+                {" · "}Missing activations:{" "}
+                {funnel.dataQuality.missingActivationMilestones}
+                {" · "}Unprojected Stripe evidence:{" "}
+                {funnel.dataQuality.unprojectedStripeEvidence}
+                {" · "}Unmapped Stripe evidence:{" "}
+                {funnel.dataQuality.unmappedStripeEvidence}
               </p>
             </div>
           </>
@@ -1104,7 +1341,8 @@ export default function AdminPage() {
                 <td className="px-4 py-2.5">
                   <span
                     className={`rounded-full px-2 py-0.5 text-xs font-medium capitalize ${
-                      statusStyles[p.billingStatus] || "bg-gray-100 text-gray-500"
+                      statusStyles[p.billingStatus] ||
+                      "bg-gray-100 text-gray-500"
                     }`}
                   >
                     {p.billingStatus.replace("_", " ")}
@@ -1120,7 +1358,8 @@ export default function AdminPage() {
                   <p>{p.setupStage}</p>
                   {p.setupHelpRequestedAt ? (
                     <p className="mt-0.5 text-xs font-medium text-emerald-700">
-                      Help requested {formatDate(p.setupHelpRequestedAt, p.timezone)}
+                      Help requested{" "}
+                      {formatDate(p.setupHelpRequestedAt, p.timezone)}
                     </p>
                   ) : null}
                 </td>
@@ -1167,12 +1406,24 @@ export default function AdminPage() {
                     )}
                   </span>
                 </td>
-                <td className="px-4 py-2.5 text-right tabular-nums">{p.locationCount}</td>
-                <td className="px-4 py-2.5 text-right tabular-nums">{p.userCount}</td>
-                <td className="px-4 py-2.5 text-right tabular-nums">{formatUsd(p.estimatedMrr)}</td>
-                <td className="px-4 py-2.5 text-right tabular-nums">{p.clientCount}</td>
-                <td className="px-4 py-2.5 text-right tabular-nums">{p.patientCount}</td>
-                <td className="px-4 py-2.5 text-muted-foreground">{p.country}</td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {p.locationCount}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {p.userCount}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {formatUsd(p.estimatedMrr)}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {p.clientCount}
+                </td>
+                <td className="px-4 py-2.5 text-right tabular-nums">
+                  {p.patientCount}
+                </td>
+                <td className="px-4 py-2.5 text-muted-foreground">
+                  {p.country}
+                </td>
                 <td className="px-4 py-2.5 text-muted-foreground">
                   {formatDate(p.createdAt, p.timezone)}
                 </td>
@@ -1180,7 +1431,10 @@ export default function AdminPage() {
             ))}
             {data.practices.length === 0 && (
               <tr>
-                <td colSpan={15} className="px-4 py-8 text-center text-muted-foreground">
+                <td
+                  colSpan={15}
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
                   No practices yet.
                 </td>
               </tr>

--- a/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
@@ -18,6 +18,7 @@ import {
   CLIENT_PHONE_MAX_LENGTH,
   CLIENT_STATE_MAX_LENGTH,
   CLIENT_ZIP_MAX_LENGTH,
+  type ClientContactMethod,
   isOptionalClientTextValid,
   isRequiredClientTextValid,
 } from "@/lib/clients/policy";
@@ -102,6 +103,9 @@ function EditClientForm() {
   });
   const [smsConsent, setSmsConsent] = useState(false);
   const [smsConsentTouched, setSmsConsentTouched] = useState(false);
+  const [preferredContactMethod, setPreferredContactMethod] =
+    useState<ClientContactMethod>("phone");
+  const [preferredContactTouched, setPreferredContactTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const {
@@ -128,6 +132,8 @@ function EditClientForm() {
       });
       setSmsConsent(client.smsConsent ?? false);
       setSmsConsentTouched(false);
+      setPreferredContactMethod(client.preferredContactMethod ?? "phone");
+      setPreferredContactTouched(false);
     }
   }, [client]);
 
@@ -161,6 +167,20 @@ function EditClientForm() {
   const phoneChanged = client
     ? !phoneNumbersMatchForConsent(client.phone, form.phone)
     : false;
+  const persistedConsentEvidenceComplete = Boolean(
+    client?.smsConsent &&
+    client.smsConsentAt &&
+    client.smsConsentSource?.trim() &&
+    client.smsConsentDisclosure?.trim(),
+  );
+  const smsPreferenceReady = Boolean(
+    smsConsent &&
+    smsPhoneValid &&
+    (smsConsentTouched || (!phoneChanged && persistedConsentEvidenceComplete)),
+  );
+  const smsPreferenceNeedsValidation =
+    preferredContactMethod === "sms" &&
+    (preferredContactTouched || phoneChanged || smsConsentTouched);
   const canSubmit =
     isRequiredClientTextValid(form.firstName, CLIENT_NAME_MAX_LENGTH) &&
     isRequiredClientTextValid(form.lastName, CLIENT_NAME_MAX_LENGTH) &&
@@ -170,7 +190,8 @@ function EditClientForm() {
     isOptionalClientTextValid(form.city, CLIENT_CITY_MAX_LENGTH) &&
     isOptionalClientTextValid(form.state, CLIENT_STATE_MAX_LENGTH) &&
     isOptionalClientTextValid(form.zip, CLIENT_ZIP_MAX_LENGTH) &&
-    (!smsConsentTouched || !smsConsent || smsPhoneValid);
+    (!smsConsentTouched || !smsConsent || smsPhoneValid) &&
+    (!smsPreferenceNeedsValidation || smsPreferenceReady);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -183,6 +204,12 @@ function EditClientForm() {
     if (smsConsentTouched && smsConsent && !smsPhoneValid) {
       setError(
         "Enter a valid mobile phone number before recording SMS consent.",
+      );
+      return;
+    }
+    if (smsPreferenceNeedsValidation && !smsPreferenceReady) {
+      setError(
+        "Confirm current SMS consent before using text messages for reminders.",
       );
       return;
     }
@@ -201,6 +228,7 @@ function EditClientForm() {
       city: form.city.trim() || undefined,
       state: form.state.trim() || undefined,
       zip: form.zip.trim() || undefined,
+      ...(preferredContactTouched ? { preferredContactMethod } : {}),
       ...(smsConsentTouched ? { smsConsent } : {}),
     });
   };
@@ -216,6 +244,12 @@ function EditClientForm() {
           : false,
       );
       setSmsConsentTouched(false);
+      if (!phoneNumbersMatchForConsent(client.phone, value)) {
+        if (preferredContactMethod === "sms") {
+          setPreferredContactMethod("phone");
+          setPreferredContactTouched(true);
+        }
+      }
     }
   };
 
@@ -326,12 +360,53 @@ function EditClientForm() {
           </div>
         </div>
 
+        <div className="rounded-md border border-border p-3">
+          <label
+            className="text-sm font-medium"
+            htmlFor="preferredContactMethod"
+          >
+            Preferred contact for reminders
+          </label>
+          <select
+            id="preferredContactMethod"
+            value={preferredContactMethod}
+            onChange={(event) => {
+              setPreferredContactMethod(
+                event.target.value as ClientContactMethod,
+              );
+              setPreferredContactTouched(true);
+            }}
+            className="mt-2 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          >
+            <option value="phone">Phone call</option>
+            <option value="email">Email</option>
+            <option value="sms">Text message</option>
+            <option value="portal">Client portal</option>
+          </select>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Text message uses SMS for appointment and vaccination reminders when
+            clinic texting is active. Current permission and a valid mobile
+            number are required.
+          </p>
+          {preferredContactMethod === "sms" && !smsPreferenceReady ? (
+            <p className="mt-2 text-xs font-medium text-amber-700">
+              {smsPreferenceNeedsValidation
+                ? "Reconfirm the disclosure below before saving text reminders as the preference."
+                : "Text reminders are paused until the client has current SMS consent."}
+            </p>
+          ) : null}
+        </div>
+
         <label className="flex items-start gap-2 rounded-md border border-border p-3 text-sm">
           <Checkbox
             checked={smsConsent}
             onChange={(e) => {
               setSmsConsent(e.target.checked);
               setSmsConsentTouched(true);
+              if (!e.target.checked && preferredContactMethod === "sms") {
+                setPreferredContactMethod("phone");
+                setPreferredContactTouched(true);
+              }
             }}
             disabled={!smsPhoneValid && !smsConsent}
             className="mt-0.5"

--- a/apps/web/app/(dashboard)/clients/new/page.tsx
+++ b/apps/web/app/(dashboard)/clients/new/page.tsx
@@ -18,6 +18,7 @@ import {
   CLIENT_PHONE_MAX_LENGTH,
   CLIENT_STATE_MAX_LENGTH,
   CLIENT_ZIP_MAX_LENGTH,
+  type ClientContactMethod,
   isOptionalClientTextValid,
   isRequiredClientTextValid,
 } from "@/lib/clients/policy";
@@ -88,6 +89,8 @@ function NewClientForm() {
     zip: "",
   });
   const [smsConsent, setSmsConsent] = useState(false);
+  const [preferredContactMethod, setPreferredContactMethod] =
+    useState<ClientContactMethod>("phone");
   const [error, setError] = useState<string | null>(null);
 
   const createClient = trpc.clients.create.useMutation({
@@ -112,14 +115,23 @@ function NewClientForm() {
     isOptionalClientTextValid(form.city, CLIENT_CITY_MAX_LENGTH) &&
     isOptionalClientTextValid(form.state, CLIENT_STATE_MAX_LENGTH) &&
     isOptionalClientTextValid(form.zip, CLIENT_ZIP_MAX_LENGTH) &&
-    (!smsConsent || smsPhoneValid);
+    (!smsConsent || smsPhoneValid) &&
+    (preferredContactMethod !== "sms" || (smsConsent && smsPhoneValid));
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
     if (smsConsent && !smsPhoneValid) {
-      setError("Enter a valid mobile phone number before recording SMS consent.");
+      setError(
+        "Enter a valid mobile phone number before recording SMS consent.",
+      );
+      return;
+    }
+    if (preferredContactMethod === "sms" && !smsConsent) {
+      setError(
+        "Confirm the client's SMS consent before using text messages for reminders.",
+      );
       return;
     }
     if (!canSubmit) {
@@ -136,6 +148,7 @@ function NewClientForm() {
       city: form.city.trim() || undefined,
       state: form.state.trim() || undefined,
       zip: form.zip.trim() || undefined,
+      preferredContactMethod,
       smsConsent,
     });
   };
@@ -144,6 +157,9 @@ function NewClientForm() {
     setForm((prev) => ({ ...prev, [field]: value }));
     if (field === "phone" && !normalizeE164(value)) {
       setSmsConsent(false);
+      setPreferredContactMethod((current) =>
+        current === "sms" ? "phone" : current,
+      );
     }
   };
 
@@ -232,10 +248,52 @@ function NewClientForm() {
           </div>
         </div>
 
+        <div className="rounded-md border border-border p-3">
+          <label
+            className="text-sm font-medium"
+            htmlFor="preferredContactMethod"
+          >
+            Preferred contact for reminders
+          </label>
+          <select
+            id="preferredContactMethod"
+            value={preferredContactMethod}
+            onChange={(event) =>
+              setPreferredContactMethod(
+                event.target.value as ClientContactMethod,
+              )
+            }
+            className="mt-2 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          >
+            <option value="phone">Phone call</option>
+            <option value="email">Email</option>
+            <option value="sms">Text message</option>
+            <option value="portal">Client portal</option>
+          </select>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Text message uses SMS for appointment and vaccination reminders when
+            clinic texting is active. The client&apos;s permission below is
+            still required.
+          </p>
+          {preferredContactMethod === "sms" && !smsConsent ? (
+            <p className="mt-2 text-xs font-medium text-amber-700">
+              Read the disclosure below and confirm consent before saving text
+              reminders as the preference.
+            </p>
+          ) : null}
+        </div>
+
         <label className="flex items-start gap-2 rounded-md border border-border p-3 text-sm">
           <Checkbox
             checked={smsConsent}
-            onChange={(e) => setSmsConsent(e.target.checked)}
+            onChange={(e) => {
+              setSmsConsent(e.target.checked);
+              if (!e.target.checked) {
+                setPreferredContactMethod((current) =>
+                  current === "sms" ? "phone" : current,
+                );
+              }
+            }}
             disabled={!smsPhoneValid}
             className="mt-0.5"
           />

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  dbExecute: vi.fn(async () => [{ ok: 1 }]),
+  dbExecute: vi.fn(async () => [{ ok: 1, scopeValid: true }]),
+  withSystem: vi.fn(
+    async (
+      database: { execute: typeof mocks.dbExecute },
+      fn: (tx: { execute: typeof mocks.dbExecute }) => Promise<unknown>,
+    ) => fn(database),
+  ),
   billingEnforced: vi.fn(() => false),
   requiredMessagingEnvNames: vi.fn(() => [
     "TELNYX_API_KEY",
@@ -35,6 +41,8 @@ vi.mock("@openpims/db/client", () => ({
     execute: mocks.dbExecute,
   },
 }));
+
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
 
 vi.mock("@openpims/db/schema-drift", async () => {
   const actual = await vi.importActual<
@@ -100,10 +108,21 @@ function stubHostedRequiredEnvs() {
   });
 }
 
+function stubValidTelnyxEnvs() {
+  vi.stubEnv("MESSAGING_PROVIDER", "telnyx");
+  vi.stubEnv("TELNYX_API_KEY", "KEY_abcdefghijklmnopqrstuvwxyz");
+  vi.stubEnv("TELNYX_PUBLIC_KEY", Buffer.alloc(32, 1).toString("base64"));
+  vi.stubEnv(
+    "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
+    Buffer.alloc(32, 2).toString("base64"),
+  );
+}
+
 afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
-  mocks.dbExecute.mockResolvedValue([{ ok: 1 }]);
+  mocks.dbExecute.mockResolvedValue([{ ok: 1, scopeValid: true }]);
+  mocks.withSystem.mockImplementation(async (database, fn) => fn(database));
   mocks.billingEnforced.mockReturnValue(false);
   mocks.requiredMessagingEnvNames.mockReturnValue([
     "TELNYX_API_KEY",
@@ -185,7 +204,7 @@ describe("health route schema drift", () => {
 
   it("does not leak connection details when the drift check itself fails", async () => {
     mocks.findSchemaDrift.mockRejectedValueOnce(
-      new Error("password=secret host=prod-db")
+      new Error("password=secret host=prod-db"),
     );
 
     const response = await GET();
@@ -202,7 +221,7 @@ describe("health route schema drift", () => {
 describe("health route", () => {
   it("does not expose raw database errors in unauthenticated health checks", async () => {
     mocks.dbExecute.mockRejectedValueOnce(
-      new Error("password=secret host=prod-db connection refused")
+      new Error("password=secret host=prod-db connection refused"),
     );
 
     const response = await GET();
@@ -226,23 +245,23 @@ describe("health route", () => {
 
     expect(response.status).toBe(503);
     expect(json.checks.hostedCore.detail).toBe(
-      "4 required hosted configuration values are missing"
+      "4 required hosted configuration values are missing",
     );
     expect(json.checks.hostedAppUrls.detail).toBe(
-      "2 required hosted app URL values are missing"
+      "2 required hosted app URL values are missing",
     );
     expect(json.checks.hostedBilling.detail).toBe(
-      "5 required hosted configuration values are missing"
+      "5 required hosted configuration values are missing",
     );
     expect(json.checks.hostedSubscriptionTax).toEqual({
       ok: false,
       detail: "Hosted subscription tax is not enabled",
     });
     expect(json.checks.hostedAi.detail).toBe(
-      "1 required hosted configuration value is missing"
+      "1 required hosted configuration value is missing",
     );
     expect(json.checks.hostedEmail.detail).toBe(
-      "4 required hosted configuration values are missing"
+      "4 required hosted configuration values are missing",
     );
     const body = JSON.stringify(json);
     expect(body).not.toContain("NEXTAUTH_SECRET");
@@ -263,7 +282,7 @@ describe("health route", () => {
     expect(body).not.toContain("MESSAGING_REGISTRATION_ENCRYPTION_KEY");
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "3 required hosted configuration values are missing",
+      detail: "3 required hosted SMS configuration issues detected",
       advisory: true,
     });
     expect(json.checks.hostedOpsAlerting).toEqual({
@@ -275,6 +294,238 @@ describe("health route", () => {
       detail: "Heartbeat URL missing",
     });
     expect(mocks.checkObjectStorageHealth).not.toHaveBeenCalled();
+  });
+
+  it("makes hosted SMS release-blocking as soon as provisioning is enabled", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    vi.stubEnv("MESSAGING_PROVIDER", "telnyx");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv(
+      "MESSAGING_PROVISIONING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail: "3 required hosted SMS configuration issues detected",
+    });
+    expect(JSON.stringify(json)).not.toContain("TELNYX_API_KEY");
+    expect(JSON.stringify(json)).not.toContain(
+      "MESSAGING_PROVISIONING_PRACTICE_IDS",
+    );
+  });
+
+  it("reports credential shape while a valid hosted SMS rollout stays deferred", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.checks.hostedSms).toEqual({
+      ok: true,
+      detail: "Hosted Telnyx credentials are structurally valid",
+      advisory: true,
+    });
+  });
+
+  it("rejects an incomplete live hosted SMS pilot scope", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail: "1 required hosted SMS configuration issue detected",
+    });
+  });
+
+  it("accepts one exact live Telnyx pilot scope", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.checks.hostedSms).toEqual({
+      ok: true,
+      detail: "Hosted SMS pilot configuration active",
+    });
+    expect(mocks.withSystem).toHaveBeenCalledOnce();
+  });
+
+  it("rejects different provisioning and sending clinic scopes", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    vi.stubEnv(
+      "MESSAGING_PROVISIONING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000bb",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail: "1 required hosted SMS configuration issue detected",
+    });
+  });
+
+  it("rejects a sending scope that is not carrier-ready in the database", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+    mocks.dbExecute
+      .mockResolvedValueOnce([{ ok: 1, scopeValid: true }])
+      .mockResolvedValueOnce([{ ok: 1, scopeValid: false }]);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail:
+        "Hosted SMS pilot scope does not match an active, carrier-ready clinic location",
+    });
+  });
+
+  it("requires Telnyx explicitly when a pilot allowlist is staged", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    vi.stubEnv("MESSAGING_PROVIDER", "twilio");
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail: "1 required hosted SMS configuration issue detected",
+    });
+  });
+
+  it("rejects malformed staged hosted SMS scope", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", "not-a-practice-id");
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail: "1 required hosted SMS configuration issue detected",
+    });
+  });
+
+  it("rejects placeholder UUIDs in staged hosted SMS scope", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-0000-0000-0000000000aa",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail: "1 required hosted SMS configuration issue detected",
+    });
+  });
+
+  it("rejects placeholder-shaped Telnyx credentials during rollout", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    vi.stubEnv("MESSAGING_PROVIDER", "telnyx");
+    vi.stubEnv("TELNYX_API_KEY", "test-api-key");
+    vi.stubEnv("TELNYX_PUBLIC_KEY", "test-public-key");
+    vi.stubEnv("MESSAGING_REGISTRATION_ENCRYPTION_KEY", "test-encryption-key");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv(
+      "MESSAGING_PROVISIONING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedSms).toEqual({
+      ok: false,
+      detail: "3 required hosted SMS configuration issues detected",
+    });
+    expect(JSON.stringify(json)).not.toContain("test-api-key");
+    expect(JSON.stringify(json)).not.toContain("test-public-key");
   });
 
   it("does not require the legacy Cloud seat price for hosted readiness", async () => {

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -10,7 +10,6 @@ import {
   STRIPE_PRICE_CLOUD_LOCATION_ENV,
   billingEnforced,
 } from "@/lib/billing/plans";
-import { requiredMessagingEnvNames } from "@/lib/messaging";
 import {
   hostedRlsRoleViolations,
   inspectHostedRlsRole,
@@ -21,6 +20,8 @@ import { envFlagEnabled } from "@/lib/env-bool";
 import { checkObjectStorageHealth } from "@/lib/s3";
 import { normalizeAppBaseUrl } from "@/lib/app-url";
 import { platformAdminEmails } from "@/lib/platform-admin";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import { withSystem } from "@/lib/tenant-db";
 
 export const dynamic = "force-dynamic";
 
@@ -69,6 +70,10 @@ const HOSTED_EMAIL_ENV_NAMES = [
   "EMAIL_SUPPORT_ADDRESS",
   "EMAIL_COMPANY_ADDRESS",
 ];
+const HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV =
+  "MESSAGING_PROVISIONING_PRACTICE_IDS";
+const HOSTED_SMS_SENDING_PRACTICE_IDS_ENV = "MESSAGING_SENDING_PRACTICE_IDS";
+const HOSTED_SMS_SENDING_LOCATION_IDS_ENV = "MESSAGING_SENDING_LOCATION_IDS";
 const HOSTED_GOOGLE_AI_ENV_NAMES = [
   "GOOGLE_API_KEY",
   "GOOGLE_GENERATIVE_AI_API_KEY",
@@ -99,7 +104,7 @@ function hostedAiCheck(): { ok: boolean; detail: string } {
 
   return hostedEnvCheck(
     HOSTED_ANTHROPIC_AI_ENV_NAMES,
-    "Hosted AI envs present"
+    "Hosted AI envs present",
   );
 }
 
@@ -110,7 +115,7 @@ const HOSTED_OPS_ALERTING_ENV_NAMES = ["OPS_ALERT_WEBHOOK_URL"];
 
 function hostedEnvCheck(
   names: string[],
-  presentDetail: string
+  presentDetail: string,
 ): { ok: boolean; detail: string } {
   const missing = names.filter((name) => !configured(name));
   return {
@@ -172,6 +177,197 @@ function hostedSubscriptionTaxCheck(): { ok: boolean; detail: string } {
     detail: ok
       ? "Hosted subscription tax is enabled"
       : "Hosted subscription tax is not enabled",
+  };
+}
+
+function commaSeparatedValues(name: string): string[] {
+  return (process.env[name] ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+function isExactPilotScope(values: string[]): boolean {
+  return values.length === 1 && isUuid(values[0]!);
+}
+
+function isBase64EncodedBytes(
+  value: string | undefined,
+  bytes: number,
+): boolean {
+  if (!value || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return false;
+  try {
+    return Buffer.from(value, "base64").length === bytes;
+  } catch {
+    return false;
+  }
+}
+
+function hostedTelnyxCredentialIssueCount(): number {
+  let issues = 0;
+  const apiKey = envValue("TELNYX_API_KEY");
+  if (!apiKey?.startsWith("KEY_") || apiKey.length < 20) issues += 1;
+  if (!isBase64EncodedBytes(envValue("TELNYX_PUBLIC_KEY"), 32)) issues += 1;
+  if (
+    !isBase64EncodedBytes(envValue("MESSAGING_REGISTRATION_ENCRYPTION_KEY"), 32)
+  ) {
+    issues += 1;
+  }
+  return issues;
+}
+
+function hostedTelnyxCredentialCheck(): { ok: boolean; detail: string } {
+  const issueCount = hostedTelnyxCredentialIssueCount();
+  return issueCount > 0
+    ? {
+        ok: false,
+        detail: `${issueCount} required hosted SMS configuration ${
+          issueCount === 1 ? "issue" : "issues"
+        } detected`,
+      }
+    : {
+        ok: true,
+        detail: "Hosted Telnyx credentials are structurally valid",
+      };
+}
+
+function hostedSmsRolloutIntended(): boolean {
+  return (
+    envFlagEnabled("MESSAGING_PROVISIONING_ENABLED") ||
+    envFlagEnabled("MESSAGING_SENDING_ENABLED") ||
+    commaSeparatedValues(HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV).length > 0 ||
+    commaSeparatedValues(HOSTED_SMS_SENDING_PRACTICE_IDS_ENV).length > 0 ||
+    commaSeparatedValues(HOSTED_SMS_SENDING_LOCATION_IDS_ENV).length > 0
+  );
+}
+
+async function hostedSmsRolloutCheck(): Promise<{
+  ok: boolean;
+  detail: string;
+}> {
+  const credentialIssues = hostedTelnyxCredentialIssueCount();
+  const provisioningEnabled = envFlagEnabled("MESSAGING_PROVISIONING_ENABLED");
+  const sendingEnabled = envFlagEnabled("MESSAGING_SENDING_ENABLED");
+  const provisioningPracticeIds = commaSeparatedValues(
+    HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV,
+  );
+  const sendingPracticeIds = commaSeparatedValues(
+    HOSTED_SMS_SENDING_PRACTICE_IDS_ENV,
+  );
+  const sendingLocationIds = commaSeparatedValues(
+    HOSTED_SMS_SENDING_LOCATION_IDS_ENV,
+  );
+  const provisioningScopePrepared = provisioningPracticeIds.length > 0;
+  const sendingScopePrepared =
+    sendingPracticeIds.length > 0 || sendingLocationIds.length > 0;
+
+  let configurationIssues = 0;
+  if (envValue("MESSAGING_PROVIDER")?.toLowerCase() !== "telnyx") {
+    configurationIssues += 1;
+  }
+  if (
+    (provisioningEnabled || provisioningScopePrepared) &&
+    !isExactPilotScope(provisioningPracticeIds)
+  ) {
+    configurationIssues += 1;
+  }
+  if (
+    (sendingEnabled || sendingScopePrepared) &&
+    (!isExactPilotScope(sendingPracticeIds) ||
+      !isExactPilotScope(sendingLocationIds))
+  ) {
+    configurationIssues += 1;
+  }
+  if (
+    provisioningScopePrepared &&
+    sendingScopePrepared &&
+    provisioningPracticeIds[0] !== sendingPracticeIds[0]
+  ) {
+    configurationIssues += 1;
+  }
+
+  const issueCount = credentialIssues + configurationIssues;
+  if (issueCount > 0) {
+    return {
+      ok: false,
+      detail: `${issueCount} required hosted SMS configuration ${
+        issueCount === 1 ? "issue" : "issues"
+      } detected`,
+    };
+  }
+
+  const pilotPracticeId = sendingPracticeIds[0] ?? provisioningPracticeIds[0]!;
+  const sendingLocationId = sendingLocationIds[0] ?? null;
+  try {
+    // Health has no tenant identity. Verify the explicitly configured rollout
+    // scope in system context so hosted RLS does not hide a valid pilot clinic.
+    const result = await withSystem(db, (tx) =>
+      tx.execute(sql`
+        select (
+          exists (
+            select 1
+            from practices as practice
+            where practice.id = ${pilotPracticeId}::uuid
+              and practice.deleted_at is null
+          )
+          and ${
+            sendingLocationId
+              ? sql`exists (
+                  select 1
+                  from locations as location
+                  join location_messaging as sender
+                    on sender.practice_id = location.practice_id
+                    and sender.location_id = location.id
+                    and sender.deleted_at is null
+                  join messaging_registrations as registration
+                    on registration.practice_id = location.practice_id
+                    and registration.deleted_at is null
+                  where location.id = ${sendingLocationId}::uuid
+                    and location.practice_id = ${pilotPracticeId}::uuid
+                    and location.deleted_at is null
+                    and sender.provider = 'telnyx'
+                    and sender.registration_status = 'active'
+                    and nullif(btrim(sender.sender_e164), '') is not null
+                    and nullif(btrim(sender.messaging_profile_id), '') is not null
+                    and sender.provider_profile_ready = true
+                    and sender.provider_profile_synced_at is not null
+                    and registration.provider = 'telnyx'
+                    and registration.status = 'active'
+                    and sender.a2p_brand_id = registration.provider_brand_id
+                    and sender.a2p_campaign_id = registration.provider_campaign_id
+                )`
+              : sql`true`
+          }
+        ) as "scopeValid"
+      `),
+    );
+    const scopeValid =
+      rowsFromExecute<{ scopeValid: boolean }>(result)[0]?.scopeValid === true;
+    if (!scopeValid) {
+      return {
+        ok: false,
+        detail:
+          "Hosted SMS pilot scope does not match an active, carrier-ready clinic location",
+      };
+    }
+  } catch {
+    return {
+      ok: false,
+      detail: "Hosted SMS pilot scope verification failed",
+    };
+  }
+
+  return {
+    ok: true,
+    detail: sendingEnabled
+      ? "Hosted SMS pilot configuration active"
+      : "Hosted SMS pilot configuration prepared and sending gated off",
   };
 }
 
@@ -241,38 +437,43 @@ export async function GET() {
 
     checks.hostedCore = hostedEnvCheck(
       HOSTED_CORE_ENV_NAMES,
-      "Hosted core envs present"
+      "Hosted core envs present",
     );
     checks.hostedAppUrls = hostedAppUrlCheck();
     checks.hostedBilling = hostedEnvCheck(
       HOSTED_BILLING_ENV_NAMES,
-      "Hosted billing envs present"
+      "Hosted billing envs present",
     );
     checks.hostedSubscriptionTax = hostedSubscriptionTaxCheck();
     const hostedStorageEnv = hostedEnvCheck(
       HOSTED_STORAGE_ENV_NAMES,
-      "Hosted storage envs present"
+      "Hosted storage envs present",
     );
     checks.hostedStorage = hostedStorageEnv.ok
       ? await checkObjectStorageHealth()
       : hostedStorageEnv;
     checks.hostedEmail = hostedEnvCheck(
       HOSTED_EMAIL_ENV_NAMES,
-      "Hosted email envs present"
+      "Hosted email envs present",
     );
     checks.hostedAi = hostedAiCheck();
     checks.hostedOps = hostedOpsCheck();
 
-    // SMS is deferred until the active provider is provisioned; everything else
-    // in hosted ops must be wired before the deployment reports ready.
-    checks.hostedSms = {
-      ...hostedEnvCheck(requiredMessagingEnvNames(), "Hosted SMS envs present"),
-      advisory: true,
-    };
+    // SMS may remain safely deferred, but the first rollout signal makes its
+    // configuration release-blocking. This prevents a production health 200
+    // while provisioning or sending is nominally enabled without credentials,
+    // webhook verification, encrypted registration storage, or exact pilot
+    // scope. Missing/partial launch state still fails closed at every send.
+    checks.hostedSms = hostedSmsRolloutIntended()
+      ? await hostedSmsRolloutCheck()
+      : {
+          ...hostedTelnyxCredentialCheck(),
+          advisory: true,
+        };
     checks.hostedOpsAlerting = {
       ...hostedEnvCheck(
         HOSTED_OPS_ALERTING_ENV_NAMES,
-        "Ops alerting configured"
+        "Ops alerting configured",
       ),
     };
     checks.hostedCronHeartbeat = cronHeartbeatConfigured();
@@ -294,6 +495,6 @@ export async function GET() {
       checks,
       latencyMs: Date.now() - startedAt,
     },
-    { status: ok ? 200 : 503 }
+    { status: ok ? 200 : 503 },
   );
 }

--- a/apps/web/app/api/webhooks/telnyx/route.test.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.test.ts
@@ -90,6 +90,7 @@ const mocks = vi.hoisted(() => {
     updateReturning,
     updateSet,
     updateWhere,
+    alertOps: vi.fn(async () => undefined),
     recordSmsDeliveryCallback: vi.fn(async () => ({
       eventId: "00000000-0000-0000-0000-0000000000dd",
       duplicate: false,
@@ -121,6 +122,10 @@ vi.mock("@/lib/messaging/telnyx-signature", () => ({
 
 vi.mock("@/lib/messaging/sms-delivery-ledger", () => ({
   recordSmsDeliveryCallback: mocks.recordSmsDeliveryCallback,
+}));
+
+vi.mock("@/lib/alerts", () => ({
+  alertOps: mocks.alertOps,
 }));
 
 const { POST } = await import("./route");
@@ -224,19 +229,19 @@ afterEach(() => {
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
   mocks.updateResults.length = 0;
+  mocks.insertResults.length = 0;
   delete process.env.TELNYX_PUBLIC_KEY;
 });
 
 describe("Telnyx webhook", () => {
   it("persists signed 10DLC failures and disables clinic senders", async () => {
     process.env.TELNYX_PUBLIC_KEY = "pub";
-    mocks.selectResults.push([
-      {
-        id: "00000000-0000-0000-0000-000000000008",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-        status: "pending",
-      },
-    ]);
+    const registration = {
+      id: "00000000-0000-0000-0000-000000000008",
+      practiceId: "00000000-0000-0000-0000-0000000000aa",
+      status: "pending",
+    };
+    mocks.selectResults.push([registration], [registration], []);
     const body = JSON.stringify({
       data: {
         event_type: "10dlc.campaign.update",
@@ -279,7 +284,129 @@ describe("Telnyx webhook", () => {
         providerProfileSyncedAt: null,
       }),
     );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "provider_state_observed",
+        operation: "registration_reconciliation",
+        reasonCode: "carrier_webhook_observed",
+        actorType: "system",
+      }),
+    );
     expect(mocks.withTenant).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges a retried 10DLC event without rewriting its projection", async () => {
+    process.env.TELNYX_PUBLIC_KEY = "pub";
+    const registration = {
+      id: "00000000-0000-0000-0000-000000000008",
+      practiceId: "00000000-0000-0000-0000-0000000000aa",
+      status: "pending",
+    };
+    mocks.selectResults.push(
+      [registration],
+      [registration],
+      [],
+      [registration],
+      [registration],
+      [{ id: "00000000-0000-0000-0000-0000000000ee" }],
+    );
+    const body = JSON.stringify({
+      data: {
+        event_type: "10dlc.campaign.update",
+        id: "evt-a2p-retry",
+        payload: {
+          brandId: "brand-1",
+          campaignId: "campaign-1",
+          status: "PENDING",
+        },
+      },
+    });
+    const request = () =>
+      new Request("https://openvpm.test/api/webhooks/telnyx", {
+        method: "POST",
+        headers: {
+          "telnyx-signature-ed25519": "sig",
+          "telnyx-timestamp": "123",
+        },
+        body,
+      });
+
+    await expect(POST(request())).resolves.toMatchObject({ status: 200 });
+    await expect(POST(request())).resolves.toMatchObject({ status: 200 });
+
+    expect(mocks.db.execute).toHaveBeenCalledTimes(2);
+    expect(mocks.updateSet).toHaveBeenCalledTimes(2);
+    expect(mocks.insertValues).toHaveBeenCalledTimes(1);
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("quarantines every matched sender when signed A2P identities cross tenants", async () => {
+    process.env.TELNYX_PUBLIC_KEY = "pub";
+    const practiceA = "00000000-0000-0000-0000-0000000000aa";
+    const practiceB = "00000000-0000-0000-0000-0000000000bb";
+    const registrationA = {
+      id: "00000000-0000-0000-0000-000000000008",
+      practiceId: practiceA,
+      status: "active",
+    };
+    const registrationB = {
+      id: "00000000-0000-0000-0000-000000000009",
+      practiceId: practiceB,
+      status: "active",
+    };
+    mocks.selectResults.push(
+      [registrationB],
+      [registrationB],
+      [
+        {
+          practiceId: practiceA,
+          locationId: "00000000-0000-0000-0000-000000000002",
+        },
+      ],
+      [registrationA],
+    );
+    const body = JSON.stringify({
+      data: {
+        event_type: "10dlc.phone_number.update",
+        id: "evt-cross-tenant",
+        payload: {
+          brandId: "brand-b",
+          campaignId: "campaign-b",
+          phoneNumber: "+15555550100",
+          status: "FAILED",
+        },
+      },
+    });
+
+    const response = await POST(
+      new Request("https://openvpm.test/api/webhooks/telnyx", {
+        method: "POST",
+        headers: {
+          "telnyx-signature-ed25519": "sig",
+          "telnyx-timestamp": "123",
+        },
+        body,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateSet).toHaveBeenCalledTimes(1);
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        registrationStatus: "action_required",
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
+      }),
+    );
+    const quarantineWhere = mocks.updateWhere.mock.calls[0]?.[0];
+    expect(sqlIncludesValue(quarantineWhere, practiceA)).toBe(true);
+    expect(sqlIncludesValue(quarantineWhere, practiceB)).toBe(true);
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Telnyx A2P identity conflict",
+      expect.stringContaining("Matching senders were disabled"),
+    );
   });
 
   it("rejects oversized payloads before signature verification or tenant work", async () => {

--- a/apps/web/app/api/webhooks/telnyx/route.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
-import { and, eq, isNull } from "drizzle-orm";
+import { createHash, randomUUID } from "node:crypto";
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
-import { locationMessaging, messagingRegistrations } from "@openpims/db";
+import {
+  locationMessaging,
+  messagingRegistrationEvents,
+  messagingRegistrations,
+} from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
 import { readRequestTextWithLimit } from "@/lib/request-json";
 import {
@@ -19,10 +24,15 @@ import {
 } from "@/lib/messaging/telnyx-events";
 import { recordSmsDeliveryCallback } from "@/lib/messaging/sms-delivery-ledger";
 import { verifyTelnyxSignature } from "@/lib/messaging/telnyx-signature";
+import { alertOps } from "@/lib/alerts";
 import {
   mergeRegistrationStatus,
   type RegistrationLifecycleStatus,
 } from "@/lib/messaging/a2p-lifecycle";
+import {
+  recordMessagingRegistrationEvent,
+  systemMessagingRegistrationActor,
+} from "@/lib/messaging/registration-events";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -37,6 +47,19 @@ function payloadTooLargeResponse() {
 function payloadString(value: unknown): string | null {
   const trimmed = typeof value === "string" ? value.trim() : "";
   return trimmed || null;
+}
+
+function providerEventOperationId(value: unknown): string {
+  const providerEventId = payloadString(value);
+  if (!providerEventId) return randomUUID();
+  const bytes = createHash("sha256")
+    .update(`telnyx-a2p-event:${providerEventId}`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 function payloadMessagingProfileId(payload: {
@@ -79,6 +102,7 @@ function a2pWebhookStatus(payload: {
 
 async function handleA2pLifecycleWebhook(opts: {
   eventType: string;
+  providerEventId?: unknown;
   payload: {
     brandId?: unknown;
     campaignId?: unknown;
@@ -95,60 +119,147 @@ async function handleA2pLifecycleWebhook(opts: {
   const providerStatus =
     payloadString(opts.payload.status) ?? payloadString(opts.payload.type);
   const observed = a2pWebhookStatus(opts.payload);
+  const operationId = providerEventOperationId(opts.providerEventId);
 
-  await withSystem(db, async (tx) => {
-    let [registration] = await tx
-      .select({
-        id: messagingRegistrations.id,
-        practiceId: messagingRegistrations.practiceId,
-        status: messagingRegistrations.status,
-      })
-      .from(messagingRegistrations)
-      .where(
-        and(
-          isNull(messagingRegistrations.deletedAt),
-          opts.eventType === "10dlc.brand.update" && brandId
-            ? eq(messagingRegistrations.providerBrandId, brandId)
-            : campaignId
-              ? eq(messagingRegistrations.providerCampaignId, campaignId)
-              : eq(
-                  messagingRegistrations.id,
-                  "00000000-0000-0000-0000-000000000000",
-                ),
-        ),
-      )
-      .limit(1);
-
-    if (!registration && phoneNumber) {
-      const [sender] = await tx
-        .select({ practiceId: locationMessaging.practiceId })
-        .from(locationMessaging)
-        .where(
-          and(
-            eq(locationMessaging.provider, "telnyx"),
-            eq(locationMessaging.senderE164, phoneNumber),
-            isNull(locationMessaging.deletedAt),
-          ),
-        )
-        .limit(1);
-      if (sender) {
-        [registration] = await tx
-          .select({
-            id: messagingRegistrations.id,
-            practiceId: messagingRegistrations.practiceId,
-            status: messagingRegistrations.status,
-          })
+  const outcome = await withSystem(db, async (tx) => {
+    // Telnyx retries signed webhooks. Serialize the provider event before any
+    // projection write, then use a one-way deterministic UUID so concurrent
+    // deliveries acknowledge cleanly instead of duplicating lifecycle evidence.
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${`telnyx-a2p-event:${operationId}`}, 0))`,
+    );
+    const brandMatches = brandId
+      ? await tx
+          .select()
           .from(messagingRegistrations)
           .where(
             and(
-              eq(messagingRegistrations.practiceId, sender.practiceId),
+              eq(messagingRegistrations.providerBrandId, brandId),
               isNull(messagingRegistrations.deletedAt),
             ),
           )
-          .limit(1);
-      }
+          .limit(2)
+      : [];
+    const campaignMatches = campaignId
+      ? await tx
+          .select()
+          .from(messagingRegistrations)
+          .where(
+            and(
+              eq(messagingRegistrations.providerCampaignId, campaignId),
+              isNull(messagingRegistrations.deletedAt),
+            ),
+          )
+          .limit(2)
+      : [];
+    const senderMatches = phoneNumber
+      ? await tx
+          .select({
+            practiceId: locationMessaging.practiceId,
+            locationId: locationMessaging.locationId,
+          })
+          .from(locationMessaging)
+          .where(
+            and(
+              eq(locationMessaging.provider, "telnyx"),
+              eq(locationMessaging.senderE164, phoneNumber),
+              isNull(locationMessaging.deletedAt),
+            ),
+          )
+          .limit(2)
+      : [];
+    const phoneRegistrationMatches =
+      senderMatches.length === 1
+        ? await tx
+            .select()
+            .from(messagingRegistrations)
+            .where(
+              and(
+                eq(
+                  messagingRegistrations.practiceId,
+                  senderMatches[0]!.practiceId,
+                ),
+                isNull(messagingRegistrations.deletedAt),
+              ),
+            )
+            .limit(2)
+        : [];
+
+    const resolvedRegistrations = [
+      ...brandMatches,
+      ...campaignMatches,
+      ...phoneRegistrationMatches,
+    ];
+    const affectedPracticeIds = [
+      ...new Set([
+        ...resolvedRegistrations.map((row) => row.practiceId),
+        ...senderMatches.map((row) => row.practiceId),
+      ]),
+    ];
+    const affectedLocationIds = [
+      ...new Set(senderMatches.map((row) => row.locationId)),
+    ];
+    const resolutionCounts = [
+      ...(brandId ? [brandMatches.length] : []),
+      ...(campaignId ? [campaignMatches.length] : []),
+      ...(phoneNumber
+        ? [senderMatches.length, phoneRegistrationMatches.length]
+        : []),
+    ];
+    const identityConflict =
+      resolutionCounts.some((count) => count !== 1) ||
+      affectedPracticeIds.length > 1;
+
+    if (identityConflict && affectedPracticeIds.length > 0) {
+      const quarantineScope =
+        affectedPracticeIds.length > 0 && affectedLocationIds.length > 0
+          ? or(
+              inArray(locationMessaging.practiceId, affectedPracticeIds),
+              inArray(locationMessaging.locationId, affectedLocationIds),
+            )
+          : affectedPracticeIds.length > 0
+            ? inArray(locationMessaging.practiceId, affectedPracticeIds)
+            : inArray(locationMessaging.locationId, affectedLocationIds);
+      await tx
+        .update(locationMessaging)
+        .set({
+          enabled: false,
+          registrationStatus: "action_required",
+          registrationDetail:
+            "Carrier webhook identities conflict. OpenVPM must reconcile the exact brand, campaign, and number before sending can resume.",
+          providerProfileReady: false,
+          providerProfileSyncedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(locationMessaging.provider, "telnyx"),
+            quarantineScope,
+            isNull(locationMessaging.deletedAt),
+          ),
+        );
+      return "identity_conflict" as const;
     }
-    if (!registration) return;
+
+    const registration =
+      brandMatches[0] ??
+      campaignMatches[0] ??
+      phoneRegistrationMatches[0] ??
+      null;
+    if (!registration) return "ignored" as const;
+
+    const [existingEvent] = await tx
+      .select({ id: messagingRegistrationEvents.id })
+      .from(messagingRegistrationEvents)
+      .where(
+        and(
+          eq(messagingRegistrationEvents.practiceId, registration.practiceId),
+          eq(messagingRegistrationEvents.operationId, operationId),
+          eq(messagingRegistrationEvents.eventType, "provider_state_observed"),
+        ),
+      )
+      .limit(1);
+    if (existingEvent) return "duplicate" as const;
 
     const next = mergeRegistrationStatus(registration.status, observed);
     const reasons = Array.isArray(opts.payload.reasons)
@@ -158,7 +269,7 @@ async function handleA2pLifecycleWebhook(opts: {
       : [];
     const detail =
       payloadString(opts.payload.description) ?? (reasons.join("; ") || null);
-    await tx
+    const [updated] = await tx
       .update(messagingRegistrations)
       .set({
         ...(opts.eventType === "10dlc.brand.update"
@@ -183,7 +294,41 @@ async function handleA2pLifecycleWebhook(opts: {
         lastSyncedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(messagingRegistrations.id, registration.id));
+      .where(
+        and(
+          eq(messagingRegistrations.id, registration.id),
+          eq(messagingRegistrations.status, registration.status),
+          brandId
+            ? eq(messagingRegistrations.providerBrandId, brandId)
+            : sql`true`,
+          campaignId
+            ? eq(messagingRegistrations.providerCampaignId, campaignId)
+            : sql`true`,
+          phoneNumber
+            ? sql`exists (
+                select 1
+                from ${locationMessaging} as sender
+                where sender.practice_id = ${registration.practiceId}
+                  and sender.provider = 'telnyx'
+                  and sender.sender_e164 = ${phoneNumber}
+                  and sender.deleted_at is null
+              )`
+            : sql`true`,
+          isNull(messagingRegistrations.deletedAt),
+        ),
+      )
+      .returning();
+    if (!updated) return "stale" as const;
+
+    await recordMessagingRegistrationEvent(tx, {
+      registration: updated,
+      eventType: "provider_state_observed",
+      operation: "registration_reconciliation",
+      statusBefore: registration.status,
+      operationId,
+      reasonCode: "carrier_webhook_observed",
+      actor: systemMessagingRegistrationActor(),
+    });
 
     await tx
       .update(locationMessaging)
@@ -211,7 +356,14 @@ async function handleA2pLifecycleWebhook(opts: {
           isNull(locationMessaging.deletedAt),
         ),
       );
+    return "applied" as const;
   });
+  if (outcome === "identity_conflict") {
+    await alertOps(
+      "Telnyx A2P identity conflict",
+      "A signed carrier lifecycle event supplied contradictory brand, campaign, or phone identities. Matching senders were disabled; reconcile the carrier portal before re-enabling texting.",
+    );
+  }
 }
 
 export async function POST(request: Request) {
@@ -285,7 +437,11 @@ export async function POST(request: Request) {
   }
 
   if (eventType && A2P_EVENT_TYPES.has(eventType)) {
-    await handleA2pLifecycleWebhook({ eventType, payload });
+    await handleA2pLifecycleWebhook({
+      eventType,
+      providerEventId: data?.id,
+      payload,
+    });
     return NextResponse.json({ ok: true });
   }
 

--- a/apps/web/components/admin/sms-recovery-console.tsx
+++ b/apps/web/components/admin/sms-recovery-console.tsx
@@ -1,0 +1,1184 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  RefreshCw,
+  RotateCcw,
+  ShieldCheck,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { trpc } from "@/lib/trpc";
+
+const EMPTY_UUID = "00000000-0000-4000-8000-000000000000";
+const QUEUE_LIMIT = 25;
+const WITHHELD_PHONE_LIKE_OPERATIONAL_ID = "[withheld: phone-like identifier]";
+
+type AttemptSelection = {
+  practiceId: string;
+  attemptId: string;
+  classification:
+    | "missing_provider_result"
+    | "outcome_unknown"
+    | "terminal_projection_pending";
+};
+
+type DeliverySelection = {
+  eventId: string;
+  queueReason:
+    | "identity_conflict"
+    | "unmatched"
+    | "unknown_status"
+    | "projection_miss";
+  pendingHistoryId: string | null;
+};
+
+type AttemptOutcome = "accepted" | "definite_failure";
+type DeliveryClassification = "sent" | "failed" | "delivered";
+type DeliveryReason =
+  | "exact_attribution_retry"
+  | "provider_portal_status_review"
+  | "projection_repair"
+  | "identity_conflict_review"
+  | "unmatched_evidence_review";
+
+const selectClassName =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50";
+
+function operationId() {
+  return window.crypto.randomUUID();
+}
+
+function formatTimestamp(value: Date | string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}
+
+function label(value: string | null | undefined) {
+  return value ? value.replaceAll("_", " ") : "—";
+}
+
+function looksLikePhoneNumber(value: string) {
+  return /^\+?\d[\d ().-]{6,18}$/.test(value.trim());
+}
+
+function safeProviderEvidenceId(value: string | null | undefined) {
+  if (!value) return "—";
+  return looksLikePhoneNumber(value)
+    ? WITHHELD_PHONE_LIKE_OPERATIONAL_ID
+    : value;
+}
+
+function EvidenceId({
+  label: idLabel,
+  value,
+}: {
+  label: string;
+  value: string | null;
+}) {
+  return (
+    <div>
+      <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {idLabel}
+      </dt>
+      <dd className="mt-0.5 break-all font-mono text-xs">{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+function QueueError({ children }: { children: string }) {
+  return (
+    <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+      {children}
+    </div>
+  );
+}
+
+function ActionNotice({
+  message,
+  error,
+}: {
+  message: string | null;
+  error: string | null;
+}) {
+  if (!message && !error) return null;
+  return (
+    <div
+      role="status"
+      className={`mt-3 rounded-md border px-3 py-2 text-sm ${
+        error
+          ? "border-destructive/30 bg-destructive/5 text-destructive"
+          : "border-green-200 bg-green-50 text-green-900"
+      }`}
+    >
+      {error ?? message}
+    </div>
+  );
+}
+
+function deliveryReasons(
+  queueReason: DeliverySelection["queueReason"],
+): Array<{ value: DeliveryReason; text: string }> {
+  if (queueReason === "identity_conflict") {
+    return [
+      {
+        value: "identity_conflict_review",
+        text: "Quarantine exact identity conflict after review",
+      },
+    ];
+  }
+  if (queueReason === "unmatched") {
+    return [
+      {
+        value: "unmatched_evidence_review",
+        text: "Quarantine exact unmatched evidence after review",
+      },
+    ];
+  }
+  return [
+    {
+      value: "exact_attribution_retry",
+      text: "Retry exact attribution and projection",
+    },
+    {
+      value: "projection_repair",
+      text: "Repair a verified projection miss",
+    },
+    {
+      value: "provider_portal_status_review",
+      text: "Record status verified in provider portal",
+    },
+  ];
+}
+
+export function SmsRecoveryConsole() {
+  const utils = trpc.useUtils();
+  const attemptQueue = trpc.admin.smsSendAttemptQueue.useQuery(
+    { staleMinutes: 15, limit: QUEUE_LIMIT },
+    { retry: false },
+  );
+  const deliveryQueue = trpc.admin.smsDeliveryEventQueue.useQuery(
+    { staleMinutes: 60, limit: QUEUE_LIMIT },
+    { retry: false },
+  );
+  const [attemptSelection, setAttemptSelection] =
+    useState<AttemptSelection | null>(null);
+  const [deliverySelection, setDeliverySelection] =
+    useState<DeliverySelection | null>(null);
+  const [attemptOutcome, setAttemptOutcome] = useState<AttemptOutcome | "">("");
+  const [attemptEvidence, setAttemptEvidence] = useState("");
+  const [providerMessageId, setProviderMessageId] = useState("");
+  const [attemptReviewed, setAttemptReviewed] = useState(false);
+  const [attemptReconciliationId, setAttemptReconciliationId] = useState<
+    string | null
+  >(null);
+  const [resendId, setResendId] = useState<string | null>(null);
+  const [resendReviewed, setResendReviewed] = useState(false);
+  const [resendCompleted, setResendCompleted] = useState(false);
+  const [deliveryReason, setDeliveryReason] = useState<DeliveryReason | "">("");
+  const [deliveryClassification, setDeliveryClassification] = useState<
+    DeliveryClassification | ""
+  >("");
+  const [deliveryReviewed, setDeliveryReviewed] = useState(false);
+  const [deliveryReconciliationId, setDeliveryReconciliationId] = useState<
+    string | null
+  >(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const attemptDetail = trpc.admin.smsSendAttempt.useQuery(
+    {
+      practiceId: attemptSelection?.practiceId ?? EMPTY_UUID,
+      attemptId: attemptSelection?.attemptId ?? EMPTY_UUID,
+    },
+    { enabled: Boolean(attemptSelection), retry: false },
+  );
+  const deliveryDetail = trpc.admin.smsDeliveryEventDetail.useQuery(
+    {
+      deliveryEventId: deliverySelection?.eventId ?? EMPTY_UUID,
+      historyLimit: 100,
+    },
+    { enabled: Boolean(deliverySelection), retry: false },
+  );
+
+  const effectiveAttemptEvent = useMemo(() => {
+    const events = attemptDetail.data?.events ?? [];
+    return (
+      events.find((event) => event.kind === "reconciliation") ??
+      events.find((event) => event.kind === "provider_result") ??
+      null
+    );
+  }, [attemptDetail.data?.events]);
+  const backendConfirmedFailure =
+    effectiveAttemptEvent?.outcome === "definite_failure";
+
+  const refreshQueues = () => {
+    void Promise.all([
+      utils.admin.smsSendAttemptQueue.invalidate(),
+      utils.admin.smsDeliveryEventQueue.invalidate(),
+      utils.admin.smsOperationsHealth.invalidate(),
+    ]);
+  };
+
+  const reconcileAttempt = trpc.admin.reconcileSmsSendAttempt.useMutation({
+    onSuccess: (result, variables) => {
+      const expectedRecorded =
+        result.attemptId === variables.attemptId &&
+        result.outcome === variables.outcome;
+      if (!expectedRecorded) {
+        setActionError(
+          "The backend did not confirm the reviewed outcome. No resend is enabled.",
+        );
+      } else {
+        setActionError(null);
+        setActionMessage(
+          variables.outcome === "definite_failure"
+            ? "Definite failure recorded. Refreshing the immutable attempt history before resend is enabled."
+            : "Provider acceptance recorded and projected from the reviewed evidence.",
+        );
+        setAttemptReviewed(false);
+        setAttemptReconciliationId(operationId());
+      }
+      void utils.admin.smsSendAttempt.invalidate({
+        practiceId: variables.practiceId,
+        attemptId: variables.attemptId,
+      });
+      refreshQueues();
+    },
+    onError: (error) => {
+      setActionMessage(null);
+      setActionError(error.message);
+    },
+  });
+  const resendAttempt = trpc.admin.resendSmsSendAttempt.useMutation({
+    onSuccess: (result, variables) => {
+      const newAttemptRecorded =
+        Boolean(result.attemptId) && result.attemptId !== variables.attemptId;
+      setResendCompleted(newAttemptRecorded);
+      setActionError(
+        newAttemptRecorded
+          ? null
+          : "error" in result
+            ? (result.error ?? "Resend was blocked.")
+            : "Resend was blocked.",
+      );
+      setActionMessage(
+        newAttemptRecorded
+          ? result.success
+            ? `Explicit resend accepted as new attempt ${result.attemptId}.`
+            : `Explicit resend created attempt ${result.attemptId}; provider outcome: ${label(result.outcome)}.`
+          : null,
+      );
+      refreshQueues();
+    },
+    onError: (error) => {
+      setActionMessage(null);
+      setActionError(error.message);
+    },
+  });
+  const reconcileDelivery = trpc.admin.reconcileSmsDeliveryEvent.useMutation({
+    onSuccess: (result) => {
+      setActionError(null);
+      setActionMessage(
+        `Delivery evidence reconciled as ${label(result.classification)} (${label(result.result)}).`,
+      );
+      setDeliveryReviewed(false);
+      setDeliveryReconciliationId(operationId());
+      if (deliverySelection) {
+        void utils.admin.smsDeliveryEventDetail.invalidate({
+          deliveryEventId: deliverySelection.eventId,
+          historyLimit: 100,
+        });
+      }
+      refreshQueues();
+    },
+    onError: (error) => {
+      setActionMessage(null);
+      setActionError(error.message);
+    },
+  });
+
+  const selectAttempt = (selection: AttemptSelection) => {
+    setAttemptSelection(selection);
+    setDeliverySelection(null);
+    setAttemptOutcome("");
+    setAttemptEvidence("");
+    setProviderMessageId("");
+    setAttemptReviewed(false);
+    setAttemptReconciliationId(operationId());
+    setResendId(operationId());
+    setResendReviewed(false);
+    setResendCompleted(false);
+    setActionMessage(null);
+    setActionError(null);
+  };
+
+  const selectDelivery = (selection: DeliverySelection) => {
+    setDeliverySelection(selection);
+    setAttemptSelection(null);
+    setDeliveryReason("");
+    setDeliveryClassification("");
+    setDeliveryReviewed(false);
+    setDeliveryReconciliationId(operationId());
+    setActionMessage(null);
+    setActionError(null);
+  };
+
+  const terminalProjectionOutcome =
+    attemptSelection?.classification === "terminal_projection_pending" &&
+    (effectiveAttemptEvent?.outcome === "accepted" ||
+      effectiveAttemptEvent?.outcome === "definite_failure")
+      ? effectiveAttemptEvent.outcome
+      : null;
+  const reviewedAttemptOutcome = terminalProjectionOutcome || attemptOutcome;
+  const reviewedProviderMessageId =
+    terminalProjectionOutcome === "accepted"
+      ? (effectiveAttemptEvent?.providerMessageId ?? "")
+      : providerMessageId.trim();
+  const providerIdLooksSensitive =
+    reviewedProviderMessageId === WITHHELD_PHONE_LIKE_OPERATIONAL_ID ||
+    looksLikePhoneNumber(reviewedProviderMessageId);
+  const canReconcileAttempt = Boolean(
+    attemptSelection &&
+    attemptDetail.data &&
+    attemptReconciliationId &&
+    reviewedAttemptOutcome &&
+    attemptEvidence &&
+    attemptReviewed &&
+    (reviewedAttemptOutcome !== "accepted" ||
+      (reviewedProviderMessageId && !providerIdLooksSensitive)) &&
+    !reconcileAttempt.isPending,
+  );
+
+  const deliveryReasonOptions = deliverySelection
+    ? deliveryReasons(deliverySelection.queueReason)
+    : [];
+  const reviewedHistory =
+    deliverySelection?.pendingHistoryId && deliveryDetail.data
+      ? deliveryDetail.data.history.find(
+          (history) => history.id === deliverySelection.pendingHistoryId,
+        )
+      : null;
+  const quarantineReason =
+    deliveryReason === "identity_conflict_review" ||
+    deliveryReason === "unmatched_evidence_review";
+  const exactQuarantineEvidence =
+    deliveryReason === "identity_conflict_review"
+      ? reviewedHistory?.result === "ambiguous"
+      : deliveryReason === "unmatched_evidence_review"
+        ? reviewedHistory?.result === "unmatched"
+        : !deliverySelection?.pendingHistoryId;
+  const canReconcileDelivery = Boolean(
+    deliverySelection &&
+    deliveryDetail.data &&
+    deliveryReconciliationId &&
+    deliveryReason &&
+    deliveryReviewed &&
+    exactQuarantineEvidence &&
+    !deliveryDetail.data.truncated &&
+    (deliveryReason !== "provider_portal_status_review" ||
+      deliveryClassification) &&
+    !reconcileDelivery.isPending,
+  );
+
+  return (
+    <section className="mt-6 rounded-lg border border-border bg-card p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <ShieldCheck className="h-4 w-4" />
+            <span className="text-sm">SMS evidence recovery</span>
+          </div>
+          <p className="mt-2 max-w-3xl text-xs text-muted-foreground">
+            Bounded, oldest-first operational evidence only. Phone numbers,
+            message bodies, free-text provider payloads, and clinic PHI are
+            never rendered here. Every write requires exact history review and a
+            fresh UUID operation key.
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={attemptQueue.isFetching || deliveryQueue.isFetching}
+          onClick={refreshQueues}
+        >
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Refresh evidence
+        </Button>
+      </div>
+
+      <ActionNotice message={actionMessage} error={actionError} />
+
+      <div className="mt-5 grid gap-5 xl:grid-cols-2">
+        <div>
+          <h3 className="text-sm font-semibold">Send-attempt exceptions</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            At most {QUEUE_LIMIT} rows. Orphan communication claims are visible
+            for investigation but have no unsafe repair shortcut.
+          </p>
+          {attemptQueue.error ? (
+            <QueueError>
+              Could not load the send-attempt recovery queue.
+            </QueueError>
+          ) : attemptQueue.data ? (
+            <div className="mt-3 overflow-x-auto rounded-md border border-border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                    <th className="px-3 py-2 font-medium">Age / provider</th>
+                    <th className="px-3 py-2 font-medium">Evidence</th>
+                    <th className="px-3 py-2 font-medium">Action</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {attemptQueue.data.items.map((item) => (
+                    <tr
+                      key={`${item.practiceId}:${item.attemptId ?? item.communicationId}`}
+                    >
+                      <td className="px-3 py-2 align-top">
+                        <p>{formatTimestamp(item.createdAt)}</p>
+                        <p className="text-xs capitalize text-muted-foreground">
+                          {item.provider ?? "No attempt"} ·{" "}
+                          {label(item.classification)}
+                        </p>
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <p className="break-all font-mono text-xs">
+                          practice {item.practiceId}
+                        </p>
+                        <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+                          {item.attemptId
+                            ? `attempt ${item.attemptId}`
+                            : `communication ${item.communicationId ?? "unavailable"}`}
+                        </p>
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        {item.attemptId ? (
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              selectAttempt({
+                                practiceId: item.practiceId,
+                                attemptId: item.attemptId!,
+                                classification:
+                                  item.classification as AttemptSelection["classification"],
+                              })
+                            }
+                          >
+                            Inspect history
+                            <ChevronRight className="ml-1 h-4 w-4" />
+                          </Button>
+                        ) : (
+                          <span className="text-xs font-medium text-amber-700">
+                            Manual investigation only
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                  {attemptQueue.data.items.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={3}
+                        className="px-3 py-6 text-center text-muted-foreground"
+                      >
+                        No stale send attempts need recovery.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">
+              Loading send evidence…
+            </p>
+          )}
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold">Delivery-event exceptions</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            At most {QUEUE_LIMIT} actionable events. Stale accepted sends
+            without a final callback remain monitor-only.
+          </p>
+          {deliveryQueue.error ? (
+            <QueueError>
+              Could not load the delivery-event recovery queue.
+            </QueueError>
+          ) : deliveryQueue.data ? (
+            <div className="mt-3 overflow-x-auto rounded-md border border-border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                    <th className="px-3 py-2 font-medium">
+                      Received / provider
+                    </th>
+                    <th className="px-3 py-2 font-medium">Evidence</th>
+                    <th className="px-3 py-2 font-medium">Action</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {deliveryQueue.data.items.map((item) => (
+                    <tr key={item.eventId}>
+                      <td className="px-3 py-2 align-top">
+                        <p>{formatTimestamp(item.receivedAt)}</p>
+                        <p className="text-xs capitalize text-muted-foreground">
+                          {item.provider} · {label(item.queueReason)}
+                        </p>
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <p className="break-all font-mono text-xs">
+                          event {item.eventId}
+                        </p>
+                        <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+                          incident{" "}
+                          {item.pendingHistoryId ?? "derived status/projection"}
+                        </p>
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            selectDelivery({
+                              eventId: item.eventId!,
+                              queueReason:
+                                item.queueReason as DeliverySelection["queueReason"],
+                              pendingHistoryId: item.pendingHistoryId,
+                            })
+                          }
+                        >
+                          Inspect history
+                          <ChevronRight className="ml-1 h-4 w-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                  {deliveryQueue.data.items.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={3}
+                        className="px-3 py-6 text-center text-muted-foreground"
+                      >
+                        No delivery events need reconciliation.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">
+              Loading delivery evidence…
+            </p>
+          )}
+          {deliveryQueue.data?.staleAcceptedWithoutFinalDelivery.length ? (
+            <div className="mt-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              {deliveryQueue.data.staleAcceptedWithoutFinalDelivery.length}{" "}
+              accepted send(s) have no final callback. Monitor provider delivery
+              evidence; this console intentionally offers no resend or status
+              override.
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {attemptSelection ? (
+        <div className="mt-6 rounded-md border border-border p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 className="font-semibold">Exact send-attempt history</h3>
+              <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+                {attemptSelection.practiceId}:{attemptSelection.attemptId}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => setAttemptSelection(null)}
+            >
+              Close
+            </Button>
+          </div>
+          {attemptDetail.error ? (
+            <QueueError>
+              Could not load this exact send-attempt history.
+            </QueueError>
+          ) : attemptDetail.data ? (
+            <>
+              <dl className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <EvidenceId
+                  label="Attempt"
+                  value={attemptDetail.data.attempt.id}
+                />
+                <EvidenceId
+                  label="Practice"
+                  value={attemptDetail.data.attempt.practiceId}
+                />
+                <EvidenceId
+                  label="Location"
+                  value={attemptDetail.data.attempt.locationId}
+                />
+                <EvidenceId
+                  label="Communication"
+                  value={attemptDetail.data.attempt.communicationId}
+                />
+              </dl>
+              <p className="mt-3 text-xs text-muted-foreground">
+                Created {formatTimestamp(attemptDetail.data.attempt.createdAt)}{" "}
+                · provider {attemptDetail.data.attempt.provider} · source{" "}
+                {label(attemptDetail.data.attempt.source)}
+              </p>
+              <div className="mt-4 overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Recorded</th>
+                      <th className="px-3 py-2 font-medium">Kind / outcome</th>
+                      <th className="px-3 py-2 font-medium">
+                        Immutable evidence IDs
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {attemptDetail.data.events.map((event) => (
+                      <tr key={event.id}>
+                        <td className="px-3 py-2 align-top">
+                          {formatTimestamp(event.createdAt)}
+                        </td>
+                        <td className="px-3 py-2 align-top capitalize">
+                          {label(event.kind)} · {label(event.outcome)}
+                        </td>
+                        <td className="px-3 py-2 align-top">
+                          <p className="break-all font-mono">
+                            event {event.id}
+                          </p>
+                          <p className="mt-1 break-all font-mono text-muted-foreground">
+                            provider message{" "}
+                            {safeProviderEvidenceId(event.providerMessageId)}
+                          </p>
+                          <p className="mt-1 break-all font-mono text-muted-foreground">
+                            key {event.eventKey}
+                          </p>
+                        </td>
+                      </tr>
+                    ))}
+                    {attemptDetail.data.events.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={3}
+                          className="px-3 py-5 text-center text-muted-foreground"
+                        >
+                          No provider-result evidence has been recorded.
+                        </td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Free-text event detail and operator identity are omitted at the
+                server boundary because they can contain sensitive data.
+              </p>
+
+              {!effectiveAttemptEvent ||
+              effectiveAttemptEvent.outcome === "outcome_unknown" ||
+              terminalProjectionOutcome ? (
+                <div className="mt-5 rounded-md border border-amber-300 bg-amber-50 p-4">
+                  <h4 className="text-sm font-semibold text-amber-950">
+                    Reconcile reviewed provider outcome
+                  </h4>
+                  <div className="mt-3 grid gap-3 md:grid-cols-2">
+                    <label className="text-xs font-medium">
+                      Reviewed outcome
+                      {terminalProjectionOutcome ? (
+                        <Input
+                          className="mt-1 capitalize"
+                          value={label(terminalProjectionOutcome)}
+                          readOnly
+                        />
+                      ) : (
+                        <select
+                          className={`${selectClassName} mt-1`}
+                          value={attemptOutcome}
+                          onChange={(event) => {
+                            setAttemptOutcome(
+                              event.target.value as AttemptOutcome | "",
+                            );
+                            if (event.target.value !== "accepted")
+                              setProviderMessageId("");
+                            setAttemptReviewed(false);
+                          }}
+                        >
+                          <option value="">Choose reviewed outcome</option>
+                          <option value="accepted">Accepted by provider</option>
+                          <option value="definite_failure">
+                            Definite failure
+                          </option>
+                        </select>
+                      )}
+                    </label>
+                    <label className="text-xs font-medium">
+                      Evidence source
+                      <select
+                        className={`${selectClassName} mt-1`}
+                        value={attemptEvidence}
+                        onChange={(event) => {
+                          setAttemptEvidence(event.target.value);
+                          setAttemptReviewed(false);
+                        }}
+                      >
+                        <option value="">Choose evidence reviewed</option>
+                        <option value="provider_portal_status">
+                          Provider portal status
+                        </option>
+                        <option value="provider_support_confirmation">
+                          Provider support confirmation
+                        </option>
+                        <option value="durable_provider_audit">
+                          Durable provider audit record
+                        </option>
+                      </select>
+                    </label>
+                  </div>
+                  {reviewedAttemptOutcome === "accepted" &&
+                  !terminalProjectionOutcome ? (
+                    <label className="mt-3 block text-xs font-medium">
+                      Exact provider message ID
+                      <Input
+                        className="mt-1 font-mono"
+                        value={providerMessageId}
+                        maxLength={255}
+                        autoComplete="off"
+                        aria-invalid={providerIdLooksSensitive}
+                        placeholder="Provider evidence ID only"
+                        onChange={(event) => {
+                          setProviderMessageId(event.target.value);
+                          setAttemptReviewed(false);
+                        }}
+                      />
+                    </label>
+                  ) : null}
+                  {providerIdLooksSensitive ? (
+                    <p className="mt-2 text-xs font-medium text-destructive">
+                      This value is phone-like or was withheld by the server. It
+                      cannot be used as recovery evidence.
+                    </p>
+                  ) : null}
+                  <label className="mt-3 flex items-start gap-2 text-xs text-amber-950">
+                    <Checkbox
+                      checked={attemptReviewed}
+                      onChange={(event) =>
+                        setAttemptReviewed(event.target.checked)
+                      }
+                    />
+                    <span>
+                      I reviewed this exact attempt and its immutable event
+                      history, confirmed the selected outcome against the
+                      evidence source, and did not copy a phone number, message
+                      body, client name, or PHI.
+                    </span>
+                  </label>
+                  <p className="mt-3 break-all font-mono text-[11px] text-amber-900">
+                    Reconciliation UUID: {attemptReconciliationId}
+                  </p>
+                  <Button
+                    type="button"
+                    className="mt-3"
+                    disabled={!canReconcileAttempt}
+                    onClick={() => {
+                      if (
+                        !attemptSelection ||
+                        !attemptReconciliationId ||
+                        !reviewedAttemptOutcome ||
+                        !attemptEvidence
+                      ) {
+                        return;
+                      }
+                      const acceptedProviderId =
+                        reviewedAttemptOutcome === "accepted"
+                          ? reviewedProviderMessageId
+                          : undefined;
+                      if (
+                        !window.confirm(
+                          `Record ${label(reviewedAttemptOutcome)} for exact attempt ${attemptSelection.attemptId}? This writes immutable reconciliation evidence.`,
+                        )
+                      ) {
+                        return;
+                      }
+                      setActionError(null);
+                      setActionMessage(null);
+                      reconcileAttempt.mutate({
+                        practiceId: attemptSelection.practiceId,
+                        attemptId: attemptSelection.attemptId,
+                        reconciliationId: attemptReconciliationId,
+                        outcome: reviewedAttemptOutcome,
+                        providerMessageId: acceptedProviderId,
+                        detail: `Evidence source ${attemptEvidence}; reviewed outcome ${reviewedAttemptOutcome}; exact immutable attempt history reviewed; sensitive content excluded.`,
+                      });
+                    }}
+                  >
+                    <CheckCircle2 className="mr-2 h-4 w-4" />
+                    Record reviewed outcome
+                  </Button>
+                </div>
+              ) : (
+                <div className="mt-5 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-900">
+                  Backend-confirmed terminal outcome:{" "}
+                  {label(effectiveAttemptEvent.outcome)}.
+                </div>
+              )}
+
+              {backendConfirmedFailure ? (
+                <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 p-4">
+                  <h4 className="text-sm font-semibold">
+                    Explicit resend after definite failure
+                  </h4>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    The backend ledger confirms a definite failure. The backend
+                    will still re-check the failed communication, provider
+                    window, clinic identity, and prior resend before sending.
+                  </p>
+                  <label className="mt-3 flex items-start gap-2 text-xs">
+                    <Checkbox
+                      checked={resendReviewed}
+                      disabled={resendCompleted}
+                      onChange={(event) =>
+                        setResendReviewed(event.target.checked)
+                      }
+                    />
+                    <span>
+                      I confirm this is the exact failed attempt and authorize
+                      one new provider send. I understand duplicate outreach is
+                      possible if external evidence was reviewed incorrectly.
+                    </span>
+                  </label>
+                  <p className="mt-3 break-all font-mono text-[11px] text-muted-foreground">
+                    Resend UUID: {resendId}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    className="mt-3"
+                    disabled={
+                      !resendReviewed ||
+                      !resendId ||
+                      resendCompleted ||
+                      resendAttempt.isPending
+                    }
+                    onClick={() => {
+                      if (!resendId) return;
+                      if (
+                        !window.confirm(
+                          `Send one new SMS for definitively failed attempt ${attemptSelection.attemptId}? This is an external side effect.`,
+                        )
+                      ) {
+                        return;
+                      }
+                      setActionError(null);
+                      setActionMessage(null);
+                      resendAttempt.mutate({
+                        practiceId: attemptSelection.practiceId,
+                        attemptId: attemptSelection.attemptId,
+                        resendId,
+                      });
+                    }}
+                  >
+                    <RotateCcw className="mr-2 h-4 w-4" />
+                    {resendCompleted
+                      ? "Resend already requested"
+                      : "Confirm one resend"}
+                  </Button>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">
+              Loading exact attempt history…
+            </p>
+          )}
+        </div>
+      ) : null}
+
+      {deliverySelection ? (
+        <div className="mt-6 rounded-md border border-border p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 className="font-semibold">Exact delivery-event history</h3>
+              <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+                {deliverySelection.eventId}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => setDeliverySelection(null)}
+            >
+              Close
+            </Button>
+          </div>
+          {deliveryDetail.error ? (
+            <QueueError>
+              Could not load this exact delivery-event history.
+            </QueueError>
+          ) : deliveryDetail.data ? (
+            <>
+              <dl className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <EvidenceId
+                  label="Event"
+                  value={deliveryDetail.data.event.id}
+                />
+                <EvidenceId
+                  label="Provider event"
+                  value={deliveryDetail.data.event.providerEventId}
+                />
+                <EvidenceId
+                  label="Provider message"
+                  value={safeProviderEvidenceId(
+                    deliveryDetail.data.event.providerMessageId,
+                  )}
+                />
+                <EvidenceId
+                  label="Payload fingerprint"
+                  value={deliveryDetail.data.event.payloadFingerprintSha256}
+                />
+              </dl>
+              <p className="mt-3 text-xs text-muted-foreground">
+                Received {formatTimestamp(deliveryDetail.data.event.receivedAt)}{" "}
+                · provider {deliveryDetail.data.event.provider} · event{" "}
+                {label(deliveryDetail.data.event.providerEventType)} · observed{" "}
+                {label(deliveryDetail.data.event.providerStatus)} · classified{" "}
+                {label(deliveryDetail.data.event.classification)} · error code{" "}
+                {deliveryDetail.data.event.providerErrorCode ?? "—"}
+              </p>
+              <div className="mt-4 overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Recorded</th>
+                      <th className="px-3 py-2 font-medium">Kind / result</th>
+                      <th className="px-3 py-2 font-medium">
+                        Exact evidence links
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {deliveryDetail.data.history.map((history) => (
+                      <tr key={history.id}>
+                        <td className="px-3 py-2 align-top">
+                          {formatTimestamp(history.createdAt)}
+                        </td>
+                        <td className="px-3 py-2 align-top capitalize">
+                          {label(history.kind)} · {label(history.result)} ·{" "}
+                          {label(history.classification)}
+                        </td>
+                        <td className="px-3 py-2 align-top">
+                          <p className="break-all font-mono">
+                            history {history.id}
+                          </p>
+                          <p className="mt-1 break-all font-mono text-muted-foreground">
+                            reviewed {history.reviewedHistoryId ?? "—"}
+                          </p>
+                          <p className="mt-1 break-all font-mono text-muted-foreground">
+                            practice {history.practiceId ?? "—"} · attempt{" "}
+                            {history.attemptId ?? "—"}
+                          </p>
+                          <p className="mt-1 break-all font-mono text-muted-foreground">
+                            key {history.eventKey}
+                          </p>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Free-text history detail and operator identity are omitted at
+                the server boundary. Candidate attribution is shown only as
+                tenant and attempt UUID pairs.
+              </p>
+              {deliveryDetail.data.truncated ? (
+                <p className="mt-2 text-xs font-medium text-destructive">
+                  This event has more history than the bounded view can show. Do
+                  not reconcile it from this console.
+                </p>
+              ) : null}
+              {deliveryDetail.data.candidateAttempts.length ? (
+                <div className="mt-3 rounded-md border border-border p-3">
+                  <p className="text-xs font-semibold">
+                    Exact attribution candidates
+                  </p>
+                  <ul className="mt-2 space-y-1 font-mono text-xs">
+                    {deliveryDetail.data.candidateAttempts.map((candidate) => (
+                      <li
+                        key={`${candidate.practiceId}:${candidate.attemptId}`}
+                        className="break-all"
+                      >
+                        {candidate.practiceId}:{candidate.attemptId}
+                      </li>
+                    ))}
+                  </ul>
+                  {deliveryDetail.data.candidateAttemptsTruncated ? (
+                    <p className="mt-2 text-xs font-medium text-amber-700">
+                      Candidate evidence is truncated; do not reconcile from
+                      this view.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+
+              <div className="mt-5 rounded-md border border-amber-300 bg-amber-50 p-4">
+                <h4 className="text-sm font-semibold text-amber-950">
+                  Reconcile reviewed delivery evidence
+                </h4>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <label className="text-xs font-medium">
+                    Reason
+                    <select
+                      className={`${selectClassName} mt-1`}
+                      value={deliveryReason}
+                      onChange={(event) => {
+                        const next = event.target.value as DeliveryReason | "";
+                        setDeliveryReason(next);
+                        if (next !== "provider_portal_status_review") {
+                          setDeliveryClassification("");
+                        }
+                        setDeliveryReviewed(false);
+                      }}
+                    >
+                      <option value="">Choose exact recovery reason</option>
+                      {deliveryReasonOptions.map((reason) => (
+                        <option key={reason.value} value={reason.value}>
+                          {reason.text}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="text-xs font-medium">
+                    Reviewed classification
+                    <select
+                      className={`${selectClassName} mt-1`}
+                      value={deliveryClassification}
+                      disabled={
+                        deliveryReason !== "provider_portal_status_review"
+                      }
+                      onChange={(event) => {
+                        setDeliveryClassification(
+                          event.target.value as DeliveryClassification | "",
+                        );
+                        setDeliveryReviewed(false);
+                      }}
+                    >
+                      <option value="">
+                        {deliveryReason === "provider_portal_status_review"
+                          ? "Choose provider-confirmed status"
+                          : "Derived from durable evidence"}
+                      </option>
+                      <option value="sent">Sent</option>
+                      <option value="failed">Failed</option>
+                      <option value="delivered">Delivered</option>
+                    </select>
+                  </label>
+                </div>
+                {quarantineReason ? (
+                  <p className="mt-3 break-all font-mono text-[11px] text-amber-900">
+                    Exact reviewed incident:{" "}
+                    {deliverySelection.pendingHistoryId ?? "missing"}
+                  </p>
+                ) : null}
+                {!exactQuarantineEvidence ? (
+                  <p className="mt-2 text-xs font-medium text-destructive">
+                    The exact unresolved history row is absent or no longer
+                    matches this incident. Refresh before acting.
+                  </p>
+                ) : null}
+                <label className="mt-3 flex items-start gap-2 text-xs text-amber-950">
+                  <Checkbox
+                    checked={deliveryReviewed}
+                    onChange={(event) =>
+                      setDeliveryReviewed(event.target.checked)
+                    }
+                  />
+                  <span>
+                    I reviewed this exact event, the complete visible immutable
+                    history, and the selected recovery evidence. I did not copy
+                    a phone number, message body, client name, or PHI.
+                  </span>
+                </label>
+                <p className="mt-3 break-all font-mono text-[11px] text-amber-900">
+                  Reconciliation UUID: {deliveryReconciliationId}
+                </p>
+                <Button
+                  type="button"
+                  className="mt-3"
+                  disabled={
+                    !canReconcileDelivery ||
+                    deliveryDetail.data.candidateAttemptsTruncated
+                  }
+                  onClick={() => {
+                    if (
+                      !deliveryReason ||
+                      !deliveryReconciliationId ||
+                      !deliverySelection
+                    ) {
+                      return;
+                    }
+                    if (
+                      !window.confirm(
+                        `Apply ${label(deliveryReason)} to exact delivery event ${deliverySelection.eventId}? This appends immutable operator evidence.`,
+                      )
+                    ) {
+                      return;
+                    }
+                    setActionError(null);
+                    setActionMessage(null);
+                    reconcileDelivery.mutate({
+                      deliveryEventId: deliverySelection.eventId,
+                      reconciliationId: deliveryReconciliationId,
+                      reviewedHistoryId: quarantineReason
+                        ? (deliverySelection.pendingHistoryId ?? undefined)
+                        : undefined,
+                      classification:
+                        deliveryReason === "provider_portal_status_review"
+                          ? deliveryClassification || undefined
+                          : undefined,
+                      reasonCode: deliveryReason,
+                    });
+                  }}
+                >
+                  <CheckCircle2 className="mr-2 h-4 w-4" />
+                  Record reviewed delivery action
+                </Button>
+              </div>
+            </>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">
+              Loading exact delivery history…
+            </p>
+          )}
+        </div>
+      ) : null}
+
+      {attemptQueue.data?.items.length === QUEUE_LIMIT ||
+      deliveryQueue.data?.items.length === QUEUE_LIMIT ? (
+        <div className="mt-4 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />A queue reached
+          its display bound. Resolve or narrow the oldest evidence, then refresh
+          before concluding the queue is clear.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/__tests__/admin-sms-recovery-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-sms-recovery-ui.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  "components/admin/sms-recovery-console.tsx",
+  "utf8",
+);
+const adminPage = readFileSync("app/(dashboard)/admin/page.tsx", "utf8");
+const adminRouter = readFileSync("server/routers/admin.ts", "utf8");
+
+describe("platform-admin SMS recovery console", () => {
+  it("is mounted beside SMS health and keeps all reads bounded", () => {
+    expect(adminPage).toContain(
+      'import { SmsRecoveryConsole } from "@/components/admin/sms-recovery-console"',
+    );
+    expect(adminPage).toContain("<SmsRecoveryConsole />");
+    expect(source).toContain("const QUEUE_LIMIT = 25");
+    expect(source).toContain("{ staleMinutes: 15, limit: QUEUE_LIMIT }");
+    expect(source).toContain("{ staleMinutes: 60, limit: QUEUE_LIMIT }");
+    expect(source).toContain("historyLimit: 100");
+    expect(source).toContain("candidateAttemptsTruncated");
+    expect(source).toContain("!deliveryDetail.data.truncated");
+  });
+
+  it("requires exact history review and UUID idempotency for every write", () => {
+    expect(source).toContain("trpc.admin.smsSendAttempt.useQuery");
+    expect(source).toContain("trpc.admin.smsDeliveryEventDetail.useQuery");
+    expect(source).toContain("trpc.admin.reconcileSmsSendAttempt.useMutation");
+    expect(source).toContain(
+      "trpc.admin.reconcileSmsDeliveryEvent.useMutation",
+    );
+    expect(source).toContain("window.crypto.randomUUID()");
+    expect(source).toContain("attemptReviewed &&");
+    expect(source).toContain("deliveryReviewed &&");
+    expect(source).toContain("exactQuarantineEvidence &&");
+    expect(source).toContain("window.confirm(");
+    expect(source).toContain("Evidence source ${attemptEvidence}");
+    expect(source).toContain("reviewedHistoryId: quarantineReason");
+  });
+
+  it("only offers resend after an exact backend-confirmed definite failure", () => {
+    expect(source).toContain(
+      'effectiveAttemptEvent?.outcome === "definite_failure"',
+    );
+    expect(source).toContain("trpc.admin.resendSmsSendAttempt.useMutation");
+    expect(source).toContain("The backend ledger confirms a definite failure");
+    expect(source).toContain("resendReviewed");
+    expect(source).toContain("resendCompleted");
+    expect(source).toMatch(/authorize\s+one new provider send/);
+    expect(source).toContain("This is an external side effect.");
+  });
+
+  it("does not render phone, body, raw payload, PHI, or operator identity fields", () => {
+    expect(source).not.toContain("destinationE164");
+    expect(source).not.toContain("senderE164");
+    expect(source).not.toContain("rawBody");
+    expect(source).not.toContain("requestedByIdentity");
+    expect(source).not.toContain("actorIdentity");
+    expect(source).not.toContain("event.detail");
+    expect(source).not.toContain("history.detail");
+    expect(source).not.toContain("clientId");
+    expect(source).toContain("looksLikePhoneNumber");
+    expect(source).toContain("safeProviderEvidenceId");
+    expect(source).toContain("WITHHELD_PHONE_LIKE_OPERATIONAL_ID");
+    expect(source).toContain(
+      "reviewedProviderMessageId === WITHHELD_PHONE_LIKE_OPERATIONAL_ID",
+    );
+    expect(source).toContain("was withheld by the server");
+    expect(source).toContain("sensitive content excluded");
+    expect(source).toContain("omitted at the");
+    expect(source).toContain("server boundary");
+  });
+
+  it("masks carrier senders and never receives their full E.164 value", () => {
+    expect(adminPage).toContain("sender.senderLast4");
+    expect(adminPage).toContain("Number ••••${sender.senderLast4}");
+    expect(adminPage).not.toContain("sender.senderE164");
+    expect(adminRouter).toMatch(/senderLast4:\s*sql<\s*string \| null\s*>/);
+    expect(adminRouter).toContain("regexp_replace");
+  });
+
+  it("keeps stale accepted sends monitor-only", () => {
+    expect(source).toContain("staleAcceptedWithoutFinalDelivery");
+    expect(source).toContain("remain monitor-only");
+    expect(source).toMatch(
+      /intentionally offers no resend or\s+status\s+override/,
+    );
+  });
+});

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -3,19 +3,26 @@ import { describe, expect, it } from "vitest";
 
 describe("admin UI", () => {
   const source = readFileSync("app/(dashboard)/admin/page.tsx", "utf8");
+  const compactSource = source.replace(/\s+/g, " ");
+  const carrierHistory = source.slice(
+    source.indexOf("{/* Messaging carrier history */}"),
+    source.indexOf("{/* Trial funnel */}"),
+  );
 
   it("separates admin forbidden, load error, loading, and missing-data states", () => {
     expect(source).toContain(
-      'import { EmptyState } from "@/components/common/empty-state"'
+      'import { EmptyState } from "@/components/common/empty-state"',
     );
     expect(source).toContain(
-      'import { PageLoading } from "@/components/common/loading"'
+      'import { PageLoading } from "@/components/common/loading"',
     );
     expect(source).toContain("error, refetch");
     expect(source).toContain('error?.data?.code === "FORBIDDEN"');
     expect(source).toContain("Access Denied");
     expect(source).toContain('title="Unable to load platform admin"');
-    expect(source).toContain("action={{ label: \"Retry\", onClick: () => refetch() }}");
+    expect(source).toContain(
+      'action={{ label: "Retry", onClick: () => refetch() }}',
+    );
     expect(source).toContain("if (isLoading) return <PageLoading");
     expect(source).toContain("if (!data)");
     expect(source).not.toContain("if (isLoading || !data)");
@@ -23,7 +30,7 @@ describe("admin UI", () => {
 
   it("shows the trial funnel tile with counts, rates, and the plain hint", () => {
     expect(source).toContain(
-      "trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false })"
+      "trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false })",
     );
     expect(source).toContain("Trial funnel (30 days)");
     expect(source).toContain("{funnel.totals.signups}");
@@ -37,17 +44,17 @@ describe("admin UI", () => {
     expect(source).toContain("{funnel.totals.currentlyActive}");
     expect(source).toContain("formatPct(funnel.totals.activationRate)");
     expect(source).toContain(
-      "formatPct(funnel.totals.firstVisitCompletionRate)"
+      "formatPct(funnel.totals.firstVisitCompletionRate)",
     );
     expect(source).toContain("formatPct(funnel.totals.paymentMethodRate)");
     expect(source).toContain("formatPct(funnel.totals.setupStartRate)");
     expect(source).toContain("formatPct(funnel.totals.setupCompletionRate)");
     expect(source).toContain("formatPct(funnel.totals.positivePaymentRate)");
-    expect(source).toContain("Activated = added a");
-    expect(source).toContain("completed clinical and billing closeout");
-    expect(source).toContain("rate is measured from");
-    expect(source).toContain("signed subscription Checkout");
-    expect(source).toContain("Legacy business-stage rows are excluded");
+    expect(compactSource).toContain("Activated = added a");
+    expect(compactSource).toContain("completed clinical and billing closeout");
+    expect(compactSource).toContain("rate is measured from");
+    expect(compactSource).toContain("signed subscription Checkout");
+    expect(compactSource).toContain("Legacy business-stage rows are excluded");
     expect(source).toContain("Could not load the funnel.");
   });
 
@@ -55,8 +62,10 @@ describe("admin UI", () => {
     expect(source).toContain("trpc.admin.activationRecovery.useQuery");
     expect(source).toContain("Clinic activation recovery");
     expect(source).toContain("clinic.queueRank");
-    expect(source).toContain("clinic.verifiedAdminEmail && clinic.verifiedAdminEmailAt");
-    expect(source).toContain('href={`mailto:${clinic.verifiedAdminEmail}`}');
+    expect(source).toMatch(
+      /clinic\.verifiedAdminEmail\s*&&\s*clinic\.verifiedAdminEmailAt/,
+    );
+    expect(source).toContain("href={`mailto:${clinic.verifiedAdminEmail}`}");
     expect(source).toContain("No verified admin contact");
     expect(source).toContain("clinic.setupStage");
     expect(source).toContain("clinic.setupHelpRequestedAt");
@@ -77,7 +86,7 @@ describe("admin UI", () => {
 
   it("shows production journey cohorts and abandonment counts", () => {
     expect(source).toContain(
-      "trpc.admin.journeyFunnel.useQuery({ days: 30 }, { retry: false })"
+      "trpc.admin.journeyFunnel.useQuery({ days: 30 }, { retry: false })",
     );
     expect(source).toContain("Production journey cohorts (30 days)");
     expect(source).toContain("journey.totals.leftBeforeTrying");
@@ -86,11 +95,13 @@ describe("admin UI", () => {
     expect(source).toContain("journey.totals.activationAbandoned");
     expect(source).toContain("journey.totals.paymentAbandoned");
     expect(source).toContain("journey.totals.clientErrors");
-    expect(source).toContain("journey.totals.historicalUnattributedRegistrations");
+    expect(source).toContain(
+      "journey.totals.historicalUnattributedRegistrations",
+    );
     expect(source).toContain("journey.totals.repairableAttributionGaps");
     expect(source).toContain("journey.weeks.map");
-    expect(source).toContain("Stalls require seven full days");
-    expect(source).toContain("active trial with a collected");
+    expect(compactSource).toContain("Stalls require seven full days");
+    expect(compactSource).toContain("active trial with a collected");
   });
 
   it("shows trial source and setup stage for diagnosing individual drop-off", () => {
@@ -104,7 +115,7 @@ describe("admin UI", () => {
     expect(source).toContain(">Metrics</th>");
     expect(source).toContain("setAnalyticsExcluded.mutate({");
     expect(source).toContain('{p.analyticsExcluded ? "Excluded" : "Exclude"}');
-    expect(source).toContain('href={`mailto:${p.adminEmail}`}');
+    expect(source).toContain("href={`mailto:${p.adminEmail}`}");
     expect(source).toContain('!p.adminEmailVerifiedAt ? " · unverified" : ""');
   });
 
@@ -122,6 +133,32 @@ describe("admin UI", () => {
     expect(source).toContain("$10 daily cap");
     expect(source).toContain('result.blockers.join("; ")');
     expect(source).toContain("sender.registrationDetail");
+    expect(source).toContain("sender.senderLast4");
+    expect(source).toContain("Number ••••${sender.senderLast4}");
+    expect(source).not.toContain("sender.senderE164");
+  });
+
+  it("shows bounded read-only redacted carrier lifecycle history", () => {
+    expect(source).toContain(
+      "trpc.admin.messagingRegistrationHistory.useQuery",
+    );
+    expect(source).toContain("const MESSAGING_HISTORY_LIMIT = 50");
+    expect(source).toContain("setMessagingHistorySelection({");
+    expect(source).toMatch(/>\s*History\s*<\/button>/);
+    expect(carrierHistory).toContain("messagingHistory.events.map");
+    expect(carrierHistory).toContain("messagingHistory.truncated");
+    expect(carrierHistory).toContain("redacted operational events");
+    expect(carrierHistory).toContain("Operational evidence");
+    expect(carrierHistory).toContain("event.actorLabel");
+    expect(carrierHistory).not.toContain("useMutation");
+    expect(carrierHistory).not.toContain("sender");
+    expect(carrierHistory).not.toContain("legalName");
+    expect(carrierHistory).not.toContain("taxId");
+    expect(carrierHistory).not.toContain("contact");
+    expect(carrierHistory).not.toContain("detail");
+    expect(carrierHistory).not.toContain("lastError");
+    expect(carrierHistory).not.toContain("actorIdentity");
+    expect(carrierHistory).not.toContain("actorName");
   });
 
   it("shows a bounded read-only SMS operations queue with operator actions", () => {
@@ -149,7 +186,7 @@ describe("admin UI", () => {
 
   it("renders practice dates in each practice timezone", () => {
     expect(source).toContain(
-      "function formatDate(d: Date | string | null, timeZone?: string | null)"
+      "function formatDate(d: Date | string | null, timeZone?: string | null)",
     );
     expect(source).toContain("if (Number.isNaN(date.getTime())) return");
     expect(source).toContain('timeZone: timeZone?.trim() || "UTC"');

--- a/apps/web/lib/__tests__/client-sms-consent-ui.test.ts
+++ b/apps/web/lib/__tests__/client-sms-consent-ui.test.ts
@@ -3,11 +3,11 @@ import { readFileSync } from "node:fs";
 
 const NEW_CLIENT_SOURCE = readFileSync(
   new URL("../../app/(dashboard)/clients/new/page.tsx", import.meta.url),
-  "utf8"
+  "utf8",
 );
 const EDIT_CLIENT_SOURCE = readFileSync(
   new URL("../../app/(dashboard)/clients/[id]/edit/page.tsx", import.meta.url),
-  "utf8"
+  "utf8",
 );
 
 describe("client SMS consent forms", () => {
@@ -15,7 +15,7 @@ describe("client SMS consent forms", () => {
     for (const source of [NEW_CLIENT_SOURCE, EDIT_CLIENT_SOURCE]) {
       expect(source).toContain("SMS_CONSENT_DISCLOSURE.snapshot");
       expect(source).toContain(
-        "I confirm the client explicitly consented to SMS"
+        "I confirm the client explicitly consented to SMS",
       );
       expect(source).toContain("read this disclosure");
     }
@@ -24,22 +24,48 @@ describe("client SMS consent forms", () => {
   it("does not resubmit persisted edit consent on unrelated saves", () => {
     expect(EDIT_CLIENT_SOURCE).toContain("smsConsentTouched");
     expect(EDIT_CLIENT_SOURCE).toContain(
-      "...(smsConsentTouched ? { smsConsent } : {})"
+      "...(smsConsentTouched ? { smsConsent } : {})",
     );
     expect(EDIT_CLIENT_SOURCE).toContain("phoneNumbersMatchForConsent");
     expect(EDIT_CLIENT_SOURCE).toContain("setSmsConsentTouched(false)");
   });
 
+  it("offers an explicit text-reminder preference in both client forms", () => {
+    for (const source of [NEW_CLIENT_SOURCE, EDIT_CLIENT_SOURCE]) {
+      expect(source).toContain("Preferred contact for reminders");
+      expect(source).toContain('<option value="sms">Text message</option>');
+      expect(source).toContain("appointment and vaccination reminders");
+      expect(source).toContain("preferredContactMethod");
+    }
+    expect(NEW_CLIENT_SOURCE).toContain("preferredContactMethod,");
+    expect(EDIT_CLIENT_SOURCE).toContain("preferredContactTouched");
+    expect(EDIT_CLIENT_SOURCE).toContain(
+      "...(preferredContactTouched ? { preferredContactMethod } : {})",
+    );
+  });
+
+  it("requires consent readiness when staff chooses text reminders", () => {
+    expect(NEW_CLIENT_SOURCE).toContain(
+      'preferredContactMethod !== "sms" || (smsConsent && smsPhoneValid)',
+    );
+    expect(EDIT_CLIENT_SOURCE).toContain("smsPreferenceReady");
+    expect(EDIT_CLIENT_SOURCE).toContain("smsPreferenceNeedsValidation");
+    expect(NEW_CLIENT_SOURCE).toContain(
+      'current === "sms" ? "phone" : current',
+    );
+    expect(EDIT_CLIENT_SOURCE).toContain('setPreferredContactMethod("phone")');
+  });
+
   it("cannot revoke a different unsaved phone than the persisted destination", () => {
     expect(EDIT_CLIENT_SOURCE).toContain(
-      "const persistedSmsPhone = normalizeE164(client?.phone)"
+      "const persistedSmsPhone = normalizeE164(client?.phone)",
     );
     expect(EDIT_CLIENT_SOURCE).toContain(
-      "!persistedSmsPhone || phoneChanged || revokeSms.isPending"
+      "!persistedSmsPhone || phoneChanged || revokeSms.isPending",
     );
     expect(EDIT_CLIENT_SOURCE).toContain("expectedPhone: persistedSmsPhone!");
     expect(EDIT_CLIENT_SOURCE).toContain(
-      "Save or discard the unsaved phone change"
+      "Save or discard the unsaved phone change",
     );
   });
 });

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -1311,4 +1311,55 @@ describe("committed Drizzle migrations", () => {
       "GRANT EXECUTE ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) TO openpims_app",
     );
   });
+
+  it("creates a PHI-free append-only carrier-registration lifecycle ledger", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0065_sudden_kabuki",
+    );
+
+    const sql = readRepoFile("packages/db/drizzle/0065_sudden_kabuki.sql");
+    const tableDefinition = sql.match(
+      /CREATE TABLE "messaging_registration_events" \([\s\S]*?\n\);/,
+    )?.[0];
+    expect(tableDefinition).toBeDefined();
+    expect(tableDefinition).not.toMatch(
+      /"(tax_id|patient_id|client_id|provider_payload|error|detail)"|\bjsonb\b/,
+    );
+    expect(sql).toContain(
+      "messaging_registration_events_registration_tenant_fk",
+    );
+    expect(sql).toContain("messaging_registration_events_location_tenant_fk");
+    expect(sql).toContain("messaging_registration_events_actor_tenant_fk");
+    expect(sql).toContain("messaging_registration_events_shape_check");
+    expect(sql).toContain("pg_catalog.pg_advisory_xact_lock");
+    expect(sql).toContain(
+      "Messaging registration event must match the exact active carrier projection.",
+    );
+    expect(sql).toContain(
+      "Messaging registration event must continue the durable carrier status chain.",
+    );
+    expect(sql).toContain("messaging_registration_events_immutable");
+    expect(sql).toContain("app.ledger_maintenance");
+    expect(sql).toContain(
+      "ALTER TABLE messaging_registration_events ENABLE ROW LEVEL SECURITY",
+    );
+    expect(sql).toContain(
+      "GRANT SELECT, INSERT ON messaging_registration_events TO openpims_app",
+    );
+    expect(sql).toContain(
+      "REVOKE ALL ON messaging_registration_events FROM authenticated",
+    );
+
+    const reset = readRepoFile("packages/db/reset.ts");
+    expect(reset).toContain('"messaging_registration_events"');
+
+    const rls = readRepoFile("packages/db/rls/enable-rls.sql");
+    expect(rls).toContain("'messaging_registration_events'");
+    expect(rls).toContain(
+      "GRANT SELECT, INSERT ON messaging_registration_events TO openpims_app",
+    );
+  });
 });

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -1331,6 +1331,15 @@ describe("committed Drizzle migrations", () => {
     expect(sql).toContain(
       "messaging_registration_events_registration_tenant_fk",
     );
+    expect(
+      sql.indexOf(
+        'CREATE UNIQUE INDEX "messaging_registrations_practice_id_uq"',
+      ),
+    ).toBeLessThan(
+      sql.indexOf(
+        'ADD CONSTRAINT "messaging_registration_events_registration_tenant_fk"',
+      ),
+    );
     expect(sql).toContain("messaging_registration_events_location_tenant_fk");
     expect(sql).toContain("messaging_registration_events_actor_tenant_fk");
     expect(sql).toContain("messaging_registration_events_shape_check");

--- a/apps/web/lib/__tests__/schema-indexes.test.ts
+++ b/apps/web/lib/__tests__/schema-indexes.test.ts
@@ -22,6 +22,7 @@ import {
   invoiceItems,
   labResults,
   locationMessaging,
+  messagingRegistrationEvents,
   messagingRegistrations,
   locations,
   patientAllergies,
@@ -210,6 +211,15 @@ describe("hot table indexes", () => {
         "messaging_registrations_practice_idx",
         "messaging_registrations_status_idx",
         "messaging_registrations_attested_by_idx",
+      ],
+    ],
+    [
+      "messaging_registration_events",
+      messagingRegistrationEvents,
+      [
+        "messaging_registration_events_registration_history_idx",
+        "messaging_registration_events_practice_time_idx",
+        "messaging_registration_events_operation_event_uq",
       ],
     ],
     [

--- a/apps/web/lib/clients/policy.ts
+++ b/apps/web/lib/clients/policy.ts
@@ -7,9 +7,17 @@ export const CLIENT_STATE_MAX_LENGTH = 64;
 export const CLIENT_ZIP_MAX_LENGTH = 16;
 export const CLIENT_SEARCH_MAX_LENGTH = 100;
 
+export const CLIENT_CONTACT_METHODS = [
+  "phone",
+  "email",
+  "sms",
+  "portal",
+] as const;
+export type ClientContactMethod = (typeof CLIENT_CONTACT_METHODS)[number];
+
 export function isRequiredClientTextValid(
   value: string,
-  maxLength: number
+  maxLength: number,
 ): boolean {
   const trimmed = value.trim();
   return trimmed.length > 0 && trimmed.length <= maxLength;
@@ -17,7 +25,7 @@ export function isRequiredClientTextValid(
 
 export function isOptionalClientTextValid(
   value: string,
-  maxLength: number
+  maxLength: number,
 ): boolean {
   return value.trim().length <= maxLength;
 }

--- a/apps/web/lib/messaging/__tests__/registration-events.test.ts
+++ b/apps/web/lib/messaging/__tests__/registration-events.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clinicMessagingRegistrationActor,
+  platformMessagingRegistrationActor,
+  recordMessagingRegistrationEvent,
+} from "../registration-events";
+
+describe("messaging registration event evidence", () => {
+  it("redacts platform identity and never stores a cross-tenant actor id", () => {
+    expect(
+      platformMessagingRegistrationActor({
+        email: "Operator.Name@Example.com",
+        name: " Platform Operator ",
+      }),
+    ).toEqual({
+      actorType: "platform_operator",
+      actorUserId: null,
+      actorIdentity: "o***@example.com",
+      actorName: "Platform Operator",
+    });
+  });
+
+  it("uses a bounded clinic actor label when the user profile name is blank", () => {
+    expect(
+      clinicMessagingRegistrationActor({
+        id: "00000000-0000-0000-0000-000000000004",
+        name: "   ",
+      }),
+    ).toMatchObject({
+      actorType: "clinic_user",
+      actorUserId: "00000000-0000-0000-0000-000000000004",
+      actorName: "Clinic admin",
+    });
+  });
+
+  it("stores only the bounded PHI-free lifecycle projection", async () => {
+    const values = vi.fn(async (_row: Record<string, unknown>) => undefined);
+    const insert = vi.fn(() => ({ values }));
+    await recordMessagingRegistrationEvent({ insert } as never, {
+      registration: {
+        id: "00000000-0000-0000-0000-000000000001",
+        practiceId: "00000000-0000-0000-0000-000000000002",
+        provider: "telnyx",
+        status: "pending",
+        providerBrandId: "brand-123",
+        providerCampaignId: null,
+        providerBrandStatus: "VERIFIED",
+        providerCampaignStatus: null,
+      },
+      eventType: "provider_operation_succeeded",
+      operation: "brand_submission",
+      statusBefore: "pending",
+      operationId: "00000000-0000-0000-0000-000000000003",
+      reasonCode: "carrier_brand_submitted",
+      actor: clinicMessagingRegistrationActor({
+        id: "00000000-0000-0000-0000-000000000004",
+        name: " Clinic Admin ",
+      }),
+    });
+
+    expect(values).toHaveBeenCalledTimes(1);
+    const row = values.mock.calls[0]![0] as Record<string, unknown>;
+    expect(row).toMatchObject({
+      eventType: "provider_operation_succeeded",
+      operation: "brand_submission",
+      reasonCode: "carrier_brand_submitted",
+      actorName: "Clinic Admin",
+      actorIdentity: null,
+    });
+    for (const forbidden of [
+      "taxId",
+      "taxIdEncrypted",
+      "taxIdLast4",
+      "patientId",
+      "clientId",
+      "providerPayload",
+      "providerError",
+      "detail",
+    ]) {
+      expect(row).not.toHaveProperty(forbidden);
+    }
+  });
+});

--- a/apps/web/lib/messaging/registration-events.ts
+++ b/apps/web/lib/messaging/registration-events.ts
@@ -1,0 +1,136 @@
+import {
+  messagingRegistrationEvents,
+  messagingRegistrations,
+} from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+
+export const messagingRegistrationReasonCodes = [
+  "clinic_registration_saved",
+  "carrier_brand_submission_started",
+  "carrier_brand_submitted",
+  "carrier_brand_not_verified",
+  "carrier_campaign_submission_started",
+  "carrier_campaign_recovered",
+  "carrier_campaign_submitted",
+  "carrier_number_assignment_started",
+  "carrier_numbers_assigned",
+  "carrier_provider_operation_failed",
+  "carrier_registration_reconciled",
+  "carrier_webhook_observed",
+  "provider_ids_attached_after_portal_review",
+  "stale_brand_lock_cleared",
+  "stale_campaign_lock_cleared",
+  "provider_profile_enabled",
+  "provider_profile_disabled",
+  "provider_profile_verified",
+] as const;
+
+export type MessagingRegistrationReasonCode =
+  (typeof messagingRegistrationReasonCodes)[number];
+
+export type MessagingRegistrationEventActor =
+  | {
+      actorType: "clinic_user";
+      actorUserId: string;
+      actorIdentity: null;
+      actorName: string;
+    }
+  | {
+      actorType: "platform_operator";
+      actorUserId: null;
+      actorIdentity: string;
+      actorName: string;
+    }
+  | {
+      actorType: "system";
+      actorUserId: null;
+      actorIdentity: null;
+      actorName: "OpenVPM system";
+    };
+
+export function clinicMessagingRegistrationActor(input: {
+  id: string;
+  name: string;
+}): MessagingRegistrationEventActor {
+  return {
+    actorType: "clinic_user",
+    actorUserId: input.id,
+    actorIdentity: null,
+    actorName: input.name.trim() || "Clinic admin",
+  };
+}
+
+function redactedIdentity(value: string | null | undefined): string {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return "reviewer-recorded";
+  const [local, domain] = normalized.split("@");
+  if (!local || !domain) return "reviewer-recorded";
+  return `${local.slice(0, 1)}***@${domain}`;
+}
+
+export function platformMessagingRegistrationActor(input: {
+  email?: string | null;
+  name?: string | null;
+}): MessagingRegistrationEventActor {
+  return {
+    actorType: "platform_operator",
+    actorUserId: null,
+    actorIdentity: redactedIdentity(input.email),
+    actorName: input.name?.trim() || "OpenVPM operator",
+  };
+}
+
+export function systemMessagingRegistrationActor(): MessagingRegistrationEventActor {
+  return {
+    actorType: "system",
+    actorUserId: null,
+    actorIdentity: null,
+    actorName: "OpenVPM system",
+  };
+}
+
+type RegistrationProjection = Pick<
+  typeof messagingRegistrations.$inferSelect,
+  | "id"
+  | "practiceId"
+  | "provider"
+  | "status"
+  | "providerBrandId"
+  | "providerCampaignId"
+  | "providerBrandStatus"
+  | "providerCampaignStatus"
+>;
+
+export async function recordMessagingRegistrationEvent(
+  db: Database,
+  input: {
+    registration: RegistrationProjection;
+    eventType: typeof messagingRegistrationEvents.$inferInsert.eventType;
+    operation: typeof messagingRegistrationEvents.$inferInsert.operation;
+    statusBefore: typeof messagingRegistrationEvents.$inferInsert.statusBefore;
+    operationId: string;
+    reasonCode: MessagingRegistrationReasonCode;
+    actor: MessagingRegistrationEventActor;
+    locationId?: string | null;
+    messagingProfileId?: string | null;
+  },
+) {
+  await db.insert(messagingRegistrationEvents).values({
+    practiceId: input.registration.practiceId,
+    registrationId: input.registration.id,
+    locationId: input.locationId ?? null,
+    eventType: input.eventType,
+    operation: input.operation,
+    statusBefore: input.statusBefore ?? null,
+    statusAfter: input.registration.status,
+    provider: input.registration.provider,
+    providerBrandId: input.registration.providerBrandId,
+    providerCampaignId: input.registration.providerCampaignId,
+    messagingProfileId: input.messagingProfileId ?? null,
+    providerBrandStatus: input.registration.providerBrandStatus,
+    providerCampaignStatus: input.registration.providerCampaignStatus,
+    ...input.actor,
+    operationId: input.operationId,
+    reasonCode: input.reasonCode,
+  });
+}

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -4,14 +4,18 @@ const mocks = vi.hoisted(() => {
   class MockTelnyxError extends Error {
     constructor(
       message: string,
-      readonly status: number
+      readonly status: number,
     ) {
       super(message);
     }
   }
   const selectResults: unknown[][] = [];
   const selectLimit = vi.fn(async () => selectResults.shift() ?? []);
-  const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+  const selectOrderBy = vi.fn(() => ({ limit: selectLimit }));
+  const selectWhere = vi.fn(() => ({
+    limit: selectLimit,
+    orderBy: selectOrderBy,
+  }));
   const selectFrom = vi.fn(() => ({ where: selectWhere }));
   const select = vi.fn(() => ({ from: selectFrom }));
   const updateReturning = vi.fn(async () => [
@@ -20,13 +24,23 @@ const mocks = vi.hoisted(() => {
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
-  const db = { select, update, execute: vi.fn(async () => undefined) };
+  const insertValues = vi.fn(async (_values: unknown) => undefined);
+  const insert = vi.fn(() => ({ values: insertValues }));
+  const db = {
+    select,
+    update,
+    insert,
+    execute: vi.fn(async () => undefined),
+  };
   return {
     db,
     selectResults,
+    selectLimit,
     update,
     updateReturning,
     updateSet,
+    insertValues,
+    noStore: vi.fn(),
     createA2pBrand: vi.fn(),
     createA2pCampaign: vi.fn(),
     ensureA2pNumberAssignment: vi.fn(),
@@ -46,16 +60,17 @@ const mocks = vi.hoisted(() => {
       async (
         database: unknown,
         _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(database)
+        fn: (tx: unknown) => unknown,
+      ) => fn(database),
     ),
     withSystem: vi.fn(async (database: unknown, fn: (tx: unknown) => unknown) =>
-      fn(database)
+      fn(database),
     ),
   };
 });
 
 vi.mock("@openpims/db/client", () => ({ db: mocks.db }));
+vi.mock("next/cache", () => ({ unstable_noStore: mocks.noStore }));
 vi.mock("@/lib/tenant-db", () => ({
   withTenant: mocks.withTenant,
   withSystem: mocks.withSystem,
@@ -150,6 +165,85 @@ afterEach(() => {
 });
 
 describe("platform messaging operations", () => {
+  it("returns bounded newest-first PHI-free registration history", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    const newest = {
+      id: "00000000-0000-0000-0000-000000000011",
+      createdAt: new Date("2026-08-09T12:01:00.000Z"),
+      practiceId: PRACTICE_ID,
+      registrationId: REGISTRATION_ID,
+      locationId: LOCATION_ID,
+      eventType: "provider_operation_succeeded",
+      operation: "campaign_submission",
+      statusBefore: "pending",
+      statusAfter: "pending",
+      provider: "telnyx",
+      providerBrandId: "brand-123",
+      providerCampaignId: "campaign-123",
+      messagingProfileId: null,
+      providerBrandStatus: "VERIFIED",
+      providerCampaignStatus: "PENDING",
+      actorType: "platform_operator",
+      actorUserId: null,
+      actorIdentity: "o***@example.com",
+      actorName: "Ops",
+      operationId: "00000000-0000-0000-0000-000000000012",
+      reasonCode: "carrier_campaign_submitted",
+      legalName: "Must not escape",
+      taxIdLast4: "6789",
+      statusDetail: "Must not escape",
+      lastError: "Must not escape",
+    };
+    mocks.selectResults.push([
+      newest,
+      {
+        ...newest,
+        id: "00000000-0000-0000-0000-000000000010",
+        createdAt: new Date("2026-08-09T12:00:00.000Z"),
+      },
+    ]);
+
+    const result = await caller().messagingRegistrationHistory({
+      practiceId: PRACTICE_ID,
+      limit: 1,
+    });
+    expect(result).toEqual({
+      cacheControl: "no-store",
+      events: [
+        expect.objectContaining({
+          id: newest.id,
+          actorLabel: "o***@example.com",
+          reasonCode: "carrier_campaign_submitted",
+        }),
+      ],
+      truncated: true,
+    });
+
+    expect(result.events[0]).not.toHaveProperty("legalName");
+    expect(result.events[0]).not.toHaveProperty("taxIdLast4");
+    expect(result.events[0]).not.toHaveProperty("statusDetail");
+    expect(result.events[0]).not.toHaveProperty("lastError");
+    expect(result.events[0]).not.toHaveProperty("actorUserId");
+    expect(result.events[0]).not.toHaveProperty("actorIdentity");
+    expect(result.events[0]).not.toHaveProperty("actorName");
+    expect(mocks.selectLimit).toHaveBeenCalledWith(2);
+    expect(mocks.noStore).toHaveBeenCalled();
+  });
+
+  it("rejects unbounded registration history reads before database access", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(
+      caller().messagingRegistrationHistory({
+        practiceId: PRACTICE_ID,
+        limit: 201,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.noStore).not.toHaveBeenCalled();
+  });
+
   it("describes the actual clinic-recorded opt-in flow and required disclosures", () => {
     const copy = messagingCampaignCopy({
       displayName: "Healthy Pets",
@@ -167,7 +261,9 @@ describe("platform messaging operations", () => {
 
     expect(copy.messageFlow).toContain("phone or in-person intake");
     expect(copy.messageFlow).toContain("optional and unchecked by default");
-    expect(copy.messageFlow).toContain("Consent is not a condition of purchase");
+    expect(copy.messageFlow).toContain(
+      "Consent is not a condition of purchase",
+    );
     expect(copy.messageFlow).toContain("/opt-in");
     expect(copy.messageFlow).toContain("/privacy");
     expect(copy.messageFlow).toContain("/terms");
@@ -212,7 +308,7 @@ describe("platform messaging operations", () => {
         practiceId: PRACTICE_ID,
         confirmProviderCharges: true,
         retryAfterProviderReview: false,
-      })
+      }),
     ).resolves.toMatchObject({
       ok: true,
       providerCampaignId: "campaign-123",
@@ -226,20 +322,40 @@ describe("platform messaging operations", () => {
         privacyPolicyUrl: "https://healthypets.example/sms-privacy",
         termsUrl: "https://healthypets.example/sms-terms",
         sample3: expect.stringContaining(
-          `https://app.openvpm.com/sms/${PRACTICE_ID}`
+          `https://app.openvpm.com/sms/${PRACTICE_ID}`,
         ),
         messageFlow: expect.stringContaining(
-          `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`
+          `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`,
         ),
         webhookUrl: "https://app.openvpm.com/api/webhooks/telnyx",
-      })
+      }),
     );
     const payload = mocks.createA2pCampaign.mock.calls[0]?.[0];
     expect(payload.messageFlow).toContain(
-      "https://healthypets.example/sms-privacy"
+      "https://healthypets.example/sms-privacy",
     );
     expect(payload.messageFlow).toContain(
-      "https://healthypets.example/sms-terms"
+      "https://healthypets.example/sms-terms",
+    );
+    const ledgerRows = mocks.insertValues.mock.calls.map(
+      (call) => call[0] as Record<string, unknown>,
+    );
+    expect(ledgerRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "provider_operation_started",
+          operation: "campaign_submission",
+          reasonCode: "carrier_campaign_submission_started",
+        }),
+        expect.objectContaining({
+          eventType: "provider_operation_succeeded",
+          operation: "campaign_submission",
+          reasonCode: "carrier_campaign_submitted",
+        }),
+      ]),
+    );
+    expect(JSON.stringify(ledgerRows)).not.toMatch(
+      /taxId|patientId|clientId|payload|lastError|statusDetail/,
     );
   });
 
@@ -252,7 +368,7 @@ describe("platform messaging operations", () => {
         practiceId: PRACTICE_ID,
         confirmProviderCharges: true,
         retryAfterProviderReview: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
     expect(mocks.withSystem).not.toHaveBeenCalled();
     expect(mocks.createA2pBrand).not.toHaveBeenCalled();
@@ -266,7 +382,7 @@ describe("platform messaging operations", () => {
       caller().submitMessagingBrand({
         practiceId: PRACTICE_ID,
         retryAfterProviderReview: false,
-      } as never)
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     expect(mocks.withSystem).not.toHaveBeenCalled();
   });
@@ -280,7 +396,7 @@ describe("platform messaging operations", () => {
         practiceId: PRACTICE_ID,
         confirmProviderCharges: true,
         retryAfterProviderReview: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(mocks.createA2pBrand).not.toHaveBeenCalled();
   });
@@ -348,6 +464,14 @@ describe("platform messaging operations", () => {
     );
     expect(mocks.updateSet).not.toHaveBeenCalledWith(
       expect.objectContaining({ enabled: true }),
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "provider_profile_enabled",
+        operation: "profile_activation",
+        locationId: LOCATION_ID,
+        messagingProfileId: "profile-123",
+      }),
     );
   });
 
@@ -601,7 +725,11 @@ describe("platform messaging operations", () => {
   it("turns off the clinic gate before disabling the provider profile", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
-    mocks.selectResults.push([activeSender()], [activeSender()]);
+    mocks.selectResults.push(
+      [activeSender()],
+      [activeSender()],
+      [activeRegistration()],
+    );
     mocks.getMessagingProfile
       .mockResolvedValueOnce(providerProfile(true))
       .mockResolvedValueOnce(providerProfile(false));
@@ -627,6 +755,14 @@ describe("platform messaging operations", () => {
         providerProfileReady: false,
       }),
     );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "provider_profile_disabled",
+        operation: "profile_deactivation",
+        locationId: LOCATION_ID,
+        messagingProfileId: "profile-123",
+      }),
+    );
   });
 
   it("targets the freshly read sender identity during provider deactivation", async () => {
@@ -641,6 +777,7 @@ describe("platform messaging operations", () => {
           senderE164: "+15555550101",
         },
       ],
+      [activeRegistration()],
     );
     mocks.getMessagingProfile
       .mockResolvedValueOnce({
@@ -677,6 +814,7 @@ describe("platform messaging operations", () => {
 
   it("invalidates every sender when recovered provider IDs change", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.selectResults.push([activeRegistration()]);
 
     await expect(
       caller().attachMessagingProviderIds({
@@ -705,6 +843,38 @@ describe("platform messaging operations", () => {
         providerProfileSyncedAt: null,
       }),
     );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "provider_ids_attached",
+        operation: "provider_id_recovery",
+        reasonCode: "provider_ids_attached_after_portal_review",
+      }),
+    );
+  });
+
+  it("refuses provider ID recovery while a provider operation lock is fresh", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.selectResults.push([
+      {
+        ...activeRegistration(),
+        submissionLockId: "00000000-0000-0000-0000-000000000007",
+        submissionLockAt: new Date(Date.now() - 5 * 60 * 1000),
+      },
+    ]);
+
+    await expect(
+      caller().attachMessagingProviderIds({
+        practiceId: PRACTICE_ID,
+        providerBrandId: "brand-recovered",
+        providerCampaignId: "campaign-recovered",
+        confirmProviderPortalReviewed: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("15-minute safety window"),
+    });
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 
   it("clears only a portal-reviewed stale lock and keeps every sender disabled", async () => {
@@ -725,7 +895,7 @@ describe("platform messaging operations", () => {
         providerObject: "brand",
         confirmProviderPortalReviewed: true,
         confirmNoProviderObjectExists: "NO_PROVIDER_OBJECT",
-      })
+      }),
     ).resolves.toEqual({ ok: true, providerObject: "brand" });
 
     expect(mocks.updateSet).toHaveBeenCalledWith(
@@ -733,13 +903,21 @@ describe("platform messaging operations", () => {
         submissionLockId: null,
         submissionLockAt: null,
         status: "action_required",
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: false,
         registrationStatus: "action_required",
-      })
+      }),
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "stale_lock_cleared",
+        operation: "submission_lock_recovery",
+        operationId: "00000000-0000-0000-0000-000000000007",
+        reasonCode: "stale_brand_lock_cleared",
+      }),
     );
   });
 
@@ -761,7 +939,7 @@ describe("platform messaging operations", () => {
         providerObject: "brand",
         confirmProviderPortalReviewed: true,
         confirmNoProviderObjectExists: "NO_PROVIDER_OBJECT",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("15-minute safety window"),

--- a/apps/web/server/__tests__/admin-sms-queue.test.ts
+++ b/apps/web/server/__tests__/admin-sms-queue.test.ts
@@ -8,6 +8,11 @@ const sharedQueues = readFileSync(
 );
 
 describe("SMS operator recovery queue", () => {
+  it("masks phone-like provider identifiers before any recovery DTO leaves tRPC", () => {
+    expect(source).toContain("function safeOperationalProviderId");
+    expect(source).toContain("WITHHELD_PHONE_LIKE_OPERATIONAL_ID");
+    expect(source).toContain("/^\\+?\\d[\\d ().-]{6,18}$/");
+  });
   const queue = sharedQueues.slice(
     sharedQueues.indexOf("loadSmsSendAttemptQueue"),
   );
@@ -46,8 +51,12 @@ describe("SMS delivery reconciliation queue", () => {
     sharedQueues.indexOf("loadSmsSendAttemptQueue"),
   );
   const deliveryDetail = source.slice(
-    source.indexOf("smsDeliveryEventQueue:"),
+    source.indexOf("smsDeliveryEventDetail:"),
     source.indexOf("smsSendAttemptQueue:"),
+  );
+  const sendDetail = source.slice(
+    source.indexOf("smsSendAttempt:", source.indexOf("smsSendAttemptQueue:")),
+    source.indexOf("reconcileSmsSendAttempt:"),
   );
 
   it("uses later exact attribution/projection to resolve historical queue rows", () => {
@@ -145,13 +154,13 @@ describe("SMS delivery reconciliation queue", () => {
     expect(deliveryQueue).toContain("providerMessageHint: null");
   });
 
-  it("provides a bounded redacted evidence/history detail workflow", () => {
+  it("provides a bounded allowlisted delivery evidence/history DTO", () => {
     expect(deliveryDetail).toContain("smsDeliveryEventDetail:");
     expect(deliveryDetail).toContain("providerMessageId:");
-    expect(deliveryDetail).toContain("reviewedHistoryId:");
     expect(deliveryDetail).toContain(
-      "redactedOperatorIdentity(row.actorIdentity)",
+      "providerMessageId: safeOperationalProviderId(",
     );
+    expect(deliveryDetail).toContain("reviewedHistoryId:");
     expect(deliveryDetail).toContain(
       "historyLimit: z.number().int().min(1).max(200).default(100)",
     );
@@ -170,5 +179,34 @@ describe("SMS delivery reconciliation queue", () => {
     expect(deliveryDetail).toContain("truncated");
     expect(deliveryDetail).not.toContain("destinationE164");
     expect(deliveryDetail).not.toContain("content:");
+    expect(deliveryDetail).not.toContain("detail:");
+    expect(deliveryDetail).not.toContain("actorIdentity:");
+    expect(deliveryDetail).not.toContain("actorName:");
+    expect(deliveryDetail).not.toContain("operatorReasonCode:");
+    expect(deliveryDetail).not.toContain("communicationId:");
+    expect(deliveryDetail).not.toContain("occurredAt:");
+    expect(deliveryDetail).not.toContain("rawBody:");
+  });
+
+  it("provides an allowlisted send-attempt evidence DTO", () => {
+    expect(sendDetail).toContain("smsSendAttempt:");
+    expect(sendDetail).toContain("communicationId:");
+    expect(sendDetail).toContain("providerMessageId:");
+    expect(sendDetail).toContain("events: events.map((event) => ({");
+    expect(sendDetail).toContain(
+      "providerMessageId: safeOperationalProviderId(",
+    );
+    expect(sendDetail).toContain("eventKey:");
+    expect(sendDetail).not.toContain("destinationE164:");
+    expect(sendDetail).not.toContain("senderE164:");
+    expect(sendDetail).not.toContain("clientId:");
+    expect(sendDetail).not.toContain("sourceId:");
+    expect(sendDetail).not.toContain("idempotencyKey:");
+    expect(sendDetail).not.toContain("registeredDisplayName:");
+    expect(sendDetail).not.toContain("senderMessagingServiceId:");
+    expect(sendDetail).not.toContain("requestedBy");
+    expect(sendDetail).not.toContain("detail:");
+    expect(sendDetail).not.toContain("actorIdentity:");
+    expect(sendDetail).not.toContain("actorName:");
   });
 });

--- a/apps/web/server/__tests__/clients-safety.test.ts
+++ b/apps/web/server/__tests__/clients-safety.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/lib/webhook-dispatcher", () => ({
 const { clientsRouter } = await import("../routers/clients");
 const { LIST_OFFSET_MAX } = await import("../routers/pagination");
 const { SMS_CONSENT_DISCLOSURE } = await import("@/lib/messaging/consent");
+const { pickReminderChannel } = await import("@/lib/messaging/reminders");
 const CLIENTS_SOURCE = readFileSync(
   new URL("../routers/clients.ts", import.meta.url),
   "utf8",
@@ -385,11 +386,20 @@ describe("clients mutation safety", () => {
       firstName: "Ada",
       lastName: "Lovelace",
       phone: "(555) 555-0123",
+      preferredContactMethod: "sms",
       smsConsent: true,
     });
 
-    expect(insertValues).toHaveBeenCalledWith(
+    const clientInsert = (
+      insertValues.mock.calls as unknown as Array<
+        [values: Record<string, unknown>]
+      >
+    )
+      .map(([values]) => values)
+      .find((values) => values.firstName === "Ada");
+    expect(clientInsert).toEqual(
       expect.objectContaining({
+        preferredContactMethod: "sms",
         smsConsent: true,
         smsConsentAt: expect.any(Date),
         smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
@@ -412,6 +422,36 @@ describe("clients mutation safety", () => {
     expect(SMS_CONSENT_DISCLOSURE.source).toContain(
       SMS_CONSENT_DISCLOSURE.version,
     );
+    expect(
+      pickReminderChannel({
+        preferredContactMethod: String(
+          clientInsert?.preferredContactMethod ?? "phone",
+        ),
+        phone: "+15555550123",
+        smsConsent: clientInsert?.smsConsent === true,
+        hasEmail: true,
+        quietHours: false,
+      }),
+    ).toBe("sms");
+  });
+
+  it("rejects an SMS reminder preference without explicit creation consent", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).create({
+        firstName: "Ada",
+        lastName: "Lovelace",
+        phone: "+15555550123",
+        preferredContactMethod: "sms",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("complete SMS consent"),
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("rejects explicit creation consent without a valid SMS destination", async () => {
@@ -469,6 +509,66 @@ describe("clients mutation safety", () => {
       address: undefined,
       notes: "Prefers morning appointments.",
     });
+  });
+
+  it("updates the reminder preference to SMS only from complete stored consent", async () => {
+    const completeConsent = {
+      id: CLIENT_ID,
+      phone: "+15555550123",
+      smsConsent: true,
+      smsConsentAt: new Date("2026-08-09T12:00:00.000Z"),
+      smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
+      smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+      preferredContactMethod: "phone",
+    };
+    const { db, updateSet, lockEvents } = createDb({
+      selectResults: [[completeConsent], [completeConsent]],
+      updatedRows: [
+        {
+          ...completeConsent,
+          preferredContactMethod: "sms",
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).update({
+        id: CLIENT_ID,
+        preferredContactMethod: "sms",
+      }),
+    ).resolves.toMatchObject({ preferredContactMethod: "sms" });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      preferredContactMethod: "sms",
+    });
+    expect(lockEvents).toEqual(["advisory", "row:update"]);
+  });
+
+  it("rejects an SMS reminder preference with incomplete stored consent evidence", async () => {
+    const incompleteConsent = {
+      id: CLIENT_ID,
+      phone: "+15555550123",
+      smsConsent: true,
+      smsConsentAt: new Date("2026-08-09T12:00:00.000Z"),
+      smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
+      smsConsentDisclosure: null,
+      preferredContactMethod: "phone",
+    };
+    const { db, updateSet } = createDb({
+      selectResults: [[incompleteConsent], [incompleteConsent]],
+    });
+
+    await expect(
+      callerWithDb(db).update({
+        id: CLIENT_ID,
+        preferredContactMethod: "sms",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("complete SMS consent"),
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("preserves consent evidence across formatting-only phone edits", async () => {

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -103,6 +103,27 @@ function preparedMessagingGate() {
   };
 }
 
+function registrationInput() {
+  return {
+    entityType: "PRIVATE_PROFIT" as const,
+    displayName: "Healthy Pets",
+    legalName: "Healthy Pets LLC",
+    taxId: "12-3456789",
+    contactFirstName: "Alex",
+    contactLastName: "Vet",
+    contactEmail: "alex@example.com",
+    businessPhone: "+15555550100",
+    street: "1 Main St",
+    city: "Denver",
+    state: "CO",
+    postalCode: "80202",
+    website: "https://example.com",
+    privacyPolicyUrl: "https://example.com/privacy",
+    termsUrl: "https://example.com/terms",
+    certifyAccuracyAndConsent: true as const,
+  };
+}
+
 function callerWithDb(db: Record<string, unknown>) {
   const session = {
     user: {
@@ -187,7 +208,21 @@ function createDb(opts?: {
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
 
-  const insertUpdate = vi.fn(async (_config: unknown) => undefined);
+  const insertReturning = vi.fn(async () => [
+    {
+      id: "00000000-0000-0000-0000-000000000008",
+      practiceId: PRACTICE_ID,
+      provider: "telnyx",
+      status: "not_started",
+      providerBrandId: null,
+      providerCampaignId: null,
+      providerBrandStatus: null,
+      providerCampaignStatus: null,
+    },
+  ]);
+  const insertUpdate = vi.fn((_config: unknown): unknown => ({
+    returning: insertReturning,
+  }));
   const insertValues = vi.fn((_values: unknown) => ({
     onConflictDoUpdate: insertUpdate,
   }));
@@ -385,26 +420,14 @@ describe("messaging location target safety", () => {
       "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
       Buffer.alloc(32, 9).toString("base64"),
     );
-    const { db, insertValues } = createDb({ selectResults: [[]] });
+    const { db, insertValues, insertUpdate } = createDb({
+      selectResults: [[]],
+    });
 
     await expect(
       callerWithDb(db).saveRegistration({
-        entityType: "PRIVATE_PROFIT",
-        displayName: "Healthy Pets",
-        legalName: "Healthy Pets LLC",
-        taxId: "12-3456789",
-        contactFirstName: "Alex",
-        contactLastName: "Vet",
-        contactEmail: "alex@example.com",
-        businessPhone: "+15555550100",
-        street: "1 Main St",
-        city: "Denver",
+        ...registrationInput(),
         state: "co",
-        postalCode: "80202",
-        website: "https://example.com",
-        privacyPolicyUrl: "https://example.com/privacy",
-        termsUrl: "https://example.com/terms",
-        certifyAccuracyAndConsent: true,
       }),
     ).resolves.toEqual({ ok: true, taxIdLast4: "6789" });
 
@@ -419,6 +442,34 @@ describe("messaging location target safety", () => {
     });
     expect(values.taxIdEncrypted).toMatch(/^v1:/);
     expect(JSON.stringify(values)).not.toContain("123456789");
+    expect(insertUpdate.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ setWhere: expect.anything() }),
+    );
+  });
+
+  it("refuses clinic registration edits while a provider operation is locked", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            taxIdEncrypted: "v1:stored",
+            taxIdLast4: "6789",
+            providerBrandId: null,
+            providerCampaignId: null,
+            submissionLockId: "00000000-0000-0000-0000-000000000007",
+            status: "pending",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).saveRegistration(registrationInput()),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("being processed"),
+    });
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("uses the hosted clinic SMS policies when custom links are omitted", async () => {
@@ -1726,16 +1777,12 @@ describe("messaging location sender join scoping", () => {
   it("requires a fresh verified provider profile at both hosted enablement writes", () => {
     const source = readSource("server/routers/messaging.ts");
 
-    expect(source).toContain(
-      "HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS",
-    );
-    expect(source.match(/eq\(locationMessaging\.providerProfileReady, true\)/g)).toHaveLength(
-      2,
-    );
+    expect(source).toContain("HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS");
     expect(
-      source.match(
-        /gte\(\s*locationMessaging\.providerProfileSyncedAt/g,
-      ),
+      source.match(/eq\(locationMessaging\.providerProfileReady, true\)/g),
+    ).toHaveLength(2);
+    expect(
+      source.match(/gte\(\s*locationMessaging\.providerProfileSyncedAt/g),
     ).toHaveLength(2);
     expect(source).toContain("OpenVPM must freshly verify");
   });

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -12,6 +12,7 @@ import {
   patients,
   locations,
   messagingRegistrations,
+  messagingRegistrationEvents,
   locationMessaging,
   smsDeliveryEventHistory,
   smsDeliveryEvents,
@@ -67,6 +68,12 @@ import { messagingProgramUrls } from "@/lib/messaging/public-program";
 import { reconcileSmsSendAttempt, resendSmsAttempt } from "@/lib/sms-dispatch";
 import { reconcileSmsDeliveryEvent } from "@/lib/messaging/sms-delivery-ledger";
 import { rowsFromExecute } from "@/lib/db/execute-rows";
+import {
+  platformMessagingRegistrationActor,
+  recordMessagingRegistrationEvent,
+  type MessagingRegistrationEventActor,
+  type MessagingRegistrationReasonCode,
+} from "@/lib/messaging/registration-events";
 
 /**
  * Platform-operator only. Crosses tenant boundaries deliberately, so it is
@@ -84,12 +91,13 @@ const platformAdminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
 
 const MESSAGING_SUBMISSION_LOCK_STALE_MS = 15 * 60 * 1000;
 const MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
+const WITHHELD_PHONE_LIKE_OPERATIONAL_ID = "[withheld: phone-like identifier]";
 
-function redactedOperatorIdentity(value: string | null): string | null {
+function safeOperationalProviderId(value: string | null): string | null {
   if (!value) return null;
-  const [local, domain] = value.split("@");
-  if (!local || !domain) return "reviewer-recorded";
-  return `${local.slice(0, 1)}***@${domain}`;
+  return /^\+?\d[\d ().-]{6,18}$/.test(value.trim())
+    ? WITHHELD_PHONE_LIKE_OPERATIONAL_ID
+    : value;
 }
 
 function assertMessagingProviderMutationsEnabled() {
@@ -229,11 +237,9 @@ async function inspectMessagingProviderReadiness(input: {
     sender,
     blockers,
     registration: {
-      id: registration.id,
-      practiceId: registration.practiceId,
+      ...registration,
       providerBrandId,
       providerCampaignId,
-      status: registration.status,
     },
   };
 }
@@ -250,6 +256,7 @@ function expectedMessagingProfileState(
     clinicEnabled: inspection.sender.enabled,
     providerProfileReady: inspection.sender.providerProfileReady,
     providerProfileSyncedAt: inspection.sender.providerProfileSyncedAt,
+    registration: inspection.registration,
   };
 }
 
@@ -293,7 +300,10 @@ async function recordMessagingProfileReady(input: {
     clinicEnabled: boolean;
     providerProfileReady: boolean;
     providerProfileSyncedAt: Date | null;
+    registration: typeof messagingRegistrations.$inferSelect;
   };
+  eventType: "provider_profile_enabled" | "provider_profile_verified";
+  actor: MessagingRegistrationEventActor;
 }) {
   await withSystem(db, async (tx) => {
     const [updated] = await tx
@@ -347,6 +357,23 @@ async function recordMessagingProfileReady(input: {
           "Messaging lifecycle state changed during provider verification. Refresh and inspect again.",
       });
     }
+    await recordMessagingRegistrationEvent(tx, {
+      registration: input.expected.registration,
+      eventType: input.eventType,
+      operation:
+        input.eventType === "provider_profile_enabled"
+          ? "profile_activation"
+          : "profile_verification",
+      statusBefore: input.expected.registration.status,
+      operationId: randomUUID(),
+      reasonCode:
+        input.eventType === "provider_profile_enabled"
+          ? "provider_profile_enabled"
+          : "provider_profile_verified",
+      actor: input.actor,
+      locationId: input.locationId,
+      messagingProfileId: input.expected.messagingProfileId,
+    });
   });
 }
 
@@ -358,6 +385,8 @@ async function recordMessagingProfileDisabled(input: {
     messagingProfileId: string;
     senderE164: string;
   };
+  registration: typeof messagingRegistrations.$inferSelect;
+  actor: MessagingRegistrationEventActor;
 }) {
   await withSystem(db, async (tx) => {
     const [updated] = await tx
@@ -390,6 +419,17 @@ async function recordMessagingProfileDisabled(input: {
           "Messaging sender identity changed during provider deactivation. Refresh and disable the current profile.",
       });
     }
+    await recordMessagingRegistrationEvent(tx, {
+      registration: input.registration,
+      eventType: "provider_profile_disabled",
+      operation: "profile_deactivation",
+      statusBefore: input.registration.status,
+      operationId: randomUUID(),
+      reasonCode: "provider_profile_disabled",
+      actor: input.actor,
+      locationId: input.locationId,
+      messagingProfileId: input.expected.messagingProfileId,
+    });
   });
 }
 
@@ -442,9 +482,10 @@ async function registrationForOperator(practiceId: string) {
 }
 
 async function claimRegistrationOperation(opts: {
-  registrationId: string;
+  registration: typeof messagingRegistrations.$inferSelect;
   operation: "brand" | "campaign" | "assignment";
   allowReviewedRetry: boolean;
+  actor: MessagingRegistrationEventActor;
 }) {
   return withSystem(db, async (tx) => {
     const lockId = randomUUID();
@@ -462,7 +503,8 @@ async function claimRegistrationOperation(opts: {
       })
       .where(
         and(
-          eq(messagingRegistrations.id, opts.registrationId),
+          eq(messagingRegistrations.id, opts.registration.id),
+          eq(messagingRegistrations.status, opts.registration.status),
           isNull(messagingRegistrations.deletedAt),
           isNull(messagingRegistrations.submissionLockId),
           opts.allowReviewedRetry
@@ -470,7 +512,7 @@ async function claimRegistrationOperation(opts: {
             : sql`${messagingRegistrations.lastError} is null`,
         ),
       )
-      .returning({ id: messagingRegistrations.id });
+      .returning();
     if (!claimed) {
       throw new TRPCError({
         code: "CONFLICT",
@@ -478,6 +520,27 @@ async function claimRegistrationOperation(opts: {
           "A provider operation is already running or a previous ambiguous failure needs operator review.",
       });
     }
+    const operation =
+      opts.operation === "brand"
+        ? ("brand_submission" as const)
+        : opts.operation === "campaign"
+          ? ("campaign_submission" as const)
+          : ("number_assignment" as const);
+    const reasonCode =
+      opts.operation === "brand"
+        ? ("carrier_brand_submission_started" as const)
+        : opts.operation === "campaign"
+          ? ("carrier_campaign_submission_started" as const)
+          : ("carrier_number_assignment_started" as const);
+    await recordMessagingRegistrationEvent(tx, {
+      registration: claimed,
+      eventType: "provider_operation_started",
+      operation,
+      statusBefore: opts.registration.status,
+      operationId: lockId,
+      reasonCode,
+      actor: opts.actor,
+    });
     return lockId;
   });
 }
@@ -486,6 +549,10 @@ async function finishRegistrationOperation(opts: {
   registrationId: string;
   lockId: string;
   values: Partial<typeof messagingRegistrations.$inferInsert>;
+  operation: "brand_submission" | "campaign_submission" | "number_assignment";
+  eventType: "provider_operation_succeeded" | "provider_operation_failed";
+  reasonCode: MessagingRegistrationReasonCode;
+  actor: MessagingRegistrationEventActor;
 }) {
   return withSystem(db, async (tx) => {
     const [updated] = await tx
@@ -503,7 +570,7 @@ async function finishRegistrationOperation(opts: {
           isNull(messagingRegistrations.deletedAt),
         ),
       )
-      .returning({ id: messagingRegistrations.id });
+      .returning();
     if (!updated) {
       throw new TRPCError({
         code: "CONFLICT",
@@ -511,6 +578,15 @@ async function finishRegistrationOperation(opts: {
           "Registration changed while the provider operation was running.",
       });
     }
+    await recordMessagingRegistrationEvent(tx, {
+      registration: updated,
+      eventType: opts.eventType,
+      operation: opts.operation,
+      statusBefore: "pending",
+      operationId: opts.lockId,
+      reasonCode: opts.reasonCode,
+      actor: opts.actor,
+    });
   });
 }
 
@@ -519,6 +595,8 @@ async function failRegistrationOperation(opts: {
   practiceId: string;
   lockId: string;
   error: unknown;
+  operation: "brand_submission" | "campaign_submission" | "number_assignment";
+  actor: MessagingRegistrationEventActor;
 }) {
   const detail =
     opts.error instanceof Error
@@ -532,6 +610,10 @@ async function failRegistrationOperation(opts: {
       statusDetail: "Carrier registration needs OpenVPM operator review.",
       lastError: detail,
     },
+    operation: opts.operation,
+    eventType: "provider_operation_failed",
+    reasonCode: "carrier_provider_operation_failed",
+    actor: opts.actor,
   });
   await withSystem(db, async (tx) => {
     await tx
@@ -1111,6 +1193,84 @@ export const adminRouter = createRouter({
     return getSmsOperationsHealth(db);
   }),
 
+  /** Newest-first, PHI-free carrier lifecycle evidence for one exact clinic. */
+  messagingRegistrationHistory: platformAdminProcedure
+    .input(
+      z
+        .object({
+          practiceId: z.string().uuid(),
+          limit: z.number().int().min(1).max(200).default(100),
+        })
+        .strict(),
+    )
+    .query(({ input }) => {
+      noStore();
+      return withSystem(db, async (tx) => {
+        const rows = await tx
+          .select({
+            id: messagingRegistrationEvents.id,
+            createdAt: messagingRegistrationEvents.createdAt,
+            practiceId: messagingRegistrationEvents.practiceId,
+            registrationId: messagingRegistrationEvents.registrationId,
+            locationId: messagingRegistrationEvents.locationId,
+            eventType: messagingRegistrationEvents.eventType,
+            operation: messagingRegistrationEvents.operation,
+            statusBefore: messagingRegistrationEvents.statusBefore,
+            statusAfter: messagingRegistrationEvents.statusAfter,
+            provider: messagingRegistrationEvents.provider,
+            providerBrandId: messagingRegistrationEvents.providerBrandId,
+            providerCampaignId: messagingRegistrationEvents.providerCampaignId,
+            messagingProfileId: messagingRegistrationEvents.messagingProfileId,
+            providerBrandStatus:
+              messagingRegistrationEvents.providerBrandStatus,
+            providerCampaignStatus:
+              messagingRegistrationEvents.providerCampaignStatus,
+            actorType: messagingRegistrationEvents.actorType,
+            actorIdentity: messagingRegistrationEvents.actorIdentity,
+            operationId: messagingRegistrationEvents.operationId,
+            reasonCode: messagingRegistrationEvents.reasonCode,
+          })
+          .from(messagingRegistrationEvents)
+          .where(eq(messagingRegistrationEvents.practiceId, input.practiceId))
+          .orderBy(
+            desc(messagingRegistrationEvents.createdAt),
+            desc(messagingRegistrationEvents.id),
+          )
+          .limit(input.limit + 1);
+        const truncated = rows.length > input.limit;
+        return {
+          cacheControl: "no-store" as const,
+          events: rows.slice(0, input.limit).map((row) => ({
+            id: row.id,
+            createdAt: row.createdAt,
+            practiceId: row.practiceId,
+            registrationId: row.registrationId,
+            locationId: row.locationId,
+            eventType: row.eventType,
+            operation: row.operation,
+            statusBefore: row.statusBefore,
+            statusAfter: row.statusAfter,
+            provider: row.provider,
+            providerBrandId: row.providerBrandId,
+            providerCampaignId: row.providerCampaignId,
+            messagingProfileId: row.messagingProfileId,
+            providerBrandStatus: row.providerBrandStatus,
+            providerCampaignStatus: row.providerCampaignStatus,
+            actorType: row.actorType,
+            actorLabel:
+              row.actorType === "clinic_user"
+                ? "Clinic admin"
+                : row.actorType === "platform_operator"
+                  ? row.actorIdentity || "OpenVPM operator"
+                  : "OpenVPM system",
+            operationId: row.operationId,
+            reasonCode: row.reasonCode,
+          })),
+          truncated,
+        };
+      });
+    }),
+
   /** Redacted A2P work queue. Legal tax IDs are never exposed here. */
   messagingRegistrationQueue: platformAdminProcedure.query(async () =>
     withSystem(db, async (tx) => {
@@ -1153,7 +1313,9 @@ export const adminRouter = createRouter({
           locationId: locationMessaging.locationId,
           provider: locationMessaging.provider,
           messagingProfileId: locationMessaging.messagingProfileId,
-          senderE164: locationMessaging.senderE164,
+          senderLast4: sql<
+            string | null
+          >`nullif(right(regexp_replace(coalesce(${locationMessaging.senderE164}, ''), '[^0-9]', '', 'g'), 4), '')`,
           registrationStatus: locationMessaging.registrationStatus,
           registrationDetail: locationMessaging.registrationDetail,
           providerProfileReady: locationMessaging.providerProfileReady,
@@ -1186,7 +1348,8 @@ export const adminRouter = createRouter({
         locationId: z.string().uuid(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
       try {
         const inspection = await inspectMessagingProviderReadiness(input);
         const { profile, blockers } = inspection;
@@ -1197,6 +1360,8 @@ export const adminRouter = createRouter({
             detail:
               "Provider profile is active and verified. A clinic admin may now enable this approved pilot sender.",
             expected: expectedMessagingProfileState(inspection),
+            eventType: "provider_profile_verified",
+            actor,
           });
         } else {
           await updateMessagingSenderDisabled({
@@ -1234,8 +1399,9 @@ export const adminRouter = createRouter({
         confirmProviderMutation: z.literal(true),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const sender = await messagingSenderForOperator(
         input.practiceId,
         input.locationId,
@@ -1253,6 +1419,7 @@ export const adminRouter = createRouter({
             input.practiceId,
             input.locationId,
           );
+          const registration = await registrationForOperator(input.practiceId);
           let profile = await getMessagingProfile(
             targetSender.messagingProfileId,
           );
@@ -1281,6 +1448,8 @@ export const adminRouter = createRouter({
               messagingProfileId: targetSender.messagingProfileId,
               senderE164: targetSender.senderE164,
             },
+            registration,
+            actor,
           });
           return {
             locationId: input.locationId,
@@ -1348,6 +1517,8 @@ export const adminRouter = createRouter({
           detail:
             "Provider profile is active and verified. A clinic admin may now enable this approved pilot sender.",
           expected: expectedMessagingProfileState(inspection),
+          eventType: "provider_profile_enabled",
+          actor,
         });
         return {
           locationId: input.locationId,
@@ -1370,8 +1541,9 @@ export const adminRouter = createRouter({
         retryAfterProviderReview: z.boolean().default(false),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const registration = await registrationForOperator(input.practiceId);
       if (registration.providerBrandId) {
         return {
@@ -1381,9 +1553,10 @@ export const adminRouter = createRouter({
         };
       }
       const lockId = await claimRegistrationOperation({
-        registrationId: registration.id,
+        registration,
         operation: "brand",
         allowReviewedRetry: input.retryAfterProviderReview,
+        actor,
       });
       try {
         const brand = await createA2pBrand({
@@ -1419,6 +1592,10 @@ export const adminRouter = createRouter({
             lastError: brand.failureReasons,
             lastSyncedAt: new Date(),
           },
+          operation: "brand_submission",
+          eventType: "provider_operation_succeeded",
+          reasonCode: "carrier_brand_submitted",
+          actor,
         });
         return { ok: true, providerBrandId: brand.brandId, reused: false };
       } catch (error) {
@@ -1427,6 +1604,8 @@ export const adminRouter = createRouter({
           practiceId: registration.practiceId,
           lockId,
           error,
+          operation: "brand_submission",
+          actor,
         });
         throw providerFailure(error);
       }
@@ -1441,8 +1620,9 @@ export const adminRouter = createRouter({
         retryAfterProviderReview: z.boolean().default(false),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const registration = await registrationForOperator(input.practiceId);
       if (!registration.providerBrandId) {
         throw new TRPCError({
@@ -1450,6 +1630,7 @@ export const adminRouter = createRouter({
           message: "Submit the clinic brand before its campaign.",
         });
       }
+      const providerBrandId = registration.providerBrandId;
       if (registration.providerCampaignId) {
         return {
           ok: true,
@@ -1458,14 +1639,14 @@ export const adminRouter = createRouter({
         };
       }
 
-      const brand = await getA2pBrand(registration.providerBrandId);
+      const brand = await getA2pBrand(providerBrandId);
       if (
         !new Set(["VERIFIED", "VETTED_VERIFIED"]).has(
           brand.identityStatus ?? "",
         )
       ) {
         await withSystem(db, async (tx) => {
-          await tx
+          const [updated] = await tx
             .update(messagingRegistrations)
             .set({
               providerBrandStatus: brand.identityStatus ?? brand.status,
@@ -1479,7 +1660,33 @@ export const adminRouter = createRouter({
               lastSyncedAt: new Date(),
               updatedAt: new Date(),
             })
-            .where(eq(messagingRegistrations.id, registration.id));
+            .where(
+              and(
+                eq(messagingRegistrations.id, registration.id),
+                eq(messagingRegistrations.status, registration.status),
+                eq(messagingRegistrations.providerBrandId, providerBrandId),
+                isNull(messagingRegistrations.providerCampaignId),
+                isNull(messagingRegistrations.submissionLockId),
+                isNull(messagingRegistrations.deletedAt),
+              ),
+            )
+            .returning();
+          if (!updated) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "Registration changed during carrier brand inspection. Refresh and retry.",
+            });
+          }
+          await recordMessagingRegistrationEvent(tx, {
+            registration: updated,
+            eventType: "provider_state_observed",
+            operation: "brand_submission",
+            statusBefore: registration.status,
+            operationId: randomUUID(),
+            reasonCode: "carrier_brand_not_verified",
+            actor,
+          });
         });
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
@@ -1489,12 +1696,12 @@ export const adminRouter = createRouter({
 
       const referenceId = campaignReferenceId(input.practiceId);
       const recovered = await findA2pCampaignByReference({
-        brandId: registration.providerBrandId,
+        brandId: providerBrandId,
         referenceId,
       });
       if (recovered) {
         await withSystem(db, async (tx) => {
-          await tx
+          const [updated] = await tx
             .update(messagingRegistrations)
             .set({
               providerCampaignId: recovered.campaignId,
@@ -1509,7 +1716,32 @@ export const adminRouter = createRouter({
               lastSyncedAt: new Date(),
               updatedAt: new Date(),
             })
-            .where(eq(messagingRegistrations.id, registration.id));
+            .where(
+              and(
+                eq(messagingRegistrations.id, registration.id),
+                eq(messagingRegistrations.status, registration.status),
+                eq(messagingRegistrations.providerBrandId, providerBrandId),
+                isNull(messagingRegistrations.providerCampaignId),
+                isNull(messagingRegistrations.submissionLockId),
+                isNull(messagingRegistrations.deletedAt),
+              ),
+            )
+            .returning();
+          if (!updated) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Registration changed during campaign recovery.",
+            });
+          }
+          await recordMessagingRegistrationEvent(tx, {
+            registration: updated,
+            eventType: "provider_operation_succeeded",
+            operation: "campaign_submission",
+            statusBefore: registration.status,
+            operationId: randomUUID(),
+            reasonCode: "carrier_campaign_recovered",
+            actor,
+          });
         });
         return {
           ok: true,
@@ -1519,9 +1751,10 @@ export const adminRouter = createRouter({
       }
 
       const lockId = await claimRegistrationOperation({
-        registrationId: registration.id,
+        registration,
         operation: "campaign",
         allowReviewedRetry: input.retryAfterProviderReview,
+        actor,
       });
       try {
         const programUrls = messagingProgramUrls(registration.practiceId);
@@ -1535,7 +1768,7 @@ export const adminRouter = createRouter({
           optInUrl: programUrls.optInUrl,
         });
         const campaign = await createA2pCampaign({
-          brandId: registration.providerBrandId,
+          brandId: providerBrandId,
           referenceId,
           displayName: registration.displayName,
           ...copy,
@@ -1559,6 +1792,10 @@ export const adminRouter = createRouter({
             lastError: campaign.failureReasons,
             lastSyncedAt: new Date(),
           },
+          operation: "campaign_submission",
+          eventType: "provider_operation_succeeded",
+          reasonCode: "carrier_campaign_submitted",
+          actor,
         });
         return {
           ok: true,
@@ -1571,6 +1808,8 @@ export const adminRouter = createRouter({
           practiceId: registration.practiceId,
           lockId,
           error,
+          operation: "campaign_submission",
+          actor,
         });
         throw providerFailure(error);
       }
@@ -1584,8 +1823,9 @@ export const adminRouter = createRouter({
         confirmProviderMutation: z.literal(true),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const registration = await registrationForOperator(input.practiceId);
       if (!registration.providerCampaignId || !registration.providerBrandId) {
         throw new TRPCError({
@@ -1624,69 +1864,111 @@ export const adminRouter = createRouter({
         });
       }
 
-      const assignments: TelnyxNumberAssignment[] = [];
-      for (const sender of senders) {
-        if (!sender.phoneNumber) continue;
-        assignments.push(
-          await ensureA2pNumberAssignment({
-            phoneNumber: sender.phoneNumber,
-            campaignId: registration.providerCampaignId,
-          }),
-        );
-      }
-      const observed = observedRegistrationStatus({
-        brandIdentityStatus: registration.providerBrandStatus,
-        campaignStatus: campaign.campaignStatus ?? campaign.status,
-        campaignSubmissionStatus: campaign.submissionStatus,
-        assignmentStatuses: assignments.map((row) => row.assignmentStatus),
+      const lockId = await claimRegistrationOperation({
+        registration,
+        operation: "assignment",
+        allowReviewedRetry: false,
+        actor,
       });
-      const next = mergeRegistrationStatus(registration.status, observed);
-      await withSystem(db, async (tx) => {
-        await tx
-          .update(messagingRegistrations)
-          .set({
-            providerCampaignStatus:
-              campaign.campaignStatus ??
-              campaign.status ??
-              campaign.submissionStatus,
-            status: next,
-            statusDetail:
-              next === "active"
-                ? "Carrier registration and all clinic number assignments are active."
-                : "Clinic numbers were submitted for carrier assignment.",
-            lastError:
-              assignments
-                .map((row) => row.failureReasons)
-                .filter(Boolean)
-                .join("; ") || null,
-            lastSyncedAt: new Date(),
-            updatedAt: new Date(),
-          })
-          .where(eq(messagingRegistrations.id, registration.id));
-        await tx
-          .update(locationMessaging)
-          .set({
-            a2pBrandId: registration.providerBrandId,
-            a2pCampaignId: registration.providerCampaignId,
-            registrationStatus: next,
-            registrationDetail:
-              next === "active"
-                ? "Carrier registration active. An admin may now enable sending."
-                : "Carrier number assignment is pending.",
-            providerProfileReady: false,
-            providerProfileSyncedAt: null,
-            enabled: false,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(locationMessaging.practiceId, input.practiceId),
-              eq(locationMessaging.provider, "telnyx"),
-              isNull(locationMessaging.deletedAt),
-            ),
+      try {
+        const assignments: TelnyxNumberAssignment[] = [];
+        for (const sender of senders) {
+          if (!sender.phoneNumber) continue;
+          assignments.push(
+            await ensureA2pNumberAssignment({
+              phoneNumber: sender.phoneNumber,
+              campaignId: registration.providerCampaignId,
+            }),
           );
-      });
-      return { ok: true, status: next, assigned: assignments.length };
+        }
+        const observed = observedRegistrationStatus({
+          brandIdentityStatus: registration.providerBrandStatus,
+          campaignStatus: campaign.campaignStatus ?? campaign.status,
+          campaignSubmissionStatus: campaign.submissionStatus,
+          assignmentStatuses: assignments.map((row) => row.assignmentStatus),
+        });
+        const next = mergeRegistrationStatus("pending", observed);
+        await withSystem(db, async (tx) => {
+          const [updated] = await tx
+            .update(messagingRegistrations)
+            .set({
+              providerCampaignStatus:
+                campaign.campaignStatus ??
+                campaign.status ??
+                campaign.submissionStatus,
+              status: next,
+              statusDetail:
+                next === "active"
+                  ? "Carrier registration and all clinic number assignments are active."
+                  : "Clinic numbers were submitted for carrier assignment.",
+              lastError:
+                assignments
+                  .map((row) => row.failureReasons)
+                  .filter(Boolean)
+                  .join("; ") || null,
+              lastSyncedAt: new Date(),
+              submissionLockId: null,
+              submissionLockAt: null,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(messagingRegistrations.id, registration.id),
+                eq(messagingRegistrations.submissionLockId, lockId),
+                isNull(messagingRegistrations.deletedAt),
+              ),
+            )
+            .returning();
+          if (!updated) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Registration changed while assigning carrier numbers.",
+            });
+          }
+          await recordMessagingRegistrationEvent(tx, {
+            registration: updated,
+            eventType: "provider_operation_succeeded",
+            operation: "number_assignment",
+            statusBefore: "pending",
+            operationId: lockId,
+            reasonCode: "carrier_numbers_assigned",
+            actor,
+          });
+          await tx
+            .update(locationMessaging)
+            .set({
+              a2pBrandId: registration.providerBrandId,
+              a2pCampaignId: registration.providerCampaignId,
+              registrationStatus: next,
+              registrationDetail:
+                next === "active"
+                  ? "Carrier registration active. An admin may now enable sending."
+                  : "Carrier number assignment is pending.",
+              providerProfileReady: false,
+              providerProfileSyncedAt: null,
+              enabled: false,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(locationMessaging.practiceId, input.practiceId),
+                eq(locationMessaging.provider, "telnyx"),
+                isNull(locationMessaging.deletedAt),
+              ),
+            );
+        });
+        return { ok: true, status: next, assigned: assignments.length };
+      } catch (error) {
+        await failRegistrationOperation({
+          registrationId: registration.id,
+          practiceId: registration.practiceId,
+          lockId,
+          error,
+          operation: "number_assignment",
+          actor,
+        });
+        throw providerFailure(error);
+      }
     }),
 
   smsDeliveryEventQueue: platformAdminProcedure
@@ -1761,7 +2043,6 @@ export const adminRouter = createRouter({
             providerStatus: smsDeliveryEvents.providerStatus,
             providerErrorCode: smsDeliveryEvents.providerErrorCode,
             classification: smsDeliveryEvents.classification,
-            occurredAt: smsDeliveryEvents.occurredAt,
             payloadFingerprintSha256:
               smsDeliveryEvents.payloadFingerprintSha256,
           })
@@ -1808,14 +2089,9 @@ export const adminRouter = createRouter({
             reviewedHistoryId: smsDeliveryEventHistory.reviewedHistoryId,
             practiceId: smsDeliveryEventHistory.practiceId,
             attemptId: smsDeliveryEventHistory.attemptId,
-            communicationId: smsDeliveryEventHistory.communicationId,
             kind: smsDeliveryEventHistory.kind,
             result: smsDeliveryEventHistory.result,
             classification: smsDeliveryEventHistory.classification,
-            detail: smsDeliveryEventHistory.detail,
-            operatorReasonCode: smsDeliveryEventHistory.operatorReasonCode,
-            actorName: smsDeliveryEventHistory.actorName,
-            actorIdentity: smsDeliveryEventHistory.actorIdentity,
             eventKey: smsDeliveryEventHistory.eventKey,
           })
           .from(smsDeliveryEventHistory)
@@ -1831,13 +2107,15 @@ export const adminRouter = createRouter({
         const visibleHistory = history.slice(0, input.historyLimit).reverse();
         return {
           cacheControl: "no-store" as const,
-          event,
+          event: {
+            ...event,
+            providerMessageId: safeOperationalProviderId(
+              event.providerMessageId,
+            ),
+          },
           candidateAttempts: candidateAttempts.slice(0, 100),
           candidateAttemptsTruncated: candidateAttempts.length > 100,
-          history: visibleHistory.map((row) => ({
-            ...row,
-            actorIdentity: redactedOperatorIdentity(row.actorIdentity),
-          })),
+          history: visibleHistory,
           truncated,
         };
       });
@@ -1876,21 +2154,10 @@ export const adminRouter = createRouter({
             id: smsSendAttempts.id,
             createdAt: smsSendAttempts.createdAt,
             practiceId: smsSendAttempts.practiceId,
-            clientId: smsSendAttempts.clientId,
             locationId: smsSendAttempts.locationId,
             communicationId: smsSendAttempts.communicationId,
-            resendOfAttemptId: smsSendAttempts.resendOfAttemptId,
             source: smsSendAttempts.source,
-            sourceId: smsSendAttempts.sourceId,
-            idempotencyKey: smsSendAttempts.idempotencyKey,
-            registeredDisplayName: smsSendAttempts.registeredDisplayName,
             provider: smsSendAttempts.provider,
-            senderMessagingServiceId: smsSendAttempts.senderMessagingServiceId,
-            senderE164: smsSendAttempts.senderE164,
-            requestedByActorType: smsSendAttempts.requestedByActorType,
-            requestedByUserId: smsSendAttempts.requestedByUserId,
-            requestedByIdentity: smsSendAttempts.requestedByIdentity,
-            requestedByName: smsSendAttempts.requestedByName,
           })
           .from(smsSendAttempts)
           .where(
@@ -1913,11 +2180,6 @@ export const adminRouter = createRouter({
             kind: smsSendAttemptEvents.kind,
             outcome: smsSendAttemptEvents.outcome,
             providerMessageId: smsSendAttemptEvents.providerMessageId,
-            detail: smsSendAttemptEvents.detail,
-            actorType: smsSendAttemptEvents.actorType,
-            actorUserId: smsSendAttemptEvents.actorUserId,
-            actorIdentity: smsSendAttemptEvents.actorIdentity,
-            actorName: smsSendAttemptEvents.actorName,
             eventKey: smsSendAttemptEvents.eventKey,
           })
           .from(smsSendAttemptEvents)
@@ -1931,7 +2193,16 @@ export const adminRouter = createRouter({
             desc(smsSendAttemptEvents.createdAt),
             desc(smsSendAttemptEvents.id),
           );
-        return { cacheControl: "no-store" as const, attempt, events };
+        return {
+          cacheControl: "no-store" as const,
+          attempt,
+          events: events.map((event) => ({
+            ...event,
+            providerMessageId: safeOperationalProviderId(
+              event.providerMessageId,
+            ),
+          })),
+        };
       });
     }),
 
@@ -1995,8 +2266,22 @@ export const adminRouter = createRouter({
         confirmProviderPortalReviewed: z.literal(true),
       }),
     )
-    .mutation(async ({ input }) =>
-      withSystem(db, async (tx) => {
+    .mutation(async ({ ctx, input }) => {
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
+      const registration = await registrationForOperator(input.practiceId);
+      if (
+        registration.submissionLockId &&
+        (!registration.submissionLockAt ||
+          registration.submissionLockAt.getTime() >
+            Date.now() - MESSAGING_SUBMISSION_LOCK_STALE_MS)
+      ) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "The provider operation is still within its 15-minute safety window.",
+        });
+      }
+      return withSystem(db, async (tx) => {
         const [updated] = await tx
           .update(messagingRegistrations)
           .set({
@@ -2015,17 +2300,46 @@ export const adminRouter = createRouter({
           })
           .where(
             and(
-              eq(messagingRegistrations.practiceId, input.practiceId),
+              eq(messagingRegistrations.id, registration.id),
+              eq(messagingRegistrations.status, registration.status),
+              registration.providerBrandId
+                ? eq(
+                    messagingRegistrations.providerBrandId,
+                    registration.providerBrandId,
+                  )
+                : isNull(messagingRegistrations.providerBrandId),
+              registration.providerCampaignId
+                ? eq(
+                    messagingRegistrations.providerCampaignId,
+                    registration.providerCampaignId,
+                  )
+                : isNull(messagingRegistrations.providerCampaignId),
+              registration.submissionLockId
+                ? eq(
+                    messagingRegistrations.submissionLockId,
+                    registration.submissionLockId,
+                  )
+                : isNull(messagingRegistrations.submissionLockId),
               isNull(messagingRegistrations.deletedAt),
             ),
           )
-          .returning({ id: messagingRegistrations.id });
+          .returning();
         if (!updated) {
           throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Registration not found.",
+            code: "CONFLICT",
+            message:
+              "Registration changed during provider ID recovery. Refresh and review again.",
           });
         }
+        await recordMessagingRegistrationEvent(tx, {
+          registration: updated,
+          eventType: "provider_ids_attached",
+          operation: "provider_id_recovery",
+          statusBefore: registration.status,
+          operationId: randomUUID(),
+          reasonCode: "provider_ids_attached_after_portal_review",
+          actor,
+        });
         await tx
           .update(locationMessaging)
           .set({
@@ -2045,8 +2359,8 @@ export const adminRouter = createRouter({
             ),
           );
         return { ok: true };
-      }),
-    ),
+      });
+    }),
 
   /**
    * Clear a crash-stale submission lock only after an operator verifies in the
@@ -2062,16 +2376,11 @@ export const adminRouter = createRouter({
         confirmNoProviderObjectExists: z.literal("NO_PROVIDER_OBJECT"),
       }),
     )
-    .mutation(async ({ input }) =>
-      withSystem(db, async (tx) => {
+    .mutation(async ({ ctx, input }) => {
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
+      return withSystem(db, async (tx) => {
         const [registration] = await tx
-          .select({
-            id: messagingRegistrations.id,
-            submissionLockId: messagingRegistrations.submissionLockId,
-            submissionLockAt: messagingRegistrations.submissionLockAt,
-            providerBrandId: messagingRegistrations.providerBrandId,
-            providerCampaignId: messagingRegistrations.providerCampaignId,
-          })
+          .select()
           .from(messagingRegistrations)
           .where(
             and(
@@ -2130,7 +2439,7 @@ export const adminRouter = createRouter({
               isNull(messagingRegistrations.deletedAt),
             ),
           )
-          .returning({ id: messagingRegistrations.id });
+          .returning();
         if (!updated) {
           throw new TRPCError({
             code: "CONFLICT",
@@ -2138,6 +2447,18 @@ export const adminRouter = createRouter({
               "The provider operation changed during recovery. Refresh and review again.",
           });
         }
+        await recordMessagingRegistrationEvent(tx, {
+          registration: updated,
+          eventType: "stale_lock_cleared",
+          operation: "submission_lock_recovery",
+          statusBefore: registration.status,
+          operationId: registration.submissionLockId,
+          reasonCode:
+            input.providerObject === "brand"
+              ? "stale_brand_lock_cleared"
+              : "stale_campaign_lock_cleared",
+          actor,
+        });
         await tx
           .update(locationMessaging)
           .set({
@@ -2156,13 +2477,14 @@ export const adminRouter = createRouter({
             ),
           );
         return { ok: true, providerObject: input.providerObject };
-      }),
-    ),
+      });
+    }),
 
   /** Read-only provider reconciliation. Safe to retry and never enables sending. */
   reconcileMessagingRegistration: platformAdminProcedure
     .input(z.object({ practiceId: z.string().uuid() }))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const registration = await registrationForOperator(input.practiceId);
       if (!registration.providerBrandId) {
         throw new TRPCError({
@@ -2212,7 +2534,7 @@ export const adminRouter = createRouter({
           .join("; ")
           .slice(0, 1000);
         await withSystem(db, async (tx) => {
-          await tx
+          const [updated] = await tx
             .update(messagingRegistrations)
             .set({
               providerBrandStatus: brand.identityStatus ?? brand.status,
@@ -2233,7 +2555,30 @@ export const adminRouter = createRouter({
               lastSyncedAt: new Date(),
               updatedAt: new Date(),
             })
-            .where(eq(messagingRegistrations.id, registration.id));
+            .where(
+              and(
+                eq(messagingRegistrations.id, registration.id),
+                eq(messagingRegistrations.status, registration.status),
+                isNull(messagingRegistrations.deletedAt),
+              ),
+            )
+            .returning();
+          if (!updated) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "Registration changed during provider reconciliation. Refresh and retry.",
+            });
+          }
+          await recordMessagingRegistrationEvent(tx, {
+            registration: updated,
+            eventType: "provider_state_observed",
+            operation: "registration_reconciliation",
+            statusBefore: registration.status,
+            operationId: randomUUID(),
+            reasonCode: "carrier_registration_reconciled",
+            actor,
+          });
           await tx
             .update(locationMessaging)
             .set({

--- a/apps/web/server/routers/clients.ts
+++ b/apps/web/server/routers/clients.ts
@@ -19,6 +19,7 @@ import { listOffsetInput } from "./pagination";
 import {
   CLIENT_ADDRESS_MAX_LENGTH,
   CLIENT_CITY_MAX_LENGTH,
+  CLIENT_CONTACT_METHODS,
   CLIENT_EMAIL_MAX_LENGTH,
   CLIENT_NAME_MAX_LENGTH,
   CLIENT_PHONE_MAX_LENGTH,
@@ -67,6 +68,7 @@ const optionalClientString = (maxLength: number) =>
     .transform((value) => value || undefined);
 const clientAddressInput = optionalClientString(CLIENT_ADDRESS_MAX_LENGTH);
 const clientNotesInput = optionalClientString(2000);
+const clientPreferredContactInput = z.enum(CLIENT_CONTACT_METHODS);
 const normalizedClientPhoneInput = z
   .string()
   .trim()
@@ -149,6 +151,28 @@ function smsSuppressionConsentError(reason: string): TRPCError {
     code: "PRECONDITION_FAILED",
     message:
       "This number is blocked from texting after a delivery or complaint event. Review the suppression before recording consent.",
+  });
+}
+
+function hasCompleteSmsConsentEvidence(state: {
+  smsConsent: boolean;
+  smsConsentAt?: Date | null;
+  smsConsentSource?: string | null;
+  smsConsentDisclosure?: string | null;
+}): boolean {
+  return Boolean(
+    state.smsConsent &&
+    state.smsConsentAt &&
+    state.smsConsentSource?.trim() &&
+    state.smsConsentDisclosure?.trim(),
+  );
+}
+
+function smsPreferredContactError(): TRPCError {
+  return new TRPCError({
+    code: "BAD_REQUEST",
+    message:
+      "Text message can be the preferred contact only after a valid mobile phone number and complete SMS consent are saved.",
   });
 }
 
@@ -340,20 +364,27 @@ export const clientsRouter = createRouter({
         state: optionalClientString(CLIENT_STATE_MAX_LENGTH),
         zip: optionalClientString(CLIENT_ZIP_MAX_LENGTH),
         notes: clientNotesInput,
+        preferredContactMethod: clientPreferredContactInput.optional(),
         smsConsent: z.boolean().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const { smsConsent, ...rest } = input;
-      if (smsConsent && !normalizeE164(rest.phone)) {
+      const { smsConsent, preferredContactMethod, ...rest } = input;
+      const normalizedPhone = normalizeE164(rest.phone);
+      if (smsConsent && !normalizedPhone) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "A valid mobile phone number is required for SMS consent",
         });
       }
+      if (
+        preferredContactMethod === "sms" &&
+        (!smsConsent || !normalizedPhone)
+      ) {
+        throw smsPreferredContactError();
+      }
 
       await assertActivePractice(ctx);
-      const normalizedPhone = normalizeE164(rest.phone);
       const consent = smsConsent
         ? {
             smsConsent: true,
@@ -388,6 +419,7 @@ export const clientsRouter = createRouter({
           .insert(clients)
           .values({
             ...rest,
+            ...(preferredContactMethod ? { preferredContactMethod } : {}),
             ...consent,
             practiceId: ctx.practiceId,
             accessToken: generatePortalAccessToken(),
@@ -449,6 +481,7 @@ export const clientsRouter = createRouter({
         state: optionalClientString(CLIENT_STATE_MAX_LENGTH),
         zip: optionalClientString(CLIENT_ZIP_MAX_LENGTH),
         notes: clientNotesInput,
+        preferredContactMethod: clientPreferredContactInput.optional(),
         smsConsent: z.boolean().optional(),
       }),
     )
@@ -458,8 +491,12 @@ export const clientsRouter = createRouter({
           input,
           "phone",
         );
-        const { id, smsConsent, phone, ...rest } = input;
-        const data: Record<string, unknown> = { ...rest };
+        const { id, smsConsent, phone, preferredContactMethod, ...rest } =
+          input;
+        const data: Record<string, unknown> = {
+          ...rest,
+          ...(preferredContactMethod ? { preferredContactMethod } : {}),
+        };
 
         if (phoneWasProvided) {
           // Drizzle ignores undefined values. Use null so an explicitly cleared
@@ -467,7 +504,11 @@ export const clientsRouter = createRouter({
           data.phone = phone ?? null;
         }
 
-        if (phoneWasProvided || smsConsent !== undefined) {
+        if (
+          phoneWasProvided ||
+          smsConsent !== undefined ||
+          preferredContactMethod === "sms"
+        ) {
           // Read without a row lock only to derive recipient advisory keys.
           // Hosted sends use advisory -> client row, so consent transitions use
           // the same order and then revalidate the row after acquiring locks.
@@ -475,6 +516,10 @@ export const clientsRouter = createRouter({
             .select({
               phone: clients.phone,
               smsConsent: clients.smsConsent,
+              smsConsentAt: clients.smsConsentAt,
+              smsConsentSource: clients.smsConsentSource,
+              smsConsentDisclosure: clients.smsConsentDisclosure,
+              preferredContactMethod: clients.preferredContactMethod,
             })
             .from(clients)
             .where(
@@ -513,6 +558,9 @@ export const clientsRouter = createRouter({
           if (smsConsent === true && newDestination) {
             lockDestinations.add(newDestination);
           }
+          if (preferredContactMethod === "sms" && newDestination) {
+            lockDestinations.add(newDestination);
+          }
           for (const destination of [...lockDestinations].sort()) {
             await acquireSmsRecipientLockInTransaction(
               tx,
@@ -526,6 +574,10 @@ export const clientsRouter = createRouter({
               id: clients.id,
               phone: clients.phone,
               smsConsent: clients.smsConsent,
+              smsConsentAt: clients.smsConsentAt,
+              smsConsentSource: clients.smsConsentSource,
+              smsConsentDisclosure: clients.smsConsentDisclosure,
+              preferredContactMethod: clients.preferredContactMethod,
             })
             .from(clients)
             .where(
@@ -565,6 +617,12 @@ export const clientsRouter = createRouter({
             existingClient.phone,
             nextPhone,
           );
+          let nextConsentState = {
+            smsConsent: existingClient.smsConsent,
+            smsConsentAt: existingClient.smsConsentAt,
+            smsConsentSource: existingClient.smsConsentSource,
+            smsConsentDisclosure: existingClient.smsConsentDisclosure,
+          };
 
           if (smsConsent === true) {
             const normalizedNextPhone = normalizeE164(nextPhone);
@@ -628,6 +686,12 @@ export const clientsRouter = createRouter({
             data.smsConsentAt = new Date();
             data.smsConsentSource = SMS_CONSENT_DISCLOSURE.source;
             data.smsConsentDisclosure = SMS_CONSENT_DISCLOSURE.snapshot;
+            nextConsentState = {
+              smsConsent: true,
+              smsConsentAt: data.smsConsentAt as Date,
+              smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
+              smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+            };
           } else if (phoneChanged || smsConsent === false) {
             if (smsConsent === false) {
               if (oldDestination) {
@@ -668,6 +732,24 @@ export const clientsRouter = createRouter({
             data.smsConsentAt = null;
             data.smsConsentSource = null;
             data.smsConsentDisclosure = null;
+            nextConsentState = {
+              smsConsent: false,
+              smsConsentAt: null,
+              smsConsentSource: null,
+              smsConsentDisclosure: null,
+            };
+          }
+
+          const nextPreferredContactMethod =
+            preferredContactMethod ??
+            existingClient.preferredContactMethod ??
+            "phone";
+          if (
+            nextPreferredContactMethod === "sms" &&
+            (!normalizeE164(nextPhone) ||
+              !hasCompleteSmsConsentEvidence(nextConsentState))
+          ) {
+            throw smsPreferredContactError();
           }
         }
 

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
 import { and, eq, gte, isNull, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
@@ -51,6 +52,10 @@ import {
   hostedMessagingLaunchBlockMessage,
   hostedMessagingLaunchDecision,
 } from "@/lib/messaging/launch-gate";
+import {
+  clinicMessagingRegistrationActor,
+  recordMessagingRegistrationEvent,
+} from "@/lib/messaging/registration-events";
 
 const adminOnly = protectedProcedure.use(requireRole("admin"));
 const MESSAGING_NUMBER_ORDERED_DETAIL =
@@ -87,11 +92,11 @@ const messagingPhoneInput = z
   .trim()
   .min(
     MESSAGING_PHONE_MIN_LENGTH,
-    `Phone number must be at least ${MESSAGING_PHONE_MIN_LENGTH} characters.`
+    `Phone number must be at least ${MESSAGING_PHONE_MIN_LENGTH} characters.`,
   )
   .max(
     MESSAGING_PHONE_MAX_LENGTH,
-    `Phone number must be at most ${MESSAGING_PHONE_MAX_LENGTH} characters.`
+    `Phone number must be at most ${MESSAGING_PHONE_MAX_LENGTH} characters.`,
   )
   .transform((value, ctx) => {
     const e164 = normalizeE164(value);
@@ -135,7 +140,7 @@ const registrationWebsiteInput = httpsUrlInput.refine(
   (value) => value.length <= 100,
   {
     message: "Website URL must be 100 characters or fewer.",
-  }
+  },
 );
 
 const a2pRegistrationInput = z.object({
@@ -191,7 +196,7 @@ function provisioningError(e: unknown): TRPCError {
 
 function quotesMatch(
   selected: z.infer<typeof selectedQuoteInput>,
-  current: z.infer<typeof selectedQuoteInput>
+  current: z.infer<typeof selectedQuoteInput>,
 ): boolean {
   return (
     selected.currency === current.currency &&
@@ -202,7 +207,7 @@ function quotesMatch(
 
 function isFailedOrderStatus(status: string): boolean {
   return ["failure", "failed", "cancelled", "canceled", "deleted"].includes(
-    status.toLowerCase()
+    status.toLowerCase(),
   );
 }
 
@@ -270,7 +275,7 @@ function assertProvisioningPracticeAllowed(practiceId: string): void {
     (process.env.MESSAGING_PROVISIONING_PRACTICE_IDS ?? "")
       .split(",")
       .map((value) => value.trim())
-      .filter(Boolean)
+      .filter(Boolean),
   );
   if (!allowed.has(practiceId)) {
     throw new TRPCError({
@@ -294,12 +299,12 @@ function assertHostedSendingAllowed(practiceId: string, locationId: string) {
 
 function hostedLaunchEligibleLocationIds(
   practiceId: string,
-  locationIds: string[]
+  locationIds: string[],
 ): ReadonlySet<string> {
   if (!billingEnforced()) return new Set(locationIds);
   const eligible = locationIds.filter(
     (locationId) =>
-      hostedMessagingLaunchDecision({ practiceId, locationId }).allowed
+      hostedMessagingLaunchDecision({ practiceId, locationId }).allowed,
   );
   // A hosted pilot is intentionally one location per practice. An operator
   // allowlisting multiple clinic locations is ambiguous and fails closed.
@@ -308,7 +313,7 @@ function hostedLaunchEligibleLocationIds(
 
 function provisioningOperationReference(
   practiceId: string,
-  locationId: string
+  locationId: string,
 ): string {
   return `openvpm:${practiceId}:${locationId}`;
 }
@@ -360,7 +365,7 @@ function splitContactName(name: string) {
 
 function stringDefault(
   schema: z.ZodType<string>,
-  value: string | null | undefined
+  value: string | null | undefined,
 ): string {
   const parsed = schema.safeParse(value ?? "");
   return parsed.success ? parsed.data : "";
@@ -399,8 +404,8 @@ export const messagingRouter = createRouter({
         and(
           eq(messagingRegistrations.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(messagingRegistrations.deletedAt)
-        )
+          isNull(messagingRegistrations.deletedAt),
+        ),
       )
       .limit(1);
     return registration ?? null;
@@ -423,8 +428,8 @@ export const messagingRouter = createRouter({
         and(
           eq(locations.practiceId, practices.id),
           eq(locations.isPrimary, true),
-          isNull(locations.deletedAt)
-        )
+          isNull(locations.deletedAt),
+        ),
       )
       .where(activePracticeWhere(ctx.practiceId))
       .limit(1);
@@ -437,18 +442,18 @@ export const messagingRouter = createRouter({
       displayName: stringDefault(registrationDisplayNameInput, practice.name),
       contactFirstName: stringDefault(
         registrationContactNameInput,
-        contactName.contactFirstName
+        contactName.contactFirstName,
       ),
       contactLastName: stringDefault(
         registrationContactNameInput,
-        contactName.contactLastName
+        contactName.contactLastName,
       ),
       contactEmail:
         stringDefault(registrationContactEmailInput, practice.email) ||
         stringDefault(registrationContactEmailInput, ctx.user.email),
       businessPhone: stringDefault(
         messagingPhoneInput,
-        practice.phone || practice.primaryLocationPhone
+        practice.phone || practice.primaryLocationPhone,
       ),
       website: stringDefault(registrationWebsiteInput, practice.website),
       ...policyUrls,
@@ -469,14 +474,16 @@ export const messagingRouter = createRouter({
           taxIdLast4: messagingRegistrations.taxIdLast4,
           providerBrandId: messagingRegistrations.providerBrandId,
           providerCampaignId: messagingRegistrations.providerCampaignId,
+          submissionLockId: messagingRegistrations.submissionLockId,
+          status: messagingRegistrations.status,
         })
         .from(messagingRegistrations)
         .where(
           and(
             eq(messagingRegistrations.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(messagingRegistrations.deletedAt)
-          )
+            isNull(messagingRegistrations.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -485,6 +492,13 @@ export const messagingRouter = createRouter({
           code: "PRECONDITION_FAILED",
           message:
             "Carrier registration has been submitted. Contact OpenVPM support before changing legal details.",
+        });
+      }
+      if (existing?.submissionLockId) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "Carrier registration is being processed. Wait for the current provider operation to finish before changing legal details.",
         });
       }
       if (!existing && !input.taxId) {
@@ -532,35 +546,62 @@ export const messagingRouter = createRouter({
           input.privacyPolicyUrl || hostedPolicyUrls!.privacyPolicyUrl,
         termsUrl: input.termsUrl || hostedPolicyUrls!.termsUrl,
       };
-      await ctx.db
-        .insert(messagingRegistrations)
-        .values({
-          practiceId: ctx.practiceId,
-          ...completedRegistrationFields,
-          taxIdEncrypted,
-          taxIdLast4,
-          complianceAttestedAt: new Date(),
-          complianceAttestedBy: ctx.user.id,
-          provider: "telnyx",
-          campaignUsecase: "MIXED",
-          status: "not_started",
-          statusDetail: "Ready for OpenVPM carrier review.",
-        })
-        .onConflictDoUpdate({
-          target: messagingRegistrations.practiceId,
-          set: {
+      await ctx.db.transaction(async (tx) => {
+        const [registration] = await tx
+          .insert(messagingRegistrations)
+          .values({
+            practiceId: ctx.practiceId,
             ...completedRegistrationFields,
             taxIdEncrypted,
             taxIdLast4,
             complianceAttestedAt: new Date(),
             complianceAttestedBy: ctx.user.id,
+            provider: "telnyx",
+            campaignUsecase: "MIXED",
             status: "not_started",
             statusDetail: "Ready for OpenVPM carrier review.",
-            lastError: null,
-            deletedAt: null,
-            updatedAt: new Date(),
-          },
+          })
+          .onConflictDoUpdate({
+            target: messagingRegistrations.practiceId,
+            set: {
+              ...completedRegistrationFields,
+              taxIdEncrypted,
+              taxIdLast4,
+              complianceAttestedAt: new Date(),
+              complianceAttestedBy: ctx.user.id,
+              status: "not_started",
+              statusDetail: "Ready for OpenVPM carrier review.",
+              lastError: null,
+              deletedAt: null,
+              updatedAt: new Date(),
+            },
+            setWhere: and(
+              eq(
+                messagingRegistrations.status,
+                existing?.status ?? "not_started",
+              ),
+              isNull(messagingRegistrations.providerBrandId),
+              isNull(messagingRegistrations.providerCampaignId),
+              isNull(messagingRegistrations.submissionLockId),
+            ),
+          })
+          .returning();
+        if (!registration) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Carrier registration changed while saving.",
+          });
+        }
+        await recordMessagingRegistrationEvent(tx as unknown as Database, {
+          registration,
+          eventType: "details_saved",
+          operation: "registration_details",
+          statusBefore: existing?.status ?? null,
+          operationId: randomUUID(),
+          reasonCode: "clinic_registration_saved",
+          actor: clinicMessagingRegistrationActor(ctx.user),
         });
+      });
 
       return { ok: true, taxIdLast4 };
     }),
@@ -589,15 +630,15 @@ export const messagingRouter = createRouter({
           eq(locationMessaging.locationId, locations.id),
           eq(locationMessaging.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(locationMessaging.deletedAt)
-        )
+          isNull(locationMessaging.deletedAt),
+        ),
       )
       .where(
         and(
           eq(locations.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(locations.deletedAt)
-        )
+          isNull(locations.deletedAt),
+        ),
       );
 
     const locationsForSummary = locs.map((l) => ({
@@ -615,7 +656,7 @@ export const messagingRouter = createRouter({
     }));
     const launchEligibleLocationIds = hostedLaunchEligibleLocationIds(
       ctx.practiceId,
-      locs.map((location) => location.locationId)
+      locs.map((location) => location.locationId),
     );
     const locationsWithLaunchState = locationsForSummary.map((location) => ({
       ...location,
@@ -665,15 +706,15 @@ export const messagingRouter = createRouter({
           eq(locationMessaging.locationId, locations.id),
           eq(locationMessaging.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(locationMessaging.deletedAt)
-        )
+          isNull(locationMessaging.deletedAt),
+        ),
       )
       .where(
         and(
           eq(locations.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(locations.deletedAt)
-        )
+          isNull(locations.deletedAt),
+        ),
       );
 
     const period = currentPeriodMonth();
@@ -691,7 +732,7 @@ export const messagingRouter = createRouter({
       getPlan(practice.tier ?? "free")?.includedSmsPerMonth ?? null;
     const launchEligibleLocationIds = hostedLaunchEligibleLocationIds(
       ctx.practiceId,
-      locs.map((location) => location.locationId)
+      locs.map((location) => location.locationId),
     );
 
     const [consentRow] = await ctx.db
@@ -702,8 +743,8 @@ export const messagingRouter = createRouter({
           eq(clients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
           eq(clients.smsConsent, true),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       );
     const [suppressedRow] = await ctx.db
       .select({ n: sql<number>`count(*)::int` })
@@ -711,8 +752,8 @@ export const messagingRouter = createRouter({
       .where(
         and(
           eq(smsSuppressions.practiceId, ctx.practiceId),
-          activePracticePredicate(ctx.practiceId)
-        )
+          activePracticePredicate(ctx.practiceId),
+        ),
       );
 
     return {
@@ -778,23 +819,23 @@ export const messagingRouter = createRouter({
         and(
           eq(locationMessaging.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(locationMessaging.deletedAt)
-        )
+          isNull(locationMessaging.deletedAt),
+        ),
       );
     const launchEligibleLocationIds = hostedLaunchEligibleLocationIds(
       ctx.practiceId,
-      rows.map((row) => row.locationId)
+      rows.map((row) => row.locationId),
     );
     return {
       hasAnyNumber: rows.some(
-        (r) => !!r.senderE164 && r.registrationStatus !== "failed"
+        (r) => !!r.senderE164 && r.registrationStatus !== "failed",
       ),
       hasActiveNumber: rows.some(
         (r) =>
           r.registrationStatus === "active" &&
           r.enabled &&
           launchEligibleLocationIds.has(r.locationId) &&
-          (!billingEnforced() || r.provider === "telnyx")
+          (!billingEnforced() || r.provider === "telnyx"),
       ),
     };
   }),
@@ -807,7 +848,7 @@ export const messagingRouter = createRouter({
           .string()
           .regex(
             new RegExp(`^\\d{${MESSAGING_AREA_CODE_LENGTH}}$`),
-            `Area code must be ${MESSAGING_AREA_CODE_LENGTH} digits`
+            `Area code must be ${MESSAGING_AREA_CODE_LENGTH} digits`,
           )
           .optional(),
         limit: z
@@ -816,7 +857,7 @@ export const messagingRouter = createRouter({
           .min(1)
           .max(MESSAGING_SEARCH_LIMIT_MAX)
           .optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       assertProvisioningEnabled();
@@ -841,8 +882,8 @@ export const messagingRouter = createRouter({
             eq(locations.id, input.locationId),
             eq(locations.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(locations.deletedAt)
-          )
+            isNull(locations.deletedAt),
+          ),
         )
         .limit(1);
       if (!loc) {
@@ -883,7 +924,7 @@ export const messagingRouter = createRouter({
           mode: z.literal("buy"),
           action: z.literal("resume"),
         }),
-      ])
+      ]),
     )
     .mutation(async ({ ctx, input }) => {
       if (input.mode === "host") {
@@ -900,7 +941,7 @@ export const messagingRouter = createRouter({
       const profileName = provisioningProfileName(input.locationId);
       const customerReference = provisioningOperationReference(
         ctx.practiceId,
-        input.locationId
+        input.locationId,
       );
       let profileId: string | null = null;
       let profileCreated = false;
@@ -937,7 +978,7 @@ export const messagingRouter = createRouter({
 
         return await ctx.db.transaction(async (tx) => {
           await tx.execute(
-            sql`select pg_advisory_xact_lock(hashtextextended(${customerReference}, 0))`
+            sql`select pg_advisory_xact_lock(hashtextextended(${customerReference}, 0))`,
           );
           // A request may have waited on the lock. Re-check immediately before
           // every possible provider mutation, not only at request entry.
@@ -951,8 +992,8 @@ export const messagingRouter = createRouter({
                 eq(locations.id, input.locationId),
                 eq(locations.practiceId, ctx.practiceId),
                 activePracticePredicate(ctx.practiceId),
-                isNull(locations.deletedAt)
-              )
+                isNull(locations.deletedAt),
+              ),
             )
             .limit(1);
           if (!loc) {
@@ -975,14 +1016,14 @@ export const messagingRouter = createRouter({
               and(
                 eq(locationMessaging.locationId, input.locationId),
                 eq(locationMessaging.practiceId, ctx.practiceId),
-                isNull(locationMessaging.deletedAt)
-              )
+                isNull(locationMessaging.deletedAt),
+              ),
             )
             .limit(1);
 
           if (input.action === "start" && !existing && !preparedThisRequest) {
             throw provisioningConflict(
-              "OpenVPM could not reserve a durable texting setup attempt. No provider profile or number was created; refresh and try again."
+              "OpenVPM could not reserve a durable texting setup attempt. No provider profile or number was created; refresh and try again.",
             );
           }
 
@@ -995,7 +1036,7 @@ export const messagingRouter = createRouter({
               !existing.senderE164
             ) {
               throw provisioningConflict(
-                "There is no failed number setup to reconcile for this location. Start a new setup or contact OpenVPM support."
+                "There is no failed number setup to reconcile for this location. Start a new setup or contact OpenVPM support.",
               );
             }
             e164 = existing.senderE164;
@@ -1010,7 +1051,7 @@ export const messagingRouter = createRouter({
           let isThisRequestPreparedGate = false;
           if (existing) {
             isThisRequestPreparedGate = Boolean(
-              input.action === "start" && preparedThisRequest
+              input.action === "start" && preparedThisRequest,
             );
             if (
               existing.provider !== "telnyx" ||
@@ -1019,7 +1060,7 @@ export const messagingRouter = createRouter({
               (existing.senderE164 && existing.senderE164 !== e164)
             ) {
               throw provisioningConflict(
-                "This location already has a different texting setup. Contact OpenVPM support before changing numbers."
+                "This location already has a different texting setup. Contact OpenVPM support before changing numbers.",
               );
             }
             if (
@@ -1036,7 +1077,7 @@ export const messagingRouter = createRouter({
             }
             if (input.action === "start" && !isThisRequestPreparedGate) {
               throw provisioningConflict(
-                "This location has an incomplete number setup. Use Reconcile provider setup; OpenVPM will not purchase another number automatically."
+                "This location has an incomplete number setup. Use Reconcile provider setup; OpenVPM will not purchase another number automatically.",
               );
             }
             profileId = existing.messagingProfileId;
@@ -1046,7 +1087,7 @@ export const messagingRouter = createRouter({
           const profiles = await findMessagingProfilesByName(profileName);
           if (profiles.length > 1) {
             throw provisioningConflict(
-              "OpenVPM found more than one incomplete provider setup for this location. No number was purchased; contact support to reconcile it."
+              "OpenVPM found more than one incomplete provider setup for this location. No number was purchased; contact support to reconcile it.",
             );
           }
           const recoveredProfile = profiles[0];
@@ -1056,7 +1097,7 @@ export const messagingRouter = createRouter({
               recoveredProfile.enabled !== false)
           ) {
             throw provisioningConflict(
-              "OpenVPM found an incomplete provider profile with unsafe settings. No number was purchased; contact support to reconcile it."
+              "OpenVPM found an incomplete provider profile with unsafe settings. No number was purchased; contact support to reconcile it.",
             );
           }
           if (
@@ -1064,7 +1105,7 @@ export const messagingRouter = createRouter({
             (!recoveredProfile || recoveredProfile.id !== profileId)
           ) {
             throw provisioningConflict(
-              "The saved provider identity does not match the recoverable setup. No number was purchased; contact support to reconcile it."
+              "The saved provider identity does not match the recoverable setup. No number was purchased; contact support to reconcile it.",
             );
           }
           profileId = recoveredProfile?.id ?? profileId;
@@ -1074,7 +1115,7 @@ export const messagingRouter = createRouter({
             await findNumberOrdersByCustomerReference(customerReference);
           if (orders.length > 1) {
             throw provisioningConflict(
-              "OpenVPM found duplicate provider orders for this location. No additional purchase was attempted; contact support to reconcile them."
+              "OpenVPM found duplicate provider orders for this location. No additional purchase was attempted; contact support to reconcile them.",
             );
           }
           const recoveredOrder = orders[0];
@@ -1090,7 +1131,7 @@ export const messagingRouter = createRouter({
             }
             if (isFailedOrderStatus(recoveredOrder.status)) {
               throw provisioningConflict(
-                "The earlier provider order is in a failed or cancelled state. No additional purchase was attempted; contact OpenVPM support."
+                "The earlier provider order is in a failed or cancelled state. No additional purchase was attempted; contact OpenVPM support.",
               );
             }
             if (!isRecoverableOrderStatus(recoveredOrder.status)) {
@@ -1106,7 +1147,7 @@ export const messagingRouter = createRouter({
             // state. Until the profile POST begins, failures such as a changed
             // quote are definitively mutation-free and may release the gate.
             conclusiveEmptyProfileState = Boolean(
-              preparedThisRequest && !recoveredProfile && !recoveredOrder
+              preparedThisRequest && !recoveredProfile && !recoveredOrder,
             );
             const currentQuotes = await findAvailableNumberQuotes(e164);
             if (
@@ -1114,7 +1155,7 @@ export const messagingRouter = createRouter({
               !quotesMatch(input.quote, currentQuotes[0]!)
             ) {
               throw provisioningConflict(
-                "The selected number or its price changed before purchase. No charge was made. Search again and review the current price."
+                "The selected number or its price changed before purchase. No charge was made. Search again and review the current price.",
               );
             }
             assertProvisioningEnabled();
@@ -1130,25 +1171,25 @@ export const messagingRouter = createRouter({
           const activeProfileId = profileId;
           if (!activeProfileId) {
             throw new Error(
-              "The provider setup did not return a durable profile identity. Retry setup or contact OpenVPM support."
+              "The provider setup did not return a durable profile identity. Retry setup or contact OpenVPM support.",
             );
           }
 
           const ownedNumbers = await findOwnedPhoneNumbers(e164);
           if (ownedNumbers.length > 1) {
             throw provisioningConflict(
-              "The provider returned duplicate ownership records for this number. No new purchase was made; contact support to reconcile it."
+              "The provider returned duplicate ownership records for this number. No new purchase was made; contact support to reconcile it.",
             );
           }
           const ownedNumber = ownedNumbers[0];
           if (
             ownedNumber &&
             ["deleted", "failed", "cancelled", "canceled"].some((status) =>
-              ownedNumber.status?.toLowerCase().includes(status)
+              ownedNumber.status?.toLowerCase().includes(status),
             )
           ) {
             throw provisioningConflict(
-              "The provider reports this number in a failed or released state. No new purchase was made; search again or contact support."
+              "The provider reports this number in a failed or released state. No new purchase was made; search again or contact support.",
             );
           }
           if (
@@ -1156,7 +1197,7 @@ export const messagingRouter = createRouter({
             ownedNumber.messagingProfileId !== activeProfileId
           ) {
             throw provisioningConflict(
-              "This number is already owned under a different provider setup. No new purchase was made; contact support before reassigning it."
+              "This number is already owned under a different provider setup. No new purchase was made; contact support before reassigning it.",
             );
           }
 
@@ -1189,7 +1230,7 @@ export const messagingRouter = createRouter({
             ) {
               purchaseOutcomeUncertain = true;
               throw new TelnyxMutationUncertainError(
-                "The provider returned an inconclusive order status. No second purchase will be attempted automatically."
+                "The provider returned an inconclusive order status. No second purchase will be attempted automatically.",
               );
             }
           }
@@ -1254,7 +1295,7 @@ export const messagingRouter = createRouter({
             // confirmed. Never mask the original setup error.
             console.error(
               "Unable to release untouched messaging profile attempt",
-              releaseError
+              releaseError,
             );
           }
         }
@@ -1265,7 +1306,7 @@ export const messagingRouter = createRouter({
               // and completed first, its durable sender owns the resources and
               // must never be deleted or overwritten by this older attempt.
               await tx.execute(
-                sql`select pg_advisory_xact_lock(hashtextextended(${customerReference}, 0))`
+                sql`select pg_advisory_xact_lock(hashtextextended(${customerReference}, 0))`,
               );
               const [current] = await tx
                 .select({
@@ -1280,8 +1321,8 @@ export const messagingRouter = createRouter({
                   and(
                     eq(locationMessaging.locationId, input.locationId),
                     eq(locationMessaging.practiceId, ctx.practiceId),
-                    isNull(locationMessaging.deletedAt)
-                  )
+                    isNull(locationMessaging.deletedAt),
+                  ),
                 )
                 .limit(1);
               const newerAttemptCompleted = Boolean(
@@ -1289,14 +1330,14 @@ export const messagingRouter = createRouter({
                 current.messagingProfileId &&
                 current.senderE164 === e164 &&
                 current.numberSource === "purchased" &&
-                current.registrationStatus !== "failed"
+                current.registrationStatus !== "failed",
               );
               const differentSetupExists = Boolean(
                 current &&
                 (current.provider !== "telnyx" ||
                   (current.senderE164 && current.senderE164 !== e164) ||
                   (current.numberSource &&
-                    current.numberSource !== "purchased"))
+                    current.numberSource !== "purchased")),
               );
               if (newerAttemptCompleted || differentSetupExists) return;
 
@@ -1373,8 +1414,8 @@ export const messagingRouter = createRouter({
             eq(locations.id, input.locationId),
             eq(locations.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(locations.deletedAt)
-          )
+            isNull(locations.deletedAt),
+          ),
         )
         .limit(1);
       if (!loc) {
@@ -1388,7 +1429,7 @@ export const messagingRouter = createRouter({
         assertHostedSendingAllowed(ctx.practiceId, input.locationId);
         if (billingEnforced()) {
           await ctx.db.execute(
-            sql`select pg_advisory_xact_lock(hashtextextended(${`hosted-sms:${ctx.practiceId}`}, 0))`
+            sql`select pg_advisory_xact_lock(hashtextextended(${`hosted-sms:${ctx.practiceId}`}, 0))`,
           );
         }
         const readySenderConditions = [
@@ -1423,10 +1464,9 @@ export const messagingRouter = createRouter({
         if (!readySender) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message:
-              billingEnforced()
-                ? "OpenVPM must freshly verify the active provider profile before enabling hosted SMS sending."
-                : "Carrier registration must be active before enabling SMS sending.",
+            message: billingEnforced()
+              ? "OpenVPM must freshly verify the active provider profile before enabling hosted SMS sending."
+              : "Carrier registration must be active before enabling SMS sending.",
           });
         }
         if (billingEnforced() && readySender.provider !== "telnyx") {
@@ -1447,14 +1487,14 @@ export const messagingRouter = createRouter({
               isNull(locationMessaging.deletedAt),
               eq(locationMessaging.enabled, true),
               eq(locationMessaging.registrationStatus, "active"),
-              hasNonBlankMessagingSender()
-            )
+              hasNonBlankMessagingSender(),
+            ),
           )
           .limit(2);
         if (
           billingEnforced() &&
           enabledSenders.some(
-            (sender) => sender.locationId !== input.locationId
+            (sender) => sender.locationId !== input.locationId,
           )
         ) {
           throw new TRPCError({
@@ -1474,7 +1514,7 @@ export const messagingRouter = createRouter({
       if (input.enabled) {
         updateConditions.push(
           eq(locationMessaging.registrationStatus, "active"),
-          hasNonBlankMessagingSender()
+          hasNonBlankMessagingSender(),
         );
         if (billingEnforced()) {
           updateConditions.push(
@@ -1518,7 +1558,7 @@ export const messagingRouter = createRouter({
         locationId: z.string().uuid(),
         to: messagingPhoneInput,
         requestId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       if (billingEnforced()) {
@@ -1537,8 +1577,8 @@ export const messagingRouter = createRouter({
             eq(locations.id, input.locationId),
             eq(locations.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(locations.deletedAt)
-          )
+            isNull(locations.deletedAt),
+          ),
         )
         .limit(1);
       if (!loc) {
@@ -1557,8 +1597,8 @@ export const messagingRouter = createRouter({
             eq(locations.id, locationMessaging.locationId),
             eq(locations.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(locations.deletedAt)
-          )
+            isNull(locations.deletedAt),
+          ),
         )
         .where(
           and(
@@ -1571,8 +1611,8 @@ export const messagingRouter = createRouter({
             isNull(locations.deletedAt),
             eq(locationMessaging.enabled, true),
             eq(locationMessaging.registrationStatus, "active"),
-            hasNonBlankMessagingSender()
-          )
+            hasNonBlankMessagingSender(),
+          ),
         )
         .limit(1);
       if (!sender) {

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -131,6 +131,24 @@ three variables are hosted-only and do not gate intentional self-host messaging
 configuration. Arbitrary hosted test destinations remain disabled; validate
 through a current, consented client workflow after approval.
 
+While provisioning, sending, and all SMS allowlists remain off/empty, the
+hosted SMS entry in `/api/health` is advisory. The first rollout signal —
+enabling provisioning or sending, or staging any pilot allowlist — makes the
+Telnyx provider selection, API key, webhook verification key, registration
+encryption key, and exact single-clinic pilot scope release-blocking. A partial,
+malformed, or multi-clinic pilot scope therefore returns `503` before a deploy
+can appear healthy. Provisioning and sending scopes must name the same active
+clinic. A sending location must belong to that clinic and have an active Telnyx
+registration, sender identity, campaign assignment, and verified provider
+profile in the production database. This health check complements the runtime
+send gates; it does not enable provisioning or sending. Rollout health also rejects placeholder
+credentials: the Telnyx v2 API key must use the provider's `KEY_` format, and
+both the Ed25519 webhook public key and registration encryption key must decode
+to 32 bytes. The same structural check remains visible as advisory health while
+the rollout is deferred. A healthy shape is still not proof of account access;
+verify the key with a read-only provider request and complete the live drill
+below.
+
 ### Controlled texting pilot activation
 
 Provider profiles are created disabled. Never enable one during number

--- a/packages/db/drizzle/0065_sudden_kabuki.sql
+++ b/packages/db/drizzle/0065_sudden_kabuki.sql
@@ -92,13 +92,13 @@ ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registrati
 ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_registration_id_messaging_registrations_id_fk" FOREIGN KEY ("registration_id") REFERENCES "public"."messaging_registrations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_location_id_locations_id_fk" FOREIGN KEY ("location_id") REFERENCES "public"."locations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "messaging_registrations_practice_id_uq" ON "messaging_registrations" USING btree ("practice_id","id");--> statement-breakpoint
 ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_registration_tenant_fk" FOREIGN KEY ("practice_id","registration_id") REFERENCES "public"."messaging_registrations"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_location_tenant_fk" FOREIGN KEY ("practice_id","location_id") REFERENCES "public"."locations"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_actor_tenant_fk" FOREIGN KEY ("practice_id","actor_user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "messaging_registration_events_registration_history_idx" ON "messaging_registration_events" USING btree ("practice_id","registration_id","created_at","id");--> statement-breakpoint
 CREATE INDEX "messaging_registration_events_practice_time_idx" ON "messaging_registration_events" USING btree ("practice_id","created_at","id");--> statement-breakpoint
 CREATE UNIQUE INDEX "messaging_registration_events_operation_event_uq" ON "messaging_registration_events" USING btree ("practice_id","operation_id","event_type");--> statement-breakpoint
-CREATE UNIQUE INDEX "messaging_registrations_practice_id_uq" ON "messaging_registrations" USING btree ("practice_id","id");--> statement-breakpoint
 CREATE OR REPLACE FUNCTION validate_messaging_registration_event_insert()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/packages/db/drizzle/0065_sudden_kabuki.sql
+++ b/packages/db/drizzle/0065_sudden_kabuki.sql
@@ -1,0 +1,225 @@
+CREATE TYPE "public"."messaging_registration_actor_type" AS ENUM('clinic_user', 'platform_operator', 'system');--> statement-breakpoint
+CREATE TYPE "public"."messaging_registration_event_type" AS ENUM('details_saved', 'provider_operation_started', 'provider_operation_succeeded', 'provider_operation_failed', 'provider_state_observed', 'provider_ids_attached', 'stale_lock_cleared', 'provider_profile_enabled', 'provider_profile_disabled', 'provider_profile_verified');--> statement-breakpoint
+CREATE TYPE "public"."messaging_registration_operation" AS ENUM('registration_details', 'brand_submission', 'campaign_submission', 'number_assignment', 'registration_reconciliation', 'provider_id_recovery', 'submission_lock_recovery', 'profile_activation', 'profile_deactivation', 'profile_verification');--> statement-breakpoint
+CREATE TABLE "messaging_registration_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"registration_id" uuid NOT NULL,
+	"location_id" uuid,
+	"event_type" "messaging_registration_event_type" NOT NULL,
+	"operation" "messaging_registration_operation" NOT NULL,
+	"status_before" "messaging_registration_status",
+	"status_after" "messaging_registration_status" NOT NULL,
+	"provider" varchar(16) NOT NULL,
+	"provider_brand_id" varchar(128),
+	"provider_campaign_id" varchar(128),
+	"messaging_profile_id" varchar(128),
+	"provider_brand_status" varchar(64),
+	"provider_campaign_status" varchar(64),
+	"actor_type" "messaging_registration_actor_type" NOT NULL,
+	"actor_user_id" uuid,
+	"actor_identity" varchar(255),
+	"actor_name" varchar(255) NOT NULL,
+	"operation_id" uuid NOT NULL,
+	"reason_code" varchar(64) NOT NULL,
+	CONSTRAINT "messaging_registration_events_shape_check" CHECK ("messaging_registration_events"."provider" in ('telnyx', 'twilio')
+        and "messaging_registration_events"."reason_code" ~ '^[a-z0-9_]{3,64}$'
+        and "messaging_registration_events"."actor_name" = btrim("messaging_registration_events"."actor_name")
+        and length("messaging_registration_events"."actor_name") between 1 and 255
+        and (
+          ("messaging_registration_events"."actor_type" = 'clinic_user'
+            and "messaging_registration_events"."actor_user_id" is not null
+            and "messaging_registration_events"."actor_identity" is null)
+          or ("messaging_registration_events"."actor_type" = 'platform_operator'
+            and "messaging_registration_events"."actor_user_id" is null
+            and length(btrim(coalesce("messaging_registration_events"."actor_identity", ''))) between 1 and 255)
+          or ("messaging_registration_events"."actor_type" = 'system'
+            and "messaging_registration_events"."actor_user_id" is null
+            and "messaging_registration_events"."actor_identity" is null)
+        )
+        and ("messaging_registration_events"."provider_brand_id" is null or (
+          "messaging_registration_events"."provider_brand_id" = btrim("messaging_registration_events"."provider_brand_id")
+          and length("messaging_registration_events"."provider_brand_id") between 3 and 128))
+        and ("messaging_registration_events"."provider_campaign_id" is null or (
+          "messaging_registration_events"."provider_campaign_id" = btrim("messaging_registration_events"."provider_campaign_id")
+          and length("messaging_registration_events"."provider_campaign_id") between 3 and 128))
+        and ("messaging_registration_events"."messaging_profile_id" is null or (
+          "messaging_registration_events"."messaging_profile_id" = btrim("messaging_registration_events"."messaging_profile_id")
+          and length("messaging_registration_events"."messaging_profile_id") between 3 and 128))
+        and ("messaging_registration_events"."provider_brand_status" is null
+          or length("messaging_registration_events"."provider_brand_status") between 1 and 64)
+        and ("messaging_registration_events"."provider_campaign_status" is null
+          or length("messaging_registration_events"."provider_campaign_status") between 1 and 64)
+        and (
+          ("messaging_registration_events"."event_type" = 'details_saved'
+            and "messaging_registration_events"."operation" = 'registration_details')
+          or ("messaging_registration_events"."event_type" in (
+              'provider_operation_started',
+              'provider_operation_succeeded',
+              'provider_operation_failed'
+            ) and "messaging_registration_events"."operation" in (
+              'brand_submission',
+              'campaign_submission',
+              'number_assignment'
+            ))
+          or ("messaging_registration_events"."event_type" = 'provider_state_observed'
+            and "messaging_registration_events"."operation" in (
+              'brand_submission',
+              'campaign_submission',
+              'registration_reconciliation'
+            ))
+          or ("messaging_registration_events"."event_type" = 'provider_ids_attached'
+            and "messaging_registration_events"."operation" = 'provider_id_recovery')
+          or ("messaging_registration_events"."event_type" = 'stale_lock_cleared'
+            and "messaging_registration_events"."operation" = 'submission_lock_recovery')
+          or ("messaging_registration_events"."event_type" = 'provider_profile_enabled'
+            and "messaging_registration_events"."operation" = 'profile_activation'
+            and "messaging_registration_events"."location_id" is not null
+            and "messaging_registration_events"."messaging_profile_id" is not null)
+          or ("messaging_registration_events"."event_type" = 'provider_profile_disabled'
+            and "messaging_registration_events"."operation" = 'profile_deactivation'
+            and "messaging_registration_events"."location_id" is not null
+            and "messaging_registration_events"."messaging_profile_id" is not null)
+          or ("messaging_registration_events"."event_type" = 'provider_profile_verified'
+            and "messaging_registration_events"."operation" = 'profile_verification'
+            and "messaging_registration_events"."location_id" is not null
+            and "messaging_registration_events"."messaging_profile_id" is not null)
+        ))
+);
+--> statement-breakpoint
+ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_registration_id_messaging_registrations_id_fk" FOREIGN KEY ("registration_id") REFERENCES "public"."messaging_registrations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_location_id_locations_id_fk" FOREIGN KEY ("location_id") REFERENCES "public"."locations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_registration_tenant_fk" FOREIGN KEY ("practice_id","registration_id") REFERENCES "public"."messaging_registrations"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_location_tenant_fk" FOREIGN KEY ("practice_id","location_id") REFERENCES "public"."locations"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messaging_registration_events" ADD CONSTRAINT "messaging_registration_events_actor_tenant_fk" FOREIGN KEY ("practice_id","actor_user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "messaging_registration_events_registration_history_idx" ON "messaging_registration_events" USING btree ("practice_id","registration_id","created_at","id");--> statement-breakpoint
+CREATE INDEX "messaging_registration_events_practice_time_idx" ON "messaging_registration_events" USING btree ("practice_id","created_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "messaging_registration_events_operation_event_uq" ON "messaging_registration_events" USING btree ("practice_id","operation_id","event_type");--> statement-breakpoint
+CREATE UNIQUE INDEX "messaging_registrations_practice_id_uq" ON "messaging_registrations" USING btree ("practice_id","id");--> statement-breakpoint
+CREATE OR REPLACE FUNCTION validate_messaging_registration_event_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+	registration public.messaging_registrations%ROWTYPE;
+	latest_status public.messaging_registration_status;
+BEGIN
+	PERFORM pg_catalog.pg_advisory_xact_lock(
+		pg_catalog.hashtextextended(
+			'messaging-registration-event:' || NEW.practice_id::text || ':' || NEW.registration_id::text,
+			0
+		)
+	);
+
+	SELECT * INTO registration
+	FROM public.messaging_registrations
+	WHERE id = NEW.registration_id
+		AND practice_id = NEW.practice_id
+		AND deleted_at IS NULL
+	FOR KEY SHARE;
+
+	IF registration.id IS NULL
+		OR NEW.created_at > pg_catalog.now()
+		OR NEW.provider IS DISTINCT FROM registration.provider
+		OR NEW.status_after IS DISTINCT FROM registration.status
+		OR NEW.provider_brand_id IS DISTINCT FROM registration.provider_brand_id
+		OR NEW.provider_campaign_id IS DISTINCT FROM registration.provider_campaign_id
+		OR NEW.provider_brand_status IS DISTINCT FROM registration.provider_brand_status
+		OR NEW.provider_campaign_status IS DISTINCT FROM registration.provider_campaign_status
+	THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'Messaging registration event must match the exact active carrier projection.';
+	END IF;
+
+	IF NEW.location_id IS NOT NULL AND NOT EXISTS (
+		SELECT 1
+		FROM public.location_messaging AS sender
+		WHERE sender.practice_id = NEW.practice_id
+			AND sender.location_id = NEW.location_id
+			AND sender.provider = NEW.provider
+			AND sender.deleted_at IS NULL
+			AND (
+				NEW.messaging_profile_id IS NULL
+				OR sender.messaging_profile_id = NEW.messaging_profile_id
+			)
+	) THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'Messaging registration event location must match the exact active sender projection.';
+	END IF;
+
+	SELECT event.status_after INTO latest_status
+	FROM public.messaging_registration_events AS event
+	WHERE event.practice_id = NEW.practice_id
+		AND event.registration_id = NEW.registration_id
+	ORDER BY event.created_at DESC, event.id DESC
+	LIMIT 1;
+
+	IF FOUND AND NEW.status_before IS DISTINCT FROM latest_status THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'Messaging registration event must continue the durable carrier status chain.';
+	END IF;
+
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER messaging_registration_events_validate
+BEFORE INSERT ON messaging_registration_events
+FOR EACH ROW EXECUTE FUNCTION validate_messaging_registration_event_insert();--> statement-breakpoint
+CREATE OR REPLACE FUNCTION reject_messaging_registration_event_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+	IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+		AND current_user = (
+			SELECT pg_catalog.pg_get_userbyid(class.relowner)
+			FROM pg_catalog.pg_class AS class
+			JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = class.relnamespace
+			WHERE namespace.nspname = TG_TABLE_SCHEMA
+				AND class.relname = TG_TABLE_NAME
+		)
+	THEN
+		IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+		RETURN NEW;
+	END IF;
+
+	RAISE EXCEPTION USING
+		ERRCODE = '55000',
+		MESSAGE = 'Messaging registration events are append-only and cannot be updated or deleted.';
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER messaging_registration_events_immutable
+BEFORE UPDATE OR DELETE ON messaging_registration_events
+FOR EACH ROW EXECUTE FUNCTION reject_messaging_registration_event_mutation();--> statement-breakpoint
+ALTER TABLE messaging_registration_events ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY tenant_isolation ON messaging_registration_events
+	USING (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	)
+	WITH CHECK (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	);--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+		REVOKE ALL ON messaging_registration_events FROM openpims_app;
+		GRANT SELECT, INSERT ON messaging_registration_events TO openpims_app;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+		REVOKE ALL ON messaging_registration_events FROM anon;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+		REVOKE ALL ON messaging_registration_events FROM authenticated;
+	END IF;
+END
+$$;

--- a/packages/db/drizzle/meta/0065_snapshot.json
+++ b/packages/db/drizzle/meta/0065_snapshot.json
@@ -1,0 +1,18822 @@
+{
+  "id": "87fe31c4-a2d0-4d40-8f78-edceb10f2d87",
+  "prevId": "d709ad3f-b1e3-4ca2-8d8f-5d7dd551703f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": ["noted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": ["recorded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["source_patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["target_patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "source_patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "target_patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "performed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": ["type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": ["type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": ["doctor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": ["recurring_series_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": ["case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": ["primary_vet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["ordered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_completed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "ordered_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "reviewed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_assigned_to"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_completed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "author_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "author_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "finalized_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": ["administered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": ["recorded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_assigned_to"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_soap_source_uq": {
+          "name": "clinical_record_corrections_practice_record_soap_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["soap_note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": ["vital_sign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["vaccination_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": ["corrected_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "corrected_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": ["practice_id", "vital_sign_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["practice_id", "vaccination_record_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": ["correction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["source_lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["replacement_lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "source_lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "replacement_lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": ["practice_id", "id", "lab_result_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_note_replacements": {
+      "name": "soap_note_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_soap_note_id": {
+          "name": "source_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_soap_note_id": {
+          "name": "replacement_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_replacements_source_history_idx": {
+          "name": "soap_note_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_source_uq": {
+          "name": "soap_note_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_replacement_uq": {
+          "name": "soap_note_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_operation_uq": {
+          "name": "soap_note_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_replacements_practice_id_practices_id_fk": {
+          "name": "soap_note_replacements_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "soap_note_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": ["correction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_source_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["source_soap_note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["replacement_soap_note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_id_users_id_fk": {
+          "name": "soap_note_replacements_actor_id_users_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_tenant_fk": {
+          "name": "soap_note_replacements_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "source_soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_tenant_fk": {
+          "name": "soap_note_replacements_replacement_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "replacement_soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_source_tenant_fk": {
+          "name": "soap_note_replacements_correction_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": ["practice_id", "id", "soap_note_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_tenant_fk": {
+          "name": "soap_note_replacements_actor_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_replacements_shape_check": {
+          "name": "soap_note_replacements_shape_check",
+          "value": "\"soap_note_replacements\".\"source_soap_note_id\" <> \"soap_note_replacements\".\"replacement_soap_note_id\"\n        and \"soap_note_replacements\".\"actor_name\" = btrim(\"soap_note_replacements\".\"actor_name\")\n        and length(btrim(\"soap_note_replacements\".\"actor_name\")) between 1 and 255\n        and \"soap_note_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": ["prescribed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "prescription_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": ["practice_id", "product_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["source_prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": ["received_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": ["prescription_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": ["practice_id", "prescription_event_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "prescription_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": ["practice_id", "product_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_id", "invoice_item_id"],
+          "columnsTo": ["invoice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": ["witnessed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": ["event_id", "endpoint"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": ["attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": ["attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": ["original_webhook_id"],
+          "columnsTo": ["webhook_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["location_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_practice_id_uq": {
+          "name": "messaging_registrations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": ["compliance_attested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registration_events": {
+      "name": "messaging_registration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "messaging_registration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "messaging_registration_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "messaging_registration_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messaging_registration_events_registration_history_idx": {
+          "name": "messaging_registration_events_registration_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_practice_time_idx": {
+          "name": "messaging_registration_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_operation_event_uq": {
+          "name": "messaging_registration_events_operation_event_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registration_events_practice_id_practices_id_fk": {
+          "name": "messaging_registration_events_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_id_messaging_registrations_id_fk": {
+          "name": "messaging_registration_events_registration_id_messaging_registrations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": ["registration_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_id_locations_id_fk": {
+          "name": "messaging_registration_events_location_id_locations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_user_id_users_id_fk": {
+          "name": "messaging_registration_events_actor_user_id_users_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_tenant_fk": {
+          "name": "messaging_registration_events_registration_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": ["practice_id", "registration_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_tenant_fk": {
+          "name": "messaging_registration_events_location_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_tenant_fk": {
+          "name": "messaging_registration_events_actor_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registration_events_shape_check": {
+          "name": "messaging_registration_events_shape_check",
+          "value": "\"messaging_registration_events\".\"provider\" in ('telnyx', 'twilio')\n        and \"messaging_registration_events\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and \"messaging_registration_events\".\"actor_name\" = btrim(\"messaging_registration_events\".\"actor_name\")\n        and length(\"messaging_registration_events\".\"actor_name\") between 1 and 255\n        and (\n          (\"messaging_registration_events\".\"actor_type\" = 'clinic_user'\n            and \"messaging_registration_events\".\"actor_user_id\" is not null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n          or (\"messaging_registration_events\".\"actor_type\" = 'platform_operator'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and length(btrim(coalesce(\"messaging_registration_events\".\"actor_identity\", ''))) between 1 and 255)\n          or (\"messaging_registration_events\".\"actor_type\" = 'system'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n        )\n        and (\"messaging_registration_events\".\"provider_brand_id\" is null or (\n          \"messaging_registration_events\".\"provider_brand_id\" = btrim(\"messaging_registration_events\".\"provider_brand_id\")\n          and length(\"messaging_registration_events\".\"provider_brand_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_campaign_id\" is null or (\n          \"messaging_registration_events\".\"provider_campaign_id\" = btrim(\"messaging_registration_events\".\"provider_campaign_id\")\n          and length(\"messaging_registration_events\".\"provider_campaign_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"messaging_profile_id\" is null or (\n          \"messaging_registration_events\".\"messaging_profile_id\" = btrim(\"messaging_registration_events\".\"messaging_profile_id\")\n          and length(\"messaging_registration_events\".\"messaging_profile_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_brand_status\" is null\n          or length(\"messaging_registration_events\".\"provider_brand_status\") between 1 and 64)\n        and (\"messaging_registration_events\".\"provider_campaign_status\" is null\n          or length(\"messaging_registration_events\".\"provider_campaign_status\") between 1 and 64)\n        and (\n          (\"messaging_registration_events\".\"event_type\" = 'details_saved'\n            and \"messaging_registration_events\".\"operation\" = 'registration_details')\n          or (\"messaging_registration_events\".\"event_type\" in (\n              'provider_operation_started',\n              'provider_operation_succeeded',\n              'provider_operation_failed'\n            ) and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'number_assignment'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_state_observed'\n            and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'registration_reconciliation'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_ids_attached'\n            and \"messaging_registration_events\".\"operation\" = 'provider_id_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'stale_lock_cleared'\n            and \"messaging_registration_events\".\"operation\" = 'submission_lock_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_enabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_activation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_disabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_deactivation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_verified'\n            and \"messaging_registration_events\".\"operation\" = 'profile_verification'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": ["delivery_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": ["communication_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": ["practice_id", "communication_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": ["delivery_event_id", "reviewed_history_id"],
+          "columnsTo": ["delivery_event_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": ["communication_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "resend_of_attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": ["practice_id", "communication_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "requested_by_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": ["practice_id", "milestone"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["committed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["follow_up_appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["clinical_finalized_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["completed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["follow_up_resolution_appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["vaccination_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": ["procedure_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "appointment_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": ["practice_id", "appointment_id", "procedure_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "appointment_id", "prescription_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["practice_id", "appointment_id", "invoice_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_id", "invoice_item_id"],
+          "columnsTo": ["invoice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "veterinarian", "technician", "front_desk", "viewer"]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": ["phone", "email", "sms", "portal"]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": ["mild", "moderate", "severe"]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": ["active", "inactive", "deceased"]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": ["male", "female", "male_neutered", "female_spayed"]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": ["weekly", "monthly", "annual"]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": ["exam", "surgery", "treatment", "boarding"]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": ["waiting", "scheduled", "cancelled"]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": ["open", "closed"]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": ["not_required", "open", "completed"]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": ["unknown", "normal", "abnormal", "critical"]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": ["pending", "completed", "reviewed"]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": ["general", "follow_up", "phone_call"]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": ["active", "resolved", "chronic"]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": ["draft", "finalized"]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": ["pending", "in_progress", "done", "skipped"]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": ["active", "completed", "discontinued"]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": ["entered_in_error"]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": ["soap_note", "vital_sign", "vaccination_record", "lab_result"]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": ["minor", "moderate", "major"]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": ["active", "completed", "cancelled", "expired"]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": ["credit", "write_off"]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": ["service", "product"]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": ["draft", "sent", "paid", "overdue", "void"]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": ["pending", "active", "action_required", "disabled"]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": ["draft", "ordered", "received"]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": ["pending", "invoiced", "waived"]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": ["phone", "sms", "email", "portal"]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": ["pending", "sent", "delivered", "read", "failed"]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": ["inbound", "outbound"]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": ["received", "administered", "wasted", "returned"]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": ["monthly", "annual"]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": ["active", "cancelled"]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": ["reserved", "accepted", "definite_failure", "outcome_unknown"]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": ["registration", "authenticated_resend"]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": ["manual", "bounce", "complaint", "suppressed"]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": ["PRIVATE_PROFIT", "NON_PROFIT"]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": ["hosted", "purchased", "toll_free"]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": ["stop", "manual", "bounce", "complaint"]
+    },
+    "public.messaging_registration_actor_type": {
+      "name": "messaging_registration_actor_type",
+      "schema": "public",
+      "values": ["clinic_user", "platform_operator", "system"]
+    },
+    "public.messaging_registration_event_type": {
+      "name": "messaging_registration_event_type",
+      "schema": "public",
+      "values": [
+        "details_saved",
+        "provider_operation_started",
+        "provider_operation_succeeded",
+        "provider_operation_failed",
+        "provider_state_observed",
+        "provider_ids_attached",
+        "stale_lock_cleared",
+        "provider_profile_enabled",
+        "provider_profile_disabled",
+        "provider_profile_verified"
+      ]
+    },
+    "public.messaging_registration_operation": {
+      "name": "messaging_registration_operation",
+      "schema": "public",
+      "values": [
+        "registration_details",
+        "brand_submission",
+        "campaign_submission",
+        "number_assignment",
+        "registration_reconciliation",
+        "provider_id_recovery",
+        "submission_lock_recovery",
+        "profile_activation",
+        "profile_deactivation",
+        "profile_verification"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": ["granted", "revoked"]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": ["staff", "client", "system"]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": ["unknown", "sent", "failed", "delivered"]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": ["automatic", "operator_reconciliation"]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": ["clinic_user", "platform_operator"]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": ["provider_result", "reconciliation"]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": ["accepted", "definite_failure", "outcome_unknown"]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": ["practice_created", "product_records", "stripe_webhook"]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": ["clients", "patients", "vaccinations", "soap_notes"]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": ["previewed", "superseded", "committing", "committed"]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": ["paid", "accounts_receivable", "no_charge"]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": ["draft", "clinical_finalized", "completed"]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": ["none", "needed", "scheduled"]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": ["scheduled", "completed", "not_needed"]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": ["print", "verbal", "declined"]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": ["prescribed", "not_needed"]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": ["unresolved", "charged", "no_charge", "voided"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1786307112561,
       "tag": "0064_rainy_spacker_dave",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1786312581327,
+      "tag": "0065_sudden_kabuki",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -6,6 +6,7 @@ import { db } from "./client";
 // Order doesn't matter with CASCADE, but we TRUNCATE every table the seed touches.
 // RESTART IDENTITY resets any serial sequences (none in this schema, but cheap).
 const TABLES = [
+  "messaging_registration_events",
   // Core / leaf tables first (purely defensive — CASCADE handles it)
   "audit_log",
   "rate_limit_buckets",

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -53,7 +53,7 @@ DECLARE
   tbls text[] := array[
     'api_keys','appointment_types','appointment_waitlist','appointments','audit_log','booking_pages',
     'capture_sessions','cases','clients','clinical_notes','clinical_record_corrections','communications','consent_forms','consent_requests','controlled_substance_log','dispense_charge_queue','email_suppressions',
-    'files','insurance_claims','insurance_policies','invoices','lab_result_events','lab_result_replacements','lab_results','location_messaging','messaging_registrations','migration_runs',
+    'files','insurance_claims','insurance_policies','invoices','lab_result_events','lab_result_replacements','lab_results','location_messaging','messaging_registration_events','messaging_registrations','migration_runs',
     'locations','patient_merge_events','patients','practice_payment_accounts','prescription_events','prescriptions','problem_list','procedures','products','purchase_orders',
     'recurring_series','rooms','services','sms_consent_events','sms_send_attempt_events','sms_send_attempts','sms_suppressions','soap_note_addenda','soap_note_replacements','soap_notes','staff_schedules','suppliers',
     'treatment_plans','treatment_templates','usage_records','users','vaccination_records',
@@ -105,6 +105,10 @@ REVOKE ALL ON soap_note_replacements FROM openpims_app;
 GRANT SELECT, INSERT ON soap_note_replacements TO openpims_app;
 REVOKE ALL ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) TO openpims_app;
+
+-- Carrier registration events are PHI-free, append-only lifecycle evidence.
+REVOKE ALL ON messaging_registration_events FROM openpims_app;
+GRANT SELECT, INSERT ON messaging_registration_events TO openpims_app;
 
 -- Patient merge events are an append-only identity correction ledger. The app
 -- can create and read attributed events but cannot rewrite or remove lineage.
@@ -294,7 +298,7 @@ BEGIN
   FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
       EXECUTE format(
-        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
+        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, messaging_registration_events, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
       );
     END IF;
   END LOOP;

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -25,6 +25,7 @@ export * from "./usage";
 export * from "./auth-tokens";
 export * from "./auth-email-observability";
 export * from "./messaging";
+export * from "./messaging-registration-events";
 export * from "./sms-consent-events";
 export * from "./sms-send-attempts";
 export * from "./demo-access";

--- a/packages/db/schema/messaging-registration-events.ts
+++ b/packages/db/schema/messaging-registration-events.ts
@@ -1,0 +1,213 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  pgEnum,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import {
+  messagingRegistrations,
+  messagingRegistrationStatusEnum,
+} from "./messaging";
+import { locations, practices } from "./practices";
+import { users } from "./users";
+
+export const messagingRegistrationEventTypeEnum = pgEnum(
+  "messaging_registration_event_type",
+  [
+    "details_saved",
+    "provider_operation_started",
+    "provider_operation_succeeded",
+    "provider_operation_failed",
+    "provider_state_observed",
+    "provider_ids_attached",
+    "stale_lock_cleared",
+    "provider_profile_enabled",
+    "provider_profile_disabled",
+    "provider_profile_verified",
+  ],
+);
+
+export const messagingRegistrationOperationEnum = pgEnum(
+  "messaging_registration_operation",
+  [
+    "registration_details",
+    "brand_submission",
+    "campaign_submission",
+    "number_assignment",
+    "registration_reconciliation",
+    "provider_id_recovery",
+    "submission_lock_recovery",
+    "profile_activation",
+    "profile_deactivation",
+    "profile_verification",
+  ],
+);
+
+export const messagingRegistrationActorTypeEnum = pgEnum(
+  "messaging_registration_actor_type",
+  ["clinic_user", "platform_operator", "system"],
+);
+
+/**
+ * Append-only, PHI-free carrier-registration evidence. The mutable registration
+ * row remains the current-state projection; this table records how it changed
+ * and which bounded operator action caused a provider mutation.
+ *
+ * Deliberately absent: tax identifiers, clinic contact/address fields, client or
+ * patient identifiers, free-form provider payloads, and provider error bodies.
+ */
+export const messagingRegistrationEvents = pgTable(
+  "messaging_registration_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    registrationId: uuid("registration_id")
+      .notNull()
+      .references(() => messagingRegistrations.id),
+    locationId: uuid("location_id").references(() => locations.id),
+    eventType: messagingRegistrationEventTypeEnum("event_type").notNull(),
+    operation: messagingRegistrationOperationEnum("operation").notNull(),
+    statusBefore: messagingRegistrationStatusEnum("status_before"),
+    statusAfter: messagingRegistrationStatusEnum("status_after").notNull(),
+    provider: varchar("provider", { length: 16 }).notNull(),
+    providerBrandId: varchar("provider_brand_id", { length: 128 }),
+    providerCampaignId: varchar("provider_campaign_id", { length: 128 }),
+    messagingProfileId: varchar("messaging_profile_id", { length: 128 }),
+    providerBrandStatus: varchar("provider_brand_status", { length: 64 }),
+    providerCampaignStatus: varchar("provider_campaign_status", { length: 64 }),
+    actorType: messagingRegistrationActorTypeEnum("actor_type").notNull(),
+    actorUserId: uuid("actor_user_id").references(() => users.id),
+    actorIdentity: varchar("actor_identity", { length: 255 }),
+    actorName: varchar("actor_name", { length: 255 }).notNull(),
+    operationId: uuid("operation_id").notNull(),
+    reasonCode: varchar("reason_code", { length: 64 }).notNull(),
+  },
+  (table) => ({
+    registrationHistoryIdx: index(
+      "messaging_registration_events_registration_history_idx",
+    ).on(table.practiceId, table.registrationId, table.createdAt, table.id),
+    practiceTimeIdx: index(
+      "messaging_registration_events_practice_time_idx",
+    ).on(table.practiceId, table.createdAt, table.id),
+    operationEventUq: uniqueIndex(
+      "messaging_registration_events_operation_event_uq",
+    ).on(table.practiceId, table.operationId, table.eventType),
+    registrationTenantFk: foreignKey({
+      columns: [table.practiceId, table.registrationId],
+      foreignColumns: [
+        messagingRegistrations.practiceId,
+        messagingRegistrations.id,
+      ],
+      name: "messaging_registration_events_registration_tenant_fk",
+    }),
+    locationTenantFk: foreignKey({
+      columns: [table.practiceId, table.locationId],
+      foreignColumns: [locations.practiceId, locations.id],
+      name: "messaging_registration_events_location_tenant_fk",
+    }),
+    actorTenantFk: foreignKey({
+      columns: [table.practiceId, table.actorUserId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "messaging_registration_events_actor_tenant_fk",
+    }),
+    shapeCheck: check(
+      "messaging_registration_events_shape_check",
+      sql`${table.provider} in ('telnyx', 'twilio')
+        and ${table.reasonCode} ~ '^[a-z0-9_]{3,64}$'
+        and ${table.actorName} = btrim(${table.actorName})
+        and length(${table.actorName}) between 1 and 255
+        and (
+          (${table.actorType} = 'clinic_user'
+            and ${table.actorUserId} is not null
+            and ${table.actorIdentity} is null)
+          or (${table.actorType} = 'platform_operator'
+            and ${table.actorUserId} is null
+            and length(btrim(coalesce(${table.actorIdentity}, ''))) between 1 and 255)
+          or (${table.actorType} = 'system'
+            and ${table.actorUserId} is null
+            and ${table.actorIdentity} is null)
+        )
+        and (${table.providerBrandId} is null or (
+          ${table.providerBrandId} = btrim(${table.providerBrandId})
+          and length(${table.providerBrandId}) between 3 and 128))
+        and (${table.providerCampaignId} is null or (
+          ${table.providerCampaignId} = btrim(${table.providerCampaignId})
+          and length(${table.providerCampaignId}) between 3 and 128))
+        and (${table.messagingProfileId} is null or (
+          ${table.messagingProfileId} = btrim(${table.messagingProfileId})
+          and length(${table.messagingProfileId}) between 3 and 128))
+        and (${table.providerBrandStatus} is null
+          or length(${table.providerBrandStatus}) between 1 and 64)
+        and (${table.providerCampaignStatus} is null
+          or length(${table.providerCampaignStatus}) between 1 and 64)
+        and (
+          (${table.eventType} = 'details_saved'
+            and ${table.operation} = 'registration_details')
+          or (${table.eventType} in (
+              'provider_operation_started',
+              'provider_operation_succeeded',
+              'provider_operation_failed'
+            ) and ${table.operation} in (
+              'brand_submission',
+              'campaign_submission',
+              'number_assignment'
+            ))
+          or (${table.eventType} = 'provider_state_observed'
+            and ${table.operation} in (
+              'brand_submission',
+              'campaign_submission',
+              'registration_reconciliation'
+            ))
+          or (${table.eventType} = 'provider_ids_attached'
+            and ${table.operation} = 'provider_id_recovery')
+          or (${table.eventType} = 'stale_lock_cleared'
+            and ${table.operation} = 'submission_lock_recovery')
+          or (${table.eventType} = 'provider_profile_enabled'
+            and ${table.operation} = 'profile_activation'
+            and ${table.locationId} is not null
+            and ${table.messagingProfileId} is not null)
+          or (${table.eventType} = 'provider_profile_disabled'
+            and ${table.operation} = 'profile_deactivation'
+            and ${table.locationId} is not null
+            and ${table.messagingProfileId} is not null)
+          or (${table.eventType} = 'provider_profile_verified'
+            and ${table.operation} = 'profile_verification'
+            and ${table.locationId} is not null
+            and ${table.messagingProfileId} is not null)
+        )`,
+    ),
+  }),
+);
+
+export const messagingRegistrationEventsRelations = relations(
+  messagingRegistrationEvents,
+  ({ one }) => ({
+    practice: one(practices, {
+      fields: [messagingRegistrationEvents.practiceId],
+      references: [practices.id],
+    }),
+    registration: one(messagingRegistrations, {
+      fields: [messagingRegistrationEvents.registrationId],
+      references: [messagingRegistrations.id],
+    }),
+    location: one(locations, {
+      fields: [messagingRegistrationEvents.locationId],
+      references: [locations.id],
+    }),
+    actor: one(users, {
+      fields: [messagingRegistrationEvents.actorUserId],
+      references: [users.id],
+    }),
+  }),
+);

--- a/packages/db/schema/messaging.ts
+++ b/packages/db/schema/messaging.ts
@@ -102,6 +102,10 @@ export const messagingRegistrations = pgTable(
     practiceIdx: uniqueIndex("messaging_registrations_practice_idx").on(
       t.practiceId,
     ),
+    practiceIdUq: uniqueIndex("messaging_registrations_practice_id_uq").on(
+      t.practiceId,
+      t.id,
+    ),
     statusIdx: index("messaging_registrations_status_idx").on(
       t.status,
       t.updatedAt,


### PR DESCRIPTION
## Why

Hosted texting was the largest remaining gap between a strong demo and a clinic-ready pilot. This release makes first-clinic activation observable, recoverable, consent-safe, and fail-closed while keeping carrier provisioning and sending disabled until an explicitly scoped pilot is ready.

## What changed

- adds rollout-aware SMS health checks for exact pilot practice/location scopes, structurally valid Telnyx credentials, hosted RLS system context, and carrier-ready database state
- adds explicit SMS reminder preference with validated phone and complete consent evidence
- adds a platform-admin recovery console for bounded failure/reconciliation queues and safe, explicit retry/recovery actions
- adds a PHI-free append-only carrier registration event ledger, RLS policy, migration, and redacted history
- hardens provider webhook replay idempotency, conflicting provider-identity quarantine, tenant isolation, and compare-and-set lifecycle transitions
- adds submission-lock and provider-observation race protection
- documents the staged activation and production health gates

## Safety

- no participant/private data or secrets
- no carrier number purchase, registration submission, real SMS, or spend
- production provisioning and sending remain disabled
- provider identifiers and operational evidence are redacted at the server boundary
- independent adversarial review: MERGE, no remaining P0/P1 findings

## Verification

- forced full test run: 3,306 passed; 1 intentionally skipped integration test
- forced production build: 43 routes generated successfully
- web and database typechecks passed
- 31 health tests and 28 Telnyx webhook tests passed
- Prettier check passed for supported changed file types
- `git diff --check` passed
- staged Gitleaks scan found no leaks