### PR TITLE
Make guided setup progress trustworthy

### DIFF
--- a/apps/web/components/dashboard/activation-checklist.tsx
+++ b/apps/web/components/dashboard/activation-checklist.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { useTour } from "@/components/tour/tour-provider";
+import { useOnboardingJourney } from "@/components/onboarding/journey-overlay";
 import { toast } from "sonner";
 import {
   DEFAULT_ONBOARDING_INTENT,
@@ -31,6 +32,18 @@ type Milestone = {
   done: boolean;
 } & ({ href: string; onClick?: never } | { onClick: () => void; href?: never });
 
+const JOURNEY_STEP_LABELS: Record<string, string> = {
+  intent: "your starting path",
+  basics: "clinic basics",
+  branding: "branding",
+  team: "your team",
+  data: "data import",
+  agent: "the AI helper",
+  phone: "texting",
+  billing: "billing",
+  allSet: "the final review",
+};
+
 /**
  * Persistent activation checklist shown on the dashboard through the whole
  * trial. Unlike the old finish-setup card (which only appeared after onboarding
@@ -40,6 +53,7 @@ type Milestone = {
  */
 export function ActivationChecklist() {
   const { start } = useTour();
+  const { openJourney } = useOnboardingJourney();
   const [hidden, setHidden] = useState(false);
   const { data: session, status } = useSession();
   const isAdmin =
@@ -304,6 +318,13 @@ export function ActivationChecklist() {
   const pct = total === 0 ? 100 : (doneCount / total) * 100;
   const allDone = doneCount === total;
   const setupHelpRequestedAt = checklistState.setupHelpRequestedAt ?? null;
+  const guidedSetupIncomplete = onboardingData.completedAt == null;
+  const guidedSetupStarted = Boolean(
+    checklistState.onboardingIntentSelectedAt || checklistState.journeyStepId,
+  );
+  const guidedSetupStage = checklistState.journeyStepId
+    ? JOURNEY_STEP_LABELS[checklistState.journeyStepId]
+    : null;
 
   // The corner X just hides the checklist for this session — it comes back next
   // visit ("show later"). "Don't show this again" dismisses it for good.
@@ -315,7 +336,7 @@ export function ActivationChecklist() {
     dismiss.mutate();
   }
 
-  if (allDone) {
+  if (allDone && !guidedSetupIncomplete) {
     return (
       <div className="relative z-20 w-full sm:fixed sm:bottom-4 sm:right-4 sm:z-[70] sm:w-[340px]">
         <div className="flex items-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-zinc-50 shadow-2xl shadow-black/30">
@@ -376,6 +397,29 @@ export function ActivationChecklist() {
           value={pct}
           className="mt-3 h-1.5 bg-zinc-800 [&>div]:bg-emerald-500"
         />
+
+        {guidedSetupIncomplete ? (
+          <button
+            type="button"
+            onClick={openJourney}
+            className="mt-3 flex w-full items-center gap-3 rounded-xl bg-emerald-500 px-3 py-2.5 text-left text-zinc-950 transition-colors hover:bg-emerald-400"
+          >
+            <Sparkles className="h-4 w-4 shrink-0" />
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-semibold">
+                {guidedSetupStarted
+                  ? "Resume guided setup"
+                  : "Start guided setup"}
+              </span>
+              <span className="block truncate text-xs text-emerald-950/75">
+                {guidedSetupStage
+                  ? `Continue at ${guidedSetupStage}`
+                  : "Choose your path and save progress as you go"}
+              </span>
+            </span>
+            <ArrowRight className="h-4 w-4 shrink-0" />
+          </button>
+        ) : null}
 
         <div className="mt-3 max-h-[45vh] space-y-1 overflow-y-auto">
           {milestones.map((m) => {

--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -128,11 +128,68 @@ export function OnboardingJourneyProvider({
   const [index, setIndex] = useState<number | null>(null);
   // Opens at most once per mount, so finishing/dismissing never reopens it.
   const opened = useRef(false);
+  // A manual CTA can be clicked before the subscription query settles. Queue
+  // that intent so the click is never lost and resolve it against stable steps.
+  const pendingManualOpen = useRef(false);
+  const pendingOpenRetryAttempted = useRef(false);
+
+  const retryPendingManualOpen = useCallback(() => {
+    if (pendingOpenRetryAttempted.current) return;
+    pendingOpenRetryAttempted.current = true;
+    toast.error("Guided setup is still loading. Retrying now.");
+    void subscription.refetch().then((result) => {
+      if (result.error && pendingManualOpen.current) {
+        pendingManualOpen.current = false;
+        pendingOpenRetryAttempted.current = false;
+        toast.error("Guided setup could not load. Please try again.");
+      }
+    });
+  }, [subscription.refetch]);
 
   const openJourney = useCallback(() => {
+    // `billingEnforced` changes the step positions. Never open against the
+    // temporary self-host step list while subscription context is loading.
     if (!isAdmin) return;
+    if (!subscription.data) {
+      pendingManualOpen.current = true;
+      if (subscription.error) {
+        retryPendingManualOpen();
+      }
+      return;
+    }
+    pendingManualOpen.current = false;
+    pendingOpenRetryAttempted.current = false;
     setIndex(resumeIndex);
-  }, [isAdmin, resumeIndex]);
+  }, [
+    isAdmin,
+    resumeIndex,
+    subscription.data,
+    subscription.error,
+    retryPendingManualOpen,
+  ]);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      pendingManualOpen.current = false;
+      pendingOpenRetryAttempted.current = false;
+      return;
+    }
+    if (!pendingManualOpen.current || index !== null) return;
+    if (!subscription.data) {
+      if (subscription.error) retryPendingManualOpen();
+      return;
+    }
+    pendingManualOpen.current = false;
+    pendingOpenRetryAttempted.current = false;
+    setIndex(resumeIndex);
+  }, [
+    isAdmin,
+    index,
+    resumeIndex,
+    retryPendingManualOpen,
+    subscription.data,
+    subscription.error,
+  ]);
 
   // Returning from Stripe Checkout during setup: ?setup=resume reopens the
   // journey at the saved step (the card step persisted "allSet" before the
@@ -142,7 +199,10 @@ export function OnboardingJourneyProvider({
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     if (params.get("setup") !== "resume") return;
-    if (!onboardingState.data) return; // wait for the saved cursor
+    // Wait for both the saved cursor and the hosted/self-host step list. A
+    // numeric index resolved against the temporary list can otherwise shift
+    // from `allSet` back to `billing` once subscription data arrives.
+    if (!onboardingState.data || !subscription.data) return;
     opened.current = true;
     params.delete("setup");
     const rest = params.toString();
@@ -152,7 +212,13 @@ export function OnboardingJourneyProvider({
       window.location.pathname + (rest ? `?${rest}` : ""),
     );
     setIndex(resumeIndex);
-  }, [isAdmin, index, onboardingState.data, resumeIndex]);
+  }, [
+    isAdmin,
+    index,
+    onboardingState.data,
+    subscription.data,
+    resumeIndex,
+  ]);
 
   useEffect(() => {
     if (opened.current || index !== null || !isAdmin) return;
@@ -274,13 +340,22 @@ function JourneyShell({
   const step = steps[index]!;
   const isLast = index >= total - 1;
 
-  // Persist the resume cursor (durable + optimistic) so a reload resumes here.
+  // Do not advance or close until the server accepts the cursor. A local-only
+  // optimistic cursor can strand a clinic at an earlier step after a reload.
   const persistCursor = useCallback(
-    (stepId: string) => {
+    async (stepId: string, dismissed?: boolean) => {
+      await setJourneyProgress.mutateAsync({ stepId, dismissed });
       utils.settings.getOnboardingState.setData(undefined, (prev) =>
-        prev ? { ...prev, journeyStepId: stepId } : prev,
+        prev
+          ? {
+              ...prev,
+              journeyStepId: stepId,
+              ...(dismissed === undefined
+                ? {}
+                : { journeyDismissed: dismissed }),
+            }
+          : prev,
       );
-      setJourneyProgress.mutate({ stepId });
     },
     [utils, setJourneyProgress],
   );
@@ -328,7 +403,7 @@ function JourneyShell({
         setContinueLabel(null);
         setContinueDisabled(false);
         const next = index + 1;
-        persistCursor(steps[next]!.id);
+        await persistCursor(steps[next]!.id, false);
         setIndex(next);
       }
     } catch (err) {
@@ -349,15 +424,24 @@ function JourneyShell({
     setIndex,
   ]);
 
-  const handleBack = useCallback(() => {
+  const handleBack = useCallback(async () => {
     if (busy || continueDisabled || state.hasPartialImport || index === 0)
       return;
-    handleRef.current = null;
-    setContinueLabel(null);
-    setContinueDisabled(false);
-    const prev = index - 1;
-    persistCursor(steps[prev]!.id);
-    setIndex(prev);
+    setBusy(true);
+    try {
+      const prev = index - 1;
+      await persistCursor(steps[prev]!.id, false);
+      handleRef.current = null;
+      setContinueLabel(null);
+      setContinueDisabled(false);
+      setIndex(prev);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Progress could not be saved.",
+      );
+    } finally {
+      setBusy(false);
+    }
   }, [
     busy,
     continueDisabled,
@@ -368,28 +452,33 @@ function JourneyShell({
     setIndex,
   ]);
 
-  const handleFinishLater = useCallback(() => {
+  const handleFinishLater = useCallback(async () => {
     if (busy || continueDisabled) return;
     // Not the same as finishing: record where we are and that it was dismissed,
     // WITHOUT marking onboarding complete. The checklist keeps nudging and the
     // user can resume from here later.
-    utils.settings.getOnboardingState.setData(undefined, (prev) =>
-      prev ? { ...prev, journeyStepId: step.id, journeyDismissed: true } : prev,
-    );
-    setJourneyProgress.mutate({ stepId: step.id, dismissed: true });
-    setIndex(null);
-    if (state.hasPartialImport) {
-      toast.success(
-        "Completed records are saved. Reopen setup or use Settings, then Data, to finish the remaining files.",
+    setBusy(true);
+    try {
+      await persistCursor(step.id, true);
+      setIndex(null);
+      if (state.hasPartialImport) {
+        toast.success(
+          "Completed records are saved. Reopen setup or use Settings, then Data, to finish the remaining files.",
+        );
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Progress could not be saved.",
       );
+    } finally {
+      setBusy(false);
     }
   }, [
     busy,
     continueDisabled,
     step.id,
     state.hasPartialImport,
-    utils,
-    setJourneyProgress,
+    persistCursor,
     setIndex,
   ]);
 
@@ -397,7 +486,7 @@ function JourneyShell({
     <DialogPrimitive.Root
       open
       onOpenChange={(open) => {
-        if (!open) handleFinishLater();
+        if (!open) void handleFinishLater();
       }}
     >
       <DialogPrimitive.Portal>

--- a/apps/web/components/onboarding/steps/choose-path.tsx
+++ b/apps/web/components/onboarding/steps/choose-path.tsx
@@ -24,6 +24,7 @@ const intentIcons = {
  * checklist and platform funnel can keep the same pathway context.
  */
 export function ChoosePathStep({ register, state, setState }: StepProps) {
+  const utils = trpc.useUtils();
   const saveIntent = trpc.settings.setOnboardingIntent.useMutation();
   const selected = getOnboardingIntentOption(state.onboardingIntent);
 
@@ -31,10 +32,22 @@ export function ChoosePathStep({ register, state, setState }: StepProps) {
     register({
       async onContinue() {
         await saveIntent.mutateAsync({ intent: state.onboardingIntent });
+        // The journey provider derives its same-session resume point from this
+        // cache. Keep it aligned with the successful server write so pausing
+        // and reopening does not return to the path question.
+        utils.settings.getOnboardingState.setData(undefined, (prev) =>
+          prev
+            ? {
+                ...prev,
+                onboardingIntent: state.onboardingIntent,
+                journeyDismissed: false,
+              }
+            : prev,
+        );
         return true;
       },
     });
-  }, [register, saveIntent, state.onboardingIntent]);
+  }, [register, saveIntent, state.onboardingIntent, utils]);
 
   return (
     <div className="space-y-5">

--- a/apps/web/components/tour/tour-provider.tsx
+++ b/apps/web/components/tour/tour-provider.tsx
@@ -108,6 +108,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
       // re-reads a stale "not_started" after a terminal status.
       utils.settings.getOnboardingState.setData(undefined, (prev) => ({
         journeyStepId: prev?.journeyStepId ?? null,
+        journeyLastProgressAt: prev?.journeyLastProgressAt ?? null,
         journeyDismissed: prev?.journeyDismissed ?? false,
         ...prev,
         onboardingIntent: prev?.onboardingIntent ?? null,

--- a/apps/web/lib/__tests__/activation-recovery.test.ts
+++ b/apps/web/lib/__tests__/activation-recovery.test.ts
@@ -23,6 +23,7 @@ const {
   computeActivationRecovery,
   deriveRecoveryNextAction,
   deriveRecoveryStage,
+  recoverySetupState,
 } = await import("@/lib/admin/activation-recovery");
 
 afterEach(() => {
@@ -93,6 +94,36 @@ describe("activation recovery", () => {
     expect(deriveRecoveryStage({ ...base, firstPositivePayment: true })).toBe(
       "first_positive_payment",
     );
+  });
+
+  it("recognizes the first path choice and retains the latest saved progress", () => {
+    const intentSelectedAt = "2026-08-07T10:00:00.000Z";
+    const journeyLastProgressAt = "2026-08-08T11:00:00.000Z";
+
+    expect(
+      recoverySetupState({
+        onboardingState: { onboardingIntentSelectedAt: intentSelectedAt },
+      }),
+    ).toMatchObject({
+      started: true,
+      completed: false,
+      stage: "Starting path",
+      lastProgressAt: new Date(intentSelectedAt),
+    });
+    expect(
+      recoverySetupState({
+        onboardingState: {
+          onboardingIntentSelectedAt: intentSelectedAt,
+          journeyStepId: "data",
+          journeyLastProgressAt,
+          journeyDismissed: false,
+        },
+      }),
+    ).toMatchObject({
+      started: true,
+      stage: "Data import",
+      lastProgressAt: new Date(journeyLastProgressAt),
+    });
   });
 
   it("covers help, contact, access, setup, activation, card, and paid actions", () => {
@@ -286,6 +317,7 @@ describe("activation recovery", () => {
     expect(source).toContain("from practice_conversion_milestones pcm");
     expect(source).toContain("pcm.milestone = 'payment_method_collected'");
     expect(source).toContain("pcm.milestone = 'first_positive_payment'");
+    expect(source).toContain("journeyLastProgressAt");
     expect(source).not.toContain("from funnel_events fe");
   });
 });

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -127,6 +127,21 @@ describe("dashboard onboarding UI states", () => {
     );
     expect(journeyProviderSource).toContain("const openJourney = useCallback(() => {");
     expect(journeyProviderSource).toContain("if (!isAdmin) return;");
+    expect(journeyProviderSource).toContain(
+      "pendingManualOpen.current = true"
+    );
+    expect(journeyProviderSource).toContain(
+      "!pendingManualOpen.current ||"
+    );
+    expect(journeyProviderSource).toContain(
+      "pendingManualOpen.current = false"
+    );
+    expect(journeyProviderSource).toContain(
+      "if (subscription.error) retryPendingManualOpen();"
+    );
+    expect(journeyProviderSource).toContain(
+      "if (result.error && pendingManualOpen.current)"
+    );
     expect(journeyProviderSource).toContain("const isOpen = isAdmin && index !== null");
     expect(journeyProviderSource).toContain("value={{ openJourney, isOpen }}");
     expect(journeyProviderSource).toMatch(/<JourneyShell\s+steps=\{steps\}/);
@@ -167,6 +182,10 @@ describe("dashboard onboarding UI states", () => {
       "requestOnboardingHelp: adminProcedure.mutation"
     );
     expect(settingsRouter).toContain('"Hands-on onboarding requested"');
+    expect(activationSource).toContain("useOnboardingJourney");
+    expect(activationSource).toContain("Resume guided setup");
+    expect(activationSource).toContain("Start guided setup");
+    expect(activationSource).toContain("onClick={openJourney}");
   });
 
   it("auto-opens the wizard for unfinished, non-dismissed onboarding and resumes durably", () => {
@@ -207,7 +226,19 @@ describe("dashboard onboarding UI states", () => {
     expect(journeyProviderSource).toContain("setIndex(resumeIndex)");
     // "I'll finish later" records dismissal WITHOUT completing onboarding.
     expect(journeyProviderSource).toContain(
-      "setJourneyProgress.mutate({ stepId: step.id, dismissed: true })"
+      "await persistCursor(step.id, true)"
+    );
+    expect(journeyProviderSource).toContain(
+      "await setJourneyProgress.mutateAsync({ stepId, dismissed })"
+    );
+    expect(journeyProviderSource).toContain(
+      "await persistCursor(steps[next]!.id, false)"
+    );
+    expect(journeyProviderSource).toContain(
+      "await persistCursor(steps[prev]!.id, false)"
+    );
+    expect(journeyProviderSource).toContain(
+      "if (!onboardingState.data || !subscription.data) return;"
     );
     expect(settingsRouter).toContain("setJourneyProgress: adminProcedure");
   });

--- a/apps/web/lib/__tests__/onboarding-ui-states.test.ts
+++ b/apps/web/lib/__tests__/onboarding-ui-states.test.ts
@@ -85,6 +85,10 @@ describe("onboarding UI states", () => {
     expect(choosePath).toContain(
       "saveIntent.mutateAsync({ intent: state.onboardingIntent })",
     );
+    expect(choosePath).toContain(
+      "onboardingIntent: state.onboardingIntent",
+    );
+    expect(choosePath).toContain("journeyDismissed: false");
     expect(settingsRouter).toContain("onboardingIntentSelectedAt");
   });
 

--- a/apps/web/lib/admin/activation-funnel.ts
+++ b/apps/web/lib/admin/activation-funnel.ts
@@ -157,7 +157,11 @@ export async function computeActivationFunnel(
         count(*) filter (
           where mt.registered_at is not null
             and (
-              nullif(s.settings -> 'onboardingState' ->> 'journeyStepId', '')
+              nullif(
+                s.settings -> 'onboardingState' ->> 'onboardingIntentSelectedAt',
+                ''
+              ) is not null
+              or nullif(s.settings -> 'onboardingState' ->> 'journeyStepId', '')
                 is not null
               or nullif(s.settings ->> 'onboardingCompletedAt', '') is not null
             )

--- a/apps/web/lib/admin/activation-recovery.ts
+++ b/apps/web/lib/admin/activation-recovery.ts
@@ -72,7 +72,9 @@ interface RecoveryRow {
 type RecoverySettings = {
   onboardingCompletedAt?: string | null;
   onboardingState?: {
+    onboardingIntentSelectedAt?: string | null;
     journeyStepId?: string | null;
+    journeyLastProgressAt?: string | null;
     journeyDismissed?: boolean;
     setupHelpRequestedAt?: string | null;
   };
@@ -122,10 +124,14 @@ export function recoverySetupState(settingsValue: unknown): {
   started: boolean;
   stage: string;
   helpRequestedAt: Date | null;
+  lastProgressAt: Date | null;
 } {
   const settings = (settingsValue ?? {}) as RecoverySettings;
   const state = settings.onboardingState;
   const helpRequestedAt = validDate(state?.setupHelpRequestedAt);
+  const intentSelectedAt = validDate(state?.onboardingIntentSelectedAt);
+  const lastProgressAt =
+    validDate(state?.journeyLastProgressAt) ?? intentSelectedAt;
   const completedAt = validDate(settings.onboardingCompletedAt);
   if (completedAt) {
     return {
@@ -134,6 +140,7 @@ export function recoverySetupState(settingsValue: unknown): {
       started: true,
       stage: "Complete",
       helpRequestedAt,
+      lastProgressAt,
     };
   }
   const step = state?.journeyStepId?.trim();
@@ -145,6 +152,17 @@ export function recoverySetupState(settingsValue: unknown): {
       started: true,
       stage: state?.journeyDismissed ? `Paused at ${label}` : label,
       helpRequestedAt,
+      lastProgressAt,
+    };
+  }
+  if (intentSelectedAt) {
+    return {
+      completed: false,
+      completedAt: null,
+      started: true,
+      stage: "Starting path",
+      helpRequestedAt,
+      lastProgressAt,
     };
   }
   return {
@@ -153,6 +171,7 @@ export function recoverySetupState(settingsValue: unknown): {
     started: false,
     stage: "Not started",
     helpRequestedAt,
+    lastProgressAt,
   };
 }
 
@@ -374,6 +393,7 @@ export async function computeActivationRecovery(
       validDate(row.lastMeaningfulActivityAt),
       setup.completedAt,
       setup.helpRequestedAt,
+      setup.lastProgressAt,
     ].reduce<Date>(
       (latest, candidate) =>
         candidate && candidate.getTime() > latest.getTime()

--- a/apps/web/lib/onboarding/__tests__/demo-data-lifecycle.test.ts
+++ b/apps/web/lib/onboarding/__tests__/demo-data-lifecycle.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { DemoDataIds } from "../defaults";
+import {
+  hasLiveDemoData,
+  mergeDemoDataProvenance,
+} from "../demo-data-lifecycle";
+
+function demoIds(prefix: string): DemoDataIds {
+  return {
+    clientIds: [`${prefix}-client`],
+    patientIds: [`${prefix}-patient`],
+    appointmentIds: [`${prefix}-appointment`],
+    soapNoteIds: [`${prefix}-soap`],
+    vaccinationIds: [`${prefix}-vaccination`],
+    problemIds: [`${prefix}-problem`],
+    invoiceIds: [`${prefix}-invoice`],
+    invoiceItemIds: [`${prefix}-invoice-item`],
+    communicationIds: [`${prefix}-communication`],
+    productIds: [`${prefix}-product`],
+  };
+}
+
+describe("demo data provenance", () => {
+  it("retains every historical sample id when a clinic reseeds", () => {
+    const historical = {
+      ...demoIds("old"),
+      clientIds: ["shared-client", "old-client"],
+      clearedAt: "2026-08-09T12:00:00.000Z",
+    };
+    const latest = {
+      ...demoIds("new"),
+      clientIds: ["shared-client", "new-client"],
+    };
+
+    expect(mergeDemoDataProvenance(historical, latest)).toEqual({
+      clientIds: ["shared-client", "old-client", "new-client"],
+      patientIds: ["old-patient", "new-patient"],
+      appointmentIds: ["old-appointment", "new-appointment"],
+      soapNoteIds: ["old-soap", "new-soap"],
+      vaccinationIds: ["old-vaccination", "new-vaccination"],
+      problemIds: ["old-problem", "new-problem"],
+      invoiceIds: ["old-invoice", "new-invoice"],
+      invoiceItemIds: ["old-invoice-item", "new-invoice-item"],
+      communicationIds: [
+        "old-communication",
+        "new-communication",
+      ],
+      productIds: ["old-product", "new-product"],
+      clearedAt: null,
+    });
+  });
+
+  it("only treats uncleared sample data as live", () => {
+    const live = { ...demoIds("live"), clearedAt: null };
+    const cleared = {
+      ...demoIds("cleared"),
+      clearedAt: "2026-08-09T12:00:00.000Z",
+    };
+
+    expect(hasLiveDemoData(live)).toBe(true);
+    expect(hasLiveDemoData(cleared)).toBe(false);
+    expect(hasLiveDemoData(undefined)).toBe(false);
+  });
+});

--- a/apps/web/lib/onboarding/demo-data-lifecycle.ts
+++ b/apps/web/lib/onboarding/demo-data-lifecycle.ts
@@ -1,0 +1,303 @@
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import {
+  appointments,
+  clients,
+  communications,
+  invoiceItems,
+  invoices,
+  patients,
+  practices,
+  problemList,
+  products,
+  soapNotes,
+  vaccinationRecords,
+} from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+import { seedDemoData, type DemoDataIds } from "./defaults";
+
+export interface DemoDataProvenance extends DemoDataIds {
+  /** Set after sample rows are cleared. IDs remain forever for attribution. */
+  clearedAt?: string | null;
+}
+
+type StoredDemoData = Partial<DemoDataIds> & {
+  clientIds: string[];
+  patientIds: string[];
+  appointmentIds: string[];
+  clearedAt?: string | null;
+};
+
+type PracticeSettingsWithDemo = {
+  demoData?: StoredDemoData;
+};
+
+function uniqueIds(...groups: Array<string[] | undefined>): string[] {
+  return [...new Set(groups.flatMap((group) => group ?? []))];
+}
+
+export function mergeDemoDataProvenance(
+  existing: StoredDemoData | undefined,
+  latest: DemoDataIds,
+): DemoDataProvenance {
+  return {
+    clientIds: uniqueIds(existing?.clientIds, latest.clientIds),
+    patientIds: uniqueIds(existing?.patientIds, latest.patientIds),
+    appointmentIds: uniqueIds(existing?.appointmentIds, latest.appointmentIds),
+    soapNoteIds: uniqueIds(existing?.soapNoteIds, latest.soapNoteIds),
+    vaccinationIds: uniqueIds(
+      existing?.vaccinationIds,
+      latest.vaccinationIds,
+    ),
+    problemIds: uniqueIds(existing?.problemIds, latest.problemIds),
+    invoiceIds: uniqueIds(existing?.invoiceIds, latest.invoiceIds),
+    invoiceItemIds: uniqueIds(
+      existing?.invoiceItemIds,
+      latest.invoiceItemIds,
+    ),
+    communicationIds: uniqueIds(
+      existing?.communicationIds,
+      latest.communicationIds,
+    ),
+    productIds: uniqueIds(existing?.productIds, latest.productIds),
+    clearedAt: null,
+  };
+}
+
+export function hasLiveDemoData(
+  demo: StoredDemoData | null | undefined,
+): boolean {
+  return Boolean(demo && !demo.clearedAt);
+}
+
+function activePracticeWhere(practiceId: string) {
+  return and(eq(practices.id, practiceId), isNull(practices.deletedAt));
+}
+
+async function lockDemoLifecycle(
+  db: Database,
+  practiceId: string,
+): Promise<void> {
+  await db.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${'openvpm:demo-data:' + practiceId}, 0))`,
+  );
+}
+
+function settingsDemoPatch(demoData: DemoDataProvenance) {
+  return sql`coalesce(${practices.settings}, '{}'::jsonb) || ${JSON.stringify({ demoData })}::jsonb`;
+}
+
+export async function clearSeededDemoData(
+  db: Database,
+  practiceId: string,
+): Promise<{ found: boolean; alreadyCleared: boolean }> {
+  return db.transaction(async (transaction) => {
+    const tx = transaction as unknown as Database;
+    await lockDemoLifecycle(tx, practiceId);
+
+    const [practice] = await tx
+      .select({ settings: practices.settings })
+      .from(practices)
+      .where(activePracticeWhere(practiceId))
+      .for("update");
+    if (!practice) return { found: false, alreadyCleared: false };
+
+    const settings = (practice.settings ?? {}) as PracticeSettingsWithDemo;
+    const demo = settings.demoData;
+    if (!demo || demo.clearedAt) {
+      return { found: true, alreadyCleared: true };
+    }
+
+    const now = new Date();
+    const storedDemoSoapNoteIds = demo.soapNoteIds ?? [];
+    let demoSoapNoteIds = [...storedDemoSoapNoteIds];
+    if (demo.appointmentIds.length > 0 || demo.patientIds.length > 0) {
+      const discoveredDemoSoapNotes = await tx
+        .select({ id: soapNotes.id })
+        .from(soapNotes)
+        .where(
+          and(
+            eq(soapNotes.practiceId, practiceId),
+            or(
+              inArray(soapNotes.appointmentId, demo.appointmentIds),
+              inArray(soapNotes.patientId, demo.patientIds),
+            ),
+          ),
+        );
+      demoSoapNoteIds = uniqueIds(
+        storedDemoSoapNoteIds,
+        discoveredDemoSoapNotes.map((note) => note.id),
+      );
+    }
+
+    if (demo.productIds?.length) {
+      await tx
+        .update(products)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(products.practiceId, practiceId),
+            inArray(products.id, demo.productIds),
+          ),
+        );
+    }
+    if (demo.communicationIds?.length) {
+      await tx
+        .update(communications)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(communications.practiceId, practiceId),
+            inArray(communications.id, demo.communicationIds),
+          ),
+        );
+    }
+    if (demo.invoiceItemIds?.length) {
+      await tx
+        .update(invoiceItems)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            inArray(invoiceItems.id, demo.invoiceItemIds),
+            sql`exists (
+              select 1
+              from ${invoices}
+              where ${invoices.id} = ${invoiceItems.invoiceId}
+                and ${invoices.practiceId} = ${practiceId}
+            )`,
+          ),
+        );
+    }
+    if (demo.invoiceIds?.length) {
+      await tx
+        .update(invoices)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(invoices.practiceId, practiceId),
+            inArray(invoices.id, demo.invoiceIds),
+          ),
+        );
+    }
+    if (demo.problemIds?.length) {
+      await tx
+        .update(problemList)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(problemList.practiceId, practiceId),
+            inArray(problemList.id, demo.problemIds),
+          ),
+        );
+    }
+    if (demo.vaccinationIds?.length) {
+      await tx
+        .update(vaccinationRecords)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(vaccinationRecords.practiceId, practiceId),
+            inArray(vaccinationRecords.id, demo.vaccinationIds),
+          ),
+        );
+    }
+    if (demoSoapNoteIds.length) {
+      await tx
+        .update(soapNotes)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(soapNotes.practiceId, practiceId),
+            inArray(soapNotes.id, demoSoapNoteIds),
+          ),
+        );
+    }
+    if (demo.appointmentIds.length) {
+      await tx
+        .update(appointments)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(appointments.practiceId, practiceId),
+            inArray(appointments.id, demo.appointmentIds),
+          ),
+        );
+    }
+    if (demo.patientIds.length) {
+      await tx
+        .update(patients)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(patients.practiceId, practiceId),
+            inArray(patients.id, demo.patientIds),
+          ),
+        );
+    }
+    if (demo.clientIds.length) {
+      await tx
+        .update(clients)
+        .set({ deletedAt: now })
+        .where(
+          and(
+            eq(clients.practiceId, practiceId),
+            inArray(clients.id, demo.clientIds),
+          ),
+        );
+    }
+
+    const preserved: DemoDataProvenance = {
+      clientIds: demo.clientIds,
+      patientIds: demo.patientIds,
+      appointmentIds: demo.appointmentIds,
+      soapNoteIds: demoSoapNoteIds,
+      vaccinationIds: demo.vaccinationIds ?? [],
+      problemIds: demo.problemIds ?? [],
+      invoiceIds: demo.invoiceIds ?? [],
+      invoiceItemIds: demo.invoiceItemIds ?? [],
+      communicationIds: demo.communicationIds ?? [],
+      productIds: demo.productIds ?? [],
+      clearedAt: now.toISOString(),
+    };
+    const [updated] = await tx
+      .update(practices)
+      .set({ settings: settingsDemoPatch(preserved) })
+      .where(activePracticeWhere(practiceId))
+      .returning({ id: practices.id });
+    if (!updated) return { found: false, alreadyCleared: false };
+
+    return { found: true, alreadyCleared: false };
+  });
+}
+
+export async function reseedSampleClinic(
+  db: Database,
+  practiceId: string,
+): Promise<{ found: boolean; alreadyPresent: boolean }> {
+  return db.transaction(async (transaction) => {
+    const tx = transaction as unknown as Database;
+    await lockDemoLifecycle(tx, practiceId);
+
+    const [practice] = await tx
+      .select({ settings: practices.settings })
+      .from(practices)
+      .where(activePracticeWhere(practiceId))
+      .for("update");
+    if (!practice) return { found: false, alreadyPresent: false };
+
+    const settings = (practice.settings ?? {}) as PracticeSettingsWithDemo;
+    if (hasLiveDemoData(settings.demoData)) {
+      return { found: true, alreadyPresent: true };
+    }
+
+    const latest = await seedDemoData(tx, { practiceId });
+    const preserved = mergeDemoDataProvenance(settings.demoData, latest);
+    const [updated] = await tx
+      .update(practices)
+      .set({ settings: settingsDemoPatch(preserved) })
+      .where(activePracticeWhere(practiceId))
+      .returning({ id: practices.id });
+    if (!updated) return { found: false, alreadyPresent: false };
+
+    return { found: true, alreadyPresent: false };
+  });
+}

--- a/apps/web/server/__tests__/admin-activation-funnel.test.ts
+++ b/apps/web/server/__tests__/admin-activation-funnel.test.ts
@@ -184,6 +184,7 @@ describe("admin activation funnel", () => {
     expect(source).toContain("pcm.milestone = 'activated'");
     expect(source).toContain("pcm.milestone = 'payment_method_collected'");
     expect(source).toContain("pcm.milestone = 'first_positive_payment'");
+    expect(source).toContain("onboardingIntentSelectedAt");
 
     // First-visit completion requires a completed, tenant-owned closeout for a
     // real appointment and uses the same post-signup/demo exclusions.

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -261,6 +261,8 @@ afterEach(() => {
   mocks.createSubscriptionCheckoutSession.mockResolvedValue({
     url: "https://stripe.example/signup-checkout",
   });
+  mocks.seedPractice.mockResolvedValue(undefined);
+  mocks.seedDemoData.mockResolvedValue({});
   vi.unstubAllEnvs();
 });
 
@@ -471,7 +473,7 @@ describe("auth router input validation", () => {
     expect(updateSet).not.toHaveBeenCalled();
   });
 
-  it("fails hosted signup before setup side effects when checkout cannot be created", async () => {
+  it("rolls back initialized hosted signup when checkout cannot be created", async () => {
     vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION", "price_location");
     mocks.billingEnforced.mockReturnValue(true);
     const consoleError = vi
@@ -504,8 +506,13 @@ describe("auth router input validation", () => {
         customerEmail: "owner@example.com",
       }),
     );
-    expect(mocks.seedPractice).not.toHaveBeenCalled();
-    expect(mocks.seedDemoData).not.toHaveBeenCalled();
+    expect(mocks.seedPractice).toHaveBeenCalledWith(
+      db,
+      { practiceId: "practice-1", locationId: "location-1" },
+    );
+    expect(mocks.seedDemoData).toHaveBeenCalledWith(db, {
+      practiceId: "practice-1",
+    });
     expect(mocks.createAuthToken).not.toHaveBeenCalled();
     expect(mocks.sendTrackedVerificationEmail).not.toHaveBeenCalled();
     expect(mocks.sendWelcomeEmail).not.toHaveBeenCalled();
@@ -514,7 +521,12 @@ describe("auth router input validation", () => {
       expect.any(Error),
     );
     consoleError.mockRestore();
-    expect(updateSet).not.toHaveBeenCalled();
+    expect(updateSet).toHaveBeenCalledWith({
+      settings: {
+        onboardingCompletedAt: null,
+        demoData: {},
+      },
+    });
   });
 
   it("creates hosted signup checkout without granting a no-card trial", async () => {
@@ -678,9 +690,49 @@ describe("auth router input validation", () => {
 
     expect(transaction).toHaveBeenCalled();
     expect(insertValues).toHaveBeenCalledTimes(3);
-    expect(mocks.seedPractice).not.toHaveBeenCalled();
+    expect(mocks.seedPractice).toHaveBeenCalledWith(
+      db,
+      { practiceId: "practice-1", locationId: "location-1" },
+    );
+    expect(mocks.seedDemoData).toHaveBeenCalledWith(db, {
+      practiceId: "practice-1",
+    });
+    expect(updateSet).toHaveBeenCalledWith({
+      settings: {
+        onboardingCompletedAt: null,
+        demoData: {},
+      },
+    });
+  });
+
+  it("fails the account transaction if starter catalog seeding fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { db, insertValues, transaction, updateSet } = createRegistrationDb();
+    mocks.seedPractice.mockRejectedValueOnce(new Error("catalog unavailable"));
+
+    await expect(
+      callerWithDb(db).register({
+        email: "owner@example.com",
+        password: "password123",
+        practiceName: "Neighborhood Veterinary",
+      }),
+    ).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Account setup failed. Please retry.",
+    });
+
+    expect(transaction).toHaveBeenCalled();
+    expect(insertValues).toHaveBeenCalledTimes(3);
     expect(mocks.seedDemoData).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.createAuthToken).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[register] clinic initialization failed:",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
   });
 });
 

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -5,6 +5,10 @@ const SETTINGS_SOURCE = readFileSync(
   new URL("../routers/settings.ts", import.meta.url),
   "utf8"
 );
+const DEMO_DATA_LIFECYCLE_SOURCE = readFileSync(
+  new URL("../../lib/onboarding/demo-data-lifecycle.ts", import.meta.url),
+  "utf8"
+);
 
 vi.mock("@/lib/billing/subscription-sync", () => ({
   syncPracticeSubscriptionQuantities: vi.fn(async () => ({
@@ -731,10 +735,7 @@ describe("settings admin stale target safety", () => {
 
 describe("settings demo data cleanup scoping", () => {
   it("scopes invoice-item cleanup through current-practice invoices", () => {
-    const clearDemoBlock = SETTINGS_SOURCE.match(
-      /clearDemoData:[\s\S]+?reseedDemoData:/
-    )?.[0];
-    const invoiceItemBlock = clearDemoBlock?.match(
+    const invoiceItemBlock = DEMO_DATA_LIFECYCLE_SOURCE.match(
       /\.update\(invoiceItems\)[\s\S]+?if \(demo\.invoiceIds/
     )?.[0];
 
@@ -746,33 +747,52 @@ describe("settings demo data cleanup scoping", () => {
       "${invoices.id} = ${invoiceItems.invoiceId}"
     );
     expect(invoiceItemBlock).toContain(
-      "${invoices.practiceId} = ${ctx.practiceId}"
+      "${invoices.practiceId} = ${practiceId}"
     );
   });
 
-  it("unions stored and user-created demo SOAP ids before immutable cleanup", () => {
-    const clearDemoBlock = SETTINGS_SOURCE.match(
-      /clearDemoData:[\s\S]+?reseedDemoData:/,
-    )?.[0];
-
-    expect(clearDemoBlock).toContain("let demoSoapNoteIds");
-    expect(clearDemoBlock).toContain("const storedDemoSoapNoteIds");
-    expect(clearDemoBlock).toContain("const discoveredDemoSoapNotes");
-    expect(clearDemoBlock).toContain("...storedDemoSoapNoteIds");
-    expect(clearDemoBlock).toContain("...discoveredDemoSoapNotes.map");
-    expect(clearDemoBlock).toContain(
+  it("preserves attribution while clearing stored and discovered demo SOAPs", () => {
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain("let demoSoapNoteIds");
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
+      "const storedDemoSoapNoteIds",
+    );
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
+      "const discoveredDemoSoapNotes",
+    );
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain("storedDemoSoapNoteIds,");
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
+      "discoveredDemoSoapNotes.map",
+    );
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
       "inArray(soapNotes.appointmentId, demo.appointmentIds)",
     );
-    expect(clearDemoBlock).toContain(
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
       "inArray(soapNotes.patientId, demo.patientIds)",
     );
-    expect(clearDemoBlock).toContain(
-      "demoData: { ...demo, soapNoteIds: demoSoapNoteIds }",
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
+      "soapNoteIds: demoSoapNoteIds",
     );
-    expect(clearDemoBlock?.indexOf("settingsMergePatch({")).toBeLessThan(
-      clearDemoBlock?.indexOf(".update(soapNotes)") ?? -1,
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
+      "clearedAt: now.toISOString()",
     );
-    expect(clearDemoBlock).toContain("inArray(soapNotes.id, demoSoapNoteIds)");
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
+      "inArray(soapNotes.id, demoSoapNoteIds)",
+    );
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).not.toContain("settingsRemoveKey");
+  });
+
+  it("serializes clear and reseed and delegates both mutations", () => {
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain("pg_advisory_xact_lock");
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain('.for("update")');
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
+      "const latest = await seedDemoData(tx, { practiceId })",
+    );
+    expect(SETTINGS_SOURCE).toContain(
+      "clearSeededDemoData(ctx.db, ctx.practiceId)",
+    );
+    expect(SETTINGS_SOURCE).toContain(
+      "reseedSampleClinic(ctx.db, ctx.practiceId)",
+    );
   });
 });
 

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -210,9 +210,26 @@ describe("settings admin stale target safety", () => {
     ).resolves.toEqual({ ok: true });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
-    expect(SETTINGS_SOURCE).toContain("onboardingStateMergePatch({");
-    expect(SETTINGS_SOURCE).toContain("onboardingIntent: input.intent");
+    expect(SETTINGS_SOURCE).toContain(
+      "onboardingIntentStatePatch(input.intent, now)",
+    );
+    expect(SETTINGS_SOURCE).toContain("'onboardingIntent', ${intent}");
     expect(SETTINGS_SOURCE).toContain("onboardingIntentSelectedAt");
+    expect(SETTINGS_SOURCE).toContain("journeyLastProgressAt");
+  });
+
+  it("keeps setup start and completion cohort timestamps first-write-wins", () => {
+    expect(SETTINGS_SOURCE).toContain("function onboardingIntentStatePatch");
+    expect(SETTINGS_SOURCE).toContain(
+      "nullif(${practices.settings}->'onboardingState'->>'onboardingIntentSelectedAt', '')",
+    );
+    expect(SETTINGS_SOURCE).toContain("function onboardingCompletionPatch");
+    expect(SETTINGS_SOURCE).toContain(
+      "nullif(${practices.settings}->>'onboardingCompletedAt', '')",
+    );
+    expect(SETTINGS_SOURCE).toContain(
+      "settings: onboardingCompletionPatch(completedAt)",
+    );
   });
 
   it("lets the clinic owner become a veterinarian provider on the primary location", async () => {

--- a/apps/web/server/__tests__/settings-welcome-context.test.ts
+++ b/apps/web/server/__tests__/settings-welcome-context.test.ts
@@ -108,6 +108,29 @@ describe("settings.welcomeContext", () => {
     expect(result.hasDemoData).toBe(true);
   });
 
+  it("treats a cleared sample marker as provenance rather than live data", async () => {
+    const clearedSettings = {
+      demoData: {
+        ...demoSettings.demoData,
+        clearedAt: "2026-08-09T12:00:00.000Z",
+      },
+    };
+    const { db } = createDb([
+      [practiceRow(clearedSettings)],
+      [], // historical demo client is soft-deleted
+      [{ id: "real-1", firstName: "Riley", lastName: "Bennett" }],
+      [], // historical demo patient is soft-deleted
+    ]);
+
+    await expect(
+      callerWithRole(db, "front_desk").welcomeContext(),
+    ).resolves.toMatchObject({
+      hasDemoData: false,
+      portalClient: { id: "real-1" },
+      demoPatientId: null,
+    });
+  });
+
   it("returns nulls for an empty practice with no demo data", async () => {
     const { db } = createDb([
       [practiceRow({})],

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -4,6 +4,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, publicProcedure, protectedProcedure } from "../trpc";
 import { users, practices, locations } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
 import { rateLimit } from "@/lib/rate-limit";
 import { seedPractice, seedDemoData } from "@/lib/onboarding/defaults";
 import {
@@ -232,8 +233,21 @@ export const authRouter = createRouter({
       }
 
       const passwordHash = await hash(input.password, PASSWORD_HASH_COST);
+      const practiceSettings: Record<string, unknown> = {};
+      if (input.acquisition) {
+        practiceSettings.acquisition = {
+          ...input.acquisition,
+          capturedAt: new Date().toISOString(),
+        };
+      }
+      if (onboardingDraft) {
+        practiceSettings.onboardingDraft = onboardingDraft;
+      }
+      if (hostedBilling) {
+        practiceSettings.onboardingCompletedAt = null;
+      }
 
-      const { practice, location, user, checkoutUrl } =
+      const { practice, user, checkoutUrl } =
         await ctx.db.transaction(async (tx) => {
           const [createdPractice] = await tx
             .insert(practices)
@@ -294,6 +308,34 @@ export const authRouter = createRouter({
             });
           }
 
+          // A clinic account must never commit with a partial starter catalog
+          // or untracked sample rows. Seed and persist provenance inside the
+          // same transaction as the practice, location, and owner.
+          try {
+            await seedPractice(tx as unknown as Database, {
+              practiceId: createdPractice.id,
+              locationId: createdLocation.id,
+            });
+            if (hostedBilling) {
+              practiceSettings.demoData = await seedDemoData(
+                tx as unknown as Database,
+                { practiceId: createdPractice.id },
+              );
+            }
+            if (Object.keys(practiceSettings).length > 0) {
+              await tx
+                .update(practices)
+                .set({ settings: practiceSettings })
+                .where(eq(practices.id, createdPractice.id));
+            }
+          } catch (err) {
+            console.error("[register] clinic initialization failed:", err);
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Account setup failed. Please retry.",
+            });
+          }
+
           let createdCheckoutUrl: string | undefined;
           if (hostedCheckoutLineItems) {
             try {
@@ -330,51 +372,10 @@ export const authRouter = createRouter({
 
           return {
             practice: createdPractice,
-            location: createdLocation,
             user: createdUser,
             checkoutUrl: createdCheckoutUrl,
           };
         });
-
-      // Seed sensible defaults (appointment types, rooms, starter services) so
-      // the new practice is usable immediately. Non-fatal: a seed hiccup must
-      // not block signup — the practice still works, just emptier.
-      try {
-        await seedPractice(ctx.db, {
-          practiceId: practice.id,
-          locationId: location?.id ?? null,
-        });
-      } catch (err) {
-        console.error("[register] practice seeding failed:", err);
-      }
-
-      // On the hosted service, seed demo data + start onboarding so the trial
-      // lands on a lively dashboard. Non-fatal. Self-host skips this.
-      const practiceSettings: Record<string, unknown> = {};
-      if (input.acquisition) {
-        practiceSettings.acquisition = {
-          ...input.acquisition,
-          capturedAt: new Date().toISOString(),
-        };
-      }
-      if (onboardingDraft) {
-        practiceSettings.onboardingDraft = onboardingDraft;
-      }
-      if (hostedBilling) {
-        practiceSettings.onboardingCompletedAt = null;
-        try {
-          const demoData = await seedDemoData(ctx.db, { practiceId: practice.id });
-          practiceSettings.demoData = demoData;
-        } catch (err) {
-          console.error("[register] demo seeding failed:", err);
-        }
-      }
-      if (Object.keys(practiceSettings).length) {
-        await ctx.db
-          .update(practices)
-          .set({ settings: practiceSettings })
-          .where(eq(practices.id, practice.id));
-      }
 
       // Durable, privacy-safe registration stage. Non-fatal so telemetry can
       // never turn a successful account creation into a failed signup.

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -187,6 +187,45 @@ function onboardingStateMergePatch(patch: Record<string, unknown>) {
   )`;
 }
 
+/**
+ * Selects (and may later change) the clinic's setup path without rewriting the
+ * first time setup actually began. That timestamp is cohort evidence, not a
+ * last-updated field.
+ */
+function onboardingIntentStatePatch(intent: OnboardingIntent, now: string) {
+  return sql`jsonb_set(
+    coalesce(${practices.settings}, '{}'::jsonb),
+    '{onboardingState}',
+    coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) ||
+      jsonb_build_object(
+        'onboardingIntent', ${intent},
+        'onboardingIntentSelectedAt', coalesce(
+          nullif(${practices.settings}->'onboardingState'->>'onboardingIntentSelectedAt', ''),
+          ${now}
+        ),
+        'journeyLastProgressAt', ${now},
+        'journeyDismissed', false
+      )
+  )`;
+}
+
+/** Keep setup completion first-write-wins while recording fresh activity. */
+function onboardingCompletionPatch(now: string) {
+  return sql`jsonb_set(
+    jsonb_set(
+      coalesce(${practices.settings}, '{}'::jsonb),
+      '{onboardingCompletedAt}',
+      to_jsonb(coalesce(
+        nullif(${practices.settings}->>'onboardingCompletedAt', ''),
+        ${now}
+      )::text)
+    ),
+    '{onboardingState}',
+    coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) ||
+      jsonb_build_object('journeyLastProgressAt', ${now})
+  )`;
+}
+
 function staffAdminRosterLockKey(practiceId: string) {
   return `settings:staff-admin-roster:${practiceId}`;
 }
@@ -303,6 +342,8 @@ interface PracticeSettings {
     onboardingIntentSelectedAt?: string;
     /** Resume cursor for the "Make it yours" setup wizard (step id, not index). */
     journeyStepId?: string | null;
+    /** Last successfully persisted journey action, used for stall recovery. */
+    journeyLastProgressAt?: string;
     /** "I'll finish later" — suppresses auto-open without completing onboarding. */
     journeyDismissed?: boolean;
     /** Sticky marker: a reviewed migration committed real clinic data. */
@@ -1169,7 +1210,7 @@ export const settingsRouter = createRouter({
 
     return {
       practiceName: practice.name,
-      hasDemoData: !!demo,
+      hasDemoData: hasLiveDemoData(demo),
       portalClient,
       demoPatientName,
       demoPatientId,
@@ -1179,12 +1220,11 @@ export const settingsRouter = createRouter({
 
   /** Mark onboarding complete. */
   completeOnboarding: adminProcedure.mutation(async ({ ctx }) => {
+    const completedAt = new Date().toISOString();
     const [updated] = await ctx.db
       .update(practices)
       .set({
-        settings: settingsMergePatch({
-          onboardingCompletedAt: new Date().toISOString(),
-        }),
+        settings: onboardingCompletionPatch(completedAt),
       })
       .where(activePracticeWhere(ctx.practiceId))
       .returning({ id: practices.id });
@@ -1256,6 +1296,7 @@ export const settingsRouter = createRouter({
       onboardingIntent: null,
       onboardingIntentSelectedAt: null,
       journeyStepId: null,
+      journeyLastProgressAt: null,
       journeyDismissed: false,
       migrationHasCommittedChanges: false,
       migrationLastCommittedAt: null,
@@ -1311,14 +1352,11 @@ export const settingsRouter = createRouter({
   setOnboardingIntent: adminProcedure
     .input(z.object({ intent: onboardingIntentInput }))
     .mutation(async ({ ctx, input }) => {
+      const now = new Date().toISOString();
       const [updated] = await ctx.db
         .update(practices)
         .set({
-          settings: onboardingStateMergePatch({
-            onboardingIntent: input.intent,
-            onboardingIntentSelectedAt: new Date().toISOString(),
-            journeyDismissed: false,
-          }),
+          settings: onboardingIntentStatePatch(input.intent, now),
         })
         .where(activePracticeWhere(ctx.practiceId))
         .returning({ id: practices.id });
@@ -1341,11 +1379,12 @@ export const settingsRouter = createRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const patch: Record<string, unknown> = {};
+      const patch: Record<string, unknown> = {
+        journeyLastProgressAt: new Date().toISOString(),
+      };
       if (input.stepId != null) patch.journeyStepId = input.stepId;
       if (input.dismissed !== undefined)
         patch.journeyDismissed = input.dismissed;
-      if (Object.keys(patch).length === 0) return { ok: true };
 
       const [updated] = await ctx.db
         .update(practices)

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -25,12 +25,7 @@ import {
   clients,
   patients,
   appointments,
-  soapNotes,
-  vaccinationRecords,
-  problemList,
   invoices,
-  invoiceItems,
-  communications,
   products,
   locations,
   locationMessaging,
@@ -42,7 +37,12 @@ import type { Database } from "@openpims/db/client";
 import { regionDefaults } from "@/lib/locale/format";
 import { alertOps } from "@/lib/alerts";
 import { syncPracticeSubscriptionQuantities } from "@/lib/billing/subscription-sync";
-import { seedDemoData } from "@/lib/onboarding/defaults";
+import {
+  clearSeededDemoData,
+  hasLiveDemoData,
+  reseedSampleClinic,
+  type DemoDataProvenance,
+} from "@/lib/onboarding/demo-data-lifecycle";
 import { createAuthToken } from "@/lib/auth-tokens";
 import { PASSWORD_HASH_COST } from "@/lib/auth-hashing";
 import { authPasswordInput } from "@/lib/auth-password";
@@ -179,10 +179,6 @@ function settingsMergePatch(patch: Record<string, unknown>) {
   return sql`coalesce(${practices.settings}, '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb`;
 }
 
-function settingsRemoveKey(key: string) {
-  return sql`coalesce(${practices.settings}, '{}'::jsonb) - ${key}`;
-}
-
 function onboardingStateMergePatch(patch: Record<string, unknown>) {
   return sql`jsonb_set(
     coalesce(${practices.settings}, '{}'::jsonb),
@@ -285,18 +281,7 @@ async function syncBillingAfterLocationChange(
 
 interface PracticeSettings {
   onboardingCompletedAt?: string | null;
-  demoData?: {
-    clientIds: string[];
-    patientIds: string[];
-    appointmentIds: string[];
-    soapNoteIds?: string[];
-    vaccinationIds?: string[];
-    problemIds?: string[];
-    invoiceIds?: string[];
-    invoiceItemIds?: string[];
-    communicationIds?: string[];
-    productIds?: string[];
-  };
+  demoData?: DemoDataProvenance;
   onboardingDraft?: {
     logoName?: string;
     brandColor?: string;
@@ -1058,7 +1043,7 @@ export const settingsRouter = createRouter({
     const demoPatientIds = new Set(settings.demoData?.patientIds ?? []);
     return {
       completedAt: settings.onboardingCompletedAt ?? null,
-      hasDemoData: !!settings.demoData,
+      hasDemoData: hasLiveDemoData(settings.demoData),
       // A secondary-PIMS buyer reaches a real-data milestone without having to
       // delete the sample clinic first. This also keeps the checklist honest
       // when real and demo patients intentionally coexist during evaluation.
@@ -1438,195 +1423,16 @@ export const settingsRouter = createRouter({
 
   /** Remove the seeded demo clients/patients/appointments (soft delete). */
   clearDemoData: adminProcedure.mutation(async ({ ctx }) => {
-    const [practice] = await ctx.db
-      .select({ settings: practices.settings })
-      .from(practices)
-      .where(activePracticeWhere(ctx.practiceId))
-      .limit(1);
-    if (!practice) {
-      throw practiceNotFound();
-    }
-    const settings = (practice.settings ?? {}) as PracticeSettings;
-    const demo = settings.demoData;
-    if (demo) {
-      const now = new Date();
-      const storedDemoSoapNoteIds = demo.soapNoteIds ?? [];
-      let demoSoapNoteIds = [...storedDemoSoapNoteIds];
-      if (demo.appointmentIds.length > 0 || demo.patientIds.length > 0) {
-        // Always discover every descendant note. Replacement SOAPs can be
-        // created after seeding and therefore are not present in saved IDs.
-        const discoveredDemoSoapNotes = await ctx.db
-          .select({ id: soapNotes.id })
-          .from(soapNotes)
-          .where(
-            and(
-              eq(soapNotes.practiceId, ctx.practiceId),
-              or(
-                inArray(soapNotes.appointmentId, demo.appointmentIds),
-                inArray(soapNotes.patientId, demo.patientIds),
-              ),
-            ),
-          );
-        demoSoapNoteIds = [
-          ...new Set([
-            ...storedDemoSoapNoteIds,
-            ...discoveredDemoSoapNotes.map((note) => note.id),
-          ]),
-        ];
-        if (demoSoapNoteIds.length !== storedDemoSoapNoteIds.length) {
-          await ctx.db
-            .update(practices)
-            .set({
-              settings: settingsMergePatch({
-                demoData: { ...demo, soapNoteIds: demoSoapNoteIds },
-              }),
-            })
-            .where(activePracticeWhere(ctx.practiceId));
-        }
-      }
-      // Soft-delete the clinical and billing records first, then the
-      // appointments/patients/clients they hang off of.
-      if (demo.productIds?.length) {
-        await ctx.db
-          .update(products)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(products.practiceId, ctx.practiceId),
-              inArray(products.id, demo.productIds),
-            ),
-          );
-      }
-      if (demo.communicationIds?.length) {
-        await ctx.db
-          .update(communications)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(communications.practiceId, ctx.practiceId),
-              inArray(communications.id, demo.communicationIds),
-            ),
-          );
-      }
-      if (demo.invoiceItemIds?.length) {
-        await ctx.db
-          .update(invoiceItems)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              inArray(invoiceItems.id, demo.invoiceItemIds),
-              sql`exists (
-                select 1
-                from ${invoices}
-                where ${invoices.id} = ${invoiceItems.invoiceId}
-                  and ${invoices.practiceId} = ${ctx.practiceId}
-              )`,
-            ),
-          );
-      }
-      if (demo.invoiceIds?.length) {
-        await ctx.db
-          .update(invoices)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(invoices.practiceId, ctx.practiceId),
-              inArray(invoices.id, demo.invoiceIds),
-            ),
-          );
-      }
-      if (demo.problemIds?.length) {
-        await ctx.db
-          .update(problemList)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(problemList.practiceId, ctx.practiceId),
-              inArray(problemList.id, demo.problemIds),
-            ),
-          );
-      }
-      if (demo.vaccinationIds?.length) {
-        await ctx.db
-          .update(vaccinationRecords)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(vaccinationRecords.practiceId, ctx.practiceId),
-              inArray(vaccinationRecords.id, demo.vaccinationIds),
-            ),
-          );
-      }
-      if (demoSoapNoteIds.length) {
-        await ctx.db
-          .update(soapNotes)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(soapNotes.practiceId, ctx.practiceId),
-              inArray(soapNotes.id, demoSoapNoteIds),
-            ),
-          );
-      }
-      if (demo.appointmentIds?.length) {
-        await ctx.db
-          .update(appointments)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(appointments.practiceId, ctx.practiceId),
-              inArray(appointments.id, demo.appointmentIds),
-            ),
-          );
-      }
-      if (demo.patientIds?.length) {
-        await ctx.db
-          .update(patients)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(patients.practiceId, ctx.practiceId),
-              inArray(patients.id, demo.patientIds),
-            ),
-          );
-      }
-      if (demo.clientIds?.length) {
-        await ctx.db
-          .update(clients)
-          .set({ deletedAt: now })
-          .where(
-            and(
-              eq(clients.practiceId, ctx.practiceId),
-              inArray(clients.id, demo.clientIds),
-            ),
-          );
-      }
-    }
-    await ctx.db
-      .update(practices)
-      .set({ settings: settingsRemoveKey("demoData") })
-      .where(activePracticeWhere(ctx.practiceId));
-    return { ok: true };
+    const result = await clearSeededDemoData(ctx.db, ctx.practiceId);
+    if (!result.found) throw practiceNotFound();
+    return { ok: true, alreadyCleared: result.alreadyCleared };
   }),
 
   /** Add the sample clients, pets, and visits back. No-op if already present. */
   reseedDemoData: adminProcedure.mutation(async ({ ctx }) => {
-    const [practice] = await ctx.db
-      .select({ settings: practices.settings })
-      .from(practices)
-      .where(activePracticeWhere(ctx.practiceId))
-      .limit(1);
-    if (!practice) {
-      throw practiceNotFound();
-    }
-    const settings = (practice.settings ?? {}) as PracticeSettings;
-    if (settings.demoData) return { ok: true, alreadyPresent: true };
-    const demoData = await seedDemoData(ctx.db, { practiceId: ctx.practiceId });
-    await ctx.db
-      .update(practices)
-      .set({ settings: settingsMergePatch({ demoData }) })
-      .where(activePracticeWhere(ctx.practiceId));
-    return { ok: true, alreadyPresent: false };
+    const result = await reseedSampleClinic(ctx.db, ctx.practiceId);
+    if (!result.found) throw practiceNotFound();
+    return { ok: true, alreadyPresent: result.alreadyPresent };
   }),
 
   // ── Staff / Users ─────────────────────────────────────────

--- a/docs/conversion-observability.md
+++ b/docs/conversion-observability.md
@@ -59,6 +59,21 @@ re-cohorted. Abandonment ages from the exact stage event: first touch before a
 demo, demo submission before registration, and each canonical milestone after
 registration.
 
+Clinic setup reporting is similarly durable. Setup starts at the first saved
+`onboardingIntentSelectedAt` (with the legacy step cursor or completion marker
+as fallbacks), and that first timestamp never changes when a clinic revisits its
+path. `journeyLastProgressAt` advances only after a setup action is persisted
+successfully and is used to age stalled setup in the recovery queue. Completion
+is also first-write-wins, so reopening or replaying the finish action cannot
+move a clinic into a newer cohort.
+
+Sample clinic IDs are cumulative provenance. Clearing sample data soft-deletes
+the rows but retains every ID with a `clearedAt` marker; reseeding merges new IDs
+into that history and clears the marker. This prevents old sample rows from
+becoming apparent real activation evidence. Account creation, starter catalog
+seeding, sample seeding, and initial provenance commit together, while clear and
+reseed operations are serialized per practice.
+
 Investigate non-zero projection drift if it persists beyond one hourly run.
 Unmapped Stripe evidence needs an operator to correct the authoritative Stripe
 customer/subscription-to-practice mapping; do not edit evidence timestamps or


### PR DESCRIPTION
## Summary

Makes hosted signup and guided setup trustworthy enough to measure and recover:

- commits practice, owner, starter catalog, sample clinic, and sample provenance in one signup transaction
- preserves cumulative sample IDs after clear/reseed so sample rows can never become real activation evidence
- serializes sample clear/reseed operations per practice
- makes setup start and completion timestamps first-write-wins
- waits for cursor persistence before advancing, going back, or pausing
- adds a prominent dashboard Start/Resume guided setup action
- fixes same-session resume, Stripe-return step resolution, queued loading/retry, and paused-state recovery
- anchors funnel setup-start and recovery aging to durable setup evidence

No database schema migration is required.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactoring / code quality
- [x] Documentation
- [ ] Other (describe):

## Testing

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes — 3,340 passed, 1 provider-dependent SMS integration skipped
- [x] `pnpm build` succeeds
- [ ] Tested manually in a local dev environment
- [ ] Added/updated E2E tests (not applicable; focused router, lifecycle, recovery, and UI contract tests added)

## Screenshots

Not captured. The UI change is a compact Start/Resume guided setup action inside the existing activation checklist.

## Checklist

- [x] Code follows the existing style (TypeScript, Tailwind, tRPC patterns)
- [x] No hardcoded secrets or credentials
- [x] Database changes include schema updates in `packages/db/schema/` (not applicable; no schema change)
- [x] New API endpoints include Zod validation and role-based access checks (not applicable; no new endpoint)

## Review notes

Two independent adversarial reviews found and verified fixes for transactional/concurrency safety and onboarding query-timing behavior. Both report no remaining release blockers.