### PR TITLE
Make provider availability location-aware

### DIFF
--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -760,7 +760,7 @@ const sections: Section[] = [
         method: "GET",
         description: "List appointment types available for portal booking.",
         input: `{ token: string }`,
-        response: `Array<{ id: string, name: string, durationMinutes: number }>`,
+        response: `Array<{ id: string, name: string, durationMinutes: number, requiresDoctor: number }>`,
         auth: "Portal token",
       },
       {
@@ -770,8 +770,9 @@ const sections: Section[] = [
         input: `{
   token: string,
   date: string, // YYYY-MM-DD
+  typeId?: string, // uses the verified type duration and provider coverage
   locationId?: string, // required when the clinic has multiple locations
-  durationMinutes?: number // 5-480 minutes, defaults to 30
+  durationMinutes?: number // legacy fallback when typeId is omitted
 }`,
         response: `Array<{ time: string, iso: string }>`,
         auth: "Portal token",
@@ -784,7 +785,7 @@ const sections: Section[] = [
         input: `{
   token: string,
   patientId: string,
-  typeId?: string,
+  typeId: string,
   locationId?: string, // required when the clinic has multiple locations
   reason: string,
   preferredDate: string, // YYYY-MM-DD

--- a/apps/web/app/portal/[token]/book/page.tsx
+++ b/apps/web/app/portal/[token]/book/page.tsx
@@ -63,6 +63,7 @@ export default function BookAppointmentPage() {
       token,
       date: preferredDate,
       durationMinutes: selectedDurationMinutes,
+      typeId: typeId || undefined,
       locationId: locationId || undefined
     },
     { enabled: !!preferredDate && hasValidAppointmentType && !!locationId }

--- a/apps/web/components/settings/provider-hours.tsx
+++ b/apps/web/components/settings/provider-hours.tsx
@@ -64,7 +64,7 @@ export function ProviderHours() {
   );
   const [editingRevision, setEditingRevision] = useState<string | null>(null);
   const [draft, setDraft] = useState<ProviderWindow[]>([]);
-  const [confirmMoveToPrimary, setConfirmMoveToPrimary] = useState(false);
+  const [selectedLocationId, setSelectedLocationId] = useState("");
   const validationError = useMemo(() => scheduleError(draft), [draft]);
   const save = trpc.settings.replaceProviderSchedule.useMutation({
     onSuccess: async () => {
@@ -74,7 +74,6 @@ export function ProviderHours() {
       ]);
       setEditingProviderId(null);
       setEditingRevision(null);
-      setConfirmMoveToPrimary(false);
       toast.success("Provider hours saved");
     },
     onError: (error) => toast.error(error.message),
@@ -106,7 +105,11 @@ export function ProviderHours() {
     );
   }
 
-  const { primaryLocation, providers, timezone } = setup.data;
+  const { locations, primaryLocation, providers, timezone } = setup.data;
+  const selectedLocation =
+    locations.find((location) => location.id === selectedLocationId) ??
+    primaryLocation ??
+    locations[0];
 
   return (
     <section className="space-y-4 rounded-lg border border-border bg-card p-4">
@@ -117,22 +120,39 @@ export function ProviderHours() {
             <h3 className="text-sm font-semibold">Provider working hours</h3>
           </div>
           <p className="mt-1 max-w-2xl text-xs text-muted-foreground">
-            Configure the weekly hours each veterinarian expects to work at the
-            primary location. Times use {timezone}. These hours are saved for
-            clinic setup and do not yet limit the schedule or client requests.
+            Set each veterinarian&apos;s weekly coverage at every clinic. Times
+            use {timezone}. Doctor-required client requests only show configured
+            provider coverage once your clinic saves its first hours.
           </p>
         </div>
-        {primaryLocation ? (
-          <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium">
-            {primaryLocation.name}
-          </span>
+        {locations.length > 0 ? (
+          <label className="text-xs font-medium text-muted-foreground">
+            Clinic location
+            <select
+              aria-label="Provider hours clinic location"
+              className="mt-1 block h-9 min-w-48 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+              value={selectedLocation?.id ?? ""}
+              onChange={(event) => {
+                setSelectedLocationId(event.target.value);
+                setEditingProviderId(null);
+                setEditingRevision(null);
+                setDraft([]);
+              }}
+            >
+              {locations.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {location.name}
+                  {location.isPrimary ? " (primary)" : ""}
+                </option>
+              ))}
+            </select>
+          </label>
         ) : null}
       </div>
 
-      {!primaryLocation ? (
+      {!selectedLocation ? (
         <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950">
-          Choose a primary location in the Locations tab before setting provider
-          hours.
+          Add an active clinic location before setting provider hours.
         </div>
       ) : providers.length === 0 ? (
         <div className="rounded-md bg-muted/50 p-4 text-sm text-muted-foreground">
@@ -143,15 +163,15 @@ export function ProviderHours() {
         <div className="space-y-3">
           {providers.map((provider) => {
             const editing = editingProviderId === provider.id;
-            const requiresMoveConsent =
-              draft.length > 0 && !provider.assignedToPrimary;
-            const requiresReplacementConsent =
-              provider.otherLocationWindowCount > 0;
-            const requiresConsent =
-              requiresMoveConsent || requiresReplacementConsent;
-            const dayCount = new Set(
-              provider.windows.map((window) => window.dayOfWeek),
-            ).size;
+            const windows =
+              provider.locationSchedules.find(
+                (schedule) => schedule.locationId === selectedLocation.id,
+              )?.windows ?? [];
+            const homeLocation = locations.find(
+              (location) => location.id === provider.locationId,
+            );
+            const dayCount = new Set(windows.map((window) => window.dayOfWeek))
+              .size;
             return (
               <div
                 key={provider.id}
@@ -161,17 +181,22 @@ export function ProviderHours() {
                   <div>
                     <p className="text-sm font-medium">{provider.name}</p>
                     <p className="text-xs text-muted-foreground">
-                      {provider.windows.length === 0
-                        ? "No working hours set"
-                        : `${dayCount} day${dayCount === 1 ? "" : "s"} · ${provider.windows.length} working window${provider.windows.length === 1 ? "" : "s"}`}
+                      {windows.length === 0
+                        ? `No hours set at ${selectedLocation.name}`
+                        : `${dayCount} day${dayCount === 1 ? "" : "s"} · ${windows.length} working window${windows.length === 1 ? "" : "s"}`}
                     </p>
-                    {provider.otherLocationWindowCount > 0 ? (
+                    {homeLocation ? (
+                      <p className="text-xs text-muted-foreground">
+                        Home base: {homeLocation.name}
+                      </p>
+                    ) : null}
+                    {provider.unspecifiedWindowCount > 0 ? (
                       <p className="text-xs text-amber-700">
-                        {provider.otherLocationWindowCount} additional working
-                        {provider.otherLocationWindowCount === 1
-                          ? " window is"
-                          : " windows are"}{" "}
-                        saved outside the primary location
+                        {provider.unspecifiedWindowCount} legacy practice-wide
+                        working{" "}
+                        {provider.unspecifiedWindowCount === 1
+                          ? "window"
+                          : "windows"}
                       </p>
                     ) : null}
                   </div>
@@ -183,27 +208,16 @@ export function ProviderHours() {
                       if (editing) {
                         setEditingProviderId(null);
                         setEditingRevision(null);
-                        setConfirmMoveToPrimary(false);
                         return;
                       }
                       setEditingProviderId(provider.id);
                       setEditingRevision(provider.revision);
-                      setConfirmMoveToPrimary(false);
-                      setDraft(
-                        provider.windows.map((window) => ({ ...window })),
-                      );
+                      setDraft(windows.map((window) => ({ ...window })));
                     }}
                   >
                     {editing ? "Close editor" : "Set hours"}
                   </Button>
                 </div>
-
-                {!provider.assignedToPrimary ? (
-                  <p className="mt-2 text-xs text-amber-700">
-                    This provider is assigned to another location.
-                    Primary-location hours require an explicit move below.
-                  </p>
-                ) : null}
 
                 {editing ? (
                   <div className="mt-4 space-y-3 border-t border-border pt-4">
@@ -223,27 +237,6 @@ export function ProviderHours() {
                         Mark all closed
                       </Button>
                     </div>
-
-                    {requiresConsent ? (
-                      <label className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-950">
-                        <input
-                          className="mt-0.5 h-4 w-4"
-                          type="checkbox"
-                          checked={confirmMoveToPrimary}
-                          onChange={(event) =>
-                            setConfirmMoveToPrimary(event.target.checked)
-                          }
-                        />
-                        <span>
-                          {requiresMoveConsent
-                            ? `Move ${provider.name} to ${primaryLocation.name} when I save these hours. This updates their staff location. `
-                            : ""}
-                          {requiresReplacementConsent
-                            ? `Saving replaces ${provider.otherLocationWindowCount} existing working ${provider.otherLocationWindowCount === 1 ? "window" : "windows"} outside ${primaryLocation.name}. Multi-location hours are not supported yet.`
-                            : ""}
-                        </span>
-                      </label>
-                    ) : null}
 
                     <div className="space-y-2">
                       {DAYS.map((dayName, dayOfWeek) => {
@@ -376,19 +369,14 @@ export function ProviderHours() {
                         disabled={
                           Boolean(validationError) ||
                           save.isPending ||
-                          editingRevision === null ||
-                          (requiresConsent && !confirmMoveToPrimary)
+                          editingRevision === null
                         }
                         onClick={() =>
                           save.mutate({
                             userId: provider.id,
+                            locationId: selectedLocation.id,
                             windows: draft,
                             expectedRevision: editingRevision!,
-                            moveToPrimaryLocation:
-                              requiresMoveConsent && confirmMoveToPrimary,
-                            replaceOtherLocationHours:
-                              requiresReplacementConsent &&
-                              confirmMoveToPrimary,
                           })
                         }
                       >
@@ -404,7 +392,6 @@ export function ProviderHours() {
                         onClick={() => {
                           setEditingProviderId(null);
                           setEditingRevision(null);
-                          setConfirmMoveToPrimary(false);
                         }}
                       >
                         Cancel

--- a/apps/web/lib/__tests__/portal-booking-ui.test.ts
+++ b/apps/web/lib/__tests__/portal-booking-ui.test.ts
@@ -45,7 +45,7 @@ describe("portal booking UI", () => {
       "const hasValidPreferredTime = isPortalBookingStartWithinBounds("
     );
     expect(source).toContain(
-      "durationMinutes: selectedDurationMinutes,\n      locationId: locationId || undefined"
+      "durationMinutes: selectedDurationMinutes,\n      typeId: typeId || undefined,\n      locationId: locationId || undefined"
     );
     expect(source).not.toContain("const appointmentTypes = types.data ?? []");
     expect(source).not.toContain(

--- a/apps/web/lib/__tests__/provider-hours-ui.test.ts
+++ b/apps/web/lib/__tests__/provider-hours-ui.test.ts
@@ -24,24 +24,20 @@ describe("provider hours settings UI", () => {
     expect(settingsPage.match(/<ProviderHours \/>/g)).toHaveLength(1);
   });
 
-  it("offers explicit hours, closed state, lunch windows, and destructive-change consent", () => {
+  it("offers explicit multi-location hours, closed state, and lunch windows", () => {
     expect(providerHours).toContain("Use Mon–Fri, 8–6");
     expect(providerHours).toContain("Mark all closed");
     expect(providerHours).toContain("Add window");
     expect(providerHours).toContain("working windows cannot overlap");
-    expect(providerHours).toContain(
-      "clinic setup and do not yet limit the schedule or client requests",
-    );
-    expect(providerHours).toContain("Move ${provider.name} to");
-    expect(providerHours).toContain(
-      "Multi-location hours are not supported yet",
-    );
+    expect(providerHours).toContain("Provider hours clinic location");
+    expect(providerHours).toContain("Doctor-required client requests");
+    expect(providerHours).toContain("locationSchedules.find");
+    expect(providerHours).toContain("Home base:");
     expect(providerHours).toContain("setEditingRevision(provider.revision)");
     expect(providerHours).toContain("expectedRevision: editingRevision!");
-    expect(providerHours).toContain("moveToPrimaryLocation:");
-    expect(providerHours).toContain("replaceOtherLocationHours:");
-    expect(providerHours).toContain(
-      "draft.length > 0 && !provider.assignedToPrimary",
+    expect(providerHours).toContain("locationId: selectedLocation.id");
+    expect(providerHours).not.toContain(
+      "Multi-location hours are not supported",
     );
   });
 });

--- a/apps/web/lib/agent/tools.ts
+++ b/apps/web/lib/agent/tools.ts
@@ -51,7 +51,11 @@ import {
   summarizePlanProgress,
   type PlanItemStatus,
 } from "@/lib/treatment-plans/progress";
-import { findOpenSlots } from "@/lib/scheduling/availability";
+import {
+  findOpenSlotsAcrossWindows,
+  intersectAvailabilityWindows,
+} from "@/lib/scheduling/availability";
+import { providerCoverageForDate } from "@/lib/scheduling/provider-availability";
 import {
   conflictMessage,
   detectConflicts,
@@ -929,6 +933,22 @@ const findOpenSlotsTool: AgentTool = {
       { hour: 18 },
       timezone
     );
+    const coverage = input.doctorId
+      ? await providerCoverageForDate(ctx.db, {
+          practiceId: ctx.practiceId,
+          date: input.date,
+          timezone,
+          locationId: location.locationId,
+          doctorId: input.doctorId,
+        })
+      : { configured: false as const, windows: [] };
+    const windows = coverage.configured
+      ? intersectAvailabilityWindows(coverage.windows, {
+          start: dayStart,
+          end: dayEnd,
+        })
+      : [{ start: dayStart, end: dayEnd }];
+    if (windows.length === 0) return [];
 
     const rows = await ctx.db
       .select({
@@ -957,9 +977,8 @@ const findOpenSlotsTool: AgentTool = {
       );
     });
 
-    return findOpenSlots({
-      dayStart,
-      dayEnd,
+    return findOpenSlotsAcrossWindows({
+      windows,
       slotMinutes: input.durationMinutes ?? 30,
       busy,
     }).map((s) => ({ start: s.start.toISOString(), end: s.end.toISOString() }));

--- a/apps/web/lib/scheduling/__tests__/availability.test.ts
+++ b/apps/web/lib/scheduling/__tests__/availability.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { findOpenSlots } from "../availability";
+import {
+  findOpenSlots,
+  findOpenSlotsAcrossWindows,
+  intersectAvailabilityWindows,
+  mergeAvailabilityWindows,
+  slotFitsAvailability,
+} from "../availability";
 
 const d = (iso: string) => new Date(iso);
 
@@ -21,7 +27,12 @@ describe("findOpenSlots", () => {
       dayStart: d("2026-06-02T09:00:00Z"),
       dayEnd: d("2026-06-02T11:00:00Z"),
       slotMinutes: 30,
-      busy: [{ startTime: d("2026-06-02T09:30:00Z"), endTime: d("2026-06-02T10:00:00Z") }],
+      busy: [
+        {
+          startTime: d("2026-06-02T09:30:00Z"),
+          endTime: d("2026-06-02T10:00:00Z"),
+        },
+      ],
     });
     const starts = slots.map((s) => s.start.toISOString());
     // 09:00 ok, 09:30 blocked, 10:00 ok (back-to-back), 10:30 ok
@@ -61,7 +72,62 @@ describe("findOpenSlots", () => {
 
   it("throws on a non-positive slot length", () => {
     expect(() =>
-      findOpenSlots({ dayStart: d("2026-06-02T09:00:00Z"), dayEnd: d("2026-06-02T10:00:00Z"), slotMinutes: 0, busy: [] })
+      findOpenSlots({
+        dayStart: d("2026-06-02T09:00:00Z"),
+        dayEnd: d("2026-06-02T10:00:00Z"),
+        slotMinutes: 0,
+        busy: [],
+      }),
     ).toThrow(/positive/);
+  });
+});
+
+describe("multi-window availability", () => {
+  it("merges overlapping provider coverage without duplicate slots", () => {
+    const windows = mergeAvailabilityWindows([
+      { start: d("2026-06-02T09:00:00Z"), end: d("2026-06-02T12:00:00Z") },
+      { start: d("2026-06-02T10:00:00Z"), end: d("2026-06-02T13:00:00Z") },
+      { start: d("2026-06-02T14:00:00Z"), end: d("2026-06-02T15:00:00Z") },
+    ]);
+    expect(windows).toEqual([
+      { start: d("2026-06-02T09:00:00Z"), end: d("2026-06-02T13:00:00Z") },
+      { start: d("2026-06-02T14:00:00Z"), end: d("2026-06-02T15:00:00Z") },
+    ]);
+    expect(
+      findOpenSlotsAcrossWindows({ windows, slotMinutes: 60, busy: [] }),
+    ).toHaveLength(5);
+  });
+
+  it("intersects coverage with the client-facing request window", () => {
+    expect(
+      intersectAvailabilityWindows(
+        [
+          { start: d("2026-06-02T07:00:00Z"), end: d("2026-06-02T10:00:00Z") },
+          { start: d("2026-06-02T16:00:00Z"), end: d("2026-06-02T20:00:00Z") },
+        ],
+        { start: d("2026-06-02T08:00:00Z"), end: d("2026-06-02T18:00:00Z") },
+      ),
+    ).toEqual([
+      { start: d("2026-06-02T08:00:00Z"), end: d("2026-06-02T10:00:00Z") },
+      { start: d("2026-06-02T16:00:00Z"), end: d("2026-06-02T18:00:00Z") },
+    ]);
+  });
+
+  it("requires the entire requested slot to fit coverage", () => {
+    const windows = [
+      { start: d("2026-06-02T09:00:00Z"), end: d("2026-06-02T10:00:00Z") },
+    ];
+    expect(
+      slotFitsAvailability(
+        { start: d("2026-06-02T09:30:00Z"), end: d("2026-06-02T10:00:00Z") },
+        windows,
+      ),
+    ).toBe(true);
+    expect(
+      slotFitsAvailability(
+        { start: d("2026-06-02T09:30:00Z"), end: d("2026-06-02T10:30:00Z") },
+        windows,
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/web/lib/scheduling/__tests__/provider-availability.test.ts
+++ b/apps/web/lib/scheduling/__tests__/provider-availability.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  providerCoverageFromRows,
+  type ProviderScheduleWindowRow,
+} from "../provider-availability";
+
+const LOCATION_A = "00000000-0000-0000-0000-000000000001";
+const LOCATION_B = "00000000-0000-0000-0000-000000000002";
+const DOCTOR_A = "00000000-0000-0000-0000-000000000003";
+const DOCTOR_B = "00000000-0000-0000-0000-000000000004";
+
+function row(
+  overrides: Partial<ProviderScheduleWindowRow> = {},
+): ProviderScheduleWindowRow {
+  return {
+    userId: DOCTOR_A,
+    locationId: LOCATION_A,
+    dayOfWeek: 1,
+    startTime: "08:00:00",
+    endTime: "17:00:00",
+    ...overrides,
+  };
+}
+
+describe("providerCoverageFromRows", () => {
+  it("preserves the generic-hours fallback until any hours are configured", () => {
+    expect(
+      providerCoverageFromRows({
+        rows: [],
+        date: "2026-08-10",
+        timezone: "America/Denver",
+        locationId: LOCATION_A,
+      }),
+    ).toEqual({ configured: false, windows: [] });
+  });
+
+  it("fails closed for a configured provider on a closed day or other location", () => {
+    const rows = [row()];
+    expect(
+      providerCoverageFromRows({
+        rows,
+        date: "2026-08-11",
+        timezone: "America/Denver",
+        locationId: LOCATION_A,
+        doctorId: DOCTOR_A,
+      }),
+    ).toEqual({ configured: true, windows: [] });
+    expect(
+      providerCoverageFromRows({
+        rows,
+        date: "2026-08-10",
+        timezone: "America/Denver",
+        locationId: LOCATION_B,
+        doctorId: DOCTOR_A,
+      }),
+    ).toEqual({ configured: true, windows: [] });
+  });
+
+  it("treats null-location legacy hours as practice-wide", () => {
+    const coverage = providerCoverageFromRows({
+      rows: [row({ locationId: null, startTime: "09:00", endTime: "12:30" })],
+      date: "2026-08-10",
+      timezone: "America/Denver",
+      locationId: LOCATION_B,
+    });
+    expect(coverage.configured).toBe(true);
+    expect(
+      coverage.windows.map((window) => [
+        window.start.toISOString(),
+        window.end.toISOString(),
+      ]),
+    ).toEqual([["2026-08-10T15:00:00.000Z", "2026-08-10T18:30:00.000Z"]]);
+  });
+
+  it("merges pooled coverage across providers and honors DST", () => {
+    const coverage = providerCoverageFromRows({
+      rows: [
+        row({ startTime: "08:00", endTime: "12:00" }),
+        row({
+          userId: DOCTOR_B,
+          startTime: "11:00",
+          endTime: "17:00",
+        }),
+      ],
+      date: "2026-11-02",
+      timezone: "America/Denver",
+      locationId: LOCATION_A,
+    });
+    expect(coverage.windows).toHaveLength(1);
+    expect(coverage.windows[0]!.start.toISOString()).toBe(
+      "2026-11-02T15:00:00.000Z",
+    );
+    expect(coverage.windows[0]!.end.toISOString()).toBe(
+      "2026-11-03T00:00:00.000Z",
+    );
+  });
+
+  it("scopes configured fallback to the requested doctor", () => {
+    expect(
+      providerCoverageFromRows({
+        rows: [row({ userId: DOCTOR_B })],
+        date: "2026-08-10",
+        timezone: "UTC",
+        locationId: LOCATION_A,
+        doctorId: DOCTOR_A,
+      }),
+    ).toEqual({ configured: false, windows: [] });
+  });
+});
+
+describe("provider availability query safety", () => {
+  const source = readFileSync(
+    new URL("../provider-availability.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("scopes active schedule and provider rows to the same practice", () => {
+    expect(source).toContain("eq(staffSchedules.practiceId, input.practiceId)");
+    expect(source).toContain("eq(users.practiceId, input.practiceId)");
+    expect(source).toContain("eq(users.isVeterinarian, true)");
+    expect(source).toContain("isNull(users.deletedAt)");
+    expect(source).toContain("isNull(staffSchedules.deletedAt)");
+  });
+});

--- a/apps/web/lib/scheduling/availability.ts
+++ b/apps/web/lib/scheduling/availability.ts
@@ -16,6 +16,11 @@ export interface OpenSlot {
   end: Date;
 }
 
+export interface AvailabilityWindow {
+  start: Date;
+  end: Date;
+}
+
 export function findOpenSlots(opts: {
   dayStart: Date;
   dayEnd: Date;
@@ -26,15 +31,83 @@ export function findOpenSlots(opts: {
 }): OpenSlot[] {
   const { dayStart, dayEnd, slotMinutes, busy } = opts;
   if (slotMinutes <= 0) throw new Error("slotMinutes must be positive.");
-  const step = (opts.stepMinutes && opts.stepMinutes > 0 ? opts.stepMinutes : slotMinutes) * 60_000;
+  const step =
+    (opts.stepMinutes && opts.stepMinutes > 0
+      ? opts.stepMinutes
+      : slotMinutes) * 60_000;
   const slotMs = slotMinutes * 60_000;
 
   const slots: OpenSlot[] = [];
   for (let t = dayStart.getTime(); t + slotMs <= dayEnd.getTime(); t += step) {
     const start = new Date(t);
     const end = new Date(t + slotMs);
-    const blocked = busy.some((b) => overlaps(start, end, b.startTime, b.endTime));
+    const blocked = busy.some((b) =>
+      overlaps(start, end, b.startTime, b.endTime),
+    );
     if (!blocked) slots.push({ start, end });
   }
   return slots;
+}
+
+/**
+ * Merge overlapping or touching working windows. Provider coverage can overlap
+ * when multiple clinicians work at once; callers need one stable set of
+ * candidate windows rather than duplicate slots.
+ */
+export function mergeAvailabilityWindows(
+  windows: AvailabilityWindow[],
+): AvailabilityWindow[] {
+  const ordered = windows
+    .filter((window) => window.start < window.end)
+    .sort((left, right) => left.start.getTime() - right.start.getTime());
+
+  const merged: AvailabilityWindow[] = [];
+  for (const window of ordered) {
+    const previous = merged.at(-1);
+    if (!previous || window.start.getTime() > previous.end.getTime()) {
+      merged.push({ start: window.start, end: window.end });
+      continue;
+    }
+    if (window.end > previous.end) previous.end = window.end;
+  }
+  return merged;
+}
+
+/** Generate open slots across one or more working windows. */
+export function findOpenSlotsAcrossWindows(opts: {
+  windows: AvailabilityWindow[];
+  slotMinutes: number;
+  stepMinutes?: number;
+  busy: BusyInterval[];
+}): OpenSlot[] {
+  return mergeAvailabilityWindows(opts.windows).flatMap((window) =>
+    findOpenSlots({
+      dayStart: window.start,
+      dayEnd: window.end,
+      slotMinutes: opts.slotMinutes,
+      stepMinutes: opts.stepMinutes,
+      busy: opts.busy,
+    }),
+  );
+}
+
+export function intersectAvailabilityWindows(
+  windows: AvailabilityWindow[],
+  bounds: AvailabilityWindow,
+): AvailabilityWindow[] {
+  return mergeAvailabilityWindows(windows)
+    .map((window) => ({
+      start: window.start > bounds.start ? window.start : bounds.start,
+      end: window.end < bounds.end ? window.end : bounds.end,
+    }))
+    .filter((window) => window.start < window.end);
+}
+
+export function slotFitsAvailability(
+  slot: AvailabilityWindow,
+  windows: AvailabilityWindow[],
+): boolean {
+  return mergeAvailabilityWindows(windows).some(
+    (window) => slot.start >= window.start && slot.end <= window.end,
+  );
 }

--- a/apps/web/lib/scheduling/provider-availability.ts
+++ b/apps/web/lib/scheduling/provider-availability.ts
@@ -1,0 +1,114 @@
+import { and, asc, eq, isNull } from "drizzle-orm";
+import type { Database } from "@openpims/db/client";
+import { staffSchedules, users } from "@openpims/db";
+import { dateInputTimeUtcInstant } from "@/lib/date-input";
+import { weekdayOfDateInput } from "@/lib/booking/page-config";
+import {
+  mergeAvailabilityWindows,
+  type AvailabilityWindow,
+} from "./availability";
+
+export interface ProviderScheduleWindowRow {
+  userId: string;
+  locationId: string | null;
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+}
+
+export interface ProviderCoverage {
+  /** False means the clinic has not opted into provider-hours enforcement. */
+  configured: boolean;
+  windows: AvailabilityWindow[];
+}
+
+function timeParts(value: string) {
+  const [hour = 0, minute = 0] = value.slice(0, 5).split(":").map(Number);
+  return { hour, minute };
+}
+
+/**
+ * Resolve a calendar day's provider coverage at one clinic location.
+ *
+ * Null-location rows are retained as a legacy practice-wide fallback. Once a
+ * provider (or, for pooled coverage, the practice) has any saved hours, an
+ * empty result means closed rather than falling back to generic 8–6 hours.
+ */
+export function providerCoverageFromRows(input: {
+  rows: ProviderScheduleWindowRow[];
+  date: string;
+  timezone?: string | null;
+  locationId: string;
+  doctorId?: string;
+}): ProviderCoverage {
+  const scopedRows = input.doctorId
+    ? input.rows.filter((row) => row.userId === input.doctorId)
+    : input.rows;
+  if (scopedRows.length === 0) return { configured: false, windows: [] };
+
+  const dayOfWeek = weekdayOfDateInput(input.date);
+  const windows = scopedRows
+    .filter(
+      (row) =>
+        row.dayOfWeek === dayOfWeek &&
+        (row.locationId === input.locationId || row.locationId === null),
+    )
+    .map((row) => ({
+      start: dateInputTimeUtcInstant(
+        input.date,
+        timeParts(row.startTime),
+        input.timezone,
+      ),
+      end: dateInputTimeUtcInstant(
+        input.date,
+        timeParts(row.endTime),
+        input.timezone,
+      ),
+    }));
+
+  return { configured: true, windows: mergeAvailabilityWindows(windows) };
+}
+
+/** Read active veterinarian hours once, then apply the pure coverage policy. */
+export async function providerCoverageForDate(
+  db: Database,
+  input: {
+    practiceId: string;
+    date: string;
+    timezone?: string | null;
+    locationId: string;
+    doctorId?: string;
+  },
+): Promise<ProviderCoverage> {
+  const rows = await db
+    .select({
+      userId: staffSchedules.userId,
+      locationId: staffSchedules.locationId,
+      dayOfWeek: staffSchedules.dayOfWeek,
+      startTime: staffSchedules.startTime,
+      endTime: staffSchedules.endTime,
+    })
+    .from(staffSchedules)
+    .innerJoin(
+      users,
+      and(
+        eq(staffSchedules.userId, users.id),
+        eq(users.practiceId, input.practiceId),
+        eq(users.isVeterinarian, true),
+        isNull(users.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(staffSchedules.practiceId, input.practiceId),
+        isNull(staffSchedules.deletedAt),
+      ),
+    )
+    .orderBy(
+      asc(staffSchedules.userId),
+      asc(staffSchedules.dayOfWeek),
+      asc(staffSchedules.startTime),
+    );
+
+  return providerCoverageFromRows({ ...input, rows });
+}

--- a/apps/web/server/__tests__/booking-router.test.ts
+++ b/apps/web/server/__tests__/booking-router.test.ts
@@ -11,6 +11,12 @@ const mocks = vi.hoisted(() => ({
   dispatchWebhookEvent: vi.fn(async () => undefined),
   recordActivationAfterAppointmentCreated: vi.fn(async () => true),
   recordAuditLog: vi.fn(async () => undefined),
+  providerCoverageForDate: vi.fn(
+    async (): Promise<{
+      configured: boolean;
+      windows: Array<{ start: Date; end: Date }>;
+    }> => ({ configured: false, windows: [] })
+  ),
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
@@ -33,6 +39,10 @@ vi.mock("@/lib/billing/plans", () => ({
 
 vi.mock("@/lib/audit", () => ({
   recordAuditLog: mocks.recordAuditLog,
+}));
+
+vi.mock("@/lib/scheduling/provider-availability", () => ({
+  providerCoverageForDate: mocks.providerCoverageForDate,
 }));
 
 const { bookingRouter } = await import("../routers/booking");
@@ -207,6 +217,10 @@ afterEach(() => {
   vi.clearAllMocks();
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
+  mocks.providerCoverageForDate.mockResolvedValue({
+    configured: false,
+    windows: [],
+  });
 });
 
 describe("public booking page", () => {
@@ -295,6 +309,55 @@ describe("public availability", () => {
       typeId: TYPE_A,
     });
     expect(result).toEqual([{ time: "17:30", iso: "2026-07-20T17:30:00.000Z" }]);
+  });
+
+  it("intersects doctor-required requests with configured provider coverage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-19T12:00:00Z"));
+    mocks.providerCoverageForDate.mockResolvedValue({
+      configured: true,
+      windows: [
+        {
+          start: new Date("2026-07-20T10:00:00Z"),
+          end: new Date("2026-07-20T12:00:00Z"),
+        },
+      ],
+    });
+    const { db } = createDb({
+      selectResults: [
+        [pageRow()],
+        [
+          {
+            id: TYPE_A,
+            name: "Wellness Exam",
+            durationMinutes: 30,
+            requiresDoctor: 1,
+          },
+        ],
+        [],
+      ],
+    });
+
+    const result = await publicCaller(db).availableSlots({
+      slug: "test-clinic",
+      date: "2026-07-20",
+      typeId: TYPE_A,
+    });
+
+    expect(result.map((slot) => slot.time)).toEqual([
+      "10:00",
+      "10:30",
+      "11:00",
+      "11:30",
+    ]);
+    expect(mocks.providerCoverageForDate).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        date: "2026-07-20",
+      }),
+    );
   });
 
   it("rejects a stale or unrequestable type before reading appointments", async () => {
@@ -460,6 +523,32 @@ describe("public booking", () => {
     });
     await expect(publicCaller(db).book(bookInput())).rejects.toMatchObject({
       code: "CONFLICT",
+    });
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tampered doctor-required request outside provider coverage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-19T12:00:00Z"));
+    mocks.providerCoverageForDate.mockResolvedValue({
+      configured: true,
+      windows: [
+        {
+          start: new Date("2026-07-20T10:00:00Z"),
+          end: new Date("2026-07-20T12:00:00Z"),
+        },
+      ],
+    });
+    const { db, insert } = createDb({
+      selectResults: [
+        [pageRow()],
+        [{ id: TYPE_A, durationMinutes: 30, requiresDoctor: 1 }],
+      ],
+    });
+
+    await expect(publicCaller(db).book(bookInput())).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("outside the clinic's provider coverage"),
     });
     expect(insert).not.toHaveBeenCalled();
   });

--- a/apps/web/server/__tests__/portal-booking-inputs.test.ts
+++ b/apps/web/server/__tests__/portal-booking-inputs.test.ts
@@ -10,6 +10,12 @@ const mocks = vi.hoisted(() => ({
   dispatchWebhookEvent: vi.fn(async () => undefined),
   recordActivationAfterAppointmentCreated: vi.fn(async () => true),
   hasHostedFullAccess: vi.fn(() => true),
+  providerCoverageForDate: vi.fn(
+    async (): Promise<{
+      configured: boolean;
+      windows: Array<{ start: Date; end: Date }>;
+    }> => ({ configured: false, windows: [] })
+  ),
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
@@ -28,6 +34,10 @@ vi.mock("@/lib/funnel-events-server", () => ({
 vi.mock("@/lib/billing/plans", () => ({
   billingEnforced: mocks.billingEnforced,
   hasHostedFullAccess: mocks.hasHostedFullAccess,
+}));
+
+vi.mock("@/lib/scheduling/provider-availability", () => ({
+  providerCoverageForDate: mocks.providerCoverageForDate,
 }));
 
 const { portalRouter } = await import("../routers/portal");
@@ -176,6 +186,10 @@ afterEach(() => {
   vi.clearAllMocks();
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
+  mocks.providerCoverageForDate.mockResolvedValue({
+    configured: false,
+    windows: [],
+  });
 });
 
 describe("portal booking input validation", () => {
@@ -607,6 +621,43 @@ describe("portal booking input validation", () => {
     expect(result.map((slot) => slot.time)).toEqual(["08:00", "12:00"]);
   });
 
+  it("uses the selected type and configured provider coverage for suggestions", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T14:00:00.000Z"));
+    mocks.providerCoverageForDate.mockResolvedValue({
+      configured: true,
+      windows: [
+        {
+          start: new Date("2026-07-02T17:00:00.000Z"),
+          end: new Date("2026-07-02T19:00:00.000Z"),
+        },
+      ],
+    });
+    const { db } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID, practiceId: PRACTICE_ID }],
+        ACTIVE_PRACTICE,
+        [{ timezone: "America/Los_Angeles" }],
+        [{ id: TYPE_ID, durationMinutes: 30, requiresDoctor: 1 }],
+        [],
+      ],
+    });
+
+    const result = await callerWithDb(db).availableSlots({
+      token: TOKEN,
+      date: "2026-07-02",
+      durationMinutes: 240,
+      typeId: TYPE_ID,
+    });
+
+    expect(result.map((slot) => slot.time)).toEqual([
+      "10:00",
+      "10:30",
+      "11:00",
+      "11:30",
+    ]);
+  });
+
   it("rejects portal appointment requests when the requested slot is no longer available", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-01T14:00:00.000Z"));
@@ -641,6 +692,45 @@ describe("portal booking input validation", () => {
     );
     expect(insert).not.toHaveBeenCalled();
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tampered doctor-required request outside provider coverage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T14:00:00.000Z"));
+    mocks.providerCoverageForDate.mockResolvedValue({
+      configured: true,
+      windows: [
+        {
+          start: new Date("2026-07-01T17:00:00.000Z"),
+          end: new Date("2026-07-01T19:00:00.000Z"),
+        },
+      ],
+    });
+    const { db, insert } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID, practiceId: PRACTICE_ID }],
+        ACTIVE_PRACTICE,
+        ACTIVE_PRACTICE,
+        [{ timezone: "America/Los_Angeles" }],
+        [{ id: PATIENT_ID, name: "Juniper" }],
+        [{ id: TYPE_ID, durationMinutes: 30, requiresDoctor: 1 }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).requestAppointment({
+        token: TOKEN,
+        patientId: PATIENT_ID,
+        typeId: TYPE_ID,
+        preferredDate: "2026-07-01",
+        preferredTime: "09:00",
+        reason: "Wellness visit",
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("outside the clinic's provider coverage"),
+    });
+    expect(insert).not.toHaveBeenCalled();
   });
 
   it("rejects portal appointment requests when the practice becomes inactive before the write", async () => {

--- a/apps/web/server/__tests__/settings-provider-hours.test.ts
+++ b/apps/web/server/__tests__/settings-provider-hours.test.ts
@@ -15,8 +15,6 @@ const LOCATION_ID = "00000000-0000-0000-0000-000000000003";
 const OTHER_LOCATION_ID = "00000000-0000-0000-0000-000000000004";
 const SCHEDULE_ID = "00000000-0000-0000-0000-000000000006";
 const OTHER_SCHEDULE_ID = "00000000-0000-0000-0000-000000000007";
-const SECONDARY_PROVIDER_ID = "00000000-0000-0000-0000-000000000005";
-const SECONDARY_SCHEDULE_ID = "00000000-0000-0000-0000-000000000008";
 const SETTINGS_SOURCE = readFileSync(
   new URL("../routers/settings.ts", import.meta.url),
   "utf8",
@@ -30,7 +28,11 @@ type RevisionRow = {
   endTime: string;
 };
 
-function revision(locationId: string | null, rows: RevisionRow[]) {
+function revision(
+  providerLocationId: string | null,
+  rows: RevisionRow[],
+  timezone = "America/Denver",
+) {
   const schedule = [...rows]
     .sort((left, right) => left.id.localeCompare(right.id))
     .map((row) => ({
@@ -41,9 +43,9 @@ function revision(locationId: string | null, rows: RevisionRow[]) {
   return createHash("sha256")
     .update(
       JSON.stringify({
-        timezone: "America/Denver",
+        timezone,
         primaryLocationId: LOCATION_ID,
-        providerLocationId: locationId,
+        providerLocationId,
         schedule,
       }),
     )
@@ -51,6 +53,20 @@ function revision(locationId: string | null, rows: RevisionRow[]) {
 }
 
 const EMPTY_REVISION = revision(null, []);
+const ACTIVE_LOCATIONS = [
+  {
+    id: LOCATION_ID,
+    name: "Main Clinic",
+    isPrimary: true,
+    timezone: "America/Denver",
+  },
+  {
+    id: OTHER_LOCATION_ID,
+    name: "North Clinic",
+    isPrimary: false,
+    timezone: "America/Denver",
+  },
+];
 
 function callerWithDb(
   db: Record<string, unknown>,
@@ -98,9 +114,7 @@ function createDb(selectResults: unknown[][]) {
   const update = vi.fn(() => ({
     set: vi.fn((value: unknown) => {
       updatedValues.push(value);
-      return {
-        where: vi.fn(() => queryChain([])),
-      };
+      return { where: vi.fn(() => queryChain([])) };
     }),
   }));
   const insert = vi.fn(() => ({
@@ -132,20 +146,21 @@ describe("provider weekly hours", () => {
     await expect(
       caller.replaceProviderSchedule({
         userId: PROVIDER_ID,
+        locationId: LOCATION_ID,
         expectedRevision: EMPTY_REVISION,
         windows: [],
       }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
-    expect(db.select).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid or overlapping windows before any database write", async () => {
+  it("rejects invalid or overlapping windows before database work", async () => {
     const { db } = createDb([]);
     const caller = callerWithDb(db);
 
     await expect(
       caller.replaceProviderSchedule({
         userId: PROVIDER_ID,
+        locationId: LOCATION_ID,
         expectedRevision: EMPTY_REVISION,
         windows: [{ dayOfWeek: 1, startTime: "18:00", endTime: "08:00" }],
       }),
@@ -153,6 +168,7 @@ describe("provider weekly hours", () => {
     await expect(
       caller.replaceProviderSchedule({
         userId: PROVIDER_ID,
+        locationId: LOCATION_ID,
         expectedRevision: EMPTY_REVISION,
         windows: [
           { dayOfWeek: 2, startTime: "08:00", endTime: "12:00" },
@@ -160,91 +176,78 @@ describe("provider weekly hours", () => {
         ],
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-
     expect(db.select).not.toHaveBeenCalled();
-    expect(db.update).not.toHaveBeenCalled();
-    expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it("returns active primary-location hours normalized to HH:MM", async () => {
+  it("returns normalized hours for every active clinic location", async () => {
+    const rows: RevisionRow[] = [
+      {
+        id: SCHEDULE_ID,
+        locationId: LOCATION_ID,
+        dayOfWeek: 1,
+        startTime: "08:00:00",
+        endTime: "12:00:00",
+      },
+      {
+        id: OTHER_SCHEDULE_ID,
+        locationId: OTHER_LOCATION_ID,
+        dayOfWeek: 2,
+        startTime: "09:00:00",
+        endTime: "16:00:00",
+      },
+    ];
     const { db } = createDb([
       [{ timezone: "America/Denver" }],
-      [{ id: LOCATION_ID, name: "Main Clinic" }],
-      [
-        { id: PROVIDER_ID, name: "Dr. Rivera", locationId: LOCATION_ID },
-        {
-          id: SECONDARY_PROVIDER_ID,
-          name: "Dr. Secondary",
-          locationId: OTHER_LOCATION_ID,
-        },
-      ],
-      [
-        {
-          id: SCHEDULE_ID,
-          userId: PROVIDER_ID,
-          locationId: LOCATION_ID,
-          dayOfWeek: 1,
-          startTime: "08:00:00",
-          endTime: "12:00:00",
-        },
-        {
-          id: OTHER_SCHEDULE_ID,
-          userId: PROVIDER_ID,
-          locationId: LOCATION_ID,
-          dayOfWeek: 1,
-          startTime: "13:00:00",
-          endTime: "17:30:00",
-        },
-        {
-          id: SECONDARY_SCHEDULE_ID,
-          userId: SECONDARY_PROVIDER_ID,
-          locationId: OTHER_LOCATION_ID,
-          dayOfWeek: 2,
-          startTime: "09:00:00",
-          endTime: "16:00:00",
-        },
-      ],
+      ACTIVE_LOCATIONS.map(({ timezone: _timezone, ...location }) => location),
+      [{ id: PROVIDER_ID, name: "Dr. Rivera", locationId: LOCATION_ID }],
+      rows.map((row) => ({ ...row, userId: PROVIDER_ID })),
     ]);
 
     const result = await callerWithDb(db).providerScheduleSetup();
 
-    expect(result.primaryLocation).toEqual({
-      id: LOCATION_ID,
-      name: "Main Clinic",
-    });
+    expect(result.primaryLocation).toMatchObject({ id: LOCATION_ID });
+    expect(result.locations).toHaveLength(2);
     expect(result.providers[0]).toMatchObject({
       id: PROVIDER_ID,
-      assignedToPrimary: true,
-      otherLocationWindowCount: 0,
+      unspecifiedWindowCount: 0,
       revision: expect.stringMatching(/^[a-f0-9]{64}$/),
-      windows: [
-        { dayOfWeek: 1, startTime: "08:00", endTime: "12:00" },
-        { dayOfWeek: 1, startTime: "13:00", endTime: "17:30" },
+      locationSchedules: [
+        {
+          locationId: LOCATION_ID,
+          windows: [{ dayOfWeek: 1, startTime: "08:00", endTime: "12:00" }],
+        },
+        {
+          locationId: OTHER_LOCATION_ID,
+          windows: [{ dayOfWeek: 2, startTime: "09:00", endTime: "16:00" }],
+        },
       ],
-    });
-    expect(result.providers[1]).toMatchObject({
-      assignedToPrimary: false,
-      otherLocationWindowCount: 1,
-      windows: [],
     });
   });
 
-  it("atomically replaces all active hours for the provider", async () => {
+  it("replaces only the selected location and never moves the provider home base", async () => {
+    const otherRow: RevisionRow = {
+      id: OTHER_SCHEDULE_ID,
+      locationId: OTHER_LOCATION_ID,
+      dayOfWeek: 2,
+      startTime: "09:00:00",
+      endTime: "16:00:00",
+    };
     const { db, insertedValues, updatedValues } = createDb([
-      [{ id: LOCATION_ID, name: "Main Clinic", timezone: "America/Denver" }],
+      ACTIVE_LOCATIONS,
       [
         {
           id: PROVIDER_ID,
-          locationId: LOCATION_ID,
+          locationId: OTHER_LOCATION_ID,
           isVeterinarian: true,
         },
       ],
-      [],
+      [otherRow],
     ]);
 
     const result = await callerWithDb(db).replaceProviderSchedule({
       userId: PROVIDER_ID,
-      expectedRevision: revision(LOCATION_ID, []),
+      locationId: LOCATION_ID,
+      expectedRevision: revision(OTHER_LOCATION_ID, [otherRow]),
       windows: [
         { dayOfWeek: 5, startTime: "13:00", endTime: "17:00" },
         { dayOfWeek: 1, startTime: "08:00", endTime: "12:00" },
@@ -258,6 +261,7 @@ describe("provider weekly hours", () => {
     });
     expect(updatedValues).toHaveLength(1);
     expect(updatedValues[0]).toMatchObject({ deletedAt: expect.any(Date) });
+    expect(updatedValues).not.toContainEqual({ locationId: LOCATION_ID });
     expect(insertedValues[0]).toEqual([
       {
         practiceId: PRACTICE_ID,
@@ -280,135 +284,44 @@ describe("provider weekly hours", () => {
       /replaceProviderSchedule:[\s\S]+?createUser:/,
     )?.[0];
     expect(replaceBlock).toMatch(
-      /eq\(staffSchedules\.userId, provider\.id\),\s+isNull\(staffSchedules\.deletedAt\)/,
+      /eq\(staffSchedules\.locationId, targetLocation\.id\)/,
     );
-    expect(replaceBlock).not.toContain(
-      "eq(staffSchedules.locationId, primaryLocation.id)",
-    );
+    expect(replaceBlock).not.toContain("update(users)");
   });
 
-  it("requires explicit confirmation before moving a provider to primary", async () => {
-    const first = createDb([
-      [{ id: LOCATION_ID, name: "Main Clinic", timezone: "America/Denver" }],
-      [
-        {
-          id: PROVIDER_ID,
-          locationId: OTHER_LOCATION_ID,
-          isVeterinarian: true,
-        },
-      ],
+  it("defaults an older client without locationId to the primary clinic", async () => {
+    const { db } = createDb([
+      ACTIVE_LOCATIONS,
+      [{ id: PROVIDER_ID, locationId: null, isVeterinarian: true }],
       [],
-    ]);
-    await expect(
-      callerWithDb(first.db).replaceProviderSchedule({
-        userId: PROVIDER_ID,
-        expectedRevision: revision(OTHER_LOCATION_ID, []),
-        windows: [{ dayOfWeek: 1, startTime: "08:00", endTime: "17:00" }],
-      }),
-    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
-    expect(first.updatedValues).toHaveLength(0);
-
-    const confirmed = createDb([
-      [{ id: LOCATION_ID, name: "Main Clinic", timezone: "America/Denver" }],
-      [
-        {
-          id: PROVIDER_ID,
-          locationId: OTHER_LOCATION_ID,
-          isVeterinarian: true,
-        },
-      ],
-      [],
-    ]);
-    await callerWithDb(confirmed.db).replaceProviderSchedule({
-      userId: PROVIDER_ID,
-      expectedRevision: revision(OTHER_LOCATION_ID, []),
-      windows: [{ dayOfWeek: 1, startTime: "08:00", endTime: "17:00" }],
-      moveToPrimaryLocation: true,
-    });
-
-    expect(confirmed.updatedValues[0]).toEqual({ locationId: LOCATION_ID });
-    expect(confirmed.insertedValues).toHaveLength(1);
-  });
-
-  it("does not move an unassigned or secondary provider when clearing hours", async () => {
-    for (const locationId of [null, OTHER_LOCATION_ID]) {
-      const state = createDb([
-        [
-          {
-            id: LOCATION_ID,
-            name: "Main Clinic",
-            timezone: "America/Denver",
-          },
-        ],
-        [
-          {
-            id: PROVIDER_ID,
-            locationId,
-            isVeterinarian: true,
-          },
-        ],
-        [],
-      ]);
-
-      await expect(
-        callerWithDb(state.db).replaceProviderSchedule({
-          userId: PROVIDER_ID,
-          expectedRevision: revision(locationId, []),
-          windows: [],
-        }),
-      ).resolves.toEqual({
-        userId: PROVIDER_ID,
-        locationId,
-        windowCount: 0,
-      });
-
-      expect(state.updatedValues).toHaveLength(1);
-      expect(state.updatedValues[0]).toMatchObject({
-        deletedAt: expect.any(Date),
-      });
-      expect(state.updatedValues).not.toContainEqual({
-        locationId: LOCATION_ID,
-      });
-      expect(state.insertedValues).toHaveLength(0);
-    }
-  });
-
-  it("requires consent before replacing hidden null or secondary-location hours", async () => {
-    const hiddenRows: RevisionRow[] = [
-      {
-        id: OTHER_SCHEDULE_ID,
-        locationId: null,
-        dayOfWeek: 2,
-        startTime: "09:00:00",
-        endTime: "12:00:00",
-      },
-    ];
-    const state = createDb([
-      [{ id: LOCATION_ID, name: "Main Clinic", timezone: "America/Denver" }],
-      [
-        {
-          id: PROVIDER_ID,
-          locationId: LOCATION_ID,
-          isVeterinarian: true,
-        },
-      ],
-      hiddenRows,
     ]);
 
     await expect(
-      callerWithDb(state.db).replaceProviderSchedule({
+      callerWithDb(db).replaceProviderSchedule({
         userId: PROVIDER_ID,
-        expectedRevision: revision(LOCATION_ID, hiddenRows),
+        expectedRevision: EMPTY_REVISION,
         windows: [],
       }),
-    ).rejects.toMatchObject({
-      code: "PRECONDITION_FAILED",
-      message: expect.stringContaining("1 working window"),
+    ).resolves.toEqual({
+      userId: PROVIDER_ID,
+      locationId: LOCATION_ID,
+      windowCount: 0,
     });
-    expect(state.updatedValues).toHaveLength(0);
   });
 
-  it("rejects stale editors before changing staff or schedules", async () => {
+  it("rejects a missing or inactive selected clinic location", async () => {
+    const { db } = createDb([ACTIVE_LOCATIONS]);
+    await expect(
+      callerWithDb(db).replaceProviderSchedule({
+        userId: PROVIDER_ID,
+        locationId: "00000000-0000-0000-0000-000000000099",
+        expectedRevision: EMPTY_REVISION,
+        windows: [],
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+
+  it("rejects stale editors before changing schedules", async () => {
     const currentRows: RevisionRow[] = [
       {
         id: SCHEDULE_ID,
@@ -419,74 +332,54 @@ describe("provider weekly hours", () => {
       },
     ];
     const state = createDb([
-      [{ id: LOCATION_ID, name: "Main Clinic", timezone: "America/Denver" }],
-      [
-        {
-          id: PROVIDER_ID,
-          locationId: LOCATION_ID,
-          isVeterinarian: true,
-        },
-      ],
+      ACTIVE_LOCATIONS,
+      [{ id: PROVIDER_ID, locationId: LOCATION_ID, isVeterinarian: true }],
       currentRows,
     ]);
 
     await expect(
       callerWithDb(state.db).replaceProviderSchedule({
         userId: PROVIDER_ID,
+        locationId: LOCATION_ID,
         expectedRevision: revision(LOCATION_ID, []),
         windows: [],
       }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
     expect(state.updatedValues).toHaveLength(0);
-    expect(state.insertedValues).toHaveLength(0);
   });
 
-  it("rejects an editor opened before the practice timezone changed", async () => {
+  it("includes timezone changes in optimistic concurrency", async () => {
+    const changedTimezoneLocations = ACTIVE_LOCATIONS.map((location) => ({
+      ...location,
+      timezone: "America/New_York",
+    }));
     const state = createDb([
-      [
-        {
-          id: LOCATION_ID,
-          name: "Main Clinic",
-          timezone: "America/New_York",
-        },
-      ],
-      [
-        {
-          id: PROVIDER_ID,
-          locationId: LOCATION_ID,
-          isVeterinarian: true,
-        },
-      ],
+      changedTimezoneLocations,
+      [{ id: PROVIDER_ID, locationId: null, isVeterinarian: true }],
       [],
     ]);
 
     await expect(
       callerWithDb(state.db).replaceProviderSchedule({
         userId: PROVIDER_ID,
-        expectedRevision: revision(LOCATION_ID, []),
-        windows: [{ dayOfWeek: 1, startTime: "08:00", endTime: "17:00" }],
+        locationId: LOCATION_ID,
+        expectedRevision: EMPTY_REVISION,
+        windows: [],
       }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
-    expect(state.updatedValues).toHaveLength(0);
-    expect(state.insertedValues).toHaveLength(0);
   });
 
   it("allows touching windows but rejects more than three in one day", async () => {
     const valid = createDb([
-      [{ id: LOCATION_ID, name: "Main Clinic", timezone: "America/Denver" }],
-      [
-        {
-          id: PROVIDER_ID,
-          locationId: LOCATION_ID,
-          isVeterinarian: true,
-        },
-      ],
+      ACTIVE_LOCATIONS,
+      [{ id: PROVIDER_ID, locationId: null, isVeterinarian: true }],
       [],
     ]);
     await expect(
       callerWithDb(valid.db).replaceProviderSchedule({
         userId: PROVIDER_ID,
-        expectedRevision: revision(LOCATION_ID, []),
+        locationId: LOCATION_ID,
+        expectedRevision: EMPTY_REVISION,
         windows: [
           { dayOfWeek: 1, startTime: "08:00", endTime: "12:00" },
           { dayOfWeek: 1, startTime: "12:00", endTime: "17:00" },
@@ -498,6 +391,7 @@ describe("provider weekly hours", () => {
     await expect(
       callerWithDb(invalid.db).replaceProviderSchedule({
         userId: PROVIDER_ID,
+        locationId: LOCATION_ID,
         expectedRevision: EMPTY_REVISION,
         windows: [
           { dayOfWeek: 1, startTime: "08:00", endTime: "09:00" },
@@ -507,71 +401,5 @@ describe("provider weekly hours", () => {
         ],
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
-    expect(invalid.db.select).not.toHaveBeenCalled();
-  });
-
-  it("blocks provider demotion while active working hours remain", async () => {
-    const { db, updatedValues } = createDb([
-      [
-        {
-          id: PROVIDER_ID,
-          role: "admin",
-          isVeterinarian: true,
-        },
-      ],
-      [],
-      [{ id: "00000000-0000-0000-0000-000000000006" }],
-    ]);
-
-    await expect(
-      callerWithDb(db).updateUser({
-        id: PROVIDER_ID,
-        isVeterinarian: false,
-      }),
-    ).rejects.toMatchObject({
-      code: "BAD_REQUEST",
-      message: expect.stringContaining("Clear this provider's working hours"),
-    });
-    expect(updatedValues).toHaveLength(0);
-  });
-
-  it("blocks the owner clinical-profile shortcut from bypassing active hours", async () => {
-    const { db, updatedValues } = createDb([
-      [{ id: PRACTICE_ID }],
-      [
-        {
-          id: ADMIN_ID,
-          isVeterinarian: true,
-          locationId: LOCATION_ID,
-        },
-      ],
-      [],
-      [{ id: SCHEDULE_ID }],
-    ]);
-
-    await expect(
-      callerWithDb(db).updateMyClinicalProfile({
-        isVeterinarian: false,
-      }),
-    ).rejects.toMatchObject({
-      code: "BAD_REQUEST",
-      message: expect.stringContaining("Clear this provider's working hours"),
-    });
-    expect(updatedValues).toHaveLength(0);
-  });
-
-  it("blocks timezone changes that would reinterpret saved wall-clock hours", async () => {
-    const { db, updatedValues } = createDb([
-      [{ timezone: "America/Denver" }],
-      [{ id: "00000000-0000-0000-0000-000000000006" }],
-    ]);
-
-    await expect(
-      callerWithDb(db).updatePractice({ timezone: "America/New_York" }),
-    ).rejects.toMatchObject({
-      code: "PRECONDITION_FAILED",
-      message: expect.stringContaining("Clear provider working hours"),
-    });
-    expect(updatedValues).toHaveLength(0);
   });
 });

--- a/apps/web/server/routers/appointments.ts
+++ b/apps/web/server/routers/appointments.ts
@@ -22,7 +22,11 @@ import {
   hasConflict,
   type ExistingBooking,
 } from "@/lib/scheduling/conflicts";
-import { findOpenSlots } from "@/lib/scheduling/availability";
+import {
+  findOpenSlotsAcrossWindows,
+  intersectAvailabilityWindows,
+} from "@/lib/scheduling/availability";
+import { providerCoverageForDate } from "@/lib/scheduling/provider-availability";
 import {
   dateInputDayUtcRange,
   formatDateInputForTimeZone,
@@ -1555,6 +1559,23 @@ export const appointmentsRouter = createRouter({
       });
       const locationId = await appointmentLocationOrThrow(ctx, input);
 
+      const coverage = input.doctorId
+        ? await providerCoverageForDate(ctx.db, {
+            practiceId: ctx.practiceId,
+            date: input.date,
+            timezone,
+            locationId,
+            doctorId: input.doctorId,
+          })
+        : { configured: false as const, windows: [] };
+      const windows = coverage.configured
+        ? intersectAvailabilityWindows(coverage.windows, {
+            start: dayStart,
+            end: dayEnd,
+          })
+        : [{ start: dayStart, end: dayEnd }];
+      if (windows.length === 0) return [];
+
       const existing = await fetchOverlapping(ctx.db, ctx.practiceId, dayStart, dayEnd);
       // Only the chosen doctor/room blocks availability; if neither given, any
       // booking on the day blocks (treat the schedule as a single resource).
@@ -1564,9 +1585,8 @@ export const appointmentsRouter = createRouter({
         return !input.doctorId && !input.roomId && b.locationId === locationId;
       });
 
-      return findOpenSlots({
-        dayStart,
-        dayEnd,
+      return findOpenSlotsAcrossWindows({
+        windows,
         slotMinutes: input.durationMinutes,
         stepMinutes: input.stepMinutes,
         busy,

--- a/apps/web/server/routers/booking.ts
+++ b/apps/web/server/routers/booking.ts
@@ -19,7 +19,12 @@ import {
   dispatchAppointmentWebhookAfterCommit,
 } from "@/lib/appointment-webhooks";
 import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
-import { findOpenSlots } from "@/lib/scheduling/availability";
+import {
+  findOpenSlotsAcrossWindows,
+  intersectAvailabilityWindows,
+  slotFitsAvailability,
+} from "@/lib/scheduling/availability";
+import { providerCoverageForDate } from "@/lib/scheduling/provider-availability";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import { generatePortalAccessToken } from "@/lib/portal/tokens";
 import { latestAssignedToForClient } from "@/lib/communications/assignment";
@@ -189,13 +194,21 @@ async function bookableTypesForPage(
   db: any,
   practiceId: string,
   bookableTypeIds: string[]
-): Promise<Array<{ id: string; name: string; durationMinutes: number }>> {
+): Promise<
+  Array<{
+    id: string;
+    name: string;
+    durationMinutes: number;
+    requiresDoctor: number;
+  }>
+> {
   if (bookableTypeIds.length === 0) return [];
   const rows = await db
     .select({
       id: appointmentTypes.id,
       name: appointmentTypes.name,
       durationMinutes: appointmentTypes.durationMinutes,
+      requiresDoctor: appointmentTypes.requiresDoctor,
     })
     .from(appointmentTypes)
     .where(
@@ -220,12 +233,17 @@ async function lockBookableTypeForRequest(
   practiceId: string,
   bookableTypeIds: string[],
   requestedTypeId: string
-): Promise<{ id: string; durationMinutes: number } | null> {
+): Promise<{
+  id: string;
+  durationMinutes: number;
+  requiresDoctor: number;
+} | null> {
   if (!bookableTypeIds.includes(requestedTypeId)) return null;
   const [type] = await db
     .select({
       id: appointmentTypes.id,
       durationMinutes: appointmentTypes.durationMinutes,
+      requiresDoctor: appointmentTypes.requiresDoctor,
     })
     .from(appointmentTypes)
     .where(
@@ -369,6 +387,23 @@ export const bookingRouter = createRouter({
         });
       }
 
+      const coverage =
+        type.requiresDoctor === 1
+          ? await providerCoverageForDate(ctx.db, {
+              practiceId: practice.id,
+              date: input.date,
+              timezone: practice.timezone,
+              locationId: location.locationId,
+            })
+          : { configured: false as const, windows: [] };
+      const windows = coverage.configured
+        ? intersectAvailabilityWindows(coverage.windows, {
+            start: window.dayStart,
+            end: window.dayEnd,
+          })
+        : [{ start: window.dayStart, end: window.dayEnd }];
+      if (windows.length === 0) return [];
+
       const busy = await ctx.db
         .select({
           startTime: appointments.startTime,
@@ -387,9 +422,8 @@ export const bookingRouter = createRouter({
         );
 
       const earliest = minimumBookableInstant(config);
-      return findOpenSlots({
-        dayStart: window.dayStart,
-        dayEnd: window.dayEnd,
+      return findOpenSlotsAcrossWindows({
+        windows,
         slotMinutes: durationMinutes,
         busy,
       })
@@ -520,6 +554,27 @@ export const bookingRouter = createRouter({
           code: "BAD_REQUEST",
           message: "That time is too soon. Please choose a later time.",
         });
+      }
+      if (type.requiresDoctor === 1) {
+        const coverage = await providerCoverageForDate(ctx.db, {
+          practiceId: practice.id,
+          date: input.date,
+          timezone: practice.timezone,
+          locationId: location.locationId,
+        });
+        if (
+          coverage.configured &&
+          !slotFitsAvailability(
+            { start: slotStart, end: slotEnd },
+            coverage.windows,
+          )
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "That time is outside the clinic's provider coverage. Please choose another time.",
+          });
+        }
       }
 
       const [conflict] = await ctx.db

--- a/apps/web/server/routers/portal.ts
+++ b/apps/web/server/routers/portal.ts
@@ -33,7 +33,12 @@ import {
   PORTAL_BOOKING_REASON_MAX_LENGTH,
   portalBookingWindow,
 } from "@/lib/portal/booking";
-import { findOpenSlots } from "@/lib/scheduling/availability";
+import {
+  findOpenSlotsAcrossWindows,
+  intersectAvailabilityWindows,
+  slotFitsAvailability,
+} from "@/lib/scheduling/availability";
+import { providerCoverageForDate } from "@/lib/scheduling/provider-availability";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import { getChargeableStripeConnectAccountId } from "@/lib/billing/payment-accounts";
 import { clinicalDateInput } from "@/lib/records/clinical-inputs";
@@ -942,6 +947,7 @@ export const portalRouter = createRouter({
           id: appointmentTypes.id,
           name: appointmentTypes.name,
           durationMinutes: appointmentTypes.durationMinutes,
+          requiresDoctor: appointmentTypes.requiresDoctor,
         })
         .from(appointmentTypes)
         .where(
@@ -965,6 +971,7 @@ export const portalRouter = createRouter({
           .min(PORTAL_BOOKING_MIN_DURATION_MINUTES)
           .max(PORTAL_BOOKING_MAX_DURATION_MINUTES)
           .default(30),
+        typeId: z.string().uuid().optional(),
         locationId: z.string().uuid().optional()
       })
     )
@@ -992,6 +999,47 @@ export const portalRouter = createRouter({
         throw new TRPCError({ code: location.code, message: location.message });
       }
 
+      const [type] = input.typeId
+        ? await ctx.db
+            .select({
+              id: appointmentTypes.id,
+              durationMinutes: appointmentTypes.durationMinutes,
+              requiresDoctor: appointmentTypes.requiresDoctor,
+            })
+            .from(appointmentTypes)
+            .where(
+              and(
+                eq(appointmentTypes.id, input.typeId),
+                eq(appointmentTypes.practiceId, client.practiceId),
+                isNull(appointmentTypes.deletedAt)
+              )
+            )
+            .limit(1)
+        : [null];
+      if (input.typeId && !type) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Appointment type not found",
+        });
+      }
+      const durationMinutes = type?.durationMinutes ?? input.durationMinutes;
+      const coverage =
+        type?.requiresDoctor === 1
+          ? await providerCoverageForDate(ctx.db, {
+              practiceId: client.practiceId,
+              date: input.date,
+              timezone,
+              locationId: location.locationId,
+            })
+          : { configured: false as const, windows: [] };
+      const windows = coverage.configured
+        ? intersectAvailabilityWindows(coverage.windows, {
+            start: dayStart,
+            end: dayEnd,
+          })
+        : [{ start: dayStart, end: dayEnd }];
+      if (windows.length === 0) return [];
+
       const busy = await ctx.db
         .select({
           startTime: appointments.startTime,
@@ -1010,10 +1058,9 @@ export const portalRouter = createRouter({
         );
 
       return filterFutureOpenSlots(
-        findOpenSlots({
-          dayStart,
-          dayEnd,
-          slotMinutes: input.durationMinutes,
+        findOpenSlotsAcrossWindows({
+          windows,
+          slotMinutes: durationMinutes,
           busy,
         })
       ).map((s) => ({
@@ -1101,6 +1148,7 @@ export const portalRouter = createRouter({
         .select({
           id: appointmentTypes.id,
           durationMinutes: appointmentTypes.durationMinutes,
+          requiresDoctor: appointmentTypes.requiresDoctor,
         })
         .from(appointmentTypes)
         .where(
@@ -1138,6 +1186,27 @@ export const portalRouter = createRouter({
           code: "BAD_REQUEST",
           message: e instanceof Error ? e.message : "Invalid date or time",
         });
+      }
+      if (type.requiresDoctor === 1) {
+        const coverage = await providerCoverageForDate(ctx.db, {
+          practiceId: client.practiceId,
+          date: input.preferredDate,
+          timezone,
+          locationId: location.locationId,
+        });
+        if (
+          coverage.configured &&
+          !slotFitsAvailability(
+            { start: slot.startTime, end: slot.endTime },
+            coverage.windows,
+          )
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "That time is outside the clinic's provider coverage. Please choose another time.",
+          });
+        }
       }
 
       const [conflict] = await ctx.db

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -1725,11 +1725,7 @@ export const settingsRouter = createRouter({
       );
   }),
 
-  /**
-   * Weekly veterinarian hours for the practice's primary location. These are
-   * stored as wall-clock times in the practice timezone. They are clinic setup
-   * data only until the shared availability engine consumes them.
-   */
+  /** Weekly veterinarian hours by clinic location, in the practice timezone. */
   providerScheduleSetup: adminProcedure.query(async ({ ctx }) => {
     const [practice] = await ctx.db
       .select({ timezone: practices.timezone })
@@ -1738,18 +1734,27 @@ export const settingsRouter = createRouter({
       .limit(1);
     if (!practice) throw practiceNotFound();
 
-    const [primaryLocation] = await ctx.db
-      .select({ id: locations.id, name: locations.name })
+    const activeLocations = await ctx.db
+      .select({
+        id: locations.id,
+        name: locations.name,
+        isPrimary: locations.isPrimary,
+      })
       .from(locations)
       .where(
         and(
           eq(locations.practiceId, ctx.practiceId),
-          eq(locations.isPrimary, true),
           isNull(locations.deletedAt),
         ),
       )
-      .orderBy(asc(locations.createdAt), asc(locations.id))
-      .limit(1);
+      .orderBy(
+        desc(locations.isPrimary),
+        asc(locations.name),
+        asc(locations.id),
+      );
+    const primaryLocation = activeLocations.find(
+      (location) => location.isPrimary,
+    );
 
     const providers = await ctx.db
       .select({
@@ -1797,31 +1802,30 @@ export const settingsRouter = createRouter({
         const providerRows = scheduleRows.filter(
           (row) => row.userId === provider.id,
         );
-        const primaryRows = primaryLocation
-          ? providerRows.filter((row) => row.locationId === primaryLocation.id)
-          : [];
         return {
           ...provider,
-          assignedToPrimary:
-            primaryLocation !== undefined &&
-            (provider.locationId === null ||
-              provider.locationId === primaryLocation.id),
-          otherLocationWindowCount: primaryLocation
-            ? providerRows.length - primaryRows.length
-            : providerRows.length,
+          unspecifiedWindowCount: providerRows.filter(
+            (row) => row.locationId === null,
+          ).length,
           revision: providerScheduleRevision(
             practice.timezone,
             primaryLocation?.id ?? null,
             provider.locationId,
             providerRows,
           ),
-          windows: primaryRows.map((row) => ({
-            dayOfWeek: row.dayOfWeek,
-            startTime: row.startTime.slice(0, 5),
-            endTime: row.endTime.slice(0, 5),
+          locationSchedules: activeLocations.map((location) => ({
+            locationId: location.id,
+            windows: providerRows
+              .filter((row) => row.locationId === location.id)
+              .map((row) => ({
+                dayOfWeek: row.dayOfWeek,
+                startTime: row.startTime.slice(0, 5),
+                endTime: row.endTime.slice(0, 5),
+              })),
           })),
         };
       }),
+      locations: activeLocations,
     };
   }),
 
@@ -1829,8 +1833,11 @@ export const settingsRouter = createRouter({
     .input(
       z.object({
         userId: z.string().uuid(),
+        locationId: z.string().uuid().optional(),
         windows: providerScheduleWindowsInput,
         expectedRevision: z.string().regex(/^[a-f0-9]{64}$/),
+        // Retained briefly so a client loaded before this release fails safe
+        // instead of failing validation during the deployment window.
         moveToPrimaryLocation: z.boolean().optional(),
         replaceOtherLocationHours: z.boolean().optional(),
       }),
@@ -1843,10 +1850,11 @@ export const settingsRouter = createRouter({
           )}::text))`,
         );
 
-        const [primaryLocation] = await tx
+        const activeLocations = await tx
           .select({
             id: locations.id,
             name: locations.name,
+            isPrimary: locations.isPrimary,
             timezone: practices.timezone,
           })
           .from(locations)
@@ -1861,17 +1869,23 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(locations.practiceId, ctx.practiceId),
-              eq(locations.isPrimary, true),
               isNull(locations.deletedAt),
             ),
           )
           .orderBy(asc(locations.createdAt), asc(locations.id))
