### PR TITLE
Redact client error telemetry

### DIFF
--- a/apps/web/app/api/error-report/route.test.ts
+++ b/apps/web/app/api/error-report/route.test.ts
@@ -88,8 +88,9 @@ describe("POST /api/error-report", () => {
       request(
         {
           source: "app-error",
-          message: "boom",
-          stack: "stack",
+          errorFamily: "TypeError",
+          message: "Patient Daisy failed to save",
+          stack: "Patient Daisy at /patients/private-record",
           digest: "digest",
           path: "/patients/323e4567-e89b-42d3-a456-426614174000?tab=records",
           anonymousId: "123e4567-e89b-42d3-a456-426614174000",
@@ -107,10 +108,10 @@ describe("POST /api/error-report", () => {
     });
     expect(mocks.captureException).toHaveBeenCalledWith({
       source: "app-error",
-      message: "boom",
-      stack: "stack",
+      message: "TypeError in client renderer",
+      stack: null,
       digest: "digest",
-      path: "/patients/323e4567-e89b-42d3-a456-426614174000?tab=records",
+      path: "/patients/:id",
     });
     expect(mocks.insertFunnelEvent).toHaveBeenCalledWith(
       {},
@@ -119,8 +120,11 @@ describe("POST /api/error-report", () => {
         anonymousId: "123e4567-e89b-42d3-a456-426614174000",
         source: "app-error",
         path: "/patients/:id",
-        metadata: { digest: "digest" },
+        metadata: { errorFamily: "TypeError", digest: "digest" },
       }
+    );
+    expect(JSON.stringify(mocks.captureException.mock.calls)).not.toContain(
+      "Daisy"
     );
   });
 
@@ -145,6 +149,51 @@ describe("POST /api/error-report", () => {
       "2026-06-27T12:05:00.000Z"
     );
     expect(mocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it("rejects unrecognized sources before forwarding the report", async () => {
+    const response = await POST(
+      request({ source: "attacker-controlled", errorFamily: "Error" })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.captureException).not.toHaveBeenCalled();
+    expect(mocks.insertFunnelEvent).not.toHaveBeenCalled();
+  });
+
+  it("discards legacy raw error content and unsafe correlation values", async () => {
+    const response = await POST(
+      request({
+        source: "global-error",
+        errorFamily: "Error",
+        message: "Client Jane and patient Daisy",
+        stack: "private stack content",
+        digest: "Client Jane's digest",
+        path: "/unexpected/Client-Jane",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.captureException).toHaveBeenCalledWith({
+      source: "global-error",
+      message: "Error in client renderer",
+      stack: null,
+      digest: null,
+      path: "/other",
+    });
+    expect(mocks.insertFunnelEvent).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        path: "/other",
+        metadata: { errorFamily: "Error" },
+      })
+    );
+    expect(JSON.stringify(mocks.captureException.mock.calls)).not.toContain(
+      "Jane"
+    );
+    expect(JSON.stringify(mocks.captureException.mock.calls)).not.toContain(
+      "Daisy"
+    );
   });
 
   it("fails closed if the rate limiter is unavailable", async () => {

--- a/apps/web/app/api/error-report/route.ts
+++ b/apps/web/app/api/error-report/route.ts
@@ -2,6 +2,12 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { db } from "@openpims/db/client";
 import { captureException } from "@/lib/error-tracking";
+import {
+  CLIENT_ERROR_FAMILIES,
+  CLIENT_ERROR_SOURCES,
+  sanitizeClientErrorDigest,
+  sanitizeClientErrorPath,
+} from "@/lib/client-error-report";
 import { insertFunnelEvent } from "@/lib/funnel-events-server";
 import { rateLimit, rateLimitResponseHeaders } from "@/lib/rate-limit";
 import { clientIpFromRequest } from "@/lib/request-ip";
@@ -13,14 +19,10 @@ import { withSystem } from "@/lib/tenant-db";
 
 const ERROR_REPORT_LIMIT = 30;
 const ERROR_REPORT_WINDOW_MS = 5 * 60 * 1000;
-const UUID_PATH_SEGMENT_RE =
-  /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
-
 const errorReportSchema = z.object({
-  source: z.string().min(1).max(80).regex(/^[a-zA-Z0-9._:/-]+$/),
-  message: z.string().min(1).max(1000),
-  stack: z.string().max(5000).optional().nullable(),
-  digest: z.string().max(200).optional().nullable(),
+  source: z.enum(CLIENT_ERROR_SOURCES),
+  errorFamily: z.enum(CLIENT_ERROR_FAMILIES).optional().default("Error"),
+  digest: z.string().max(120).optional().nullable(),
   path: z.string().max(500).startsWith("/").optional().nullable(),
   anonymousId: z.string().uuid().optional().nullable(),
 });
@@ -36,11 +38,6 @@ function errorReportRateLimitResponse(result: {
       headers: rateLimitResponseHeaders(ERROR_REPORT_LIMIT, result),
     }
   );
-}
-
-function cleanPath(path: string | null | undefined): string | undefined {
-  if (!path) return undefined;
-  return path.split(/[?#]/, 1)[0]!.replace(UUID_PATH_SEGMENT_RE, ":id");
 }
 
 async function enforceErrorReportRateLimit(ip: string) {
@@ -85,16 +82,27 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false }, { status: 400 });
   }
 
-  const { anonymousId, ...report } = parsed.data;
-  await captureException(report);
+  const { anonymousId, source, errorFamily } = parsed.data;
+  const digest = sanitizeClientErrorDigest(parsed.data.digest);
+  const path = sanitizeClientErrorPath(parsed.data.path);
+  await captureException({
+    source,
+    message: `${errorFamily} in client renderer`,
+    stack: null,
+    digest,
+    path,
+  });
   try {
     await withSystem(db, (tx) =>
       insertFunnelEvent(tx, {
         eventName: "client_error",
         anonymousId,
-        source: parsed.data.source,
-        path: cleanPath(parsed.data.path),
-        metadata: parsed.data.digest ? { digest: parsed.data.digest } : {},
+        source,
+        path: path ?? undefined,
+        metadata: {
+          errorFamily,
+          ...(digest ? { digest } : {}),
+        },
       })
     );
   } catch (error) {

--- a/apps/web/components/common/__tests__/report-client-error.test.ts
+++ b/apps/web/components/common/__tests__/report-client-error.test.ts
@@ -32,10 +32,12 @@ describe("reportClientError", () => {
     const body = await (payload as Blob).text();
     expect(JSON.parse(body)).toMatchObject({
       source: "app-error",
-      message: "boom",
+      errorFamily: "Error",
       digest: "digest-1",
       path: "/patients",
     });
+    expect(body).not.toContain("boom");
+    expect(body).not.toContain("stack");
   });
 
   it("falls back to fetch when sendBeacon cannot queue the report", () => {
@@ -51,7 +53,7 @@ describe("reportClientError", () => {
       expect.objectContaining({
         method: "POST",
         keepalive: true,
-        body: expect.stringContaining("queue full"),
+        body: expect.not.stringContaining("queue full"),
       })
     );
   });
@@ -86,5 +88,28 @@ describe("reportClientError", () => {
     expect(() =>
       reportClientError("app-error", new Error("boom"))
     ).not.toThrow();
+  });
+
+  it("redacts record identifiers and drops unsafe digests before transport", async () => {
+    stubPath("/patients/323e4567-e89b-42d3-a456-426614174000/edit");
+    const sendBeacon = vi.fn((_: string, __?: BodyInit | null) => true);
+    vi.stubGlobal("navigator", { sendBeacon });
+    vi.stubGlobal("fetch", vi.fn());
+
+    reportClientError(
+      "app-error",
+      Object.assign(new Error("Patient Daisy failed to save"), {
+        digest: "Daisy's record",
+      })
+    );
+
+    const [, payload] = sendBeacon.mock.calls[0]!;
+    const body = await (payload as Blob).text();
+    expect(JSON.parse(body)).toMatchObject({
+      path: "/patients/:id/edit",
+      digest: null,
+    });
+    expect(body).not.toContain("Daisy");
+    expect(body).not.toContain("323e4567");
   });
 });

--- a/apps/web/components/common/app-error-view.tsx
+++ b/apps/web/components/common/app-error-view.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { AlertTriangle, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { reportClientError } from "@/components/common/report-client-error";
+import type { ClientErrorSource } from "@/lib/client-error-report";
 
 export function AppErrorView({
   error,
@@ -12,7 +13,7 @@ export function AppErrorView({
 }: {
   error: Error & { digest?: string };
   reset: () => void;
-  source: string;
+  source: ClientErrorSource;
 }) {
   React.useEffect(() => {
     reportClientError(source, error);

--- a/apps/web/components/common/report-client-error.ts
+++ b/apps/web/components/common/report-client-error.ts
@@ -1,19 +1,27 @@
 "use client";
 
 import { fetchWithClientTimeout } from "@/lib/client-fetch";
+import {
+  classifyClientError,
+  sanitizeClientErrorDigest,
+  sanitizeClientErrorPath,
+  type ClientErrorSource,
+} from "@/lib/client-error-report";
 import { getFunnelVisitorId } from "@/lib/funnel-visitor";
 
 export function reportClientError(
-  source: string,
+  source: ClientErrorSource,
   error: Error & { digest?: string }
 ): void {
   const endpoint = "/api/error-report";
   const payload = JSON.stringify({
     source,
-    message: error.message || "Unknown error",
-    stack: error.stack ?? null,
-    digest: error.digest ?? null,
-    path: typeof window !== "undefined" ? window.location.pathname : null,
+    errorFamily: classifyClientError(error),
+    digest: sanitizeClientErrorDigest(error.digest),
+    path:
+      typeof window !== "undefined"
+        ? sanitizeClientErrorPath(window.location.pathname)
+        : null,
     anonymousId: getFunnelVisitorId(),
   });
 

--- a/apps/web/lib/__tests__/client-error-report.test.ts
+++ b/apps/web/lib/__tests__/client-error-report.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyClientError,
+  sanitizeClientErrorDigest,
+  sanitizeClientErrorPath,
+} from "../client-error-report";
+
+describe("client error report privacy", () => {
+  it("keeps only allowlisted error families", () => {
+    expect(classifyClientError(new TypeError("private content"))).toBe(
+      "TypeError"
+    );
+    const custom = new Error("private content");
+    custom.name = "Patient Daisy Error";
+    expect(classifyClientError(custom)).toBe("Error");
+  });
+
+  it("keeps opaque digests and rejects human-readable content", () => {
+    expect(sanitizeClientErrorDigest("next-abc_123.4")).toBe(
+      "next-abc_123.4"
+    );
+    expect(sanitizeClientErrorDigest("Patient Daisy failed")).toBeNull();
+  });
+
+  it.each([
+    ["/patients/323e4567-e89b-42d3-a456-426614174000/edit", "/patients/:id/edit"],
+    ["/portal/private-token/pets/private-pet", "/portal/:token/pets/:id"],
+    ["/book/identifying-clinic-slug", "/book/:slug"],
+    ["/settings?tab=messaging", "/settings"],
+    ["/unrecognized/Client-Jane", "/other"],
+  ])("maps %s to a non-identifying route", (path, expected) => {
+    expect(sanitizeClientErrorPath(path)).toBe(expected);
+  });
+});

--- a/apps/web/lib/client-error-report.ts
+++ b/apps/web/lib/client-error-report.ts
@@ -1,0 +1,114 @@
+export const CLIENT_ERROR_SOURCES = [
+  "app-error",
+  "global-error",
+  "react-error-boundary",
+] as const;
+
+export type ClientErrorSource = (typeof CLIENT_ERROR_SOURCES)[number];
+
+export const CLIENT_ERROR_FAMILIES = [
+  "Error",
+  "TypeError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "URIError",
+  "AggregateError",
+  "DOMException",
+] as const;
+
+export type ClientErrorFamily = (typeof CLIENT_ERROR_FAMILIES)[number];
+
+const CLIENT_ERROR_FAMILY_SET = new Set<string>(CLIENT_ERROR_FAMILIES);
+const SAFE_DIGEST_RE = /^[A-Za-z0-9._-]{1,120}$/;
+
+const STATIC_ROUTES = new Set([
+  "/",
+  "/accept-invite",
+  "/admin",
+  "/agent",
+  "/api-docs",
+  "/api-docs/ai",
+  "/billing",
+  "/billing/new",
+  "/clients",
+  "/clients/new",
+  "/controlled-substances",
+  "/forgot-password",
+  "/inbox",
+  "/inventory",
+  "/lab-results",
+  "/legal/privacy",
+  "/legal/terms",
+  "/login",
+  "/onboarding",
+  "/patients",
+  "/patients/duplicates",
+  "/patients/new",
+  "/recalls",
+  "/records",
+  "/register",
+  "/reports",
+  "/reset-password",
+  "/schedule",
+  "/settings",
+  "/verify-email",
+  "/whiteboard",
+]);
+
+const DYNAMIC_ROUTES: Array<[RegExp, string]> = [
+  [/^\/book\/[^/]+$/, "/book/:slug"],
+  [/^\/capture\/[^/]+$/, "/capture/:token"],
+  [/^\/clients\/[^/]+\/edit$/, "/clients/:id/edit"],
+  [/^\/clients\/[^/]+$/, "/clients/:id"],
+  [/^\/encounters\/[^/]+$/, "/encounters/:id"],
+  [/^\/patients\/[^/]+\/edit$/, "/patients/:id/edit"],
+  [/^\/patients\/[^/]+$/, "/patients/:id"],
+  [/^\/portal\/[^/]+\/appointments$/, "/portal/:token/appointments"],
+  [/^\/portal\/[^/]+\/book$/, "/portal/:token/book"],
+  [/^\/portal\/[^/]+\/invoices$/, "/portal/:token/invoices"],
+  [/^\/portal\/[^/]+\/messages$/, "/portal/:token/messages"],
+  [/^\/portal\/[^/]+\/pets\/[^/]+$/, "/portal/:token/pets/:id"],
+  [/^\/portal\/[^/]+$/, "/portal/:token"],
+  [/^\/records\/new-soap\/[^/]+$/, "/records/new-soap/:id"],
+  [/^\/records\/replace-soap\/[^/]+$/, "/records/replace-soap/:id"],
+  [/^\/sign\/[^/]+$/, "/sign/:token"],
+  [/^\/sms\/[^/]+\/opt-in$/, "/sms/:id/opt-in"],
+  [/^\/sms\/[^/]+\/privacy$/, "/sms/:id/privacy"],
+  [/^\/sms\/[^/]+\/terms$/, "/sms/:id/terms"],
+  [/^\/sms\/[^/]+$/, "/sms/:id"],
+];
+
+export function classifyClientError(error: Error): ClientErrorFamily {
+  return CLIENT_ERROR_FAMILY_SET.has(error.name)
+    ? (error.name as ClientErrorFamily)
+    : "Error";
+}
+
+export function sanitizeClientErrorDigest(
+  digest: string | null | undefined
+): string | null {
+  return digest && SAFE_DIGEST_RE.test(digest) ? digest : null;
+}
+
+export function sanitizeClientErrorPath(
+  input: string | null | undefined
+): string | null {
+  if (!input) return null;
+
+  let pathname: string;
+  try {
+    pathname = new URL(input, "https://openvpm.local").pathname;
+  } catch {
+    return "/other";
+  }
+
+  if (pathname.length > 1) pathname = pathname.replace(/\/+$/, "");
+  if (STATIC_ROUTES.has(pathname)) return pathname;
+
+  for (const [pattern, template] of DYNAMIC_ROUTES) {
+    if (pattern.test(pathname)) return template;
+  }
+
+  return "/other";
+}


### PR DESCRIPTION
## Outcome

Prevents browser-side operational error reports from forwarding clinic or patient data while preserving enough signal to group and fix failures.

- removes raw browser error messages and stacks from the reporting payload
- allowlists report sources and coarse error families
- accepts only opaque correlation digests
- maps every known page to a non-identifying route template and collapses unknown paths to `/other`
- repeats sanitization server-side and discards legacy raw fields from cached clients
- retains anonymous funnel counts with safe error family, route template, and optional digest metadata

## Verification

- `pnpm test` — 3,325 passed, 1 provider-dependent integration test skipped
- `pnpm build`
- `pnpm --filter @openpims/web type-check`
- focused telemetry/privacy suite — 19 passed
- `git diff --check`
- changed-file secret scan (only route-name false positives for `forgot-password` / `reset-password`)