### PR TITLE
Keep clinical work bound to visits

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -14,6 +20,7 @@ import {
   ClipboardList,
   Download,
   FileText,
+  FlaskConical,
   Loader2,
   Package,
   Pill,
@@ -21,6 +28,8 @@ import {
   Receipt,
   Stethoscope,
   Save,
+  Scissors,
+  Syringe,
   Trash2,
   UserRound,
 } from "lucide-react";
@@ -35,6 +44,10 @@ import {
 import { centsToMoney, moneyToCents } from "@/lib/billing/invoice-balance";
 import { tryCalculateInvoiceTaxTotals } from "@/lib/billing/invoice-tax";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
+import {
+  APPOINTMENT_PATIENT_SEARCH_MAX_LENGTH,
+  isAppointmentPatientSearchInputValid,
+} from "@/lib/scheduling/appointment-policy";
 import { ServicePicker } from "@/components/billing/service-picker";
 import { CapturePhotos } from "@/components/records/capture-photos";
 import { ConsentSign } from "@/components/records/consent-sign";
@@ -104,6 +117,14 @@ function canRecordVitals(role?: string | null): boolean {
   return role === "admin" || role === "veterinarian" || role === "technician";
 }
 
+function canRecordVisitWork(role?: string | null): boolean {
+  return role === "admin" || role === "veterinarian" || role === "technician";
+}
+
+function canRecordProcedure(role?: string | null): boolean {
+  return role === "admin" || role === "veterinarian";
+}
+
 function canManageBilling(role?: string | null): boolean {
   return role === "admin" || role === "front_desk";
 }
@@ -119,6 +140,166 @@ function nextVisitAction(status: string): {
     return { label: "Start exam", status: "in_exam" };
   }
   return null;
+}
+
+function PatientAssignmentPanel({
+  appointmentId,
+  clientName,
+}: {
+  appointmentId: string;
+  clientName: string;
+}) {
+  const utils = trpc.useUtils();
+  const [search, setSearch] = useState("");
+  const [selectedPatient, setSelectedPatient] = useState<{
+    id: string;
+    name: string;
+    species: string | null;
+    breed: string | null;
+    clientFirstName: string | null;
+    clientLastName: string | null;
+  } | null>(null);
+  const deferredSearch = useDeferredValue(search.trim());
+  const searchIsValid = isAppointmentPatientSearchInputValid(search);
+  const canSearch = deferredSearch.length > 0 && searchIsValid;
+  const patientSearch = trpc.patients.search.useQuery(
+    { query: deferredSearch, status: "active" },
+    { enabled: canSearch },
+  );
+  const attachPatient = trpc.appointments.attachPatient.useMutation({
+    onSuccess: async () => {
+      toast.success("Patient attached to visit");
+      await Promise.all([
+        utils.appointments.getById.invalidate({ id: appointmentId }),
+        utils.appointments.list.invalidate(),
+        utils.encounters.getCloseout.invalidate({ appointmentId }),
+      ]);
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  return (
+    <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-950 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+      <div className="flex items-start gap-3">
+        <UserRound className="mt-0.5 h-5 w-5 shrink-0" />
+        <div>
+          <p className="font-medium">Attach a patient before clinical care</p>
+          <p className="mt-1 text-sm">
+            {clientName
+              ? "Choose a patient belonging to " + clientName + "."
+              : "Choose the patient and OpenVPM will attach the matching client."}{" "}
+            The exam cannot start until both records are active and matched.
+          </p>
+        </div>
+      </div>
+
+      {selectedPatient ? (
+        <div className="mt-4 rounded-md border border-amber-300 bg-background/80 p-3 text-sm text-foreground dark:border-amber-800">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="font-medium">{selectedPatient.name}</p>
+              <p className="text-xs text-muted-foreground">
+                {[selectedPatient.species, selectedPatient.breed]
+                  .filter(Boolean)
+                  .join(" · ") || "Patient details unavailable"}
+                {selectedPatient.clientFirstName
+                  ? " · " +
+                    selectedPatient.clientFirstName +
+                    " " +
+                    (selectedPatient.clientLastName ?? "")
+                  : ""}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={attachPatient.isPending}
+                onClick={() => setSelectedPatient(null)}
+              >
+                Change
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={attachPatient.isPending}
+                onClick={() =>
+                  attachPatient.mutate({
+                    id: appointmentId,
+                    patientId: selectedPatient.id,
+                  })
+                }
+              >
+                {attachPatient.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : null}
+                Attach patient
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-4">
+          <Input
+            value={search}
+            maxLength={APPOINTMENT_PATIENT_SEARCH_MAX_LENGTH}
+            aria-label="Search patient to attach"
+            aria-invalid={!searchIsValid}
+            placeholder="Search patient name or breed"
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          {!searchIsValid ? (
+            <p className="mt-2 text-xs text-destructive">
+              Patient search is too long.
+            </p>
+          ) : patientSearch.error ? (
+            <p className="mt-2 text-xs text-destructive">
+              Patient search failed. Retry before attaching a record.
+            </p>
+          ) : canSearch && patientSearch.isLoading ? (
+            <p className="mt-2 inline-flex items-center gap-2 text-xs">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Searching patients...
+            </p>
+          ) : canSearch && patientSearch.data?.length === 0 ? (
+            <p className="mt-2 text-xs">
+              No active patient matched.{" "}
+              <Link className="font-medium underline" href="/patients/new">
+                Create the patient record
+              </Link>{" "}
+              and then return to this visit.
+            </p>
+          ) : patientSearch.data?.length ? (
+            <div className="mt-2 overflow-hidden rounded-md border border-amber-300 bg-background text-foreground dark:border-amber-800">
+              {patientSearch.data.map((patient) => (
+                <button
+                  type="button"
+                  key={patient.id}
+                  className="flex w-full items-center justify-between gap-3 border-b border-border px-3 py-2 text-left text-sm last:border-0 hover:bg-muted"
+                  onClick={() => setSelectedPatient(patient)}
+                >
+                  <span>
+                    <span className="font-medium">{patient.name}</span>
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      {[patient.species, patient.breed]
+                        .filter(Boolean)
+                        .join(" · ")}
+                    </span>
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {[patient.clientFirstName, patient.clientLastName]
+                      .filter(Boolean)
+                      .join(" ") || "No active client"}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function formatAppointmentTime(
@@ -256,6 +437,8 @@ export default function EncounterWorkspacePage() {
     appointment.status === "in_exam" &&
     closeoutQuery.data?.closeout?.status !== "clinical_finalized" &&
     closeoutQuery.data?.closeout?.status !== "completed";
+  const missingClinicalTarget =
+    !appointment.patientId || !appointment.clientId;
   const activeInvoices =
     invoicesQuery.data?.items.filter(
       (invoice) => !invoice.isEstimate && invoice.status !== "void",
@@ -314,7 +497,15 @@ export default function EncounterWorkspacePage() {
         </div>
         {nextAction && canManageVisit(role) ? (
           <Button
-            disabled={updateStatus.isPending}
+            disabled={
+              updateStatus.isPending ||
+              (nextAction.status === "in_exam" && missingClinicalTarget)
+            }
+            title={
+              nextAction.status === "in_exam" && missingClinicalTarget
+                ? "Attach a patient before starting the exam."
+                : undefined
+            }
             onClick={() =>
               updateStatus.mutate({
                 id: appointmentId,
@@ -360,12 +551,19 @@ export default function EncounterWorkspacePage() {
             </CardHeader>
             <CardContent>
               {!appointment.patientId ? (
-                <EmptyState
-                  icon={UserRound}
-                  title="Attach a patient first"
-                  description="Clinical documentation and billing need a patient and client on the appointment."
-                  className="p-8"
-                />
+                canManageVisit(role) ? (
+                  <PatientAssignmentPanel
+                    appointmentId={appointmentId}
+                    clientName={clientName}
+                  />
+                ) : (
+                  <EmptyState
+                    icon={UserRound}
+                    title="Patient assignment required"
+                    description="A teammate with visit access must attach the active patient and matching client before clinical care begins."
+                    className="p-8"
+                  />
+                )
               ) : patientQuery.error ||
                 (!patientQuery.isLoading && !patient) ? (
                 <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
@@ -431,17 +629,43 @@ export default function EncounterWorkspacePage() {
                         </a>
                       </Button>
                     ) : null}
-                    {canCreateSoap(role) &&
-                    appointment.status === "in_exam" &&
-                    closeoutQuery.data?.closeout?.status !==
-                      "clinical_finalized" &&
-                    closeoutQuery.data?.closeout?.status !== "completed" ? (
+                    {canCreateSoap(role) && visitOpenForClinicalEntry ? (
                       <Button size="sm" variant="outline" asChild>
                         <Link
                           href={`/records?patientId=${appointment.patientId}&appointmentId=${appointmentId}&tab=prescriptions&new=1`}
                         >
                           <Pill className="mr-2 h-4 w-4" />
                           Prescribe
+                        </Link>
+                      </Button>
+                    ) : null}
+                    {canRecordVisitWork(role) && visitOpenForClinicalEntry ? (
+                      <>
+                        <Button size="sm" variant="outline" asChild>
+                          <Link
+                            href={`/records?patientId=${appointment.patientId}&appointmentId=${appointmentId}&tab=vaccinations&new=1`}
+                          >
+                            <Syringe className="mr-2 h-4 w-4" />
+                            Vaccination
+                          </Link>
+                        </Button>
+                        <Button size="sm" variant="outline" asChild>
+                          <Link
+                            href={`/records?patientId=${appointment.patientId}&appointmentId=${appointmentId}&tab=labResults&new=1`}
+                          >
+                            <FlaskConical className="mr-2 h-4 w-4" />
+                            Lab result
+                          </Link>
+                        </Button>
+                      </>
+                    ) : null}
+                    {canRecordProcedure(role) && visitOpenForClinicalEntry ? (
+                      <Button size="sm" variant="outline" asChild>
+                        <Link
+                          href={`/records?patientId=${appointment.patientId}&appointmentId=${appointmentId}&tab=procedures&new=1`}
+                        >
+                          <Scissors className="mr-2 h-4 w-4" />
+                          Procedure
                         </Link>
                       </Button>
                     ) : null}
@@ -466,9 +690,10 @@ export default function EncounterWorkspacePage() {
                   </div>
 
                   <p className="text-xs text-muted-foreground">
-                    SOAP notes created here are linked to this appointment.
-                    Photos and signatures captured during an open visit attach
-                    to the active visit automatically.
+                    Use these visit actions so SOAP notes, prescriptions,
+                    vaccinations, lab results, procedures, photos, and
+                    signatures stay linked to this appointment and its charge
+                    reconciliation.
                   </p>
                 </div>
               )}

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -104,6 +104,10 @@ const tabs: { id: Tab; label: string; icon: React.ElementType }[] = [
   { id: "procedures", label: "Procedures", icon: Scissors },
 ];
 
+function isTab(value: string | null): value is Tab {
+  return tabs.some((tab) => tab.id === value);
+}
+
 function RecordsChartChunkLoading() {
   return (
     <div className="rounded-lg border border-border bg-card p-4">
@@ -597,11 +601,11 @@ function RecordsPageContent() {
   const { data: session } = useSession();
   const linkedPatientId = searchParams.get("patientId") ?? "";
   const linkedAppointmentId = searchParams.get("appointmentId") ?? "";
-  const shouldOpenPrescription =
-    searchParams.get("tab") === "prescriptions" &&
-    searchParams.get("new") === "1";
+  const requestedTab = searchParams.get("tab");
+  const shouldOpenNewRecord = searchParams.get("new") === "1";
   const requestedAmendLabResultId = searchParams.get("amendLabResultId");
-  const appliedVisitLink = useRef(false);
+  const visitContextKey = linkedPatientId ? searchParams.toString() : "";
+  const appliedVisitLink = useRef<string | null>(null);
   const appliedSoapHash = useRef<string | null>(null);
   const appliedLabAmendLink = useRef<string | null>(null);
   const prescriptionOperationId = useRef<string | null>(null);
@@ -658,7 +662,14 @@ function RecordsPageContent() {
   );
 
   useEffect(() => {
-    if (appliedVisitLink.current || !linkedPatientQuery.data) return;
+    if (
+      !visitContextKey ||
+      appliedVisitLink.current === visitContextKey ||
+      !linkedPatientQuery.data ||
+      linkedPatientQuery.data.id !== linkedPatientId
+    ) {
+      return;
+    }
     const linkedPatient = linkedPatientQuery.data;
     setSelectedPatient({
       id: linkedPatient.id,
@@ -669,15 +680,36 @@ function RecordsPageContent() {
       clientLastName: linkedPatient.clientLastName,
     });
     setSearchQuery(linkedPatient.name);
-    const linkedTab = searchParams.get("tab");
-    if (linkedTab === "prescriptions" || linkedTab === "labResults") {
+    const linkedTab = requestedTab;
+    if (isTab(linkedTab)) {
       setActiveTab(linkedTab);
     }
-    if (shouldOpenPrescription) {
-      setShowPrescriptionForm(true);
+    setShowVaccinationForm(false);
+    setVaccinationForm(initialVaccinationForm());
+    setShowLabForm(false);
+    setLabForm(initialLabResultForm());
+    setReplacesLabResultId(null);
+    setReplacementPatient(null);
+    setReplacementPatientSearch("");
+    setShowProcedureForm(false);
+    setProcedureForm(initialProcedureForm());
+    setShowPrescriptionForm(false);
+    setPrescriptionForm(initialPrescriptionForm());
+    if (shouldOpenNewRecord) {
+      if (linkedTab === "vaccinations") setShowVaccinationForm(true);
+      if (linkedTab === "prescriptions") setShowPrescriptionForm(true);
+      if (linkedTab === "labResults") setShowLabForm(true);
+      if (linkedTab === "procedures") setShowProcedureForm(true);
     }
-    appliedVisitLink.current = true;
-  }, [linkedPatientQuery.data, searchParams, shouldOpenPrescription]);
+    appliedVisitLink.current = visitContextKey;
+  }, [
+    linkedAppointmentId,
+    linkedPatientId,
+    linkedPatientQuery.data,
+    requestedTab,
+    shouldOpenNewRecord,
+    visitContextKey,
+  ]);
 
   const {
     data: searchResults,
@@ -699,6 +731,9 @@ function RecordsPageContent() {
   );
 
   const patientId = selectedPatient?.id ?? "";
+  const visitContextMatchesPatient =
+    !linkedAppointmentId ||
+    (Boolean(linkedPatientId) && linkedPatientId === patientId);
   const recordsSettings = trpc.records.settings.useQuery(undefined, {
     staleTime: 5 * 60 * 1000,
   });
@@ -980,10 +1015,22 @@ function RecordsPageContent() {
     ? activeTab
     : visibleTabs[0]?.id;
 
+  async function refreshLinkedVisit() {
+    if (!linkedAppointmentId) return;
+    await Promise.all([
+      utils.encounters.getCloseout.invalidate({
+        appointmentId: linkedAppointmentId,
+      }),
+      utils.encounters.getVisitReconciliation.invalidate({
+        appointmentId: linkedAppointmentId,
+      }),
+    ]);
+  }
+
   const createVaccination = trpc.records.createVaccination.useMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success("Vaccination recorded");
-      refetchVaccinations();
+      await Promise.all([refetchVaccinations(), refreshLinkedVisit()]);
       setShowVaccinationForm(false);
       setVaccinationForm(initialVaccinationForm());
     },
@@ -1021,6 +1068,7 @@ function RecordsPageContent() {
       await Promise.all([
         refetchLabResults(),
         utils.records.listLabReviewInbox.invalidate(),
+        refreshLinkedVisit(),
       ]);
       setShowLabForm(false);
       setLabForm(initialLabResultForm());
@@ -1067,9 +1115,9 @@ function RecordsPageContent() {
     },
   });
   const createProcedure = trpc.records.createProcedure.useMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success("Procedure recorded");
-      refetchProcedures();
+      await Promise.all([refetchProcedures(), refreshLinkedVisit()]);
       setShowProcedureForm(false);
       setProcedureForm(initialProcedureForm());
     },
@@ -1078,14 +1126,9 @@ function RecordsPageContent() {
     },
   });
   const createPrescription = trpc.records.createPrescription.useMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success("Prescription created");
-      refetchPrescriptions();
-      if (linkedAppointmentId) {
-        utils.encounters.getCloseout.invalidate({
-          appointmentId: linkedAppointmentId,
-        });
-      }
+      await Promise.all([refetchPrescriptions(), refreshLinkedVisit()]);
       setShowPrescriptionForm(false);
       setPrescriptionForm(initialPrescriptionForm(recordsTimeZone));
       prescriptionOperationId.current = null;
@@ -1096,6 +1139,7 @@ function RecordsPageContent() {
   });
   const canSubmitVaccination =
     Boolean(patientId) &&
+    visitContextMatchesPatient &&
     isVaccinationRequiredTextInputValid(
       vaccinationForm.vaccineName,
       VACCINATION_NAME_MAX_LENGTH
@@ -1121,6 +1165,8 @@ function RecordsPageContent() {
     !createProblem.isPending;
   const canSubmitLabResult =
     Boolean(patientId) &&
+    visitContextMatchesPatient &&
+    (!linkedAppointmentId || !replacesLabResultId) &&
     (!replacesLabResultId || Boolean(replacementPatient)) &&
     (!replacesLabResultId || Boolean(labForm.resultValue.trim())) &&
     isLabRequiredTextInputValid(labForm.testName, LAB_TEST_NAME_MAX_LENGTH) &&
@@ -1138,6 +1184,7 @@ function RecordsPageContent() {
     !createLabResult.isPending;
   const canSubmitProcedure =
     Boolean(patientId) &&
+    visitContextMatchesPatient &&
     isProcedureRequiredTextInputValid(
       procedureForm.name,
       PROCEDURE_NAME_MAX_LENGTH
@@ -1157,6 +1204,8 @@ function RecordsPageContent() {
     ) &&
     !createProcedure.isPending;
   const canSubmitPrescription =
+    Boolean(patientId) &&
+    visitContextMatchesPatient &&
     isPrescriptionRequiredTextInputValid(
       prescriptionForm.medicationName,
       PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH
@@ -1301,28 +1350,58 @@ function RecordsPageContent() {
               </span>
             )}
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setSelectedPatient(null);
-              setSearchQuery("");
-              setShowVaccinationForm(false);
-              setVaccinationForm(initialVaccinationForm());
-              setShowProblemForm(false);
-              setProblemForm(initialProblemForm());
-              setShowLabForm(false);
-              setLabForm(initialLabResultForm());
-              setShowProcedureForm(false);
-              setProcedureForm(initialProcedureForm());
-              setShowPrescriptionForm(false);
-              setPrescriptionForm(initialPrescriptionForm());
-            }}
-          >
-            Change Patient
-          </Button>
+          {!linkedAppointmentId ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setSelectedPatient(null);
+                setSearchQuery("");
+                setShowVaccinationForm(false);
+                setVaccinationForm(initialVaccinationForm());
+                setShowProblemForm(false);
+                setProblemForm(initialProblemForm());
+                setShowLabForm(false);
+                setLabForm(initialLabResultForm());
+                setShowProcedureForm(false);
+                setProcedureForm(initialProcedureForm());
+                setShowPrescriptionForm(false);
+                setPrescriptionForm(initialPrescriptionForm());
+              }}
+            >
+              Change Patient
+            </Button>
+          ) : null}
         </div>
       )}
+
+      {selectedPatient &&
+      linkedAppointmentId &&
+      linkedPatientId === selectedPatient.id ? (
+        <div className="mt-3 flex flex-col gap-2 rounded-lg border border-teal-300 bg-teal-50 px-4 py-3 text-sm text-teal-950 dark:border-teal-900 dark:bg-teal-950/30 dark:text-teal-100 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-medium">Recording for this visit</p>
+            <p className="mt-0.5 text-xs">
+              New clinical work created here will stay attached to the active
+              appointment and appear in checkout reconciliation.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" asChild>
+              <Link href={`/encounters/${linkedAppointmentId}`}>
+                Back to visit
+              </Link>
+            </Button>
+            <Button size="sm" variant="ghost" asChild>
+              <Link
+                href={`/records?patientId=${encodeURIComponent(linkedPatientId)}&tab=${encodeURIComponent(requestedTab ?? "soap")}`}
+              >
+                Leave visit context
+              </Link>
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       {/* Tabs */}
       {selectedPatient && (
@@ -1769,10 +1848,7 @@ function RecordsPageContent() {
                       if (!canSubmitVaccination) return;
                       createVaccination.mutate({
                         patientId,
-                        appointmentId:
-                          linkedAppointmentId && linkedPatientId === patientId
-                            ? linkedAppointmentId
-                            : undefined,
+                        appointmentId: linkedAppointmentId || undefined,
                         vaccineName: vaccinationForm.vaccineName.trim(),
                         lotNumber:
                           vaccinationForm.lotNumber.trim() || undefined,
@@ -2065,10 +2141,7 @@ function RecordsPageContent() {
                       createPrescription.mutate({
                         patientId,
                         operationId: prescriptionOperationId.current,
-                        appointmentId:
-                          linkedAppointmentId && linkedPatientId === patientId
-                            ? linkedAppointmentId
-                            : undefined,
+                        appointmentId: linkedAppointmentId || undefined,
                         medicationName:
                           prescriptionForm.medicationName.trim(),
                         productId: prescriptionForm.productId || undefined,
@@ -2806,11 +2879,7 @@ function RecordsPageContent() {
                           replacementPatient?.id === selectedPatient?.id
                             ? replacementSourceLabResult?.appointmentId ??
                               undefined
-                            : !replacesLabResultId &&
-                                linkedAppointmentId &&
-                                linkedPatientId === patientId
-                              ? linkedAppointmentId
-                              : undefined,
+                            : linkedAppointmentId || undefined,
                         testName: labForm.testName.trim(),
                         resultValue: labForm.resultValue.trim() || undefined,
                         unit: labForm.unit.trim() || undefined,
@@ -3420,10 +3489,7 @@ function RecordsPageContent() {
                         procedureForm.durationMinutes.trim();
                       createProcedure.mutate({
                         patientId,
-                        appointmentId:
-                          linkedAppointmentId && linkedPatientId === patientId
-                            ? linkedAppointmentId
-                            : undefined,
+                        appointmentId: linkedAppointmentId || undefined,
                         name: procedureForm.name.trim(),
                         description:
                           procedureForm.description.trim() || undefined,

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -1083,7 +1083,17 @@ function AppointmentDetailPopover({
     statusActions.push({ label: "No Show", status: "no_show", variant: "outline" });
     statusActions.push({ label: "Cancel", status: "cancelled", variant: "destructive" });
   } else if (current === "checked_in") {
-    statusActions.push({ label: "In Exam", status: "in_exam", variant: "default" });
+    const missingClinicalTarget =
+      !appointment.patientId || !appointment.clientId;
+    statusActions.push({
+      label: "In Exam",
+      status: "in_exam",
+      variant: "default",
+      disabled: missingClinicalTarget,
+      disabledReason: missingClinicalTarget
+        ? "Open the visit and attach a patient before starting the exam."
+        : undefined,
+    });
     statusActions.push({ label: "No Show", status: "no_show", variant: "outline" });
   } else if (current === "no_show" || current === "cancelled") {
     statusActions.push({ label: "Reopen", status: "scheduled", variant: "outline" });

--- a/apps/web/app/(dashboard)/whiteboard/page.tsx
+++ b/apps/web/app/(dashboard)/whiteboard/page.tsx
@@ -35,6 +35,8 @@ type WhiteboardAppointment = {
   status: string;
   startTime: Date | string;
   notes: string | null;
+  patientId: string | null;
+  clientId: string | null;
   patientName: string | null;
   patientSpecies: string | null;
   patientPhotoUrl: string | null;
@@ -408,6 +410,8 @@ function AppointmentDetailModal({
       .join(" ") || "Unknown Client";
 
   const current = appointment.status as AppointmentStatus;
+  const missingClinicalTarget =
+    !appointment.patientId || !appointment.clientId;
 
   const statusActions: {
     label: string;
@@ -540,7 +544,15 @@ function AppointmentDetailModal({
                 key={action.status}
                 size="sm"
                 variant={action.variant}
-                disabled={isUpdating}
+                disabled={
+                  isUpdating ||
+                  (action.status === "in_exam" && missingClinicalTarget)
+                }
+                title={
+                  action.status === "in_exam" && missingClinicalTarget
+                    ? "Open the visit and attach an active patient before starting the exam."
+                    : undefined
+                }
                 onClick={() => onStatusChange(appointment.id, action.status)}
               >
                 {isUpdating ? (

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -40,6 +40,59 @@ describe("clinic encounter workspace", () => {
     expect(workspaceSource).toContain("Charge capture");
   });
 
+  it("repairs patientless appointments before allowing an exam to start", () => {
+    expect(workspaceSource).toContain(
+      "trpc.appointments.attachPatient.useMutation",
+    );
+    expect(workspaceSource).toContain("Attach a patient before clinical care");
+    expect(workspaceSource).toContain("Search patient to attach");
+    expect(workspaceSource).toContain("Patient attached to visit");
+    expect(workspaceSource).toContain(
+      'nextAction.status === "in_exam" && missingClinicalTarget',
+    );
+    expect(scheduleSource).toContain(
+      "Open the visit and attach a patient before starting the exam.",
+    );
+  });
+
+  it("keeps every visit work action appointment-bound through records", () => {
+    for (const tab of [
+      "vaccinations",
+      "prescriptions",
+      "labResults",
+      "procedures",
+    ]) {
+      expect(workspaceSource).toContain(`tab=${tab}&new=1`);
+    }
+    expect(recordsSource).toContain("const shouldOpenNewRecord");
+    expect(recordsSource).toContain("const visitContextKey");
+    expect(recordsSource).toContain(
+      "appliedVisitLink.current === visitContextKey",
+    );
+    expect(recordsSource).toContain(
+      "linkedPatientQuery.data.id !== linkedPatientId",
+    );
+    expect(recordsSource).toContain(
+      'if (linkedTab === "vaccinations") setShowVaccinationForm(true)',
+    );
+    expect(recordsSource).toContain(
+      'if (linkedTab === "labResults") setShowLabForm(true)',
+    );
+    expect(recordsSource).toContain(
+      'if (linkedTab === "procedures") setShowProcedureForm(true)',
+    );
+    expect(recordsSource).toContain("Recording for this visit");
+    expect(recordsSource).toContain("Leave visit context");
+    expect(recordsSource).toContain("visitContextMatchesPatient");
+    expect(recordsSource).toContain(
+      "appointmentId: linkedAppointmentId || undefined",
+    );
+    expect(recordsSource).toContain("{!linkedAppointmentId ? (");
+    expect(recordsSource).toContain(
+      "utils.encounters.getVisitReconciliation.invalidate",
+    );
+  });
+
   it("links SOAP documentation to the appointment and returns to the visit", () => {
     expect(workspaceSource).toContain("?appointmentId=${appointmentId}");
     expect(soapSource).toContain(

--- a/apps/web/lib/__tests__/whiteboard-ui.test.ts
+++ b/apps/web/lib/__tests__/whiteboard-ui.test.ts
@@ -14,6 +14,13 @@ describe("whiteboard appointment workflow UI", () => {
     expect(source).not.toContain(
       'statusActions.push({ label: "Back to Exam", status: "in_exam"'
     );
+    expect(source).toContain("const missingClinicalTarget");
+    expect(source).toContain(
+      'action.status === "in_exam" && missingClinicalTarget'
+    );
+    expect(source).toContain(
+      "Open the visit and attach an active patient before starting the exam."
+    );
   });
 
   it("keeps status updates hidden for read-only viewer access", () => {

--- a/apps/web/server/__tests__/appointments-safety.test.ts
+++ b/apps/web/server/__tests__/appointments-safety.test.ts
@@ -78,6 +78,7 @@ function createDb(opts?: {
     const builder = {
       from: vi.fn(() => builder),
       leftJoin: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
       where: vi.fn(() => afterWhere),
       orderBy: vi.fn(() => builder),
       limit: vi.fn(async () => result),
@@ -763,7 +764,18 @@ describe("appointments target safety", () => {
 
   it("does not dispatch checked-in webhooks for later workflow transitions", async () => {
     const { db, updateSet } = createDb({
-      selectResults: [[{ id: APPOINTMENT_ID, status: "checked_in" }]],
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "checked_in",
+            patientId: PATIENT_ID,
+            clientId: CLIENT_ID,
+            activePatientId: PATIENT_ID,
+            activeClientId: CLIENT_ID,
+          },
+        ],
+      ],
       updatedRows: [{ id: APPOINTMENT_ID, status: "in_exam" }],
     });
 
@@ -779,6 +791,178 @@ describe("appointments target safety", () => {
 
     expect(updateSet).toHaveBeenCalledWith({ status: "in_exam" });
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("blocks an exam from starting without an active matched patient and client", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "checked_in",
+            patientId: null,
+            clientId: CLIENT_ID,
+            activePatientId: null,
+            activeClientId: CLIENT_ID,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "in_exam",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Attach an active patient and matching client before starting the exam.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("attaches an active patient and its matching client under the appointment lock", async () => {
+    const updated = {
+      id: APPOINTMENT_ID,
+      status: "checked_in",
+      patientId: PATIENT_ID,
+      clientId: CLIENT_ID,
+    };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "checked_in",
+            patientId: null,
+            clientId: CLIENT_ID,
+          },
+        ],
+        [{ id: PATIENT_ID, clientId: CLIENT_ID }],
+      ],
+      updatedRows: [updated],
+    });
+
+    await expect(
+      callerWithDb(db).attachPatient({
+        id: APPOINTMENT_ID,
+        patientId: PATIENT_ID,
+      })
+    ).resolves.toEqual(updated);
+    expect(updateSet).toHaveBeenCalledWith({
+      patientId: PATIENT_ID,
+      clientId: CLIENT_ID,
+    });
+  });
+
+  it("does not attach a patient owned by a different appointment client", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "checked_in",
+            patientId: null,
+            clientId: CLIENT_ID,
+          },
+        ],
+        [{ id: PATIENT_ID, clientId: OTHER_CLIENT_ID }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).attachPatient({
+        id: APPOINTMENT_ID,
+        patientId: PATIENT_ID,
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Choose a patient belonging to the client already attached to this appointment.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not silently retarget an appointment that already has a patient", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "checked_in",
+            patientId: "00000000-0000-0000-0000-000000000044",
+            clientId: CLIENT_ID,
+          },
+        ],
+        [{ id: PATIENT_ID, clientId: CLIENT_ID }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).attachPatient({
+        id: APPOINTMENT_ID,
+        patientId: PATIENT_ID,
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This appointment already has a patient. Do not silently retarget a clinical visit.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not attach a patient to a terminal appointment", async () => {
+    const { db, select, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "cancelled",
+            patientId: null,
+            clientId: CLIENT_ID,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).attachPatient({
+        id: APPOINTMENT_ID,
+        patientId: PATIENT_ID,
+      })
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("fails closed if the appointment changes while attaching a patient", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "checked_in",
+            patientId: null,
+            clientId: CLIENT_ID,
+          },
+        ],
+        [{ id: PATIENT_ID, clientId: CLIENT_ID }],
+      ],
+      updatedRows: [],
+    });
+
+    await expect(
+      callerWithDb(db).attachPatient({
+        id: APPOINTMENT_ID,
+        patientId: PATIENT_ID,
+      })
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message:
+        "Appointment changed while attaching the patient. Refresh and retry.",
+    });
+    expect(updateSet).toHaveBeenCalledTimes(1);
   });
 
   it("rejects appointment status races after transition validation", async () => {

--- a/apps/web/server/__tests__/whiteboard.test.ts
+++ b/apps/web/server/__tests__/whiteboard.test.ts
@@ -69,6 +69,7 @@ function createStatusDb(opts?: {
     };
     const builder = {
       from: vi.fn(() => builder),
+      leftJoin: vi.fn(() => builder),
       where: vi.fn(() => afterWhere),
     };
     return builder;
@@ -264,8 +265,17 @@ describe("whiteboard workflows", () => {
   });
 
   it("does not dispatch checked-in webhooks after the check-in transition", async () => {
+    const patientId = "00000000-0000-0000-0000-000000000003";
+    const clientId = "00000000-0000-0000-0000-000000000004";
     const { db, updateSet } = createStatusDb({
-      selectResults: [[{ id: APPOINTMENT_ID, status: "checked_in" }]],
+      selectResults: [[{
+        id: APPOINTMENT_ID,
+        status: "checked_in",
+        patientId,
+        clientId,
+        activePatientId: patientId,
+        activeClientId: clientId,
+      }]],
       updatedRows: [{ id: APPOINTMENT_ID, status: "in_exam" }],
     });
 
@@ -278,6 +288,32 @@ describe("whiteboard workflows", () => {
 
     expect(updateSet).toHaveBeenCalledWith({ status: "in_exam" });
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("blocks exam entry without an active patient and matching client", async () => {
+    const { db, updateSet } = createStatusDb({
+      selectResults: [[{
+        id: APPOINTMENT_ID,
+        status: "checked_in",
+        patientId: "00000000-0000-0000-0000-000000000003",
+        clientId: "00000000-0000-0000-0000-000000000004",
+        activePatientId: null,
+        activeClientId: "00000000-0000-0000-0000-000000000004",
+      }]],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "in_exam",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Attach an active patient and matching client before starting the exam.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("rejects missing, deleted, or cross-tenant appointments", async () => {
@@ -385,7 +421,7 @@ describe("whiteboard query scoping", () => {
 
   it("keeps displayed patients tied to the appointment client", () => {
     expect(source).toMatch(
-      /leftJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(patients\.deletedAt\)\s*\)\s*\)/s
+      /leftJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, ctx\.practiceId\),\s*eq\(patients\.status, "active"\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(patients\.deletedAt\)\s*\)\s*\)/s
     );
   });
 
@@ -397,6 +433,7 @@ describe("whiteboard query scoping", () => {
 
   it("uses the shared appointment status workflow guard for updates", () => {
     expect(source).toContain("canTransitionAppointmentStatus");
+    expect(source).toContain('.for("update", { of: appointments })');
     expect(source).toContain("eq(appointments.status, current.status)");
     expect(source).toMatch(
       /eq\(appointments\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(appointments\.deletedAt\)/

--- a/apps/web/server/routers/appointments.ts
+++ b/apps/web/server/routers/appointments.ts
@@ -765,7 +765,10 @@ export const appointmentsRouter = createRouter({
             id: appointments.id,
             status: appointments.status,
             doctorId: appointments.doctorId,
+            patientId: appointments.patientId,
             clientId: appointments.clientId,
+            activePatientId: patients.id,
+            activeClientId: clients.id,
             startTime: appointments.startTime,
             updatedAt: appointments.updatedAt,
             typeRequiresDoctor: appointmentTypes.requiresDoctor,
@@ -777,6 +780,24 @@ export const appointmentsRouter = createRouter({
               eq(appointments.typeId, appointmentTypes.id),
               eq(appointmentTypes.practiceId, ctx.practiceId),
               isNull(appointmentTypes.deletedAt)
+            )
+          )
+          .leftJoin(
+            patients,
+            and(
+              eq(appointments.patientId, patients.id),
+              eq(patients.clientId, appointments.clientId),
+              eq(patients.practiceId, ctx.practiceId),
+              eq(patients.status, "active"),
+              isNull(patients.deletedAt)
+            )
+          )
+          .leftJoin(
+            clients,
+            and(
+              eq(appointments.clientId, clients.id),
+              eq(clients.practiceId, ctx.practiceId),
+              isNull(clients.deletedAt)
             )
           )
           .where(
@@ -821,6 +842,19 @@ export const appointmentsRouter = createRouter({
               input.status === "confirmed"
                 ? "Assign a doctor before confirming this appointment."
                 : "Assign a doctor before checking in this appointment.",
+          });
+        }
+        if (
+          input.status === "in_exam" &&
+          (!current.patientId ||
+            !current.clientId ||
+            current.activePatientId !== current.patientId ||
+            current.activeClientId !== current.clientId)
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Attach an active patient and matching client before starting the exam.",
           });
         }
         const isNewConfirmation =
@@ -1000,6 +1034,138 @@ export const appointmentsRouter = createRouter({
       }
       return appt;
     }),
+
+  attachPatient: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician", "front_desk"))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        patientId: z.string().uuid(),
+      })
+    )
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const [current] = await tx
+          .select({
+            id: appointments.id,
+            status: appointments.status,
+            patientId: appointments.patientId,
+            clientId: appointments.clientId,
+          })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.id, input.id),
+              eq(appointments.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(appointments.deletedAt)
+            )
+          )
+          .for("update");
+
+        if (!current) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Appointment not found",
+          });
+        }
+        if (
+          !["scheduled", "confirmed", "checked_in", "in_exam"].includes(
+            current.status
+          )
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "A patient can only be attached before the appointment is closed, cancelled, or marked no-show.",
+          });
+        }
+
+        const [target] = await tx
+          .select({
+            id: patients.id,
+            clientId: patients.clientId,
+          })
+          .from(patients)
+          .innerJoin(
+            clients,
+            and(
+              eq(patients.clientId, clients.id),
+              eq(clients.practiceId, ctx.practiceId),
+              isNull(clients.deletedAt)
+            )
+          )
+          .where(
+            and(
+              eq(patients.id, input.patientId),
+              eq(patients.practiceId, ctx.practiceId),
+              eq(patients.status, "active"),
+              isNull(patients.deletedAt)
+            )
+          )
+          .for("share");
+
+        if (!target) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Patient not found",
+          });
+        }
+        if (current.patientId) {
+          if (
+            current.patientId === target.id &&
+            current.clientId === target.clientId
+          ) {
+            return current;
+          }
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "This appointment already has a patient. Do not silently retarget a clinical visit.",
+          });
+        }
+        if (current.clientId && current.clientId !== target.clientId) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Choose a patient belonging to the client already attached to this appointment.",
+          });
+        }
+
+        const [updated] = await tx
+          .update(appointments)
+          .set({
+            patientId: target.id,
+            clientId: target.clientId,
+          })
+          .where(
+            and(
+              eq(appointments.id, current.id),
+              eq(appointments.practiceId, ctx.practiceId),
+              eq(appointments.status, current.status),
+              isNull(appointments.patientId),
+              current.clientId
+                ? eq(appointments.clientId, current.clientId)
+                : isNull(appointments.clientId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(appointments.deletedAt)
+            )
+          )
+          .returning({
+            id: appointments.id,
+            status: appointments.status,
+            patientId: appointments.patientId,
+            clientId: appointments.clientId,
+          });
+        if (!updated) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Appointment changed while attaching the patient. Refresh and retry.",
+          });
+        }
+        return updated;
+      })
+    ),
 
   cancelRecurringSeries: protectedProcedure
     .use(requireRole("admin", "veterinarian", "front_desk"))

--- a/apps/web/server/routers/patients.ts
+++ b/apps/web/server/routers/patients.ts
@@ -860,8 +860,25 @@ export const patientsRouter = createRouter({
     }),
 
   search: protectedProcedure
-    .input(z.object({ query: patientSearchQueryInput }))
+    .input(
+      z.object({
+        query: patientSearchQueryInput,
+        status: patientStatusInput.optional(),
+      })
+    )
     .query(async ({ ctx, input }) => {
+      const conditions = [
+        eq(patients.practiceId, ctx.practiceId),
+        activePracticePredicate(ctx.practiceId),
+        isNull(patients.deletedAt),
+        or(
+          ilike(patients.name, `%${input.query}%`),
+          ilike(patients.breed, `%${input.query}%`)
+        )!,
+      ];
+      if (input.status) {
+        conditions.push(eq(patients.status, input.status));
+      }
       return ctx.db
         .select({
           id: patients.id,
@@ -880,17 +897,7 @@ export const patientsRouter = createRouter({
             isNull(clients.deletedAt)
           )
         )
-        .where(
-          and(
-            eq(patients.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt),
-            or(
-              ilike(patients.name, `%${input.query}%`),
-              ilike(patients.breed, `%${input.query}%`)
-            )
-          )
-        )
+        .where(and(...conditions))
         .limit(10);
     }),
 

--- a/apps/web/server/routers/whiteboard.ts
+++ b/apps/web/server/routers/whiteboard.ts
@@ -87,6 +87,8 @@ export const whiteboardRouter = createRouter({
         status: appointments.status,
         startTime: appointments.startTime,
         notes: appointments.notes,
+        patientId: patients.id,
+        clientId: clients.id,
         patientName: patients.name,
         patientSpecies: patients.species,
         patientPhotoUrl: patients.photoUrl,
@@ -104,6 +106,7 @@ export const whiteboardRouter = createRouter({
           eq(appointments.patientId, patients.id),
           eq(patients.clientId, appointments.clientId),
           eq(patients.practiceId, ctx.practiceId),
+          eq(patients.status, "active"),
           activePracticePredicate(ctx.practiceId),
           isNull(patients.deletedAt)
         )
@@ -173,8 +176,33 @@ export const whiteboardRouter = createRouter({
     .mutation(async ({ ctx, input }) => {
       const { current, appt } = await ctx.db.transaction(async (tx) => {
         const [current] = await tx
-          .select({ id: appointments.id, status: appointments.status })
+          .select({
+            id: appointments.id,
+            status: appointments.status,
+            patientId: appointments.patientId,
+            clientId: appointments.clientId,
+            activePatientId: patients.id,
+            activeClientId: clients.id,
+          })
           .from(appointments)
+          .leftJoin(
+            patients,
+            and(
+              eq(appointments.patientId, patients.id),
+              eq(patients.clientId, appointments.clientId),
+              eq(patients.practiceId, ctx.practiceId),
+              eq(patients.status, "active"),
+              isNull(patients.deletedAt)
+            )
+          )
+          .leftJoin(
+            clients,
+            and(
+              eq(appointments.clientId, clients.id),
+              eq(clients.practiceId, ctx.practiceId),
+              isNull(clients.deletedAt)
+            )
+          )
           .where(
             and(
               eq(appointments.id, input.id),
@@ -183,7 +211,9 @@ export const whiteboardRouter = createRouter({
               isNull(appointments.deletedAt)
             )
           )
-          .for("update");
+          // Lock only the appointment owner row; PostgreSQL cannot apply
+          // FOR UPDATE to the nullable side of these validation LEFT JOINs.
+          .for("update", { of: appointments });
         if (!current) {
           throw new TRPCError({
             code: "NOT_FOUND",
@@ -200,6 +230,19 @@ export const whiteboardRouter = createRouter({
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: `Cannot change appointment status from ${current.status} to ${input.status}.`,
+          });
+        }
+        if (
+          input.status === "in_exam" &&
+          (!current.patientId ||
+            !current.clientId ||
+            current.activePatientId !== current.patientId ||
+            current.activeClientId !== current.clientId)
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Attach an active patient and matching client before starting the exam.",
           });
         }
 


### PR DESCRIPTION
## Outcome

Clinic staff can no longer begin clinical care without an active, matched patient and client, and work opened from a visit stays bound to that appointment through reconciliation.

## What changed

- blocks `in_exam` transitions in both Schedule and Whiteboard unless the appointment has an active patient and matching active client
- adds a locked, tenant-scoped, compare-and-set patient attachment workflow for legacy/request appointments
- lets staff find and attach only active patients from the encounter workspace
- adds visit-bound vaccination, prescription, manual lab result, and procedure actions
- keeps Records URL context synchronized across same-page navigation and never silently drops an appointment ID
- adds an explicit “Leave visit context” action
- refreshes closeout and reconciliation after linked clinical work is recorded
- disables unsafe shortcuts in Schedule and Whiteboard

## Safety

- appointment row is locked before attachment or status transition
- inactive, deceased, deleted, cross-tenant, mismatched-client, terminal, and retargeting cases fail closed
- lost-update races return a conflict
- no schema migration, provider send, payment, or production data write

## Verification

- `pnpm test`: 3,334 passed, 1 provider-dependent SMS integration skipped
- `pnpm build`: passed
- focused visit/records/whiteboard safety suites: 159 passed
- web TypeScript check: passed
- `git diff --check`: passed
- changed-file secret scan: no findings
- independent adversarial review: no remaining P0/P1 findings after fixes