### PR TITLE
Make pay-later checkout create receivables

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/billing/policy";
 import { centsToMoney, moneyToCents } from "@/lib/billing/invoice-balance";
 import { tryCalculateInvoiceTaxTotals } from "@/lib/billing/invoice-tax";
+import { formatDateInputForTimeZone } from "@/lib/date-input";
 import { ServicePicker } from "@/components/billing/service-picker";
 import { CapturePhotos } from "@/components/records/capture-photos";
 import { ConsentSign } from "@/components/records/consent-sign";
@@ -142,6 +143,24 @@ function formatAppointmentTime(
       minute: "2-digit",
     });
   }
+}
+
+function addDateInputDays(value: string, days: number): string {
+  const [year, month, day] = value.split("-").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(
+    2,
+    "0",
+  )}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+function defaultPayLaterDueDate(timeZone?: string | null): string {
+  const today = formatDateInputForTimeZone(new Date(), timeZone);
+  return addDateInputDays(today, 30);
 }
 
 function formatClinicDate(value: string): string {
@@ -562,7 +581,9 @@ function VisitCloseout({
   const utils = trpc.useUtils();
   const data = closeoutQuery.data;
   const closeout = data?.closeout ?? null;
+  const activeInvoice = data?.invoices[0] ?? null;
   const hydratedRevision = useRef<string | null>(null);
+  const hydratedInvoice = useRef<string | null>(null);
   const [diagnosisSummary, setDiagnosisSummary] = useState("");
   const [dischargeInstructions, setDischargeInstructions] = useState("");
   const [warningSigns, setWarningSigns] = useState("");
@@ -583,6 +604,7 @@ function VisitCloseout({
     "" | "paid" | "accounts_receivable" | "no_charge"
   >("");
   const [noChargeReason, setNoChargeReason] = useState("");
+  const [invoiceDueDate, setInvoiceDueDate] = useState("");
   const [handoffMethod, setHandoffMethod] = useState<
     "" | "print" | "verbal" | "declined"
   >("");
@@ -617,11 +639,28 @@ function VisitCloseout({
     hydratedRevision.current = key;
   }, [closeout, data]);
 
+  useEffect(() => {
+    if (!data) return;
+    const key = activeInvoice
+      ? `${activeInvoice.id}:${activeInvoice.dueDate ?? "unscheduled"}`
+      : "no-invoice";
+    if (hydratedInvoice.current === key) return;
+    setInvoiceDueDate(
+      activeInvoice?.dueDate ?? defaultPayLaterDueDate(data.practice.timezone),
+    );
+    hydratedInvoice.current = key;
+  }, [activeInvoice, data]);
+
   const refresh = async () => {
     await Promise.all([
       utils.encounters.getCloseout.invalidate({ appointmentId }),
       utils.appointments.getById.invalidate({ id: appointmentId }),
       utils.appointments.list.invalidate(),
+      utils.billing.listInvoices.invalidate({
+        appointmentId,
+        limit: 25,
+        offset: 0,
+      }),
       utils.whiteboard.getActive.invalidate(),
     ]);
   };
@@ -697,7 +736,6 @@ function VisitCloseout({
     followUpAssignedTo: followUpAssignedTo || null,
     documentationExceptionReason: documentationExceptionReason || null,
   } as const;
-  const activeInvoice = data?.invoices[0] ?? null;
   const clientName = [appointment.clientFirstName, appointment.clientLastName]
     .filter(Boolean)
     .join(" ");
@@ -1244,6 +1282,12 @@ function VisitCloseout({
             activeInvoice={activeInvoice}
             chargeDisposition={chargeDisposition}
             setChargeDisposition={setChargeDisposition}
+            invoiceDueDate={invoiceDueDate}
+            setInvoiceDueDate={setInvoiceDueDate}
+            minimumDueDate={formatDateInputForTimeZone(
+              new Date(),
+              data.practice.timezone,
+            )}
             noChargeReason={noChargeReason}
             setNoChargeReason={setNoChargeReason}
             handoffMethod={handoffMethod}
@@ -1259,6 +1303,10 @@ function VisitCloseout({
                 noChargeReason:
                   chargeDisposition === "no_charge"
                     ? noChargeReason || null
+                    : null,
+                invoiceDueDate:
+                  chargeDisposition === "accounts_receivable"
+                    ? invoiceDueDate
                     : null,
                 handoffMethod,
               });
@@ -1869,6 +1917,9 @@ function OperationalCloseoutForm({
   activeInvoice,
   chargeDisposition,
   setChargeDisposition,
+  invoiceDueDate,
+  setInvoiceDueDate,
+  minimumDueDate,
   noChargeReason,
   setNoChargeReason,
   handoffMethod,
@@ -1888,6 +1939,9 @@ function OperationalCloseoutForm({
   setChargeDisposition: (
     value: "" | "paid" | "accounts_receivable" | "no_charge",
   ) => void;
+  invoiceDueDate: string;
+  setInvoiceDueDate: (value: string) => void;
+  minimumDueDate: string;
   noChargeReason: string;
   setNoChargeReason: (value: string) => void;
   handoffMethod: "" | "print" | "verbal" | "declined";
@@ -1905,8 +1959,9 @@ function OperationalCloseoutForm({
   const accountsReceivableReady = Boolean(
     activeInvoice &&
     activeInvoice.itemCount > 0 &&
-    (activeInvoice.status === "sent" || activeInvoice.status === "overdue") &&
-    activeInvoice.dueDate &&
+    ["draft", "sent", "overdue"].includes(activeInvoice.status) &&
+    invoiceDueDate &&
+    invoiceDueDate >= minimumDueDate &&
     activeInvoice.balanceDueCents > 0,
   );
   const noChargeReady = !activeInvoice;
@@ -1954,7 +2009,7 @@ function OperationalCloseoutForm({
               value="accounts_receivable"
               disabled={!accountsReceivableReady}
             >
-              Pay later — sent with due date
+              Pay later — present with due date
             </option>
             <option value="no_charge" disabled={!noChargeReady}>
               No charge for this visit{noChargeReady ? "" : " — invoice exists"}
@@ -1993,6 +2048,26 @@ function OperationalCloseoutForm({
           />
         </div>
       ) : null}
+      {chargeDisposition === "accounts_receivable" ? (
+        <div className="rounded-md border border-blue-500/30 bg-blue-500/5 p-3">
+          <label className="text-sm font-medium" htmlFor="closeout-invoice-due-date">
+            Payment due date
+          </label>
+          <Input
+            id="closeout-invoice-due-date"
+            type="date"
+            min={minimumDueDate}
+            value={invoiceDueDate}
+            onChange={(event) => setInvoiceDueDate(event.target.value)}
+            className="mt-1 max-w-xs"
+          />
+          <p className="mt-2 text-xs text-muted-foreground">
+            Completing the visit will present this invoice, preserve its open
+            balance, and place it in accounts receivable. This does not charge a
+            card or send an email automatically.
+          </p>
+        </div>
+      ) : null}
       {activeInvoice ? (
         <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
           Invoice is <strong>{activeInvoice.status}</strong>, has{" "}
@@ -2003,7 +2078,7 @@ function OperationalCloseoutForm({
             ? "Ready for paid checkout. "
             : accountsReceivableReady
               ? "Ready for accounts-receivable checkout. "
-              : "Resolve the invoice status, balance, and due date before checkout. "}
+              : "Save charges and choose a valid due date before checkout. "}
           <Button variant="link" size="sm" asChild className="h-auto p-0">
             <Link href={`/billing?expand=${activeInvoice.id}`}>
               Open billing

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -178,6 +178,10 @@ describe("clinic encounter workspace", () => {
     expect(workspaceSource).toContain("Finalize clinical handoff");
     expect(workspaceSource).toContain("Billing and owner handoff");
     expect(workspaceSource).toContain("Download discharge");
+    expect(workspaceSource).toContain("defaultPayLaterDueDate");
+    expect(workspaceSource).toContain('type="date"');
+    expect(workspaceSource).toContain("Pay later — present with due date");
+    expect(workspaceSource).toContain("invoiceDueDate:");
     expect(workspaceSource).not.toContain(
       'return { label: "Check out", status: "checked_out" }',
     );

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -97,6 +97,7 @@ const openAppointment = {
   patientId: PATIENT_ID,
   clientId: CLIENT_ID,
   requiresDoctor: 1,
+  practiceTimezone: "America/Denver",
 };
 
 const clinicalFinalized = {
@@ -425,30 +426,15 @@ describe("encounter closeout safety", () => {
     expect(updateSet).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      label: "paid",
-      chargeDisposition: "paid" as const,
-      invoice: {
-        id: INVOICE_ID,
-        status: "paid",
-        total: "100.00",
-        paidAmount: "100.00",
-        dueDate: null,
-      },
-    },
-    {
-      label: "accounts receivable",
-      chargeDisposition: "accounts_receivable" as const,
-      invoice: {
-        id: INVOICE_ID,
-        status: "sent",
-        total: "100.00",
-        paidAmount: "0.00",
-        dueDate: "2026-09-01",
-      },
-    },
-  ])("completes a verified $label visit", async ({ chargeDisposition, invoice }) => {
+  it("completes a verified paid visit", async () => {
+    const chargeDisposition = "paid" as const;
+    const invoice = {
+      id: INVOICE_ID,
+      status: "paid",
+      total: "100.00",
+      paidAmount: "100.00",
+      dueDate: null,
+    };
     const completed = {
       ...clinicalFinalized,
       status: "completed",
@@ -487,6 +473,151 @@ describe("encounter closeout safety", () => {
         invoiceId: INVOICE_ID,
       })
     );
+  });
+
+  it("presents a draft invoice with a due date while completing pay later", async () => {
+    const invoiceDueDate = "2099-09-01";
+    const completed = {
+      ...clinicalFinalized,
+      status: "completed",
+      revision: 3,
+      chargeDisposition: "accounts_receivable",
+      invoiceId: INVOICE_ID,
+      handoffMethod: "print",
+    };
+    const checkedOut = { ...openAppointment, status: "checked_out" };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [clinicalFinalized],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            total: "100.00",
+            paidAmount: "0.00",
+            dueDate: null,
+          },
+        ],
+        [{ itemCount: 1 }],
+        [{ adjustedAmount: "0" }],
+      ],
+      updateResults: [[{ id: INVOICE_ID }], [completed], [checkedOut]],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition: "accounts_receivable",
+        noChargeReason: null,
+        invoiceDueDate,
+        handoffMethod: "print",
+      }),
+    ).resolves.toEqual({ closeout: completed, appointment: checkedOut });
+    expect(updateSet).toHaveBeenNthCalledWith(1, {
+      status: "sent",
+      dueDate: invoiceDueDate,
+    });
+    expect(updateSet).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        status: "completed",
+        chargeDisposition: "accounts_receivable",
+        invoiceId: INVOICE_ID,
+      }),
+    );
+  });
+
+  it("requires a current or future due date for pay-later checkout", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [clinicalFinalized],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            total: "100.00",
+            paidAmount: "0.00",
+            dueDate: null,
+          },
+        ],
+        [{ itemCount: 1 }],
+        [{ adjustedAmount: "0" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition: "accounts_receivable",
+        noChargeReason: null,
+        invoiceDueDate: "2000-01-01",
+        handoffMethod: "print",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Choose today or a future invoice due date.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit due date before reading pay-later visit state", async () => {
+    const { db, select, updateSet } = createDb({});
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition: "accounts_receivable",
+        noChargeReason: null,
+        handoffMethod: "print",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not complete when invoice presentation loses its race", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [clinicalFinalized],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            total: "100.00",
+            paidAmount: "0.00",
+            dueDate: null,
+          },
+        ],
+        [{ itemCount: 1 }],
+        [{ adjustedAmount: "0" }],
+      ],
+      updateResults: [[]],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition: "accounts_receivable",
+        noChargeReason: null,
+        invoiceDueDate: "2099-09-01",
+        handoffMethod: "print",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message:
+        "Invoice changed while preparing pay later. Refresh and retry.",
+    });
+    expect(updateSet).toHaveBeenCalledTimes(1);
   });
 
   it("requires a linked SOAP note or an attributable exception", async () => {

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -190,6 +190,7 @@ const completeVisitInput = z
     expectedRevision: z.number().int().min(1),
     chargeDisposition: z.enum(["paid", "accounts_receivable", "no_charge"]),
     noChargeReason: optionalText("No-charge reason", CLOSEOUT_REASON_MAX_LENGTH),
+    invoiceDueDate: clinicalDateInput("Invoice due date").nullish(),
     handoffMethod: z.enum(["print", "verbal", "declined"]),
   })
   .superRefine((input, ctx) => {
@@ -205,6 +206,26 @@ const completeVisitInput = z
         code: z.ZodIssueCode.custom,
         path: ["noChargeReason"],
         message: "A no-charge reason is only used for no-charge visits.",
+      });
+    }
+    if (
+      input.chargeDisposition === "accounts_receivable" &&
+      !input.invoiceDueDate
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["invoiceDueDate"],
+        message: "Choose when the pay-later invoice is due.",
+      });
+    }
+    if (
+      input.chargeDisposition !== "accounts_receivable" &&
+      input.invoiceDueDate
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["invoiceDueDate"],
+        message: "An invoice due date is only used for pay-later visits.",
       });
     }
   });