-          .limit(1)
           .for("share");
-        if (!primaryLocation) {
+        const primaryLocation = activeLocations.find(
+          (location) => location.isPrimary,
+        );
+        const targetLocation = input.locationId
+          ? activeLocations.find((location) => location.id === input.locationId)
+          : primaryLocation;
+        if (!targetLocation) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: "Set a primary location before adding provider hours.",
+            message: input.locationId
+              ? "Choose an active clinic location before saving provider hours."
+              : "Set a primary location before adding provider hours.",
           });
         }
 
@@ -1920,8 +1934,8 @@ export const settingsRouter = createRouter({
 
         if (
           providerScheduleRevision(
-            primaryLocation.timezone,
-            primaryLocation.id,
+            targetLocation.timezone,
+            primaryLocation?.id ?? null,
             provider.locationId,
             currentRows,
           ) !== input.expectedRevision
@@ -1932,50 +1946,6 @@ export const settingsRouter = createRouter({
           });
         }
 
-        const hasNewWindows = input.windows.length > 0;
-        const otherLocationWindowCount = currentRows.filter(
-          (row) => row.locationId !== primaryLocation.id,
-        ).length;
-        if (
-          otherLocationWindowCount > 0 &&
-          input.replaceOtherLocationHours !== true
-        ) {
-          throw new TRPCError({
-            code: "PRECONDITION_FAILED",
-            message: `Confirm replacing ${otherLocationWindowCount} working ${otherLocationWindowCount === 1 ? "window" : "windows"} saved outside the primary location.`,
-          });
-        }
-
-        const movingFromAnotherLocation =
-          hasNewWindows &&
-          provider.locationId !== null &&
-          provider.locationId !== primaryLocation.id;
-        if (movingFromAnotherLocation) {
-          if (input.moveToPrimaryLocation !== true) {
-            throw new TRPCError({
-              code: "PRECONDITION_FAILED",
-              message:
-                "Confirm moving this provider to the primary location before setting primary-location hours.",
-            });
-          }
-        }
-
-        // Empty schedules clear existing hours without changing the staff
-        // assignment. New hours attach an unassigned provider automatically;
-        // moving a provider from another location requires consent above.
-        if (hasNewWindows && provider.locationId !== primaryLocation.id) {
-          await tx
-            .update(users)
-            .set({ locationId: primaryLocation.id })
-            .where(
-              and(
-                eq(users.id, provider.id),
-                eq(users.practiceId, ctx.practiceId),
-                isNull(users.deletedAt),
-              ),
-            );
-        }
-
         await tx
           .update(staffSchedules)
           .set({ deletedAt: new Date() })
@@ -1983,6 +1953,7 @@ export const settingsRouter = createRouter({
             and(
               eq(staffSchedules.practiceId, ctx.practiceId),
               eq(staffSchedules.userId, provider.id),
+              eq(staffSchedules.locationId, targetLocation.id),
               isNull(staffSchedules.deletedAt),
             ),
           );
@@ -1997,7 +1968,7 @@ export const settingsRouter = createRouter({
             orderedWindows.map((window) => ({
               practiceId: ctx.practiceId,
               userId: provider.id,
-              locationId: primaryLocation.id,
+              locationId: targetLocation.id,
               dayOfWeek: window.dayOfWeek,
               startTime: window.startTime,
               endTime: window.endTime,
@@ -2007,7 +1978,7 @@ export const settingsRouter = createRouter({
 
         return {
           userId: provider.id,
-          locationId: hasNewWindows ? primaryLocation.id : provider.locationId,
+          locationId: targetLocation.id,
           windowCount: orderedWindows.length,
         };
       });


### PR DESCRIPTION
## Outcome

Provider hours now model real multi-location clinic coverage and actively constrain doctor-required client booking suggestions and writes.

## What changed

- Configure each veterinarian's weekly hours independently at every active clinic location.
- Preserve provider home base as informational; saving coverage no longer moves staff between locations or deletes hours elsewhere.
- Keep the current generic 8–6 fallback until a clinic deliberately saves its first provider hours.
- Once configured, intersect public booking and portal suggestions with actual provider coverage.
- Revalidate exact public/portal requests server-side so a tampered or stale client cannot book outside coverage.
- Apply doctor-specific coverage to dashboard and assistant slot lookup while preserving staff override paths.
- Handle lunch/split shifts, pooled overlapping coverage, legacy practice-wide rows, practice timezones, and DST.
- Verify portal type duration server-side when a type is supplied and document the expanded contract.

## Safety and rollout

Production and staging aggregate checks found zero current provider-hour rows, so this release requires no migration and changes no existing clinic availability until an administrator opts in by saving hours.

Public and portal scheduling remain conservative about existing location capacity, and non-doctor appointment types are not restricted by veterinarian hours.

## Verification

- Full web test suite: green
- Focused scheduling/settings/booking suite: 185 tests green
- TypeScript: green
- Production build: green
- Drizzle schema generation: no changes
- Diff whitespace, secret, and public-repo safety scans: clean