@@ -2341,16 +2362,57 @@ export const encountersRouter = createRouter({
           }
           if (
             input.chargeDisposition === "accounts_receivable" &&
-            (!["sent", "overdue"].includes(invoice.status) ||
-              !invoice.dueDate ||
+            (!["draft", "sent", "overdue"].includes(invoice.status) ||
               invoice.balanceDueCents <= 0)
           ) {
             throw new TRPCError({
               code: "PRECONDITION_FAILED",
-              message: "Pay-later visits need a sent invoice, due date, and open balance.",
+              message: "Pay-later visits need an unpaid invoice with saved charges.",
             });
           }
-          invoiceId = invoice.id;
+          if (input.chargeDisposition === "accounts_receivable") {
+            const invoiceDueDate = input.invoiceDueDate!;
+            const practiceToday = formatDateInputForTimeZone(
+              new Date(),
+              appointment.practiceTimezone
+            );
+            if (invoiceDueDate < practiceToday) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Choose today or a future invoice due date.",
+              });
+            }
+
+            const [presentedInvoice] = await tx
+              .update(invoices)
+              .set({ status: "sent", dueDate: invoiceDueDate })
+              .where(
+                and(
+                  eq(invoices.id, invoice.id),
+                  eq(invoices.practiceId, ctx.practiceId),
+                  eq(invoices.appointmentId, input.appointmentId),
+                  eq(invoices.patientId, appointment.patientId),
+                  eq(invoices.clientId, appointment.clientId),
+                  eq(invoices.status, invoice.status),
+                  invoice.dueDate
+                    ? eq(invoices.dueDate, invoice.dueDate)
+                    : isNull(invoices.dueDate),
+                  eq(invoices.isEstimate, false),
+                  isNull(invoices.deletedAt)
+                )
+              )
+              .returning({ id: invoices.id });
+            if (!presentedInvoice) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message:
+                  "Invoice changed while preparing pay later. Refresh and retry.",
+              });
+            }
+            invoiceId = presentedInvoice.id;
+          } else {
+            invoiceId = invoice.id;
+          }
         }
 
         const now = new Date();


### PR DESCRIPTION
## Outcome

Turns the encounter Pay Later choice into a complete accounts-receivable workflow instead of a dead end.

- allows an unpaid draft invoice with saved charges to be presented at checkout
- requires a clinic-timezone due date and defaults it to 30 days in the UI
- atomically presents the invoice and completes the visit under the existing appointment lock
- fails closed on stale invoice state, missing/past due dates, or concurrent changes
- makes clear that checkout does not charge a card or send an email automatically
- refreshes billing state after completion

## Verification

- `pnpm test` — 3,315 passed, 1 provider-dependent integration test skipped
- `pnpm build`
- web typecheck
- focused billing/closeout suite — 108 passed
- `git diff --check`
- changed-file secret scan