### PR TITLE
Add clinic-controlled communication safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
@@ -86,6 +86,14 @@ jobs:
         env:
           SMS_QUEUE_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run lib/messaging/__tests__/sms-operations-queues.integration.test.ts
+
+      # The reminder sweep is a candidate list. Prove against real PostgreSQL
+      # that dispatch-time revalidation honors clinic enablement, each clinic's
+      # lead window, cancellation, and rescheduling before a provider claim.
+      - name: Execute appointment reminder policy SQL
+        env:
+          REMINDER_POLICY_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run lib/messaging/__tests__/appointment-reminder-eligibility.integration.test.ts
 
       - run: pnpm --filter @openpims/db db:rls:test
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/apps/web/app/api/cron/reminders/route.test.ts
+++ b/apps/web/app/api/cron/reminders/route.test.ts
@@ -3,8 +3,26 @@ import { readFileSync } from "node:fs";
 
 const mocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
-  const select = vi.fn(() => {
-    const result = selectResults.shift() ?? [];
+  const eligibilityResults: unknown[][] = [];
+  const recipientResults: unknown[][] = [];
+  const select = vi.fn((fields?: Record<string, unknown>) => {
+    const result = Object.prototype.hasOwnProperty.call(
+      fields ?? {},
+      "dispatchEligible",
+    )
+      ? (eligibilityResults.shift() ?? [{ dispatchEligible: true }])
+      : Object.prototype.hasOwnProperty.call(fields ?? {}, "recipientEmail")
+        ? (recipientResults.shift() ?? [
+            {
+              recipientEmail: "ada@lovelacevet.com",
+              suppressionReason: null,
+              clientFirstName: "Ada",
+              clientLastName: "Lovelace",
+              patientName: "Miso",
+              practiceName: "Neighborhood Veterinary",
+            },
+          ])
+        : (selectResults.shift() ?? []);
     const afterWhere: {
       limit: ReturnType<typeof vi.fn>;
       orderBy: ReturnType<typeof vi.fn>;
@@ -54,6 +72,8 @@ const mocks = vi.hoisted(() => {
   return {
     db,
     selectResults,
+    eligibilityResults,
+    recipientResults,
     claimResults,
     deleteResults,
     insertValues,
@@ -150,6 +170,8 @@ afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
+  mocks.eligibilityResults.length = 0;
+  mocks.recipientResults.length = 0;
   mocks.claimResults.length = 0;
   mocks.deleteResults.length = 0;
 });
@@ -174,6 +196,29 @@ describe("appointment reminder cron", () => {
     expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 
+  it("does not claim or dispatch an appointment that becomes ineligible after the sweep", async () => {
+    mocks.selectResults.push([appointment()]);
+    mocks.eligibilityResults.push([]);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/reminders"),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      sent: 0,
+      failed: 0,
+      skipped: 0,
+      deduped: 0,
+      suppressed: 0,
+    });
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("1 no longer eligible"),
+    );
+  });
+
   it("suppresses seeded demo appointments before any provider or delivery claim", async () => {
     mocks.selectResults.push([
       appointment({
@@ -196,7 +241,7 @@ describe("appointment reminder cron", () => {
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(mocks.insertValues).not.toHaveBeenCalled();
     expect(consoleLog).toHaveBeenCalledWith(
-      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (1 demo, 0 reserved address) out of 1 total",
+      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 0 no longer eligible, 1 suppressed (1 demo, 0 reserved address) out of 1 total",
     );
     expect(consoleLog).not.toHaveBeenCalledWith(
       expect.stringContaining("Miso"),
@@ -228,7 +273,7 @@ describe("appointment reminder cron", () => {
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(mocks.insertValues).not.toHaveBeenCalled();
     expect(consoleLog).toHaveBeenCalledWith(
-      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (0 demo, 1 reserved address) out of 1 total",
+      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 0 no longer eligible, 1 suppressed (0 demo, 1 reserved address) out of 1 total",
     );
   });
 
@@ -400,6 +445,16 @@ describe("appointment reminder cron", () => {
   });
 
   it("blocks scheduled email reminders to provider-suppressed recipients", async () => {
+    mocks.recipientResults.push([
+      {
+        recipientEmail: "ada@lovelacevet.com",
+        suppressionReason: "bounce",
+        clientFirstName: "Ada",
+        clientLastName: "Lovelace",
+        patientName: "Miso",
+        practiceName: "Neighborhood Veterinary",
+      },
+    ]);
     mocks.selectResults.push([
       appointment({
         preferredContactMethod: "email",
@@ -440,7 +495,44 @@ describe("appointment reminder cron", () => {
     );
   });
 
+  it("honors an email suppression added after the sweep and before provider dispatch", async () => {
+    mocks.selectResults.push([
+      appointment({
+        preferredContactMethod: "email",
+        emailSuppressionReason: null,
+      }),
+    ]);
+    mocks.recipientResults.push([
+      {
+        recipientEmail: "new-address@example.com",
+        suppressionReason: "bounce",
+        clientFirstName: "Ada",
+        clientLastName: "Lovelace",
+        patientName: "Miso",
+        practiceName: "Neighborhood Veterinary",
+      },
+    ]);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/reminders"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      sent: 0,
+      failed: 1,
+    });
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "email",
+        status: "failed",
+        content: expect.stringContaining("delivery bounce"),
+      }),
+    );
+  });
+
   it("fails SMS-only scheduled reminders when no active sender exists", async () => {
+    mocks.recipientResults.push([]);
     mocks.selectResults.push([appointment({ clientEmail: null })], []);
 
     const response = await GET(
@@ -660,6 +752,13 @@ describe("appointment reminder cron", () => {
 
 describe("appointment reminder cron query scoping", () => {
   const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+  const claimSource = readFileSync(
+    new URL(
+      "../../../../lib/messaging/appointment-reminder.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
 
   function expectScopedJoin(table: string, foreignKey: string) {
     expect(source).toMatch(
@@ -684,8 +783,28 @@ describe("appointment reminder cron query scoping", () => {
       /innerJoin\(\s*practices,\s*and\(\s*eq\(appointments\.practiceId, practices\.id\),\s*isNull\(practices\.deletedAt\),?\s*\),?\s*\)/s,
     );
     expect(source).toContain('eq(appointments.status, "confirmed")');
+    expect(source).toContain("eq(practices.appointmentRemindersEnabled, true)");
+    expect(source).toContain("practices.appointmentReminderLeadHours");
+    expect(source).toContain("interval '1 hour'");
     expect(source).not.toContain(
       'inArray(appointments.status, ["scheduled", "confirmed"])',
+    );
+  });
+
+  it("revalidates clinic and appointment state inside the tenant claim", () => {
+    expect(source).toContain("appointmentReminderDispatchEligible(tx");
+    expect(claimSource).toContain(
+      "eq(practices.appointmentRemindersEnabled, true)",
+    );
+    expect(claimSource).toContain('eq(appointments.status, "confirmed")');
+    expect(claimSource).toContain(
+      "eq(appointments.startTime, options.startTime)",
+    );
+    expect(claimSource).toContain("practices.appointmentReminderLeadHours");
+    expect(claimSource).toContain("isNull(appointments.deletedAt)");
+    expect(source).toContain("currentAppointmentReminderEmailRecipient(tx");
+    expect(claimSource).toContain(
+      "sql`${emailSuppressions.email} = lower(trim(${clients.email}))`",
     );
   });
 

--- a/apps/web/app/api/cron/reminders/route.test.ts
+++ b/apps/web/app/api/cron/reminders/route.test.ts
@@ -786,6 +786,8 @@ describe("appointment reminder cron query scoping", () => {
     expect(source).toContain("eq(practices.appointmentRemindersEnabled, true)");
     expect(source).toContain("practices.appointmentReminderLeadHours");
     expect(source).toContain("interval '1 hour'");
+    expect(source).toContain("now.toISOString()}::timestamptz");
+    expect(source).not.toContain("sql`${now} +");
     expect(source).not.toContain(
       'inArray(appointments.status, ["scheduled", "confirmed"])',
     );
@@ -801,6 +803,8 @@ describe("appointment reminder cron query scoping", () => {
       "eq(appointments.startTime, options.startTime)",
     );
     expect(claimSource).toContain("practices.appointmentReminderLeadHours");
+    expect(claimSource).toContain("options.now.toISOString()}::timestamptz");
+    expect(claimSource).not.toContain("sql`${options.now} +");
     expect(claimSource).toContain("isNull(appointments.deletedAt)");
     expect(source).toContain("currentAppointmentReminderEmailRecipient(tx");
     expect(claimSource).toContain(

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -29,6 +29,8 @@ import { automatedAppointmentReminderSuppressionReason } from "@/lib/automated-r
 import {
   appointmentReminderDedupeKey,
   appointmentReminderSmsIdempotencyKey,
+  appointmentReminderDispatchEligible,
+  currentAppointmentReminderEmailRecipient,
   claimAppointmentReminderCommunication,
 } from "@/lib/messaging/appointment-reminder";
 
@@ -80,18 +82,34 @@ async function claimReminderCommunication(opts: {
   channel: ReminderChannel;
   patientName: string | null;
   startTime: Date;
-  dedupeKey: string;
-}): Promise<string | null> {
-  return withTenant(db, opts.practiceId, (tx) =>
-    claimAppointmentReminderCommunication(tx, {
+  now: Date;
+}): Promise<
+  | { status: "claimed"; communicationId: string }
+  | { status: "deduped" }
+  | { status: "ineligible" }
+> {
+  return withTenant(db, opts.practiceId, async (tx) => {
+    const eligible = await appointmentReminderDispatchEligible(tx, {
+      practiceId: opts.practiceId,
+      appointmentId: opts.appointmentId,
+      clientId: opts.clientId,
+      startTime: opts.startTime,
+      now: opts.now,
+    });
+    if (!eligible) return { status: "ineligible" };
+
+    const communicationId = await claimAppointmentReminderCommunication(tx, {
       practiceId: opts.practiceId,
       appointmentId: opts.appointmentId,
       clientId: opts.clientId,
       channel: opts.channel,
       patientName: opts.patientName,
       startTime: opts.startTime,
-    }),
-  );
+    });
+    return communicationId
+      ? { status: "claimed", communicationId }
+      : { status: "deduped" };
+  });
 }
 
 async function recordReminderOutcome(opts: {
@@ -130,17 +148,32 @@ async function recordReminderOutcome(opts: {
   );
 }
 
+async function currentEmailRecipient(opts: {
+  practiceId: string;
+  appointmentId: string;
+  clientId: string;
+  startTime: Date;
+}) {
+  return withTenant(db, opts.practiceId, (tx) =>
+    currentAppointmentReminderEmailRecipient(tx, {
+      ...opts,
+      now: new Date(),
+    }),
+  );
+}
+
 export async function GET(request: Request) {
   const authError = cronAuthError(request);
   if (authError) return authError;
 
   try {
     const now = new Date();
-    const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 
     // Cross-tenant sweep across all practices → system context (RLS bypass).
     // Joins the client's contact prefs/consent, the practice (name/phone/tz for
     // the message + quiet hours), and the room's location (for its own number).
+    // A clinic must explicitly enable automated reminders; the configured lead
+    // time controls the upper edge of its rolling hourly window.
     const upcomingAppointments = await withSystem(db, (tx) =>
       tx
         .select({
@@ -161,7 +194,9 @@ export async function GET(request: Request) {
           practiceName: practices.name,
           practicePhone: practices.phone,
           practiceTimezone: practices.timezone,
-          locationId: sql<string | null>`coalesce(${appointments.locationId}, ${rooms.locationId})`,
+          locationId: sql<
+            string | null
+          >`coalesce(${appointments.locationId}, ${rooms.locationId})`,
           isSeededDemoClient: sql<boolean>`
             coalesce(${practices.settings} -> 'demoData' -> 'clientIds', '[]'::jsonb)
               @> to_jsonb(${appointments.clientId}::text)
@@ -227,8 +262,12 @@ export async function GET(request: Request) {
             isNull(patients.deletedAt),
             eq(clients.practiceId, appointments.practiceId),
             isNull(clients.deletedAt),
+            eq(practices.appointmentRemindersEnabled, true),
             gte(appointments.startTime, now),
-            lte(appointments.startTime, in24h),
+            lte(
+              appointments.startTime,
+              sql`${now} + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
+            ),
             eq(appointments.status, "confirmed"),
           ),
         )
@@ -239,6 +278,7 @@ export async function GET(request: Request) {
     let failed = 0;
     let skipped = 0; // SMS-preferred but deferred by quiet hours (no email fallback)
     let deduped = 0;
+    let ineligible = 0;
     let suppressed = 0; // Seeded demo rows or reserved fixture addresses.
     let suppressedDemo = 0;
     let suppressedReservedAddress = 0;
@@ -320,15 +360,32 @@ export async function GET(request: Request) {
       const emailReminder = async (
         communicationId: string,
       ): Promise<boolean> => {
-        const clientEmail = normalizeEmailSuppressionAddress(appt.clientEmail);
-        if (!clientEmail) return false;
-        if (appt.emailSuppressionReason) {
+        const currentRecipient = await currentEmailRecipient({
+          practiceId: appt.practiceId,
+          appointmentId: appt.id,
+          clientId: appt.clientId!,
+          startTime: startDate,
+        });
+        const clientEmail = normalizeEmailSuppressionAddress(
+          currentRecipient?.recipientEmail,
+        );
+        if (!currentRecipient || !clientEmail) {
+          await recordReminderOutcome({
+            practiceId: appt.practiceId,
+            communicationId,
+            channel: "email",
+            content: `Automated appointment reminder blocked because the appointment or current client email is no longer eligible`,
+            status: "failed",
+          });
+          return false;
+        }
+        if (currentRecipient.suppressionReason) {
           await recordReminderOutcome({
             practiceId: appt.practiceId,
             communicationId,
             channel: "email",
             content: `Automated appointment reminder blocked for ${appt.patientName} on ${appt.startTime.toISOString()}: ${emailSuppressionSendBlockMessage(
-              appt.emailSuppressionReason,
+              currentRecipient.suppressionReason,
             )}`,
             status: "failed",
           });
@@ -339,11 +396,11 @@ export async function GET(request: Request) {
         try {
           const result = await sendAppointmentReminder({
             to: clientEmail,
-            clientName: `${appt.clientFirstName} ${appt.clientLastName}`,
-            patientName: appt.patientName ?? "Unknown",
+            clientName: `${currentRecipient.clientFirstName} ${currentRecipient.clientLastName}`,
+            patientName: currentRecipient.patientName ?? "Unknown",
             appointmentDate,
             appointmentTime,
-            practiceName: appt.practiceName ?? "",
+            practiceName: currentRecipient.practiceName,
           });
           success = result.success;
           providerMessageId = result.id;
@@ -402,19 +459,24 @@ export async function GET(request: Request) {
         const initialChannel: ReminderChannel =
           channel === "sms" ? "sms" : "email";
         claimedChannel = initialChannel;
-        const communicationId = await claimReminderCommunication({
+        const claim = await claimReminderCommunication({
           practiceId: appt.practiceId,
           appointmentId: appt.id,
           clientId: appt.clientId,
           channel: initialChannel,
           patientName: appt.patientName,
           startTime: startDate,
-          dedupeKey,
+          now: new Date(),
         });
-        if (!communicationId) {
+        if (claim.status === "ineligible") {
+          ineligible++;
+          continue;
+        }
+        if (claim.status === "deduped") {
           deduped++;
           continue;
         }
+        const communicationId = claim.communicationId;
         claimedCommunicationId = communicationId;
 
         if (channel === "sms") {
@@ -534,22 +596,22 @@ export async function GET(request: Request) {
       }
     }
 
-    const eligible = upcomingAppointments.length - suppressed;
+    const eligible = upcomingAppointments.length - suppressed - ineligible;
     console.log(
-      `Cron reminders completed: ${sent} sent, ${failed} failed, ${skipped} deferred (quiet hours), ${deduped} deduped, ${suppressed} suppressed (${suppressedDemo} demo, ${suppressedReservedAddress} reserved address) out of ${upcomingAppointments.length} total`,
+      `Cron reminders completed: ${sent} sent, ${failed} failed, ${skipped} deferred (quiet hours), ${deduped} deduped, ${ineligible} no longer eligible, ${suppressed} suppressed (${suppressedDemo} demo, ${suppressedReservedAddress} reserved address) out of ${upcomingAppointments.length} total`,
     );
 
     if (failed > 0) {
       void alertOps(
         "Appointment reminders had failures",
-        `${failed} of ${eligible} eligible reminders failed to send (${sent} sent, ${skipped} deferred, ${deduped} deduped, ${suppressed} suppressed).`,
+        `${failed} of ${eligible} eligible reminders failed to send (${sent} sent, ${skipped} deferred, ${deduped} deduped, ${ineligible} no longer eligible, ${suppressed} suppressed).`,
       );
     }
 
     await reportCronHeartbeat({
       job: "reminders",
       status: failed > 0 ? "degraded" : "ok",
-      detail: `${sent} sent, ${failed} failed, ${skipped} deferred, ${deduped} deduped, ${suppressed} suppressed`,
+      detail: `${sent} sent, ${failed} failed, ${skipped} deferred, ${deduped} deduped, ${ineligible} no longer eligible, ${suppressed} suppressed`,
       metrics: {
         total: upcomingAppointments.length,
         eligible,
@@ -557,6 +619,7 @@ export async function GET(request: Request) {
         failed,
         skipped,
         deduped,
+        ineligible,
         suppressed,
         suppressedDemo,
         suppressedReservedAddress,

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -266,7 +266,7 @@ export async function GET(request: Request) {
             gte(appointments.startTime, now),
             lte(
               appointments.startTime,
-              sql`${now} + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
+              sql`${now.toISOString()}::timestamptz + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
             ),
             eq(appointments.status, "confirmed"),
           ),

--- a/apps/web/components/dashboard/activation-checklist.tsx
+++ b/apps/web/components/dashboard/activation-checklist.tsx
@@ -171,6 +171,8 @@ export function ActivationChecklist() {
   const pathway = getOnboardingIntentOption(
     checklistState.onboardingIntent ?? DEFAULT_ONBOARDING_INTENT,
   );
+  const includeTextingMilestone =
+    textingData.setupAvailable || textingData.hasAnyNumber;
 
   const explorationMilestones: Milestone[] = [
     {
@@ -243,13 +245,17 @@ export function ActivationChecklist() {
         bookingData.page.config.bookableTypeIds.length > 0,
       href: "/settings?tab=booking",
     },
-    {
-      key: "texting",
-      label: "Finish texting activation",
-      hint: "Submit carrier registration and wait for approval. Texting is not live until an active number is enabled.",
-      done: textingData.hasActiveNumber,
-      href: "/settings?tab=messaging&setup=texting",
-    },
+    ...(includeTextingMilestone
+      ? [
+          {
+            key: "texting",
+            label: "Finish texting activation",
+            hint: "Submit carrier registration and wait for approval. Texting is not live until an active number is enabled.",
+            done: textingData.hasActiveNumber,
+            href: "/settings?tab=messaging&setup=texting",
+          } as Milestone,
+        ]
+      : []),
     ...(clientPaymentData.stripeConfigured
       ? [
           {

--- a/apps/web/components/onboarding/steps/set-up-texting.tsx
+++ b/apps/web/components/onboarding/steps/set-up-texting.tsx
@@ -56,8 +56,20 @@ export function SetUpTextingStep({
   })();
 
   const messaging = location?.messaging ?? null;
+  const hosted = status.data?.launch.hosted ?? false;
+  const setupAvailable = status.data?.launch.setupAvailable;
+  const setupCapabilityKnown = Boolean(status.data);
+  const hasAnyNumber = Boolean(
+    status.data?.locations.some(
+      (loc) =>
+        loc.messaging?.senderE164?.trim() &&
+        loc.messaging.registrationStatus !== "failed",
+    ),
+  );
+  const setupDisabled = setupAvailable === false;
+  const setupUnavailable = setupAvailable === false && !hasAnyNumber;
   const hasSender = Boolean(
-    messaging?.senderE164?.trim() && messaging?.messagingProfileId?.trim()
+    messaging?.senderE164?.trim() && messaging?.messagingProfileId?.trim(),
   );
   const isFailed = messaging?.registrationStatus === "failed";
   const isConfigured = hasSender && !isFailed;
@@ -68,7 +80,7 @@ export function SetUpTextingStep({
   const statusDetail = (() => {
     if (!messaging) return null;
     if (isFailed) {
-      return "Number setup did not finish. Reconcile the saved provider setup in Messaging settings; OpenVPM will not buy another number automatically.";
+      return "Number setup did not finish. Reconcile the saved provider setup in Messaging settings; the system will not buy another number automatically.";
     }
     if (messaging.registrationStatus === "not_started" && hasSender) {
       return "Number order accepted. Carrier registration has not been submitted; complete the clinic details in Messaging settings.";
@@ -84,14 +96,18 @@ export function SetUpTextingStep({
       messaging.enabled &&
       messaging.launchEligible === false
     ) {
-      return "Carrier registration is approved, but outbound texting remains off until OpenVPM approves this clinic location for the controlled pilot.";
+      return hosted
+        ? "Carrier registration is approved, but outbound texting remains off until OpenVPM approves this clinic location for the controlled pilot."
+        : "Carrier registration is approved, but outbound texting remains off until your administrator enables this clinic location.";
     }
     if (isActive) return "Texting is active.";
     if (messaging.registrationStatus === "action_required") {
       return "Carrier registration needs more clinic information. Review the request in Messaging settings.";
     }
     if (messaging.registrationStatus === "suspended") {
-      return "Texting is suspended. Review Messaging settings and contact OpenVPM support.";
+      return hosted
+        ? "Texting is suspended. Review Messaging settings and contact OpenVPM support."
+        : "Texting is suspended. Review Messaging settings and contact your administrator.";
     }
     return "Texting is not ready yet. Review Messaging settings before sending.";
   })();
@@ -99,10 +115,53 @@ export function SetUpTextingStep({
   return (
     <div className="space-y-5">
       <p className="text-sm leading-6 text-slate-600">
-        Text your clients about appointments, reminders, and results, and let
-        them text you back. OpenVPM can set up a new local texting number; your
-        existing clinic voice line stays unchanged. This is optional, so skip it
-        and set it up later if you like.
+        {!setupCapabilityKnown ? (
+          <>
+            Texting setup is optional. We are checking whether new-number setup
+            is available for this clinic. Email appointment reminders remain
+            available, so you can continue and return to texting later.
+          </>
+        ) : setupDisabled ? (
+          hosted ? (
+            <>
+              {hasAnyNumber
+                ? "Your clinic has an existing texting setup to review, but new-number setup is not currently available. "
+                : "Texting setup is currently a controlled clinic pilot and is not available for this clinic yet. "}
+              Email appointment reminders remain available, so you can continue
+              without new texting setup. Review{" "}
+              <Link
+                href="/settings?tab=messaging"
+                className="font-medium text-emerald-700 underline underline-offset-2"
+              >
+                Messaging settings
+              </Link>{" "}
+              or{" "}
+              <a
+                href="mailto:support@openvpm.com?subject=OpenVPM%20texting%20pilot"
+                className="font-medium text-emerald-700 underline underline-offset-2"
+              >
+                contact OpenVPM support
+              </a>{" "}
+              {hasAnyNumber
+                ? " for help with the existing setup."
+                : " when your clinic is ready to join the pilot."}
+            </>
+          ) : (
+            <>
+              Texting number setup is disabled in this deployment. Email
+              appointment reminders remain available, so you can continue
+              without texting. Ask your deployment administrator to configure
+              the provider and enable provisioning before setup.
+            </>
+          )
+        ) : (
+          <>
+            Text your clients about appointments, reminders, and results, and
+            let them text you back. OpenVPM can set up a new local texting
+            number; your existing clinic voice line stays unchanged. This is
+            optional, so skip it and set it up later if you like.
+          </>
+        )}
       </p>
 
       <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4">
@@ -125,6 +184,29 @@ export function SetUpTextingStep({
                   Retry this step before starting or changing setup.
                 </p>
               </div>
+            ) : setupUnavailable ? (
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-slate-900">
+                  {hosted
+                    ? "Texting setup is in a controlled pilot"
+                    : "Texting number setup is disabled"}
+                </p>
+                <p className="text-xs text-slate-500">
+                  {hosted
+                    ? "Email appointment reminders remain available while OpenVPM approves clinics for texting setup."
+                    : "Email appointment reminders remain available while your administrator configures texting."}
+                </p>
+              </div>
+            ) : setupDisabled && !messaging ? (
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-slate-900">
+                  New-number setup is unavailable
+                </p>
+                <p className="text-xs text-slate-500">
+                  Review the clinic&apos;s existing texting setup in Messaging
+                  settings.
+                </p>
+              </div>
             ) : messaging ? (
               <div className="space-y-1">
                 <p className="text-sm font-medium text-slate-900">
@@ -144,14 +226,14 @@ export function SetUpTextingStep({
             )}
           </div>
           {!status.isLoading && !status.error && location ? (
-            messaging ? (
+            setupAvailable === false || messaging ? (
               <Button asChild type="button" variant="outline" size="sm">
                 <Link href="/settings?tab=messaging">
                   {isConfigured ? <Check className="mr-1.5 h-4 w-4" /> : null}
-                  Review
+                  Messaging settings
                 </Link>
               </Button>
-            ) : (
+            ) : setupAvailable ? (
               <Button
                 type="button"
                 variant="default"
@@ -160,17 +242,20 @@ export function SetUpTextingStep({
               >
                 Set up texting
               </Button>
-            )
+            ) : null
           ) : null}
         </div>
       </div>
 
-      <MessagingWizard
-        location={location}
-        open={wizardOpen}
-        onOpenChange={setWizardOpen}
-        onChanged={() => void status.refetch()}
-      />
+      {setupAvailable ? (
+        <MessagingWizard
+          location={location}
+          hosted={hosted}
+          open={wizardOpen}
+          onOpenChange={setWizardOpen}
+          onChanged={() => void status.refetch()}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/settings/messaging-registration-form.tsx
+++ b/apps/web/components/settings/messaging-registration-form.tsx
@@ -101,11 +101,13 @@ export function MessagingRegistrationForm() {
   }, [data, defaults]);
 
   const submitted = Boolean(
-    data?.providerBrandStatus || data?.providerCampaignStatus
+    data?.providerBrandStatus || data?.providerCampaignStatus,
   );
   const save = trpc.messaging.saveRegistration.useMutation({
     onSuccess: () => {
-      toast.success("Carrier registration details saved for OpenVPM review.");
+      toast.success(
+        "Carrier registration details saved for administrator review.",
+      );
       setForm((current) => ({ ...current, taxId: "" }));
       setAttested(false);
       utils.messaging.getRegistration.invalidate();
@@ -144,7 +146,7 @@ export function MessagingRegistrationForm() {
           <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
             US carriers verify the clinic and its texting use case before
             messages can send. Saving this form does not submit or charge
-            anything; an OpenVPM operator reviews it first.
+            anything; your messaging administrator reviews it first.
           </p>
         </div>
         {data ? (
@@ -222,7 +224,7 @@ export function MessagingRegistrationForm() {
             onChange={(event) =>
               update(
                 "entityType",
-                event.target.value as FormState["entityType"]
+                event.target.value as FormState["entityType"],
               )
             }
             disabled={submitted}

--- a/apps/web/components/settings/messaging-tab.tsx
+++ b/apps/web/components/settings/messaging-tab.tsx
@@ -41,12 +41,26 @@ const REGISTRATION_BADGE: Record<
 };
 
 const EMPTY_MESSAGING_LOCATIONS: MessagingSetupLocation[] = [];
+const APPOINTMENT_REMINDER_LEAD_OPTIONS = [24, 48, 72] as const;
+
+function confirmReminderCatchUp(
+  action: "enable" | "expand",
+  leadHours: (typeof APPOINTMENT_REMINDER_LEAD_OPTIONS)[number],
+) {
+  const actionLabel =
+    action === "enable"
+      ? "Enabling automatic reminders"
+      : `Increasing the reminder window to ${leadHours} hours`;
+  return window.confirm(
+    `${actionLabel} may send reminders for existing eligible confirmed appointments on the next hourly run. Continue?`,
+  );
+}
 
 function hasConfiguredSender(
-  messaging: NonNullable<MessagingSetupLocation["messaging"]>
+  messaging: NonNullable<MessagingSetupLocation["messaging"]>,
 ) {
   return Boolean(
-    messaging.senderE164?.trim() || messaging.messagingProfileId?.trim()
+    messaging.senderE164?.trim() || messaging.messagingProfileId?.trim(),
   );
 }
 
@@ -55,6 +69,18 @@ export function MessagingTab() {
   const { data, isLoading, error, refetch } =
     trpc.messaging.getStatus.useQuery();
   const utils = trpc.useUtils();
+  const updateReminderSettings =
+    trpc.messaging.setAppointmentReminderSettings.useMutation({
+      onSuccess: async (_result, variables) => {
+        await utils.messaging.getStatus.invalidate();
+        toast.success(
+          variables.enabled
+            ? "Appointment reminders enabled"
+            : "Appointment reminders turned off",
+        );
+      },
+      onError: (mutationError) => toast.error(mutationError.message),
+    });
   const [wizardLocation, setWizardLocation] =
     useState<MessagingSetupLocation | null>(null);
   const openedSetupParam = useRef(false);
@@ -67,11 +93,12 @@ export function MessagingTab() {
   useEffect(() => {
     if (openedSetupParam.current) return;
     if (searchParams.get("setup") !== "texting") return;
+    if (!data?.launch.setupAvailable) return;
     const loc = setupLocations.find((l) => !l.messaging) ?? setupLocations[0];
     if (!loc) return;
     openedSetupParam.current = true;
     setWizardLocation(loc);
-  }, [setupLocations, searchParams]);
+  }, [data?.launch.setupAvailable, setupLocations, searchParams]);
 
   if (isLoading) {
     return (
@@ -102,6 +129,7 @@ export function MessagingTab() {
   const locations = data.locations as MessagingSetupLocation[];
   const usage = data.usage;
   const consent = data.consent;
+  const reminderSettings = data.appointmentReminders;
 
   return (
     <div className="max-w-3xl space-y-6">
@@ -116,16 +144,98 @@ export function MessagingTab() {
         </p>
       </div>
 
-      {data.launch.hosted && !data.launch.pilotEnabled ? (
+      {data.launch.hosted && !data.launch.setupAvailable ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950">
+          <p className="font-medium">Texting is a controlled clinic pilot</p>
+          <p className="mt-1">
+            Number setup is not enabled for this clinic yet, so OpenVPM will not
+            search for or purchase a number. Email appointment reminders remain
+            available. Contact OpenVPM support when your clinic is ready to join
+            the texting pilot.
+          </p>
+        </div>
+      ) : data.launch.hosted && !data.launch.pilotEnabled ? (
         <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950">
           <p className="font-medium">Outbound texting is safely off</p>
           <p className="mt-1">
-            OpenVPM enables one approved clinic location at a time after carrier
-            activation and pilot review. Setup can continue, but no SMS can send
-            until your clinic and location are explicitly approved.
+            Your clinic can continue setup, but no SMS can send until carrier
+            activation is complete and OpenVPM approves the exact clinic
+            location for the controlled pilot.
           </p>
         </div>
       ) : null}
+
+      <div className="rounded-lg border border-border bg-card p-4 sm:p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="font-medium">Automatic appointment reminders</p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              Send one reminder for each confirmed appointment. Delivery follows
+              the client&apos;s saved reminder preference. Texts require
+              recorded consent and an active clinic number; suppressed email
+              addresses stay blocked.
+            </p>
+          </div>
+          <Checkbox
+            aria-label="Enable automatic appointment reminders"
+            checked={reminderSettings.enabled}
+            disabled={updateReminderSettings.isPending}
+            onChange={(event) => {
+              const enabled = event.target.checked;
+              if (
+                enabled &&
+                !confirmReminderCatchUp(
+                  "enable",
+                  reminderSettings.leadHours as 24 | 48 | 72,
+                )
+              ) {
+                return;
+              }
+              updateReminderSettings.mutate({
+                enabled,
+                leadHours: reminderSettings.leadHours as 24 | 48 | 72,
+              });
+            }}
+          />
+        </div>
+
+        <label className="mt-4 block max-w-xs space-y-1.5 text-sm">
+          <span className="font-medium">Send approximately</span>
+          <select
+            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            value={reminderSettings.leadHours}
+            disabled={updateReminderSettings.isPending}
+            onChange={(event) => {
+              const leadHours = Number(event.target.value) as 24 | 48 | 72;
+              if (
+                reminderSettings.enabled &&
+                leadHours > reminderSettings.leadHours &&
+                !confirmReminderCatchUp("expand", leadHours)
+              ) {
+                return;
+              }
+              updateReminderSettings.mutate({
+                enabled: reminderSettings.enabled,
+                leadHours,
+              });
+            }}
+          >
+            {APPOINTMENT_REMINDER_LEAD_OPTIONS.map((hours) => (
+              <option key={hours} value={hours}>
+                {hours} hours before the appointment
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <p className="mt-3 text-xs text-muted-foreground">
+          {reminderSettings.enabled
+            ? "Automatic reminders are on. "
+            : "Off by default. No automatic appointment reminders are sent until a clinic administrator enables them here. "}
+          Enabling reminders or increasing this window may send reminders for
+          existing eligible confirmed appointments on the next hourly run.
+        </p>
+      </div>
 
       {/* Usage + consent summary */}
       <div className="grid gap-4 sm:grid-cols-3">
@@ -156,6 +266,8 @@ export function MessagingTab() {
           <LocationCard
             key={loc.locationId}
             loc={loc}
+            hosted={data.launch.hosted}
+            setupAvailable={data.launch.setupAvailable}
             testSendAllowed={data.launch.testSendAllowed}
             onStartSetup={() => setWizardLocation(loc)}
           />
@@ -167,16 +279,22 @@ export function MessagingTab() {
         )}
       </div>
 
-      <MessagingRegistrationForm />
+      {data.launch.setupAvailable ||
+      locations.some((location) => location.messaging) ? (
+        <MessagingRegistrationForm />
+      ) : null}
 
-      <MessagingWizard
-        location={wizardLocation}
-        open={Boolean(wizardLocation)}
-        onOpenChange={(open) => {
-          if (!open) setWizardLocation(null);
-        }}
-        onChanged={() => utils.messaging.getStatus.invalidate()}
-      />
+      {data.launch.setupAvailable ? (
+        <MessagingWizard
+          location={wizardLocation}
+          hosted={data.launch.hosted}
+          open={Boolean(wizardLocation)}
+          onOpenChange={(open) => {
+            if (!open) setWizardLocation(null);
+          }}
+          onChanged={() => utils.messaging.getStatus.invalidate()}
+        />
+      ) : null}
     </div>
   );
 }
@@ -235,10 +353,14 @@ function SummaryStat({
 
 function LocationCard({
   loc,
+  hosted,
+  setupAvailable,
   testSendAllowed,
   onStartSetup,
 }: {
   loc: MessagingSetupLocation;
+  hosted: boolean;
+  setupAvailable: boolean;
   testSendAllowed: boolean;
   onStartSetup: () => void;
 }) {
@@ -266,11 +388,18 @@ function LocationCard({
       {loc.messaging ? (
         <ConfiguredLocation
           loc={loc}
+          hosted={hosted}
+          setupAvailable={setupAvailable}
           testSendAllowed={testSendAllowed}
           onChanged={refresh}
         />
       ) : (
-        <UnconfiguredLocation loc={loc} onStartSetup={onStartSetup} />
+        <UnconfiguredLocation
+          loc={loc}
+          hosted={hosted}
+          setupAvailable={setupAvailable}
+          onStartSetup={onStartSetup}
+        />
       )}
     </div>
   );
@@ -278,10 +407,14 @@ function LocationCard({
 
 function ConfiguredLocation({
   loc,
+  hosted,
+  setupAvailable,
   testSendAllowed,
   onChanged,
 }: {
   loc: MessagingSetupLocation;
+  hosted: boolean;
+  setupAvailable: boolean;
   testSendAllowed: boolean;
   onChanged: () => void;
 }) {
@@ -316,7 +449,7 @@ function ConfiguredLocation({
   const reconcileSetup = trpc.messaging.provisionNumber.useMutation({
     onSuccess: () => {
       toast.success(
-        "Provider setup reconciled. No additional number was purchased."
+        "Provider setup reconciled. No additional number was purchased.",
       );
       onChanged();
     },
@@ -357,7 +490,7 @@ function ConfiguredLocation({
         </div>
       ) : null}
 
-      {m.registrationStatus === "failed" && !m.enabled ? (
+      {m.registrationStatus === "failed" && !m.enabled && setupAvailable ? (
         <Button
           variant="outline"
           disabled={reconcileSetup.isPending}
@@ -374,6 +507,12 @@ function ConfiguredLocation({
           ) : null}
           Reconcile provider setup
         </Button>
+      ) : m.registrationStatus === "failed" && !m.enabled ? (
+        <p className="text-xs text-muted-foreground">
+          {hosted
+            ? "OpenVPM support must review this failed pilot setup before another provider reconciliation attempt."
+            : "Your OpenVPM administrator must enable provisioning before another provider reconciliation attempt."}
+        </p>
       ) : null}
 
       <label className="flex items-center gap-2 text-sm">
@@ -435,9 +574,13 @@ function ConfiguredLocation({
 
 function UnconfiguredLocation({
   loc,
+  hosted,
+  setupAvailable,
   onStartSetup,
 }: {
   loc: MessagingSetupLocation;
+  hosted: boolean;
+  setupAvailable: boolean;
   onStartSetup: () => void;
 }) {
   return (
@@ -446,8 +589,11 @@ function UnconfiguredLocation({
         <div className="space-y-1">
           <p className="text-sm font-medium">Texting is not set up yet</p>
           <p className="text-sm text-muted-foreground">
-            Start a guided setup and choose a new local texting number. Your
-            existing clinic phone line will not be ported or changed.
+            {setupAvailable
+              ? "Start a guided setup and choose a new local texting number. Your existing clinic phone line will not be ported or changed."
+              : hosted
+                ? "OpenVPM will enable number setup after your clinic joins the controlled texting pilot. Email reminders can be used now."
+                : "Number setup is disabled by your OpenVPM administrator. Email reminders can be used now."}
           </p>
           {loc.existingPhone ? (
             <p className="text-xs text-muted-foreground">
@@ -455,9 +601,11 @@ function UnconfiguredLocation({
             </p>
           ) : null}
         </div>
-        <Button onClick={onStartSetup} className="shrink-0">
-          Set up texting
-        </Button>
+        {setupAvailable ? (
+          <Button onClick={onStartSetup} className="shrink-0">
+            Set up texting
+          </Button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/components/settings/messaging-wizard.tsx
+++ b/apps/web/components/settings/messaging-wizard.tsx
@@ -84,11 +84,13 @@ const STEPS: { id: Step; title: string }[] = [
 
 export function MessagingWizard({
   location,
+  hosted,
   open,
   onOpenChange,
   onChanged,
 }: {
   location: MessagingSetupLocation | null;
+  hosted: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onChanged: () => void;
@@ -96,7 +98,7 @@ export function MessagingWizard({
   const utils = trpc.useUtils();
   const defaultMode = useMemo(
     () => defaultMessagingSetupMode(location?.existingPhone),
-    [location?.existingPhone]
+    [location?.existingPhone],
   );
   const [step, setStep] = useState<Step>("choose");
   const [mode, setMode] = useState<MessagingSetupMode>(defaultMode);
@@ -109,10 +111,10 @@ export function MessagingWizard({
   const [numbers, setNumbers] = useState<SearchNumber[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedNumber, setSelectedNumber] = useState<SearchNumber | null>(
-    null
+    null,
   );
   const [provisionedSender, setProvisionedSender] = useState<string | null>(
-    null
+    null,
   );
   const [chargeAcknowledged, setChargeAcknowledged] = useState(false);
 
@@ -135,7 +137,7 @@ export function MessagingWizard({
       setProvisionedSender(result.senderE164);
       setStep("done");
       toast.success(
-        "Number order accepted. Sending stays off until carrier approval."
+        "Number order accepted. Sending stays off until carrier approval.",
       );
       onChanged();
     },
@@ -180,7 +182,7 @@ export function MessagingWizard({
     setHasSearched(false);
     try {
       const result = await utils.messaging.searchNumbers.fetch(
-        areaCode ? { areaCode } : {}
+        areaCode ? { areaCode } : {},
       );
       setNumbers(result);
       setSelectedNumber(result[0] ?? null);
@@ -273,7 +275,7 @@ export function MessagingWizard({
                 key={s.id}
                 className={cn(
                   "h-1.5 flex-1 rounded-full transition-colors",
-                  i <= currentIndex ? "bg-emerald-500" : "bg-slate-200"
+                  i <= currentIndex ? "bg-emerald-500" : "bg-slate-200",
                 )}
               />
             ))}
@@ -292,6 +294,7 @@ export function MessagingWizard({
             ) : null}
             {step === "confirm" ? (
               <ConfirmStep
+                hosted={hosted}
                 mode={mode}
                 location={location}
                 eligibility={eligibility}
@@ -317,6 +320,7 @@ export function MessagingWizard({
             ) : null}
             {step === "registration" ? (
               <RegistrationStep
+                hosted={hosted}
                 mode={mode}
                 location={location}
                 selectedNumber={selectedNumber}
@@ -324,7 +328,9 @@ export function MessagingWizard({
                 setChargeAcknowledged={setChargeAcknowledged}
               />
             ) : null}
-            {step === "done" ? <DoneStep sender={provisionedSender} /> : null}
+            {step === "done" ? (
+              <DoneStep sender={provisionedSender} hosted={hosted} />
+            ) : null}
           </div>
 
           <div className="mt-6 flex items-center justify-between border-t border-slate-200 pt-5">
@@ -399,7 +405,7 @@ function ChooseStep({
           "w-full rounded-xl border p-4 text-left transition-colors",
           mode === "buy"
             ? "border-emerald-500 bg-emerald-50"
-            : "border-slate-200 hover:border-emerald-300"
+            : "border-slate-200 hover:border-emerald-300",
         )}
       >
         <div className="flex items-start gap-3">
@@ -419,6 +425,7 @@ function ChooseStep({
 }
 
 function ConfirmStep({
+  hosted,
   mode,
   location,
   eligibility,
@@ -432,6 +439,7 @@ function ConfirmStep({
   setSelectedNumber,
   searchNumbers,
 }: {
+  hosted: boolean;
   mode: MessagingSetupMode;
   location: MessagingSetupLocation;
   eligibility: { eligible: boolean; detail?: string } | null;
@@ -491,7 +499,10 @@ function ConfirmStep({
       <p className="text-sm leading-6 text-slate-600">
         Search for a local number. The selected number will be assigned to this
         location. Carrier registration remains not started until you complete
-        the clinic details and OpenVPM reviews them.
+        the clinic details and{" "}
+        {hosted
+          ? "OpenVPM reviews them."
+          : "your administrator finishes provider activation."}
       </p>
       <div className="flex flex-wrap items-end gap-2">
         <label className="space-y-1.5">
@@ -502,7 +513,7 @@ function ConfirmStep({
               setAreaCode(
                 e.target.value
                   .replace(/\D/g, "")
-                  .slice(0, MESSAGING_AREA_CODE_LENGTH)
+                  .slice(0, MESSAGING_AREA_CODE_LENGTH),
               )
             }
             maxLength={MESSAGING_AREA_CODE_LENGTH}
@@ -536,7 +547,7 @@ function ConfirmStep({
                 "flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors",
                 selectedNumber?.phoneNumber === n.phoneNumber
                   ? "bg-emerald-50"
-                  : "hover:bg-slate-50"
+                  : "hover:bg-slate-50",
               )}
             >
               <span className="font-medium text-slate-950">
@@ -566,12 +577,14 @@ function ConfirmStep({
 }
 
 function RegistrationStep({
+  hosted,
   mode,
   location,
   selectedNumber,
   chargeAcknowledged,
   setChargeAcknowledged,
 }: {
+  hosted: boolean;
   mode: MessagingSetupMode;
   location: MessagingSetupLocation;
   selectedNumber: SearchNumber | null;
@@ -607,10 +620,9 @@ function RegistrationStep({
           Carrier approval is required before live US texting.
         </p>
         <p className="mt-2 text-sm leading-6 text-teal-800">
-          OpenVPM will set up the number and keep sending off. After this step,
-          complete the clinic&apos;s legal and consent details in Messaging
-          settings; OpenVPM reviews them before any fee-bearing carrier
-          submission.
+          {hosted
+            ? "The selected number will be saved with sending off. After this step, complete the clinic's legal and consent details in Messaging settings; OpenVPM reviews them before any fee-bearing carrier submission."
+            : "The selected number will be saved with sending off. After this step, complete the clinic's legal and consent details in Messaging settings; your administrator must finish carrier activation before sending."}
         </p>
       </div>
       <label className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950">
@@ -622,15 +634,21 @@ function RegistrationStep({
         />
         <span>
           I authorize the exact upfront and monthly provider charges shown above
-          for this selected number. Texting and fee-bearing carrier registration
-          stay off until later approval.
+          for this selected number. Texting stays off until carrier approval is
+          active and an administrator enables sending.
         </span>
       </label>
     </div>
   );
 }
 
-function DoneStep({ sender }: { sender: string | null }) {
+function DoneStep({
+  sender,
+  hosted,
+}: {
+  sender: string | null;
+  hosted: boolean;
+}) {
   return (
     <div className="space-y-5">
       <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
@@ -650,10 +668,9 @@ function DoneStep({ sender }: { sender: string | null }) {
           Next: carrier approval
         </p>
         <p className="mt-2 text-sm leading-6 text-slate-600">
-          Complete the US carrier registration form in Messaging settings.
-          OpenVPM will review and submit it. Hosted sending remains off until
-          the clinic and one location are explicitly approved for the pilot;
-          after approval, validate through a current consented client workflow.
+          {hosted
+            ? "Complete the US carrier registration form in Messaging settings. OpenVPM will review and submit it. Hosted sending remains off until the clinic and one location are explicitly approved for the pilot; after approval, validate through a current consented client workflow."
+            : "Complete the US carrier registration form in Messaging settings. Your administrator must finish provider activation before enabling sending; after approval, validate through a current consented client workflow."}
         </p>
       </div>
     </div>

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -4,15 +4,15 @@ import { describe, expect, it } from "vitest";
 describe("dashboard onboarding UI states", () => {
   const activationSource = readFileSync(
     "components/dashboard/activation-checklist.tsx",
-    "utf8"
+    "utf8",
   );
   const tourProviderSource = readFileSync(
     "components/tour/tour-provider.tsx",
-    "utf8"
+    "utf8",
   );
   const journeyProviderSource = readFileSync(
     "components/onboarding/journey-overlay.tsx",
-    "utf8"
+    "utf8",
   );
   const settingsRouter = readFileSync("server/routers/settings.ts", "utf8");
 
@@ -24,63 +24,73 @@ describe("dashboard onboarding UI states", () => {
     expect(activationSource).toContain("const isChecklistLoading");
     expect(activationSource).toContain("practice.isLoading");
     expect(activationSource).toContain(
-      "if (isChecklistLoading) return <ActivationChecklistLoading />"
+      "if (isChecklistLoading) return <ActivationChecklistLoading />",
     );
     expect(activationSource).toContain("!clientPayments.data");
     expect(activationSource).toContain(
-      "Setup checklist data was unavailable. Try loading it again."
+      "Setup checklist data was unavailable. Try loading it again.",
     );
     expect(activationSource).toContain("state.refetch()");
     expect(activationSource).toContain("onboarding.refetch()");
     expect(activationSource).toContain("practice.refetch()");
     expect(activationSource).toContain("sub.refetch()");
     expect(activationSource.indexOf("if (loadError)")).toBeLessThan(
-      activationSource.indexOf("if (isChecklistLoading)")
+      activationSource.indexOf("if (isChecklistLoading)"),
     );
     expect(activationSource.indexOf("if (isChecklistLoading)")).toBeLessThan(
-      activationSource.indexOf("!clientPayments.data")
+      activationSource.indexOf("!clientPayments.data"),
     );
     expect(activationSource.indexOf("!clientPayments.data")).toBeLessThan(
-      activationSource.indexOf("const practiceData = practice.data")
+      activationSource.indexOf("const practiceData = practice.data"),
     );
     expect(activationSource).toContain("const checklistState = state.data");
-    expect(activationSource).toContain("const onboardingData = onboarding.data");
+    expect(activationSource).toContain(
+      "const onboardingData = onboarding.data",
+    );
     expect(activationSource).toContain("const practiceData = practice.data");
     expect(activationSource).toContain("const subscriptionData = sub.data");
     expect(activationSource).toContain(
-      "const practiceName = practiceData.name ?? \"your practice\""
-    );
-    expect(activationSource).toContain("done: !!practiceData.logoUrl || !!brandColor");
-    expect(activationSource).toContain(
-      "done: onboardingData.hasRealData"
-    );
-    expect(activationSource).toContain('label: "Configure appointment requests"');
-    expect(activationSource).toContain(
-      "bookingData.page?.published === true &&"
+      'const practiceName = practiceData.name ?? "your practice"',
     );
     expect(activationSource).toContain(
-      "bookingData.page.config.bookableTypeIds.length > 0"
+      "done: !!practiceData.logoUrl || !!brandColor",
+    );
+    expect(activationSource).toContain("done: onboardingData.hasRealData");
+    expect(activationSource).toContain(
+      'label: "Configure appointment requests"',
+    );
+    expect(activationSource).toContain(
+      "bookingData.page?.published === true &&",
+    );
+    expect(activationSource).toContain(
+      "bookingData.page.config.bookableTypeIds.length > 0",
     );
     expect(activationSource).toContain('label: "Finish texting activation"');
     expect(activationSource).toContain("done: textingData.hasActiveNumber");
+    expect(activationSource).toContain(
+      "textingData.setupAvailable || textingData.hasAnyNumber",
+    );
+    expect(activationSource.indexOf("includeTextingMilestone")).toBeLessThan(
+      activationSource.indexOf('key: "texting"'),
+    );
     expect(activationSource).toContain('label: "Add one real client and pet"');
     expect(activationSource).toContain('href: "/clients/new"');
     expect(activationSource).toContain(
-      'label: "Book that pet\'s first appointment"'
+      'label: "Book that pet\'s first appointment"',
     );
     expect(activationSource).toContain(
-      "done: onboardingData.hasRealAppointment"
+      "done: onboardingData.hasRealAppointment",
     );
     expect(activationSource).toContain('label: "Complete your first visit"');
     expect(activationSource).toContain(
-      "done: onboardingData.hasCompletedRealVisit"
+      "done: onboardingData.hasCompletedRealVisit",
     );
     expect(activationSource).toContain(
-      "`/encounters/${onboardingData.nextRealAppointmentId}`"
+      "`/encounters/${onboardingData.nextRealAppointmentId}`",
     );
     expect(activationSource).toContain(': "/schedule"');
     expect(activationSource.indexOf('key: "firstAppointment"')).toBeLessThan(
-      activationSource.indexOf('key: "firstVisit"')
+      activationSource.indexOf('key: "firstVisit"'),
     );
     expect(activationSource).toContain('label: "Set up client card payments"');
     expect(activationSource).toContain("done: clientPaymentData.enabled");
@@ -99,60 +109,68 @@ describe("dashboard onboarding UI states", () => {
   });
 
   it("keeps tour setup persistence admin-only at the provider boundary", () => {
-    expect(tourProviderSource).toContain('import { useSession } from "next-auth/react"');
     expect(tourProviderSource).toContain(
-      'status === "authenticated" && session?.user?.role === "admin"'
+      'import { useSession } from "next-auth/react"',
+    );
+    expect(tourProviderSource).toContain(
+      'status === "authenticated" && session?.user?.role === "admin"',
     );
     expect(tourProviderSource).toContain("enabled: isAdmin");
     expect(tourProviderSource).toContain("if (!isAdmin) return;");
     expect(tourProviderSource).toContain(
-      "migrationSource: prev?.migrationSource ?? null"
+      "migrationSource: prev?.migrationSource ?? null",
     );
     expect(tourProviderSource).toContain(
-      "prev?.migrationSourceHasCommittedChanges ?? false"
+      "prev?.migrationSourceHasCommittedChanges ?? false",
     );
     expect(tourProviderSource).toContain(
-      "migrationCompletedModes: prev?.migrationCompletedModes ?? []"
+      "migrationCompletedModes: prev?.migrationCompletedModes ?? []",
     );
     expect(tourProviderSource).toContain(
-      "setTourStatus.mutate({ status, lastStepId: stepId ?? null })"
+      "setTourStatus.mutate({ status, lastStepId: stepId ?? null })",
     );
     expect(settingsRouter).toContain("setTourStatus: adminProcedure");
   });
 
   it("keeps guided setup overlay mutations admin-only at the provider boundary", () => {
-    expect(journeyProviderSource).toContain('import { useSession } from "next-auth/react"');
     expect(journeyProviderSource).toContain(
-      'status === "authenticated" && session?.user?.role === "admin"'
+      'import { useSession } from "next-auth/react"',
     );
-    expect(journeyProviderSource).toContain("const openJourney = useCallback(() => {");
+    expect(journeyProviderSource).toContain(
+      'status === "authenticated" && session?.user?.role === "admin"',
+    );
+    expect(journeyProviderSource).toContain(
+      "const openJourney = useCallback(() => {",
+    );
     expect(journeyProviderSource).toContain("if (!isAdmin) return;");
+    expect(journeyProviderSource).toContain("pendingManualOpen.current = true");
+    expect(journeyProviderSource).toContain("!pendingManualOpen.current ||");
     expect(journeyProviderSource).toContain(
-      "pendingManualOpen.current = true"
+      "pendingManualOpen.current = false",
     );
     expect(journeyProviderSource).toContain(
-      "!pendingManualOpen.current ||"
+      "if (subscription.error) retryPendingManualOpen();",
     );
     expect(journeyProviderSource).toContain(
-      "pendingManualOpen.current = false"
+      "if (result.error && pendingManualOpen.current)",
     );
     expect(journeyProviderSource).toContain(
-      "if (subscription.error) retryPendingManualOpen();"
+      "const isOpen = isAdmin && index !== null",
     );
-    expect(journeyProviderSource).toContain(
-      "if (result.error && pendingManualOpen.current)"
-    );
-    expect(journeyProviderSource).toContain("const isOpen = isAdmin && index !== null");
     expect(journeyProviderSource).toContain("value={{ openJourney, isOpen }}");
     expect(journeyProviderSource).toMatch(/<JourneyShell\s+steps=\{steps\}/);
-    expect(journeyProviderSource).toContain("disabled={busy || continueDisabled}");
     expect(journeyProviderSource).toContain(
-      "trpc.settings.completeOnboarding.useMutation"
+      "disabled={busy || continueDisabled}",
     );
     expect(journeyProviderSource).toContain(
-      "trpc.settings.clearDemoData.useMutation"
+      "trpc.settings.completeOnboarding.useMutation",
     );
-    expect(settingsRouter).toContain("completeOnboarding: adminProcedure.mutation");
+    expect(journeyProviderSource).toContain(
+      "trpc.settings.clearDemoData.useMutation",
+    );
+    expect(settingsRouter).toContain(
+      "completeOnboarding: adminProcedure.mutation",
+    );
     expect(settingsRouter).toContain("clearDemoData: adminProcedure.mutation");
     expect(settingsRouter).toContain("setOnboardingIntent: adminProcedure");
   });
@@ -167,19 +185,19 @@ describe("dashboard onboarding UI states", () => {
 
   it("turns the activation checklist into a mobile first-win path with a persisted help request", () => {
     expect(activationSource).toContain(
-      "trpc.settings.requestOnboardingHelp.useMutation"
+      "trpc.settings.requestOnboardingHelp.useMutation",
     );
     expect(activationSource).toContain("Help me set this up");
     expect(activationSource).toContain("Setup help requested");
     expect(activationSource).toContain("setupHelpRequestedAt");
     expect(activationSource).toContain(
-      "relative z-20 w-full sm:fixed sm:bottom-4"
+      "relative z-20 w-full sm:fixed sm:bottom-4",
     );
     expect(activationSource).not.toContain(
-      "fixed bottom-4 right-4 z-[70] hidden"
+      "fixed bottom-4 right-4 z-[70] hidden",
     );
     expect(settingsRouter).toContain(
-      "requestOnboardingHelp: adminProcedure.mutation"
+      "requestOnboardingHelp: adminProcedure.mutation",
     );
     expect(settingsRouter).toContain('"Hands-on onboarding requested"');
     expect(activationSource).toContain("useOnboardingJourney");
@@ -191,29 +209,27 @@ describe("dashboard onboarding UI states", () => {
   it("auto-opens the wizard for unfinished, non-dismissed onboarding and resumes durably", () => {
     // Auto-open gate: only when onboarding is not finished and not dismissed.
     expect(journeyProviderSource).toContain(
-      "onboardingStatus.data.completedAt == null"
+      "onboardingStatus.data.completedAt == null",
     );
     expect(journeyProviderSource).toContain(
-      "onboardingState.data.journeyDismissed === true"
+      "onboardingState.data.journeyDismissed === true",
     );
     expect(journeyProviderSource).toContain(
-      "if (notFinished && !dismissed && !established)"
+      "if (notFinished && !dismissed && !established)",
     );
     // Established practices (seeded demo, self-host upgrades) are never
     // greeted like new signups even without a recorded completion date.
     expect(journeyProviderSource).toContain(
-      "onboardingStatus.data.establishedPractice === true"
+      "onboardingStatus.data.establishedPractice === true",
     );
     expect(settingsRouter).toContain("ESTABLISHED_PRACTICE_PATIENT_THRESHOLD");
     expect(settingsRouter).toContain(
-      "eq(visitCloseouts.practiceId, ctx.practiceId)"
+      "eq(visitCloseouts.practiceId, ctx.practiceId)",
     );
-    expect(settingsRouter).toContain(
-      'eq(visitCloseouts.status, "completed")'
-    );
+    expect(settingsRouter).toContain('eq(visitCloseouts.status, "completed")');
     expect(settingsRouter).toContain("isNull(visitCloseouts.deletedAt)");
     expect(settingsRouter).toContain(
-      "eq(appointments.practiceId, ctx.practiceId)"
+      "eq(appointments.practiceId, ctx.practiceId)",
     );
     expect(settingsRouter).toContain("realAppointmentFilter");
     expect(settingsRouter).toContain("when 'in_exam' then 0");
@@ -221,24 +237,24 @@ describe("dashboard onboarding UI states", () => {
     expect(settingsRouter).toContain("asc(appointments.id)");
     // Resume from the durable cursor rather than always step 0.
     expect(journeyProviderSource).toContain(
-      "steps.findIndex((s) => s.id === journeyStepId)"
+      "steps.findIndex((s) => s.id === journeyStepId)",
     );
     expect(journeyProviderSource).toContain("setIndex(resumeIndex)");
     // "I'll finish later" records dismissal WITHOUT completing onboarding.
     expect(journeyProviderSource).toContain(
-      "await persistCursor(step.id, true)"
+      "await persistCursor(step.id, true)",
     );
     expect(journeyProviderSource).toContain(
-      "await setJourneyProgress.mutateAsync({ stepId, dismissed })"
+      "await setJourneyProgress.mutateAsync({ stepId, dismissed })",
     );
     expect(journeyProviderSource).toContain(
-      "await persistCursor(steps[next]!.id, false)"
+      "await persistCursor(steps[next]!.id, false)",
     );
     expect(journeyProviderSource).toContain(
-      "await persistCursor(steps[prev]!.id, false)"
+      "await persistCursor(steps[prev]!.id, false)",
     );
     expect(journeyProviderSource).toContain(
-      "if (!onboardingState.data || !subscription.data) return;"
+      "if (!onboardingState.data || !subscription.data) return;",
     );
     expect(settingsRouter).toContain("setJourneyProgress: adminProcedure");
   });

--- a/apps/web/lib/__tests__/messaging-settings-ui.test.ts
+++ b/apps/web/lib/__tests__/messaging-settings-ui.test.ts
@@ -12,16 +12,20 @@ import {
 describe("messaging settings UI", () => {
   const tabSource = readFileSync(
     "components/settings/messaging-tab.tsx",
-    "utf8"
+    "utf8",
   );
   const wizardSource = readFileSync(
     "components/settings/messaging-wizard.tsx",
-    "utf8"
+    "utf8",
+  );
+  const registrationSource = readFileSync(
+    "components/settings/messaging-registration-form.tsx",
+    "utf8",
   );
   const routerSource = readFileSync("server/routers/messaging.ts", "utf8");
   const onboardingSource = readFileSync(
     "components/onboarding/steps/set-up-texting.tsx",
-    "utf8"
+    "utf8",
   );
 
   it("keeps messaging phone policy aligned across settings and router", () => {
@@ -50,9 +54,7 @@ describe("messaging settings UI", () => {
     expect(tabSource).toContain('m.registrationStatus === "active"');
     expect(tabSource).toContain("hasConfiguredSender(m)");
     expect(tabSource).toContain("m.launchEligible !== false");
-    expect(tabSource).toContain(
-      "m.providerProfileAttestationFresh !== false",
-    );
+    expect(tabSource).toContain("m.providerProfileAttestationFresh !== false");
     expect(tabSource).toContain("waitingForProviderVerification");
     expect(tabSource).toContain("Provider safety check required");
     expect(tabSource).toContain("does not need to repeat carrier");
@@ -68,31 +70,94 @@ describe("messaging settings UI", () => {
     expect(tabSource).toContain("isMessagingPhoneInputValid(testTo)");
     expect(tabSource).toContain("maxLength={MESSAGING_PHONE_MAX_LENGTH}");
     expect(tabSource).toContain(
-      "disabled={setEnabled.isPending || (!m.enabled && !canEnableSending)}"
+      "disabled={setEnabled.isPending || (!m.enabled && !canEnableSending)}",
     );
     expect(tabSource).toContain(
-      "disabled={!canSendTest || testSend.isPending}"
+      "disabled={!canSendTest || testSend.isPending}",
     );
     expect(tabSource).toContain("to: testTo.trim()");
     expect(tabSource).toContain("Outbound texting is safely off");
     expect(tabSource).toContain("Arbitrary test destinations are disabled");
+    expect(tabSource).toContain("data.launch.setupAvailable");
+    expect(tabSource).toContain("Texting is a controlled clinic pilot");
+    expect(tabSource).toContain(
+      "OpenVPM will not\n            search for or purchase a number",
+    );
+    expect(tabSource).toContain(
+      "Email appointment reminders remain\n            available",
+    );
+    expect(tabSource).toContain(
+      "{data.launch.setupAvailable ? (\n        <MessagingWizard",
+    );
+    expect(tabSource).toContain(
+      "{setupAvailable ? (\n          <Button onClick={onStartSetup}",
+    );
     expect(wizardSource).toContain("MESSAGING_AREA_CODE_LENGTH");
     expect(wizardSource).toContain("isMessagingAreaCodeInputValid(areaCode)");
     expect(wizardSource).toContain(
-      "disabled={checking || !isMessagingAreaCodeInputValid(areaCode)}"
+      "disabled={checking || !isMessagingAreaCodeInputValid(areaCode)}",
     );
     expect(wizardSource).toContain(
-      "validate through a current consented client workflow"
+      "validate through a current consented client workflow",
     );
     expect(wizardSource).not.toContain("send a test from the active location");
     expect(tabSource).toContain("<MessagingRegistrationForm />");
+    expect(tabSource).toContain(
+      "data.launch.setupAvailable ||\n      locations.some((location) => location.messaging)",
+    );
+    expect(tabSource).toContain(
+      "Number setup is disabled by your OpenVPM administrator",
+    );
+    expect(tabSource).toContain("hosted={data.launch.hosted}");
+    expect(wizardSource).toContain("hosted: boolean");
+    expect(wizardSource).toContain(
+      "<ConfirmStep\n                hosted={hosted}",
+    );
+    expect(wizardSource).toContain(
+      'hosted\n          ? "OpenVPM reviews them."\n          : "your administrator finishes provider activation."',
+    );
+    expect(wizardSource).toContain(
+      "Your administrator must finish provider activation",
+    );
+    expect(wizardSource).toContain("Hosted sending remains off");
+    expect(registrationSource).toContain(
+      "Carrier registration details saved for administrator review.",
+    );
+    expect(registrationSource).toContain(
+      "your messaging administrator reviews it first.",
+    );
+    expect(registrationSource).not.toContain("an OpenVPM operator reviews it");
+    expect(tabSource).toContain(
+      "OpenVPM support must review this failed pilot setup",
+    );
+    expect(routerSource).toContain(
+      "!existing && !provisioningAvailableForPractice(ctx.practiceId)",
+    );
     expect(wizardSource).not.toContain("trpc.messaging.testSend.useMutation");
     expect(wizardSource).not.toContain("isMessagingPhoneInputValid(testTo)");
     expect(wizardSource).not.toContain(
-      "maxLength={MESSAGING_PHONE_MAX_LENGTH}"
+      "maxLength={MESSAGING_PHONE_MAX_LENGTH}",
     );
     expect(wizardSource).not.toContain("to: testTo.trim()");
     expect(wizardSource).not.toContain("Send test");
+  });
+
+  it("keeps automatic reminders explicit, constrained, and off by default", () => {
+    expect(tabSource).toContain("Automatic appointment reminders");
+    expect(tabSource).toContain("APPOINTMENT_REMINDER_LEAD_OPTIONS");
+    expect(tabSource).toContain("[24, 48, 72] as const");
+    expect(tabSource).toContain("setAppointmentReminderSettings");
+    expect(tabSource).toContain("Off by default");
+    expect(tabSource).toContain("confirmReminderCatchUp");
+    expect(tabSource).toContain('!confirmReminderCatchUp("expand", leadHours)');
+    expect(tabSource).toContain(
+      "Enabling reminders or increasing this window may send reminders for",
+    );
+    expect(tabSource).toContain(
+      "existing eligible confirmed appointments on the next hourly run.",
+    );
+    expect(routerSource).toContain("appointmentReminderLeadHoursInput");
+    expect(routerSource).toContain("appointmentRemindersEnabled");
   });
 
   it("surfaces messaging status query failures and missing payloads before showing placeholder stats", () => {
@@ -104,13 +169,13 @@ describe("messaging settings UI", () => {
     expect(tabSource).toContain("Messaging status is unavailable");
     expect(tabSource).toContain("onRetry={() => void refetch()}");
     expect(tabSource.indexOf("if (error)")).toBeLessThan(
-      tabSource.indexOf("if (!data)")
+      tabSource.indexOf("if (!data)"),
     );
     expect(tabSource.indexOf("if (!data)")).toBeLessThan(
-      tabSource.indexOf("const usage = data.usage")
+      tabSource.indexOf("const usage = data.usage"),
     );
     expect(tabSource).toContain(
-      "const locations = data.locations as MessagingSetupLocation[]"
+      "const locations = data.locations as MessagingSetupLocation[]",
     );
     expect(tabSource).not.toContain("data?.locations ?? []");
     expect(tabSource).not.toContain("const usage = data?.usage");
@@ -119,16 +184,16 @@ describe("messaging settings UI", () => {
 
   it("is explicit about unsupported existing numbers, charges, and recoverable setup", () => {
     expect(wizardSource).toContain(
-      "Existing-number texting is not available yet"
+      "Existing-number texting is not available yet",
     );
     expect(wizardSource).toContain("will not be ported, hosted, or changed");
     expect(wizardSource).toContain("chargeAcknowledged");
     expect(wizardSource).toContain(
-      "I authorize the exact upfront and monthly provider charges"
+      "I authorize the exact upfront and monthly provider charges",
     );
     expect(wizardSource).toContain("confirmProviderCharges: true");
     expect(wizardSource).toContain(
-      '(step === "registration" &&\n      mode === "buy" &&\n      Boolean(selectedNumber) &&\n      chargeAcknowledged)'
+      '(step === "registration" &&\n      mode === "buy" &&\n      Boolean(selectedNumber) &&\n      chargeAcknowledged)',
     );
     expect(wizardSource).toContain("upfrontCost");
     expect(wizardSource).toContain("monthlyCost");
@@ -137,7 +202,7 @@ describe("messaging settings UI", () => {
     expect(tabSource).toContain("Reconcile provider setup");
     expect(tabSource).toContain('action: "resume"');
     expect(onboardingSource).not.toContain(
-      "You can text from your existing number"
+      "You can text from your existing number",
     );
     expect(onboardingSource).toContain("Number order accepted");
     expect(onboardingSource).toContain("Carrier registration is under review");
@@ -147,5 +212,34 @@ describe("messaging settings UI", () => {
     expect(routerSource).toContain("assertProvisioningEnabled();");
     expect(routerSource).toContain("confirmProviderCharges: z.literal(true)");
     expect(routerSource).toContain("findNumberOrdersByCustomerReference");
+  });
+
+  it("keeps unavailable texting setup out of the onboarding purchase flow", () => {
+    expect(onboardingSource).toContain("status.data?.launch.setupAvailable");
+    expect(onboardingSource).toContain(
+      "const setupUnavailable = setupAvailable === false && !hasAnyNumber",
+    );
+    expect(onboardingSource).toContain("controlled clinic pilot");
+    expect(onboardingSource).toContain("Email appointment reminders remain");
+    expect(onboardingSource).toContain("const setupCapabilityKnown");
+    expect(onboardingSource).toContain("{!setupCapabilityKnown ? (");
+    expect(onboardingSource).toContain(
+      "We are checking whether new-number setup",
+    );
+    expect(onboardingSource).toContain(
+      "Texting number setup is disabled in this deployment",
+    );
+    expect(onboardingSource).toContain(
+      "Your clinic has an existing texting setup to review",
+    );
+    expect(onboardingSource).toContain("setupDisabled && !messaging");
+    expect(onboardingSource).toContain('href="/settings?tab=messaging"');
+    expect(onboardingSource).toContain(
+      'href="mailto:support@openvpm.com?subject=OpenVPM%20texting%20pilot"',
+    );
+    expect(onboardingSource).toContain("setupAvailable === false || messaging");
+    expect(onboardingSource).toContain(
+      "{setupAvailable ? (\n        <MessagingWizard",
+    );
   });
 });

--- a/apps/web/lib/messaging/__tests__/appointment-reminder-eligibility.integration.test.ts
+++ b/apps/web/lib/messaging/__tests__/appointment-reminder-eligibility.integration.test.ts
@@ -1,0 +1,235 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { db } from "@openpims/db/client";
+import {
+  appointments,
+  clients,
+  emailSuppressions,
+  patients,
+  practices,
+} from "@openpims/db";
+import {
+  appointmentReminderDispatchEligible,
+  currentAppointmentReminderEmailRecipient,
+} from "@/lib/messaging/appointment-reminder";
+
+const describeWithPostgres = process.env.REMINDER_POLICY_DB_INTEGRATION
+  ? describe
+  : describe.skip;
+
+describeWithPostgres("appointment reminder dispatch eligibility SQL", () => {
+  it("honors each clinic's enablement, lead window, and current appointment state", async () => {
+    const enabledPracticeId = randomUUID();
+    const disabledPracticeId = randomUUID();
+    const enabledClientId = randomUUID();
+    const disabledClientId = randomUUID();
+    const enabledPatientId = randomUUID();
+    const disabledPatientId = randomUUID();
+    const soonAppointmentId = randomUUID();
+    const laterAppointmentId = randomUUID();
+    const disabledAppointmentId = randomUUID();
+    const now = new Date("2026-08-10T12:00:00.000Z");
+    const in12Hours = new Date("2026-08-11T00:00:00.000Z");
+    const in48Hours = new Date("2026-08-12T12:00:00.000Z");
+
+    await db.transaction(async (tx) => {
+      try {
+        await tx.insert(practices).values([
+          {
+            id: enabledPracticeId,
+            name: "Reminder integration enabled",
+            appointmentRemindersEnabled: true,
+            appointmentReminderLeadHours: 24,
+          },
+          {
+            id: disabledPracticeId,
+            name: "Reminder integration disabled",
+            appointmentRemindersEnabled: false,
+            appointmentReminderLeadHours: 72,
+          },
+        ]);
+        await tx.insert(clients).values([
+          {
+            id: enabledClientId,
+            practiceId: enabledPracticeId,
+            firstName: "Enabled",
+            lastName: "Client",
+          },
+          {
+            id: disabledClientId,
+            practiceId: disabledPracticeId,
+            firstName: "Disabled",
+            lastName: "Client",
+          },
+        ]);
+        await tx.insert(patients).values([
+          {
+            id: enabledPatientId,
+            practiceId: enabledPracticeId,
+            clientId: enabledClientId,
+            name: "Miso",
+            species: "feline",
+          },
+          {
+            id: disabledPatientId,
+            practiceId: disabledPracticeId,
+            clientId: disabledClientId,
+            name: "Pico",
+            species: "canine",
+          },
+        ]);
+        await tx.insert(appointments).values([
+          {
+            id: soonAppointmentId,
+            practiceId: enabledPracticeId,
+            clientId: enabledClientId,
+            patientId: enabledPatientId,
+            startTime: in12Hours,
+            endTime: new Date(in12Hours.getTime() + 30 * 60 * 1000),
+            status: "confirmed",
+          },
+          {
+            id: laterAppointmentId,
+            practiceId: enabledPracticeId,
+            clientId: enabledClientId,
+            patientId: enabledPatientId,
+            startTime: in48Hours,
+            endTime: new Date(in48Hours.getTime() + 30 * 60 * 1000),
+            status: "confirmed",
+          },
+          {
+            id: disabledAppointmentId,
+            practiceId: disabledPracticeId,
+            clientId: disabledClientId,
+            patientId: disabledPatientId,
+            startTime: in48Hours,
+            endTime: new Date(in48Hours.getTime() + 30 * 60 * 1000),
+            status: "confirmed",
+          },
+        ]);
+
+        const eligible = (options: {
+          practiceId: string;
+          appointmentId: string;
+          clientId: string;
+          startTime: Date;
+        }) =>
+          appointmentReminderDispatchEligible(tx, {
+            ...options,
+            now,
+          });
+
+        await expect(
+          eligible({
+            practiceId: enabledPracticeId,
+            appointmentId: soonAppointmentId,
+            clientId: enabledClientId,
+            startTime: in12Hours,
+          }),
+        ).resolves.toBe(true);
+
+        await tx
+          .update(clients)
+          .set({ email: "updated@example.com" })
+          .where(eq(clients.id, enabledClientId));
+        await tx.insert(emailSuppressions).values({
+          practiceId: enabledPracticeId,
+          email: "updated@example.com",
+          reason: "complaint",
+        });
+        await expect(
+          currentAppointmentReminderEmailRecipient(tx, {
+            practiceId: enabledPracticeId,
+            appointmentId: soonAppointmentId,
+            clientId: enabledClientId,
+            startTime: in12Hours,
+            now,
+          }),
+        ).resolves.toMatchObject({
+          recipientEmail: "updated@example.com",
+          suppressionReason: "complaint",
+        });
+        await expect(
+          eligible({
+            practiceId: enabledPracticeId,
+            appointmentId: laterAppointmentId,
+            clientId: enabledClientId,
+            startTime: in48Hours,
+          }),
+        ).resolves.toBe(false);
+        await expect(
+          eligible({
+            practiceId: disabledPracticeId,
+            appointmentId: disabledAppointmentId,
+            clientId: disabledClientId,
+            startTime: in48Hours,
+          }),
+        ).resolves.toBe(false);
+
+        await tx
+          .update(practices)
+          .set({ appointmentReminderLeadHours: 72 })
+          .where(eq(practices.id, enabledPracticeId));
+        await expect(
+          eligible({
+            practiceId: enabledPracticeId,
+            appointmentId: laterAppointmentId,
+            clientId: enabledClientId,
+            startTime: in48Hours,
+          }),
+        ).resolves.toBe(true);
+
+        await tx
+          .update(appointments)
+          .set({ status: "cancelled" })
+          .where(eq(appointments.id, laterAppointmentId));
+        await expect(
+          eligible({
+            practiceId: enabledPracticeId,
+            appointmentId: laterAppointmentId,
+            clientId: enabledClientId,
+            startTime: in48Hours,
+          }),
+        ).resolves.toBe(false);
+
+        await tx
+          .update(appointments)
+          .set({ status: "confirmed", startTime: in12Hours })
+          .where(eq(appointments.id, laterAppointmentId));
+        await expect(
+          eligible({
+            practiceId: enabledPracticeId,
+            appointmentId: laterAppointmentId,
+            clientId: enabledClientId,
+            startTime: in48Hours,
+          }),
+        ).resolves.toBe(false);
+      } finally {
+        await tx
+          .delete(emailSuppressions)
+          .where(eq(emailSuppressions.practiceId, enabledPracticeId));
+        await tx
+          .delete(appointments)
+          .where(
+            inArray(appointments.id, [
+              soonAppointmentId,
+              laterAppointmentId,
+              disabledAppointmentId,
+            ]),
+          );
+        await tx
+          .delete(patients)
+          .where(inArray(patients.id, [enabledPatientId, disabledPatientId]));
+        await tx
+          .delete(clients)
+          .where(inArray(clients.id, [enabledClientId, disabledClientId]));
+        await tx
+          .delete(practices)
+          .where(
+            inArray(practices.id, [enabledPracticeId, disabledPracticeId]),
+          );
+      }
+    });
+  });
+});

--- a/apps/web/lib/messaging/__tests__/appointment-reminder-eligibility.integration.test.ts
+++ b/apps/web/lib/messaging/__tests__/appointment-reminder-eligibility.integration.test.ts
@@ -6,6 +6,7 @@ import {
   appointments,
   clients,
   emailSuppressions,
+  locations,
   patients,
   practices,
 } from "@openpims/db";
@@ -24,6 +25,8 @@ describeWithPostgres("appointment reminder dispatch eligibility SQL", () => {
     const disabledPracticeId = randomUUID();
     const enabledClientId = randomUUID();
     const disabledClientId = randomUUID();
+    const enabledLocationId = randomUUID();
+    const disabledLocationId = randomUUID();
     const enabledPatientId = randomUUID();
     const disabledPatientId = randomUUID();
     const soonAppointmentId = randomUUID();
@@ -47,6 +50,20 @@ describeWithPostgres("appointment reminder dispatch eligibility SQL", () => {
             name: "Reminder integration disabled",
             appointmentRemindersEnabled: false,
             appointmentReminderLeadHours: 72,
+          },
+        ]);
+        await tx.insert(locations).values([
+          {
+            id: enabledLocationId,
+            practiceId: enabledPracticeId,
+            name: "Enabled reminder location",
+            isPrimary: true,
+          },
+          {
+            id: disabledLocationId,
+            practiceId: disabledPracticeId,
+            name: "Disabled reminder location",
+            isPrimary: true,
           },
         ]);
         await tx.insert(clients).values([
@@ -83,6 +100,7 @@ describeWithPostgres("appointment reminder dispatch eligibility SQL", () => {
           {
             id: soonAppointmentId,
             practiceId: enabledPracticeId,
+            locationId: enabledLocationId,
             clientId: enabledClientId,
             patientId: enabledPatientId,
             startTime: in12Hours,
@@ -92,6 +110,7 @@ describeWithPostgres("appointment reminder dispatch eligibility SQL", () => {
           {
             id: laterAppointmentId,
             practiceId: enabledPracticeId,
+            locationId: enabledLocationId,
             clientId: enabledClientId,
             patientId: enabledPatientId,
             startTime: in48Hours,
@@ -101,6 +120,7 @@ describeWithPostgres("appointment reminder dispatch eligibility SQL", () => {
           {
             id: disabledAppointmentId,
             practiceId: disabledPracticeId,
+            locationId: disabledLocationId,
             clientId: disabledClientId,
             patientId: disabledPatientId,
             startTime: in48Hours,
@@ -224,6 +244,11 @@ describeWithPostgres("appointment reminder dispatch eligibility SQL", () => {
         await tx
           .delete(clients)
           .where(inArray(clients.id, [enabledClientId, disabledClientId]));
+        await tx
+          .delete(locations)
+          .where(
+            inArray(locations.id, [enabledLocationId, disabledLocationId]),
+          );
         await tx
           .delete(practices)
           .where(

--- a/apps/web/lib/messaging/appointment-reminder.ts
+++ b/apps/web/lib/messaging/appointment-reminder.ts
@@ -1,5 +1,13 @@
 import type { Database } from "@openpims/db/client";
-import { communications } from "@openpims/db";
+import {
+  appointments,
+  clients,
+  communications,
+  emailSuppressions,
+  patients,
+  practices,
+} from "@openpims/db";
+import { and, eq, gte, isNull, lte, sql } from "drizzle-orm";
 import { recoverStaleUnreservedSmsCommunication } from "@/lib/messaging/durable-sms-communication";
 
 export function appointmentReminderDedupeKey(appointment: {
@@ -16,6 +24,156 @@ export function appointmentReminderSmsIdempotencyKey(appointment: {
   startTime: Date | string;
 }): string {
   return `sms:${appointmentReminderDedupeKey(appointment)}`;
+}
+
+/**
+ * Revalidate the mutable clinic/appointment boundary immediately before a
+ * reminder claim. The hourly sweep is only a candidate list: an admin can turn
+ * reminders off, or staff can cancel/reschedule an appointment, while the job
+ * is running. Provider dispatch must never rely on that stale snapshot.
+ */
+export async function appointmentReminderDispatchEligible(
+  db: Pick<Database, "select">,
+  options: {
+    practiceId: string;
+    appointmentId: string;
+    clientId: string;
+    startTime: Date;
+    now: Date;
+  },
+): Promise<boolean> {
+  const [eligible] = await db
+    .select({ dispatchEligible: appointments.id })
+    .from(appointments)
+    .innerJoin(
+      practices,
+      and(
+        eq(practices.id, appointments.practiceId),
+        isNull(practices.deletedAt),
+        eq(practices.appointmentRemindersEnabled, true),
+      ),
+    )
+    .innerJoin(
+      clients,
+      and(
+        eq(clients.id, appointments.clientId),
+        eq(clients.practiceId, appointments.practiceId),
+        isNull(clients.deletedAt),
+      ),
+    )
+    .innerJoin(
+      patients,
+      and(
+        eq(patients.id, appointments.patientId),
+        eq(patients.clientId, appointments.clientId),
+        eq(patients.practiceId, appointments.practiceId),
+        isNull(patients.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(appointments.id, options.appointmentId),
+        eq(appointments.practiceId, options.practiceId),
+        eq(appointments.clientId, options.clientId),
+        eq(appointments.startTime, options.startTime),
+        eq(appointments.status, "confirmed"),
+        isNull(appointments.deletedAt),
+        gte(appointments.startTime, options.now),
+        lte(
+          appointments.startTime,
+          sql`${options.now} + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
+        ),
+      ),
+    )
+    .limit(1);
+
+  return Boolean(eligible);
+}
+
+/**
+ * Resolve the recipient again immediately before an email provider call. This
+ * is intentionally separate from the sweep and claim so an address edit,
+ * bounce, complaint, cancellation, or clinic kill-switch committed while the
+ * job is running is honored before any email leaves OpenVPM.
+ */
+export async function currentAppointmentReminderEmailRecipient(
+  db: Pick<Database, "select">,
+  options: {
+    practiceId: string;
+    appointmentId: string;
+    clientId: string;
+    startTime: Date;
+    now: Date;
+  },
+): Promise<{
+  recipientEmail: string | null;
+  suppressionReason: string | null;
+  clientFirstName: string;
+  clientLastName: string;
+  patientName: string | null;
+  practiceName: string;
+} | null> {
+  const [recipient] = await db
+    .select({
+      recipientEmail: clients.email,
+      suppressionReason: emailSuppressions.reason,
+      clientFirstName: clients.firstName,
+      clientLastName: clients.lastName,
+      patientName: patients.name,
+      practiceName: practices.name,
+    })
+    .from(appointments)
+    .innerJoin(
+      practices,
+      and(
+        eq(practices.id, appointments.practiceId),
+        isNull(practices.deletedAt),
+        eq(practices.appointmentRemindersEnabled, true),
+      ),
+    )
+    .innerJoin(
+      clients,
+      and(
+        eq(clients.id, appointments.clientId),
+        eq(clients.practiceId, appointments.practiceId),
+        isNull(clients.deletedAt),
+      ),
+    )
+    .innerJoin(
+      patients,
+      and(
+        eq(patients.id, appointments.patientId),
+        eq(patients.clientId, appointments.clientId),
+        eq(patients.practiceId, appointments.practiceId),
+        isNull(patients.deletedAt),
+      ),
+    )
+    .leftJoin(
+      emailSuppressions,
+      and(
+        eq(emailSuppressions.practiceId, appointments.practiceId),
+        sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
+        isNull(emailSuppressions.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(appointments.id, options.appointmentId),
+        eq(appointments.practiceId, options.practiceId),
+        eq(appointments.clientId, options.clientId),
+        eq(appointments.startTime, options.startTime),
+        eq(appointments.status, "confirmed"),
+        isNull(appointments.deletedAt),
+        gte(appointments.startTime, options.now),
+        lte(
+          appointments.startTime,
+          sql`${options.now} + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
+        ),
+      ),
+    )
+    .limit(1);
+
+  return recipient ?? null;
 }
 
 /**

--- a/apps/web/lib/messaging/appointment-reminder.ts
+++ b/apps/web/lib/messaging/appointment-reminder.ts
@@ -81,7 +81,7 @@ export async function appointmentReminderDispatchEligible(
         gte(appointments.startTime, options.now),
         lte(
           appointments.startTime,
-          sql`${options.now} + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
+          sql`${options.now.toISOString()}::timestamptz + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
         ),
       ),
     )
@@ -167,7 +167,7 @@ export async function currentAppointmentReminderEmailRecipient(
         gte(appointments.startTime, options.now),
         lte(
           appointments.startTime,
-          sql`${options.now} + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
+          sql`${options.now.toISOString()}::timestamptz + (${practices.appointmentReminderLeadHours} * interval '1 hour')`,
         ),
       ),
     )

--- a/apps/web/server/__tests__/messaging-inbox-status.test.ts
+++ b/apps/web/server/__tests__/messaging-inbox-status.test.ts
@@ -23,7 +23,7 @@ function thenableRows(rows: Record<string, unknown>[]) {
     limit: vi.fn(async () => rows),
     then: (
       resolve: (value: Record<string, unknown>[]) => unknown,
-      reject?: (error: unknown) => unknown
+      reject?: (error: unknown) => unknown,
     ) => Promise.resolve(rows).then(resolve, reject),
   };
 }
@@ -84,7 +84,7 @@ describe("messaging.getInboxStatus", () => {
     ]);
 
     await expect(
-      callerWithDb(db, "admin").getInboxStatus()
+      callerWithDb(db, "admin").getInboxStatus(),
     ).resolves.toMatchObject({
       canManage: true,
       summary: {
@@ -177,14 +177,37 @@ describe("messaging.activationSummary", () => {
     vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
     const { db } = createDb([activeRow]);
     await expect(
-      callerWithDb(db, "admin").activationSummary()
-    ).resolves.toEqual({ hasAnyNumber: true, hasActiveNumber: false });
+      callerWithDb(db, "admin").activationSummary(),
+    ).resolves.toEqual({
+      setupAvailable: false,
+      hasAnyNumber: true,
+      hasActiveNumber: false,
+    });
+  });
+
+  it("reports setup availability only for an allowlisted hosted clinic", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", PRACTICE_ID);
+    const { db } = createDb([]);
+
+    await expect(
+      callerWithDb(db, "admin").activationSummary(),
+    ).resolves.toEqual({
+      setupAvailable: true,
+      hasAnyNumber: false,
+      hasActiveNumber: false,
+    });
   });
 
   it("preserves self-host active sender behavior", async () => {
     const { db } = createDb([activeRow]);
     await expect(
-      callerWithDb(db, "admin").activationSummary()
-    ).resolves.toEqual({ hasAnyNumber: true, hasActiveNumber: true });
+      callerWithDb(db, "admin").activationSummary(),
+    ).resolves.toEqual({
+      setupAvailable: false,
+      hasAnyNumber: true,
+      hasActiveNumber: true,
+    });
   });
 });

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -326,9 +326,83 @@ describe("messaging provisioning kill-switch", () => {
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
     expect(mocks.buyNumber).not.toHaveBeenCalled();
   });
+
+  it("does not search provider inventory for a hosted clinic outside the pilot", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const { db } = createDb({
+      practiceRows: [
+        {
+          tier: "cloud",
+          billingStatus: "trialing",
+          trialEndsAt: new Date("2099-01-01T00:00:00Z"),
+        },
+      ],
+      selectResults: [[{ id: PRACTICE_ID }]],
+    });
+
+    await expect(
+      callerWithDb(db).searchNumbers({ areaCode: "212" }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("approved pilot clinics"),
+    });
+
+    expect(mocks.searchAvailableNumbers).not.toHaveBeenCalled();
+  });
 });
 
 describe("messaging location target safety", () => {
+  it("keeps automated appointment reminders admin-controlled and constrained", async () => {
+    const { db, updateSet } = createDb({
+      updateRows: [{ enabled: true, leadHours: 48 }],
+    });
+
+    await expect(
+      callerWithDb(db).setAppointmentReminderSettings({
+        enabled: true,
+        leadHours: 48,
+      }),
+    ).resolves.toEqual({ enabled: true, leadHours: 48 });
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appointmentRemindersEnabled: true,
+        appointmentReminderLeadHours: 48,
+        updatedAt: expect.any(Date),
+      }),
+    );
+  });
+
+  it("rejects unsupported appointment reminder lead times before database access", async () => {
+    const { db, select, updateSet } = createDb();
+
+    await expect(
+      callerWithDb(db).setAppointmentReminderSettings({
+        enabled: true,
+        leadHours: 36 as 24,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not change appointment reminder settings for a missing practice", async () => {
+    const { db, updateSet } = createDb({ practiceRows: [] });
+
+    await expect(
+      callerWithDb(db).setAppointmentReminderSettings({
+        enabled: true,
+        leadHours: 24,
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Practice not found",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
   it("prefills carrier registration from the active clinic without exposing legal fields", async () => {
     vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
     const { db } = createDb({
@@ -445,6 +519,29 @@ describe("messaging location target safety", () => {
     expect(insertUpdate.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({ setWhere: expect.anything() }),
     );
+  });
+
+  it("does not collect new carrier registration data outside the hosted pilot", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const { db, insertValues } = createDb({
+      practiceRows: [
+        {
+          tier: "cloud",
+          billingStatus: "trialing",
+          trialEndsAt: new Date("2099-01-01T00:00:00Z"),
+        },
+      ],
+      selectResults: [[{ id: PRACTICE_ID }], [], []],
+    });
+
+    await expect(
+      callerWithDb(db).saveRegistration(registrationInput()),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("approved texting pilot clinics"),
+    });
+
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("refuses clinic registration edits while a provider operation is locked", async () => {

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -1,14 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 
+const mocks = vi.hoisted(() => ({
+  createAuthToken: vi.fn(async () => "invite-token"),
+  sendStaffInviteEmail: vi.fn(async () => ({ success: true })),
+}));
+
 const SETTINGS_SOURCE = readFileSync(
   new URL("../routers/settings.ts", import.meta.url),
-  "utf8"
+  "utf8",
 );
 const DEMO_DATA_LIFECYCLE_SOURCE = readFileSync(
   new URL("../../lib/onboarding/demo-data-lifecycle.ts", import.meta.url),
-  "utf8"
+  "utf8",
 );
+
+vi.mock("@/lib/auth-tokens", () => ({
+  createAuthToken: mocks.createAuthToken,
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendStaffInviteEmail: mocks.sendStaffInviteEmail,
+}));
 
 vi.mock("@/lib/billing/subscription-sync", () => ({
   syncPracticeSubscriptionQuantities: vi.fn(async () => ({
@@ -21,12 +34,10 @@ vi.mock("@/lib/billing/subscription-sync", () => ({
 }));
 
 const { settingsRouter } = await import("../routers/settings");
-const { syncPracticeSubscriptionQuantities } = await import(
-  "@/lib/billing/subscription-sync"
-);
-const { AUTH_PASSWORD_MAX_LENGTH, AUTH_PASSWORD_MIN_LENGTH } = await import(
-  "@/lib/auth-password"
-);
+const { syncPracticeSubscriptionQuantities } =
+  await import("@/lib/billing/subscription-sync");
+const { AUTH_PASSWORD_MAX_LENGTH, AUTH_PASSWORD_MIN_LENGTH } =
+  await import("@/lib/auth-password");
 const {
   SETTINGS_EMAIL_MAX_LENGTH,
   STAFF_NAME_MAX_LENGTH,
@@ -60,6 +71,7 @@ function createDb(opts?: {
   updatedRows?: unknown[];
   selectRows?: unknown[];
   selectResults?: unknown[][];
+  insertedRows?: unknown[];
 }) {
   const selectResults = [...(opts?.selectResults ?? [])];
   const select = vi.fn(() => ({
@@ -80,19 +92,21 @@ function createDb(opts?: {
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
-  const insertReturning = vi.fn(async () => []);
+  const insertReturning = vi.fn(async () => opts?.insertedRows ?? []);
   const insertValues = vi.fn(() => ({ returning: insertReturning }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
+  const transaction = vi.fn(async (fn: (tx: unknown) => unknown) => fn(db));
+  const execute = vi.fn(async () => undefined);
   const db: Record<string, unknown> = {
-    transaction: async (fn: (tx: unknown) => unknown) => fn(db),
-    execute: vi.fn(async () => undefined),
+    transaction,
+    execute,
     select,
     update,
     insert,
   };
 
-  return { db, updateSet, insertValues };
+  return { db, transaction, execute, updateSet, insertValues };
 }
 
 beforeEach(() => {
@@ -104,50 +118,50 @@ describe("settings admin stale target safety", () => {
     const { db, updateSet, insertValues } = createDb();
 
     await expect(
-      callerWithDb(db).updatePractice({ name: "A".repeat(256) })
+      callerWithDb(db).updatePractice({ name: "A".repeat(256) }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).updatePractice({ address: "A".repeat(501) })
+      callerWithDb(db).updatePractice({ address: "A".repeat(501) }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).updatePractice({ phone: "1".repeat(33) })
+      callerWithDb(db).updatePractice({ phone: "1".repeat(33) }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).updatePractice({ country: "U1" })
+      callerWithDb(db).updatePractice({ country: "U1" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).updatePractice({ timezone: "   " })
+      callerWithDb(db).updatePractice({ timezone: "   " }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).updatePractice({ timezone: "Mars/Olympus_Mons" })
+      callerWithDb(db).updatePractice({ timezone: "Mars/Olympus_Mons" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).updatePractice({ taxRatePercent: "100.01" })
+      callerWithDb(db).updatePractice({ taxRatePercent: "100.01" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).updateUser({ id: STAFF_ID, name: "A".repeat(256) })
+      callerWithDb(db).updateUser({ id: STAFF_ID, name: "A".repeat(256) }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).updateAppointmentType({
         id: TYPE_ID,
         name: "A".repeat(129),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).createRoom({
         name: "A".repeat(129),
         type: "exam",
-        locationId: LOCATION_ID
-      })
+        locationId: LOCATION_ID,
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -156,7 +170,7 @@ describe("settings admin stale target safety", () => {
         email: "taylor@example.com",
         password: "p".repeat(AUTH_PASSWORD_MIN_LENGTH - 1),
         role: "front_desk",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -165,21 +179,21 @@ describe("settings admin stale target safety", () => {
         email: "taylor@example.com",
         password: "p".repeat(AUTH_PASSWORD_MAX_LENGTH + 1),
         role: "front_desk",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     const oversizedInviteEmail = `${"a".repeat(64)}@${"b".repeat(
-      63
+      63,
     )}.${"c".repeat(63)}.${"d".repeat(63)}.com`;
     expect(oversizedInviteEmail.length).toBeGreaterThan(
-      SETTINGS_EMAIL_MAX_LENGTH
+      SETTINGS_EMAIL_MAX_LENGTH,
     );
 
     await expect(
       callerWithDb(db).inviteStaff({
         email: oversizedInviteEmail,
         role: "front_desk",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -187,18 +201,18 @@ describe("settings admin stale target safety", () => {
         email: "invite@example.com",
         name: "A".repeat(STAFF_NAME_MAX_LENGTH + 1),
         role: "front_desk",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).setTourStatus({
         status: "in_progress",
         lastStepId: "A".repeat(129),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).setOnboardingIntent({ intent: "unknown" as never })
+      callerWithDb(db).setOnboardingIntent({ intent: "unknown" as never }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -211,7 +225,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).setOnboardingIntent({ intent: "alongside" })
+      callerWithDb(db).setOnboardingIntent({ intent: "alongside" }),
     ).resolves.toEqual({ ok: true });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
@@ -320,7 +334,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).getAccountDeletionRequest()
+      callerWithDb(db).getAccountDeletionRequest(),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -344,7 +358,7 @@ describe("settings admin stale target safety", () => {
     updateSet.mockClear();
 
     await expect(
-      callerWithDb(db).updatePractice({ name: "Neighborhood Veterinary" })
+      callerWithDb(db).updatePractice({ name: "Neighborhood Veterinary" }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -359,7 +373,7 @@ describe("settings admin stale target safety", () => {
     expect(SETTINGS_SOURCE).toContain('message: "Practice not found"');
     expect(
       SETTINGS_SOURCE.match(/activePracticeWhere\(ctx\.practiceId\)/g)
-        ?.length ?? 0
+        ?.length ?? 0,
     ).toBeGreaterThanOrEqual(15);
     expect(SETTINGS_SOURCE).not.toContain("practice?.settings ?? {}");
     expect(SETTINGS_SOURCE).not.toContain('practice?.name ?? "OpenVPM"');
@@ -369,7 +383,7 @@ describe("settings admin stale target safety", () => {
     const { db, updateSet } = createDb({ updatedRows: [] });
 
     await expect(
-      callerWithDb(db).updateUser({ id: STAFF_ID, name: "Taylor" })
+      callerWithDb(db).updateUser({ id: STAFF_ID, name: "Taylor" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).toHaveBeenCalledWith({ name: "Taylor" });
@@ -384,7 +398,7 @@ describe("settings admin stale target safety", () => {
         email: "Taylor@Example.com",
         password: "password123",
         role: "front_desk",
-      })
+      }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -407,7 +421,7 @@ describe("settings admin stale target safety", () => {
         email: "taylor@example.com",
         password: "password123",
         role: "front_desk",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -425,7 +439,7 @@ describe("settings admin stale target safety", () => {
       callerWithDb(db).inviteStaff({
         email: "invite@example.com",
         role: "front_desk",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -435,24 +449,165 @@ describe("settings admin stale target safety", () => {
     expect(syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
   });
 
+  it("reports provider refusal and safely retries the same pending staff invite", async () => {
+    const invitedUser = {
+      id: STAFF_ID,
+      email: "invite@example.com",
+      practiceId: PRACTICE_ID,
+      emailVerifiedAt: null,
+      deletedAt: null,
+    };
+    const { db, execute, insertValues } = createDb({
+      selectResults: [
+        [{ name: "Neighborhood Veterinary" }],
+        [],
+        [{ name: "Neighborhood Veterinary" }],
+        [invitedUser],
+        [{ id: "previous-invite-token" }],
+      ],
+      insertedRows: [invitedUser],
+    });
+    mocks.sendStaffInviteEmail
+      .mockResolvedValueOnce({ success: false })
+      .mockResolvedValueOnce({ success: true });
+    mocks.createAuthToken
+      .mockResolvedValueOnce("first-invite-token")
+      .mockResolvedValueOnce("retry-invite-token");
+
+    await expect(
+      callerWithDb(db).inviteStaff({
+        email: invitedUser.email,
+        role: "front_desk",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_GATEWAY",
+      message:
+        "Staff access was saved, but the invitation email could not be sent. Please retry the invite in a moment.",
+    });
+
+    await expect(
+      callerWithDb(db).inviteStaff({
+        email: invitedUser.email,
+        role: "front_desk",
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(mocks.sendStaffInviteEmail).toHaveBeenCalledTimes(2);
+    expect(mocks.sendStaffInviteEmail).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        inviteUrl:
+          "http://localhost:3000/accept-invite?token=retry-invite-token",
+      }),
+    );
+    expect(mocks.createAuthToken).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenCalled();
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    expect(syncPracticeSubscriptionQuantities).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps staff identity and token issuance atomic when token storage fails", async () => {
+    const invitedUser = {
+      id: STAFF_ID,
+      email: "invite@example.com",
+    };
+    const { db, transaction, execute } = createDb({
+      selectResults: [[{ name: "Neighborhood Veterinary" }], []],
+      insertedRows: [invitedUser],
+    });
+    mocks.createAuthToken.mockRejectedValueOnce(
+      new Error("token-storage-secret"),
+    );
+
+    await expect(
+      callerWithDb(db).inviteStaff({
+        email: invitedUser.email,
+        role: "front_desk",
+      }),
+    ).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: expect.not.stringContaining("token-storage-secret"),
+    });
+
+    expect(transaction).toHaveBeenCalled();
+    expect(execute).toHaveBeenCalled();
+    expect(mocks.sendStaffInviteEmail).not.toHaveBeenCalled();
+    expect(syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
+    expect(SETTINGS_SOURCE).toMatch(/staffInviteLockKey\(\s*email,\s*\)/);
+    expect(SETTINGS_SOURCE).toContain("db: tx as unknown as Database");
+  });
+
+  it("does not treat an ordinary unverified user as a pending invite retry", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [{ name: "Neighborhood Veterinary" }],
+        [
+          {
+            id: STAFF_ID,
+            email: "existing@example.com",
+            practiceId: PRACTICE_ID,
+            emailVerifiedAt: null,
+            deletedAt: null,
+          },
+        ],
+        [],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).inviteStaff({
+        email: "existing@example.com",
+        role: "front_desk",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(mocks.createAuthToken).not.toHaveBeenCalled();
+    expect(mocks.sendStaffInviteEmail).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes thrown invitation-provider errors", async () => {
+    const invitedUser = {
+      id: STAFF_ID,
+      email: "invite@example.com",
+    };
+    const { db } = createDb({
+      selectResults: [[{ name: "Neighborhood Veterinary" }], []],
+      insertedRows: [invitedUser],
+    });
+    mocks.sendStaffInviteEmail.mockRejectedValueOnce(
+      new Error("provider-secret-response"),
+    );
+
+    await expect(
+      callerWithDb(db).inviteStaff({
+        email: invitedUser.email,
+        role: "front_desk",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_GATEWAY",
+      message: expect.not.stringContaining("provider-secret-response"),
+    });
+  });
+
   it("requires an active practice for staff reads, writes, and deactivation dependencies", () => {
     const staffBlock = SETTINGS_SOURCE.match(
-      /\/\/ ── Staff \/ Users[\s\S]+?\/\/ ── Appointment Types/
+      /\/\/ ── Staff \/ Users[\s\S]+?\/\/ ── Appointment Types/,
     )?.[0];
 
     expect(staffBlock).toContain("await assertActivePractice(ctx)");
     expect(
       staffBlock?.match(/activePracticePredicate\(ctx\.practiceId\)/g)
-        ?.length ?? 0
+        ?.length ?? 0,
     ).toBeGreaterThanOrEqual(10);
     expect(staffBlock).toMatch(
-      /eq\(users\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(users\.deletedAt\)/
+      /eq\(users\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(users\.deletedAt\)/,
     );
     expect(staffBlock).toMatch(
-      /eq\(appointments\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointments\.deletedAt\)/
+      /eq\(appointments\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointments\.deletedAt\)/,
     );
     expect(staffBlock).toMatch(
-      /eq\(staffSchedules\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(staffSchedules\.deletedAt\)/
+      /eq\(staffSchedules\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(staffSchedules\.deletedAt\)/,
     );
     expect(staffBlock).toContain("activePracticeWhere(ctx.practiceId)");
     expect(staffBlock).toContain("eq(users.role, targetUser.role)");
@@ -464,7 +619,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).updateUser({ id: STAFF_ID, role: "viewer" })
+      callerWithDb(db).updateUser({ id: STAFF_ID, role: "viewer" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(db.execute).toHaveBeenCalled();
@@ -473,15 +628,12 @@ describe("settings admin stale target safety", () => {
 
   it("allows admin demotion when another active admin remains", async () => {
     const { db, updateSet } = createDb({
-      selectResults: [
-        [{ id: STAFF_ID, role: "admin" }],
-        [{ id: USER_ID }],
-      ],
+      selectResults: [[{ id: STAFF_ID, role: "admin" }], [{ id: USER_ID }]],
       updatedRows: [{ id: STAFF_ID, role: "viewer" }],
     });
 
     await expect(
-      callerWithDb(db).updateUser({ id: STAFF_ID, role: "viewer" })
+      callerWithDb(db).updateUser({ id: STAFF_ID, role: "viewer" }),
     ).resolves.toMatchObject({ id: STAFF_ID, role: "viewer" });
 
     expect(db.execute).toHaveBeenCalled();
@@ -490,15 +642,12 @@ describe("settings admin stale target safety", () => {
 
   it("rejects stale staff role demotions", async () => {
     const { db, updateSet } = createDb({
-      selectResults: [
-        [{ id: STAFF_ID, role: "admin" }],
-        [{ id: USER_ID }],
-      ],
+      selectResults: [[{ id: STAFF_ID, role: "admin" }], [{ id: USER_ID }]],
       updatedRows: [],
     });
 
     await expect(
-      callerWithDb(db).updateUser({ id: STAFF_ID, role: "viewer" })
+      callerWithDb(db).updateUser({ id: STAFF_ID, role: "viewer" }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
 
     expect(db.execute).toHaveBeenCalled();
@@ -509,7 +658,7 @@ describe("settings admin stale target safety", () => {
     const { db, updateSet } = createDb();
 
     await expect(
-      callerWithDb(db).deactivateUser({ id: USER_ID })
+      callerWithDb(db).deactivateUser({ id: USER_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -520,7 +669,7 @@ describe("settings admin stale target safety", () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).deactivateUser({ id: STAFF_ID })
+      callerWithDb(db).deactivateUser({ id: STAFF_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -533,7 +682,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deactivateUser({ id: STAFF_ID })
+      callerWithDb(db).deactivateUser({ id: STAFF_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -549,7 +698,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deactivateUser({ id: STAFF_ID })
+      callerWithDb(db).deactivateUser({ id: STAFF_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -566,7 +715,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deactivateUser({ id: STAFF_ID })
+      callerWithDb(db).deactivateUser({ id: STAFF_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -580,7 +729,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deactivateUser({ id: STAFF_ID })
+      callerWithDb(db).deactivateUser({ id: STAFF_ID }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
 
     expect(db.execute).toHaveBeenCalled();
@@ -592,7 +741,7 @@ describe("settings admin stale target safety", () => {
     const { db, updateSet } = createDb({ updatedRows: [] });
 
     await expect(
-      callerWithDb(db).restoreUser({ id: STAFF_ID })
+      callerWithDb(db).restoreUser({ id: STAFF_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: null });
@@ -604,17 +753,19 @@ describe("settings admin stale target safety", () => {
       selectResults: [[], [], [], []],
     });
 
-    await expect(callerWithDb(db).listAppointmentTypes()).rejects.toMatchObject({
-      code: "NOT_FOUND",
-      message: "Practice not found",
-    });
+    await expect(callerWithDb(db).listAppointmentTypes()).rejects.toMatchObject(
+      {
+        code: "NOT_FOUND",
+        message: "Practice not found",
+      },
+    );
 
     await expect(
       callerWithDb(db).createAppointmentType({
         name: "Consultation",
         durationMinutes: 30,
         color: "#1a8f8a",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -629,8 +780,8 @@ describe("settings admin stale target safety", () => {
       callerWithDb(db).createRoom({
         name: "Exam 1",
         type: "exam",
-        locationId: LOCATION_ID
-      })
+        locationId: LOCATION_ID,
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -647,7 +798,7 @@ describe("settings admin stale target safety", () => {
       callerWithDb(db).updateAppointmentType({
         id: TYPE_ID,
         name: "Surgery",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).toHaveBeenCalledWith({ name: "Surgery" });
@@ -657,7 +808,7 @@ describe("settings admin stale target safety", () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID })
+      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -669,7 +820,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID })
+      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -681,7 +832,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID })
+      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -694,7 +845,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID })
+      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID }),
     ).resolves.toEqual({ success: true });
 
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: expect.any(Date) });
@@ -711,7 +862,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID })
+      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: expect.stringContaining("appointment request page"),
@@ -724,7 +875,7 @@ describe("settings admin stale target safety", () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).deleteRoom({ id: ROOM_ID })
+      callerWithDb(db).deleteRoom({ id: ROOM_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -736,7 +887,7 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).deleteRoom({ id: ROOM_ID })
+      callerWithDb(db).deleteRoom({ id: ROOM_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -748,9 +899,9 @@ describe("settings admin stale target safety", () => {
       updatedRows: [{ id: ROOM_ID }],
     });
 
-    await expect(
-      callerWithDb(db).deleteRoom({ id: ROOM_ID })
-    ).resolves.toEqual({ success: true });
+    await expect(callerWithDb(db).deleteRoom({ id: ROOM_ID })).resolves.toEqual(
+      { success: true },
+    );
 
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: expect.any(Date) });
   });
@@ -759,33 +910,29 @@ describe("settings admin stale target safety", () => {
 describe("settings demo data cleanup scoping", () => {
   it("scopes invoice-item cleanup through current-practice invoices", () => {
     const invoiceItemBlock = DEMO_DATA_LIFECYCLE_SOURCE.match(
-      /\.update\(invoiceItems\)[\s\S]+?if \(demo\.invoiceIds/
+      /\.update\(invoiceItems\)[\s\S]+?if \(demo\.invoiceIds/,
     )?.[0];
 
     expect(invoiceItemBlock).toContain(
-      "inArray(invoiceItems.id, demo.invoiceItemIds)"
+      "inArray(invoiceItems.id, demo.invoiceItemIds)",
     );
     expect(invoiceItemBlock).toContain("from ${invoices}");
     expect(invoiceItemBlock).toContain(
-      "${invoices.id} = ${invoiceItems.invoiceId}"
+      "${invoices.id} = ${invoiceItems.invoiceId}",
     );
     expect(invoiceItemBlock).toContain(
-      "${invoices.practiceId} = ${practiceId}"
+      "${invoices.practiceId} = ${practiceId}",
     );
   });
 
   it("preserves attribution while clearing stored and discovered demo SOAPs", () => {
     expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain("let demoSoapNoteIds");
-    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
-      "const storedDemoSoapNoteIds",
-    );
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain("const storedDemoSoapNoteIds");
     expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
       "const discoveredDemoSoapNotes",
     );
     expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain("storedDemoSoapNoteIds,");
-    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
-      "discoveredDemoSoapNotes.map",
-    );
+    expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain("discoveredDemoSoapNotes.map");
     expect(DEMO_DATA_LIFECYCLE_SOURCE).toContain(
       "inArray(soapNotes.appointmentId, demo.appointmentIds)",
     );
@@ -822,113 +969,117 @@ describe("settings demo data cleanup scoping", () => {
 describe("settings scheduling metadata delete safety", () => {
   it("requires an active practice for appointment type and room reads and writes", () => {
     const appointmentTypeBlock = SETTINGS_SOURCE.match(
-      /\/\/ ── Appointment Types[\s\S]+?\/\/ ── Rooms/
+      /\/\/ ── Appointment Types[\s\S]+?\/\/ ── Rooms/,
     )?.[0];
     const roomBlock = SETTINGS_SOURCE.match(
-      /\/\/ ── Rooms[\s\S]+?\n\s*\}\),\n\}\);/
+      /\/\/ ── Rooms[\s\S]+?\n\s*\}\),\n\}\);/,
     )?.[0];
 
     expect(appointmentTypeBlock).toContain("await assertActivePractice(ctx)");
     expect(
       appointmentTypeBlock?.match(/activePracticePredicate\(ctx\.practiceId\)/g)
-        ?.length ?? 0
+        ?.length ?? 0,
     ).toBeGreaterThanOrEqual(6);
     expect(appointmentTypeBlock).toMatch(
-      /eq\(appointmentTypes\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointmentTypes\.deletedAt\)/
+      /eq\(appointmentTypes\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointmentTypes\.deletedAt\)/,
     );
     expect(appointmentTypeBlock).toMatch(
-      /eq\(appointmentWaitlist\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+eq\(appointmentWaitlist\.status, "waiting"\)/
+      /eq\(appointmentWaitlist\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+eq\(appointmentWaitlist\.status, "waiting"\)/,
     );
 
     expect(roomBlock).toContain("await assertActivePractice(ctx)");
     expect(
       roomBlock?.match(/activePracticePredicate\(ctx\.practiceId\)/g)?.length ??
-        0
+        0,
     ).toBeGreaterThanOrEqual(4);
     expect(roomBlock).toMatch(
-      /eq\(rooms\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(rooms\.deletedAt\)/
+      /eq\(rooms\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(rooms\.deletedAt\)/,
     );
   });
 
   it("guards appointment type and room deletes with tenant-scoped active scheduling checks", () => {
     const appointmentTypeDeleteBlock = SETTINGS_SOURCE.match(
-      /deleteAppointmentType:[\s\S]+?\/\/ ── Rooms/
+      /deleteAppointmentType:[\s\S]+?\/\/ ── Rooms/,
     )?.[0];
     const roomDeleteBlock = SETTINGS_SOURCE.match(
-      /deleteRoom:[\s\S]+?\n\s*\}\),\n\}\);/
+      /deleteRoom:[\s\S]+?\n\s*\}\),\n\}\);/,
     )?.[0];
 
-    expect(appointmentTypeDeleteBlock).toContain("eq(appointments.typeId, input.id)");
     expect(appointmentTypeDeleteBlock).toContain(
-      "eq(appointments.practiceId, ctx.practiceId)"
+      "eq(appointments.typeId, input.id)",
     );
     expect(appointmentTypeDeleteBlock).toContain(
-      "activePracticePredicate(ctx.practiceId)"
+      "eq(appointments.practiceId, ctx.practiceId)",
     );
     expect(appointmentTypeDeleteBlock).toContain(
-      "inArray(appointments.status, activeSchedulingStatuses)"
+      "activePracticePredicate(ctx.practiceId)",
     );
     expect(appointmentTypeDeleteBlock).toContain(
-      "eq(appointmentWaitlist.typeId, input.id)"
+      "inArray(appointments.status, activeSchedulingStatuses)",
     );
     expect(appointmentTypeDeleteBlock).toContain(
-      "eq(appointmentWaitlist.practiceId, ctx.practiceId)"
+      "eq(appointmentWaitlist.typeId, input.id)",
     );
     expect(appointmentTypeDeleteBlock).toContain(
-      "activePracticePredicate(ctx.practiceId)"
+      "eq(appointmentWaitlist.practiceId, ctx.practiceId)",
     );
     expect(appointmentTypeDeleteBlock).toContain(
-      'eq(appointmentWaitlist.status, "waiting")'
+      "activePracticePredicate(ctx.practiceId)",
+    );
+    expect(appointmentTypeDeleteBlock).toContain(
+      'eq(appointmentWaitlist.status, "waiting")',
     );
     expect(appointmentTypeDeleteBlock).toContain('.for("update")');
     expect(appointmentTypeDeleteBlock).toContain(
-      "parseBookingPageConfig(publishedPage.config)"
+      "parseBookingPageConfig(publishedPage.config)",
     );
 
     expect(roomDeleteBlock).toContain("eq(appointments.roomId, input.id)");
     expect(roomDeleteBlock).toContain(
-      "eq(appointments.practiceId, ctx.practiceId)"
+      "eq(appointments.practiceId, ctx.practiceId)",
     );
-    expect(roomDeleteBlock).toContain("activePracticePredicate(ctx.practiceId)");
     expect(roomDeleteBlock).toContain(
-      "inArray(appointments.status, activeSchedulingStatuses)"
+      "activePracticePredicate(ctx.practiceId)",
+    );
+    expect(roomDeleteBlock).toContain(
+      "inArray(appointments.status, activeSchedulingStatuses)",
     );
   });
 
   it("guards staff deactivation with admin and active appointment checks", () => {
     const deactivateBlock = SETTINGS_SOURCE.match(
-      /deactivateUser:[\s\S]+?restoreUser:/
+      /deactivateUser:[\s\S]+?restoreUser:/,
     )?.[0];
 
     expect(deactivateBlock).toContain("input.id === ctx.user.id");
     expect(deactivateBlock).toContain("pg_advisory_xact_lock");
-    expect(deactivateBlock).toContain("targetUser.role === \"admin\"");
-    expect(deactivateBlock).toContain("eq(users.role, \"admin\")");
+    expect(deactivateBlock).toContain('targetUser.role === "admin"');
+    expect(deactivateBlock).toContain('eq(users.role, "admin")');
     expect(deactivateBlock).toContain("ne(users.id, input.id)");
     expect(deactivateBlock).toContain("eq(users.role, targetUser.role)");
     expect(deactivateBlock).toContain("eq(appointments.doctorId, input.id)");
     expect(deactivateBlock).toContain(
-      "eq(appointments.practiceId, ctx.practiceId)"
+      "eq(appointments.practiceId, ctx.practiceId)",
     );
     expect(deactivateBlock).toContain(
-      "inArray(appointments.status, activeSchedulingStatuses)"
+      "inArray(appointments.status, activeSchedulingStatuses)",
     );
     expect(deactivateBlock).toContain("eq(staffSchedules.userId, input.id)");
     expect(deactivateBlock).toContain(
-      "eq(staffSchedules.practiceId, ctx.practiceId)"
+      "eq(staffSchedules.practiceId, ctx.practiceId)",
     );
     expect(deactivateBlock).toContain("isNull(staffSchedules.deletedAt)");
   });
 
   it("guards staff role demotions with an admin roster lock", () => {
     const updateUserBlock = SETTINGS_SOURCE.match(
-      /updateUser:[\s\S]+?deactivateUser:/
+      /updateUser:[\s\S]+?deactivateUser:/,
     )?.[0];
 
     expect(updateUserBlock).toContain('data.role !== "admin"');
     expect(updateUserBlock).toContain("pg_advisory_xact_lock");
-    expect(updateUserBlock).toContain("targetUser.role === \"admin\"");
-    expect(updateUserBlock).toContain("eq(users.role, \"admin\")");
+    expect(updateUserBlock).toContain('targetUser.role === "admin"');
+    expect(updateUserBlock).toContain('eq(users.role, "admin")');
     expect(updateUserBlock).toContain("ne(users.id, id)");
     expect(updateUserBlock).toContain("eq(users.role, targetUser.role)");
   });

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -69,6 +69,11 @@ const EXISTING_NUMBER_UNAVAILABLE_DETAIL =
 const INCONCLUSIVE_ORDER_DETAIL =
   "OpenVPM could not conclusively reconcile the earlier number order. No additional purchase was attempted. Contact OpenVPM support before trying another number.";
 const HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
+const appointmentReminderLeadHoursInput = z.union([
+  z.literal(24),
+  z.literal(48),
+  z.literal(72),
+]);
 
 const providerPriceInput = z
   .string()
@@ -253,9 +258,13 @@ async function assertActivePractice(ctx: {
  * so provisioning stays off until ops flips MESSAGING_PROVISIONING_ENABLED.
  * The Telnyx key alone being present must not open the purchase path.
  */
-function assertProvisioningEnabled(): void {
+function provisioningEnabled(): boolean {
   const flag = process.env.MESSAGING_PROVISIONING_ENABLED?.trim().toLowerCase();
-  if (flag !== "true" && flag !== "1") {
+  return flag === "true" || flag === "1";
+}
+
+function assertProvisioningEnabled(): void {
+  if (!provisioningEnabled()) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message:
@@ -269,21 +278,29 @@ function assertProvisioningEnabled(): void {
  * During controlled rollout, require an explicit tenant allowlist in addition
  * to the global kill-switch. Self-hosters retain the switch-only path.
  */
-function assertProvisioningPracticeAllowed(practiceId: string): void {
-  if (!billingEnforced()) return;
+function provisioningPracticeAllowed(practiceId: string): boolean {
+  if (!billingEnforced()) return true;
   const allowed = new Set(
     (process.env.MESSAGING_PROVISIONING_PRACTICE_IDS ?? "")
       .split(",")
       .map((value) => value.trim())
       .filter(Boolean),
   );
-  if (!allowed.has(practiceId)) {
+  return allowed.has(practiceId);
+}
+
+function assertProvisioningPracticeAllowed(practiceId: string): void {
+  if (!provisioningPracticeAllowed(practiceId)) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message:
         "Texting number setup is available only to approved pilot clinics. Contact OpenVPM support.",
     });
   }
+}
+
+function provisioningAvailableForPractice(practiceId: string): boolean {
+  return provisioningEnabled() && provisioningPracticeAllowed(practiceId);
 }
 
 function assertHostedSendingAllowed(practiceId: string, locationId: string) {
@@ -486,6 +503,31 @@ export const messagingRouter = createRouter({
           ),
         )
         .limit(1);
+
+      // Do not collect new legal/contact/EIN data for clinics outside the
+      // controlled provisioning scope. Existing registrations or sender rows
+      // remain editable so an already-started pilot can be reconciled safely.
+      if (!existing && !provisioningAvailableForPractice(ctx.practiceId)) {
+        const [existingSender] = await ctx.db
+          .select({ locationId: locationMessaging.locationId })
+          .from(locationMessaging)
+          .where(
+            and(
+              eq(locationMessaging.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(locationMessaging.deletedAt),
+            ),
+          )
+          .limit(1);
+        if (!existingSender) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: billingEnforced()
+              ? "Carrier registration is available only to approved texting pilot clinics. Contact OpenVPM support."
+              : "Carrier registration is disabled by this OpenVPM deployment.",
+          });
+        }
+      }
 
       if (existing?.providerBrandId || existing?.providerCampaignId) {
         throw new TRPCError({
@@ -721,7 +763,11 @@ export const messagingRouter = createRouter({
     const smsUsed = await usageForPractice(ctx.practiceId, "sms", period);
 
     const [practice] = await ctx.db
-      .select({ tier: practices.subscriptionTier })
+      .select({
+        tier: practices.subscriptionTier,
+        appointmentRemindersEnabled: practices.appointmentRemindersEnabled,
+        appointmentReminderLeadHours: practices.appointmentReminderLeadHours,
+      })
       .from(practices)
       .where(activePracticeWhere(ctx.practiceId))
       .limit(1);
@@ -791,14 +837,50 @@ export const messagingRouter = createRouter({
         optedIn: consentRow?.n ?? 0,
         suppressed: suppressedRow?.n ?? 0,
       },
+      appointmentReminders: {
+        enabled: practice.appointmentRemindersEnabled,
+        leadHours: practice.appointmentReminderLeadHours,
+      },
       launch: {
         hosted: billingEnforced(),
-        pilotEnabled:
-          !billingEnforced() || launchEligibleLocationIds.size === 1,
+        setupAvailable: provisioningAvailableForPractice(ctx.practiceId),
+        pilotEnabled: !billingEnforced() || launchEligibleLocationIds.size > 0,
         testSendAllowed: !billingEnforced(),
       },
     };
   }),
+
+  /**
+   * Clinic-controlled automated appointment reminder policy. Reminders are
+   * default-off in the database and can only be enabled by a clinic admin.
+   */
+  setAppointmentReminderSettings: adminOnly
+    .input(
+      z.object({
+        enabled: z.boolean(),
+        leadHours: appointmentReminderLeadHoursInput,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertActivePractice(ctx);
+      const [updated] = await ctx.db
+        .update(practices)
+        .set({
+          appointmentRemindersEnabled: input.enabled,
+          appointmentReminderLeadHours: input.leadHours,
+          updatedAt: new Date(),
+        })
+        .where(activePracticeWhere(ctx.practiceId))
+        .returning({
+          enabled: practices.appointmentRemindersEnabled,
+          leadHours: practices.appointmentReminderLeadHours,
+        });
+
+      if (!updated) {
+        throw practiceNotFound();
+      }
+      return updated;
+    }),
 
   /**
    * Lightweight messaging state for the activation checklist: whether a number
@@ -827,6 +909,7 @@ export const messagingRouter = createRouter({
       rows.map((row) => row.locationId),
     );
     return {
+      setupAvailable: provisioningAvailableForPractice(ctx.practiceId),
       hasAnyNumber: rows.some(
         (r) => !!r.senderE164 && r.registrationStatus !== "failed",
       ),
@@ -862,6 +945,7 @@ export const messagingRouter = createRouter({
     .query(async ({ ctx, input }) => {
       assertProvisioningEnabled();
       await assertActivePractice(ctx);
+      assertProvisioningPracticeAllowed(ctx.practiceId);
       try {
         return await searchAvailableNumbers(input);
       } catch (e) {

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -32,6 +32,7 @@ import {
   migrationRuns,
   visitCloseouts,
   bookingPages,
+  authTokens,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { regionDefaults } from "@/lib/locale/format";
@@ -318,6 +319,10 @@ function onboardingCompletionPatch(now: string) {
 
 function staffAdminRosterLockKey(practiceId: string) {
   return `settings:staff-admin-roster:${practiceId}`;
+}
+
+function staffInviteLockKey(email: string) {
+  return `settings:staff-invite:${email}`;
 }
 
 function activePracticeWhere(practiceId: string) {
@@ -2120,6 +2125,7 @@ export const settingsRouter = createRouter({
    * Invite a staff member by email. Creates the user with an unguessable
    * placeholder password (passwordHash is NOT NULL) and an unverified email,
    * then emails an "invite" link to set their password via /accept-invite.
+   * A retry for the same pending invite reuses the user and rotates the token.
    */
   inviteStaff: adminProcedure
     .input(
@@ -2148,75 +2154,147 @@ export const settingsRouter = createRouter({
         throw practiceNotFound();
       }
 
-      const [existing] = await ctx.db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.email, email))
-        .limit(1);
-      if (existing) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "A user with that email already exists.",
-        });
-      }
+      // The user identity and invite token are one atomic unit. The email lock
+      // serializes first invites and retries across practices, matching the
+      // global unique-email boundary and ensuring only the newest token stays
+      // active. A token failure rolls back a newly inserted staff seat.
+      const { user, token } = await ctx.db
+        .transaction(async (tx) => {
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${staffInviteLockKey(
+              email,
+            )}::text))`,
+          );
+          const [existing] = await tx
+            .select({
+              id: users.id,
+              email: users.email,
+              practiceId: users.practiceId,
+              emailVerifiedAt: users.emailVerifiedAt,
+              deletedAt: users.deletedAt,
+            })
+            .from(users)
+            .where(eq(users.email, email))
+            .limit(1);
 
-      // Derive a display name from the email local-part when not provided.
-      const name =
-        input.name?.trim() ||
-        (() => {
-          const local = email.split("@")[0] ?? "";
-          const words = local
-            .split(/[._-]+/)
-            .filter(Boolean)
-            .map((w) => w[0]!.toUpperCase() + w.slice(1));
-          return words.join(" ") || "Team Member";
-        })();
+          let user: { id: string; email: string };
+          if (existing) {
+            // Provider failures leave the pending staff row in place so billing
+            // and the roster stay consistent. Only a prior invite token proves
+            // this is a safe retry; ordinary users retain the conflict path.
+            const [priorInvite] = await tx
+              .select({ id: authTokens.id })
+              .from(authTokens)
+              .where(
+                and(
+                  eq(authTokens.userId, existing.id),
+                  eq(authTokens.type, "invite"),
+                ),
+              )
+              .limit(1);
+            const isPendingInviteRetry =
+              existing.practiceId === ctx.practiceId &&
+              existing.emailVerifiedAt === null &&
+              existing.deletedAt === null &&
+              Boolean(priorInvite);
 
-      // Unguessable placeholder — replaced when the invite is accepted.
-      const passwordHash = await hash(
-        `invite:${randomUUID()}:${randomUUID()}`,
-        PASSWORD_HASH_COST,
-      );
+            if (!isPendingInviteRetry) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message: "A user with that email already exists.",
+              });
+            }
+            user = { id: existing.id, email: existing.email };
+          } else {
+            // Derive a display name from the email local-part when not provided.
+            const name =
+              input.name?.trim() ||
+              (() => {
+                const local = email.split("@")[0] ?? "";
+                const words = local
+                  .split(/[._-]+/)
+                  .filter(Boolean)
+                  .map((w) => w[0]!.toUpperCase() + w.slice(1));
+                return words.join(" ") || "Team Member";
+              })();
 
-      const [user] = await ctx.db
-        .insert(users)
-        .values({
-          email,
-          name,
-          role: input.role,
-          isVeterinarian: input.role === "veterinarian",
-          passwordHash,
-          emailVerifiedAt: null,
-          practiceId: ctx.practiceId,
+            // Unguessable placeholder — replaced when the invite is accepted.
+            const passwordHash = await hash(
+              `invite:${randomUUID()}:${randomUUID()}`,
+              PASSWORD_HASH_COST,
+            );
+
+            const [createdUser] = await tx
+              .insert(users)
+              .values({
+                email,
+                name,
+                role: input.role,
+                isVeterinarian: input.role === "veterinarian",
+                passwordHash,
+                emailVerifiedAt: null,
+                practiceId: ctx.practiceId,
+              })
+              .returning({
+                id: users.id,
+                email: users.email,
+              });
+            if (!createdUser) {
+              throw new TRPCError({
+                code: "INTERNAL_SERVER_ERROR",
+                message: "The staff invitation could not be created.",
+              });
+            }
+            user = createdUser;
+          }
+
+          const token = await createAuthToken({
+            userId: user.id,
+            email: user.email,
+            type: "invite",
+            db: tx as unknown as Database,
+          });
+          return { user, token };
         })
-        .returning({
-          id: users.id,
-          email: users.email,
-          name: users.name,
-          role: users.role,
-          isVeterinarian: users.isVeterinarian,
+        .catch((error) => {
+          if (error instanceof TRPCError) throw error;
+          console.error("[inviteStaff] identity preparation failed");
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              "The staff invitation could not be prepared. Please retry in a moment.",
+          });
         });
-
-      const token = await createAuthToken({
-        userId: user!.id,
-        email: user!.email,
-        type: "invite",
-        db: ctx.db,
-      });
       const inviteUrl = `${appBaseUrl()}/accept-invite?token=${token}`;
 
+      // Keep the pending seat synchronized even when delivery is refused. A
+      // later retry is idempotent: it reuses this user and rotates the token.
+      await syncBillingAfterStaffChange(ctx.db, ctx.practiceId);
+
       try {
-        await sendStaffInviteEmail({
-          to: user!.email,
+        const delivery = await sendStaffInviteEmail({
+          to: user.email,
           inviterName: ctx.user.name,
           practiceName: practice.name,
           inviteUrl,
         });
+        if (!delivery.success) {
+          console.error("[inviteStaff] email provider refused delivery");
+          throw new TRPCError({
+            code: "BAD_GATEWAY",
+            message:
+              "Staff access was saved, but the invitation email could not be sent. Please retry the invite in a moment.",
+          });
+        }
       } catch (err) {
-        console.error("[inviteStaff] email failed:", err);
+        if (err instanceof TRPCError) throw err;
+        console.error("[inviteStaff] email provider request failed");
+        throw new TRPCError({
+          code: "BAD_GATEWAY",
+          message:
+            "Staff access was saved, but the invitation email could not be sent. Please retry the invite in a moment.",
+        });
       }
-
-      await syncBillingAfterStaffChange(ctx.db, ctx.practiceId);
 
       return {
         ok: true,

--- a/packages/db/drizzle/0071_boring_devos.sql
+++ b/packages/db/drizzle/0071_boring_devos.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "practices" ADD COLUMN "appointment_reminders_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "practices" ADD COLUMN "appointment_reminder_lead_hours" integer DEFAULT 24 NOT NULL;--> statement-breakpoint
+ALTER TABLE "practices" ADD CONSTRAINT "practices_appointment_reminder_lead_hours_check" CHECK ("practices"."appointment_reminder_lead_hours" in (24, 48, 72));

--- a/packages/db/drizzle/meta/0071_snapshot.json
+++ b/packages/db/drizzle/meta/0071_snapshot.json
@@ -1,0 +1,21116 @@
+{
+  "id": "93bb34b3-5cb4-4d4d-bd76-548baf4de293",
+  "prevId": "f4f18ac9-a21d-4f20-8089-d410b3088ea8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_reminders_enabled": {
+          "name": "appointment_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appointment_reminder_lead_hours": {
+          "name": "appointment_reminder_lead_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practices_appointment_reminder_lead_hours_check": {
+          "name": "practices_appointment_reminder_lead_hours_check",
+          "value": "\"practices\".\"appointment_reminder_lead_hours\" in (24, 48, 72)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "is_veterinarian": {
+          "name": "is_veterinarian",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_veterinarian_idx": {
+          "name": "users_veterinarian_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_veterinarian",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_location_time_idx": {
+          "name": "appointments_location_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_id_locations_id_fk": {
+          "name": "appointments_location_id_locations_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_tenant_fk": {
+          "name": "appointments_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_location_tenant_fk": {
+          "name": "appointments_room_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "practice_id",
+            "location_id",
+            "room_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "location_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "appointments_time_range_check": {
+          "name": "appointments_time_range_check",
+          "value": "\"appointments\".\"start_time\" < \"appointments\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_practice_location_id_uq": {
+          "name": "rooms_practice_location_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_tenant_fk": {
+          "name": "rooms_location_tenant_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_active_day_idx": {
+          "name": "staff_schedules_active_day_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"staff_schedules\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_window_uq": {
+          "name": "staff_schedules_active_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_null_location_window_uq": {
+          "name": "staff_schedules_active_null_location_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_tenant_fk": {
+          "name": "staff_schedules_user_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_tenant_fk": {
+          "name": "staff_schedules_location_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "staff_schedules_day_of_week_check": {
+          "name": "staff_schedules_day_of_week_check",
+          "value": "\"staff_schedules\".\"day_of_week\" between 0 and 6"
+        },
+        "staff_schedules_time_range_check": {
+          "name": "staff_schedules_time_range_check",
+          "value": "\"staff_schedules\".\"start_time\" < \"staff_schedules\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "finalized_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_soap_source_uq": {
+          "name": "clinical_record_corrections_practice_record_soap_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "lab_result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_note_replacements": {
+      "name": "soap_note_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_soap_note_id": {
+          "name": "source_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_soap_note_id": {
+          "name": "replacement_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_replacements_source_history_idx": {
+          "name": "soap_note_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_source_uq": {
+          "name": "soap_note_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_replacement_uq": {
+          "name": "soap_note_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_operation_uq": {
+          "name": "soap_note_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_replacements_practice_id_practices_id_fk": {
+          "name": "soap_note_replacements_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "soap_note_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_source_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_id_users_id_fk": {
+          "name": "soap_note_replacements_actor_id_users_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_tenant_fk": {
+          "name": "soap_note_replacements_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_tenant_fk": {
+          "name": "soap_note_replacements_replacement_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_source_tenant_fk": {
+          "name": "soap_note_replacements_correction_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "soap_note_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_tenant_fk": {
+          "name": "soap_note_replacements_actor_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_replacements_shape_check": {
+          "name": "soap_note_replacements_shape_check",
+          "value": "\"soap_note_replacements\".\"source_soap_note_id\" <> \"soap_note_replacements\".\"replacement_soap_note_id\"\n        and \"soap_note_replacements\".\"actor_name\" = btrim(\"soap_note_replacements\".\"actor_name\")\n        and length(btrim(\"soap_note_replacements\".\"actor_name\")) between 1 and 255\n        and \"soap_note_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": [
+            "original_webhook_id"
+          ],
+          "columnsTo": [
+            "webhook_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_practice_id_uq": {
+          "name": "messaging_registrations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registration_events": {
+      "name": "messaging_registration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "messaging_registration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "messaging_registration_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "messaging_registration_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messaging_registration_events_registration_history_idx": {
+          "name": "messaging_registration_events_registration_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_practice_time_idx": {
+          "name": "messaging_registration_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_operation_event_uq": {
+          "name": "messaging_registration_events_operation_event_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registration_events_practice_id_practices_id_fk": {
+          "name": "messaging_registration_events_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_id_messaging_registrations_id_fk": {
+          "name": "messaging_registration_events_registration_id_messaging_registrations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_id_locations_id_fk": {
+          "name": "messaging_registration_events_location_id_locations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_user_id_users_id_fk": {
+          "name": "messaging_registration_events_actor_user_id_users_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_tenant_fk": {
+          "name": "messaging_registration_events_registration_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "practice_id",
+            "registration_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_tenant_fk": {
+          "name": "messaging_registration_events_location_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_tenant_fk": {
+          "name": "messaging_registration_events_actor_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registration_events_shape_check": {
+          "name": "messaging_registration_events_shape_check",
+          "value": "\"messaging_registration_events\".\"provider\" in ('telnyx', 'twilio')\n        and \"messaging_registration_events\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and \"messaging_registration_events\".\"actor_name\" = btrim(\"messaging_registration_events\".\"actor_name\")\n        and length(\"messaging_registration_events\".\"actor_name\") between 1 and 255\n        and (\n          (\"messaging_registration_events\".\"actor_type\" = 'clinic_user'\n            and \"messaging_registration_events\".\"actor_user_id\" is not null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n          or (\"messaging_registration_events\".\"actor_type\" = 'platform_operator'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and length(btrim(coalesce(\"messaging_registration_events\".\"actor_identity\", ''))) between 1 and 255)\n          or (\"messaging_registration_events\".\"actor_type\" = 'system'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n        )\n        and (\"messaging_registration_events\".\"provider_brand_id\" is null or (\n          \"messaging_registration_events\".\"provider_brand_id\" = btrim(\"messaging_registration_events\".\"provider_brand_id\")\n          and length(\"messaging_registration_events\".\"provider_brand_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_campaign_id\" is null or (\n          \"messaging_registration_events\".\"provider_campaign_id\" = btrim(\"messaging_registration_events\".\"provider_campaign_id\")\n          and length(\"messaging_registration_events\".\"provider_campaign_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"messaging_profile_id\" is null or (\n          \"messaging_registration_events\".\"messaging_profile_id\" = btrim(\"messaging_registration_events\".\"messaging_profile_id\")\n          and length(\"messaging_registration_events\".\"messaging_profile_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_brand_status\" is null\n          or length(\"messaging_registration_events\".\"provider_brand_status\") between 1 and 64)\n        and (\"messaging_registration_events\".\"provider_campaign_status\" is null\n          or length(\"messaging_registration_events\".\"provider_campaign_status\") between 1 and 64)\n        and (\n          (\"messaging_registration_events\".\"event_type\" = 'details_saved'\n            and \"messaging_registration_events\".\"operation\" = 'registration_details')\n          or (\"messaging_registration_events\".\"event_type\" in (\n              'provider_operation_started',\n              'provider_operation_succeeded',\n              'provider_operation_failed'\n            ) and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'number_assignment'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_state_observed'\n            and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'registration_reconciliation'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_ids_attached'\n            and \"messaging_registration_events\".\"operation\" = 'provider_id_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'stale_lock_cleared'\n            and \"messaging_registration_events\".\"operation\" = 'submission_lock_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_enabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_activation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_disabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_deactivation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_verified'\n            and \"messaging_registration_events\".\"operation\" = 'profile_verification'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": [
+            "delivery_event_id",
+            "reviewed_history_id"
+          ],
+          "columnsTo": [
+            "delivery_event_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_email_identity": {
+      "name": "platform_email_identity",
+      "schema": "",
+      "columns": {
+        "key_slot": {
+          "name": "key_slot",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_identity_singleton_check": {
+          "name": "platform_email_identity_singleton_check",
+          "value": "\"platform_email_identity\".\"key_slot\" = 1"
+        },
+        "platform_email_identity_fingerprint_check": {
+          "name": "platform_email_identity_fingerprint_check",
+          "value": "\"platform_email_identity\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preference_events": {
+      "name": "platform_email_preference_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_marketing_enabled": {
+          "name": "requested_marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_key_hash": {
+          "name": "provider_event_key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preference_events_recipient_timeline_idx": {
+          "name": "platform_email_preference_events_recipient_timeline_idx",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preference_events_provider_event_key_uq": {
+          "name": "platform_email_preference_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider_event_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preference_events_email_hash_check": {
+          "name": "platform_email_preference_events_email_hash_check",
+          "value": "\"platform_email_preference_events\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_identity_fingerprint_check": {
+          "name": "platform_email_preference_events_identity_fingerprint_check",
+          "value": "\"platform_email_preference_events\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_provider_event_key_hash_check": {
+          "name": "platform_email_preference_events_provider_event_key_hash_check",
+          "value": "\"platform_email_preference_events\".\"provider_event_key_hash\" IS NULL OR \"platform_email_preference_events\".\"provider_event_key_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_source_check": {
+          "name": "platform_email_preference_events_source_check",
+          "value": "\"platform_email_preference_events\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preference_events_reason_check": {
+          "name": "platform_email_preference_events_reason_check",
+          "value": "\"platform_email_preference_events\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preference_events_request_state_check": {
+          "name": "platform_email_preference_events_request_state_check",
+          "value": "(\"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preferences": {
+      "name": "platform_email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing_enabled": {
+          "name": "marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preferences_email_hash_uq": {
+          "name": "platform_email_preferences_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preferences_identity_fingerprint_idx": {
+          "name": "platform_email_preferences_identity_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "identity_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preferences_email_hash_check": {
+          "name": "platform_email_preferences_email_hash_check",
+          "value": "\"platform_email_preferences\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_identity_fingerprint_check": {
+          "name": "platform_email_preferences_identity_fingerprint_check",
+          "value": "\"platform_email_preferences\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_source_check": {
+          "name": "platform_email_preferences_source_check",
+          "value": "\"platform_email_preferences\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preferences_reason_check": {
+          "name": "platform_email_preferences_reason_check",
+          "value": "\"platform_email_preferences\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preferences_state_check": {
+          "name": "platform_email_preferences_state_check",
+          "value": "(\"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": [
+        "not_required",
+        "open",
+        "completed"
+      ]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "normal",
+        "abnormal",
+        "critical"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "finalized"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": [
+        "registration",
+        "authenticated_resend"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.messaging_registration_actor_type": {
+      "name": "messaging_registration_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator",
+        "system"
+      ]
+    },
+    "public.messaging_registration_event_type": {
+      "name": "messaging_registration_event_type",
+      "schema": "public",
+      "values": [
+        "details_saved",
+        "provider_operation_started",
+        "provider_operation_succeeded",
+        "provider_operation_failed",
+        "provider_state_observed",
+        "provider_ids_attached",
+        "stale_lock_cleared",
+        "provider_profile_enabled",
+        "provider_profile_disabled",
+        "provider_profile_verified"
+      ]
+    },
+    "public.messaging_registration_operation": {
+      "name": "messaging_registration_operation",
+      "schema": "public",
+      "values": [
+        "registration_details",
+        "brand_submission",
+        "campaign_submission",
+        "number_assignment",
+        "registration_reconciliation",
+        "provider_id_recovery",
+        "submission_lock_recovery",
+        "profile_activation",
+        "profile_deactivation",
+        "profile_verification"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "sent",
+        "failed",
+        "delivered"
+      ]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": [
+        "automatic",
+        "operator_reconciliation"
+      ]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1786339170251,
       "tag": "0070_petite_quasimodo",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1786343344347,
+      "tag": "0071_boring_devos",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema/practices.ts
+++ b/packages/db/schema/practices.ts
@@ -5,12 +5,14 @@ import {
   text,
   jsonb,
   boolean,
+  integer,
   numeric,
   timestamp,
   index,
   uniqueIndex,
+  check,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import { baseColumns } from "./common";
 
 export const practices = pgTable(
@@ -47,6 +49,15 @@ export const practices = pgTable(
       .notNull()
       .default("8.00"),
     vatNumber: varchar("vat_number", { length: 32 }), // shown on invoices where applicable
+    // Automated appointment reminders are deliberately clinic-controlled.
+    // New and existing clinics remain off until an admin explicitly enables
+    // them after reviewing contact preferences and messaging setup.
+    appointmentRemindersEnabled: boolean("appointment_reminders_enabled")
+      .notNull()
+      .default(false),
+    appointmentReminderLeadHours: integer("appointment_reminder_lead_hours")
+      .notNull()
+      .default(24),
     // Capability token for the read-only ICS schedule feed (null = feed off).
     // Practice-wide by design: one shared clinic calendar, same trust
     // boundary as the whiteboard. Rotating it invalidates the old URL.
@@ -70,6 +81,10 @@ export const practices = pgTable(
     // treats NULLs as distinct, so practices without a feed are unaffected.
     calendarFeedTokenUq: uniqueIndex("practices_calendar_feed_token_uq").on(
       table.calendarFeedToken,
+    ),
+    appointmentReminderLeadHoursCheck: check(
+      "practices_appointment_reminder_lead_hours_check",
+      sql`${table.appointmentReminderLeadHours} in (24, 48, 72)`,
     ),
   }),
 );


### PR DESCRIPTION
## Summary

- Add default-off, clinic-controlled appointment reminders with 24/48/72-hour lead times, visible catch-up disclosure, and confirmation before enabling or expanding a live reminder window.
- Re-check appointment, tenant, recipient, and suppression eligibility immediately before reminder dispatch.
- Gate hosted number setup to approved clinics and make hosted/self-hosted setup ownership and availability truthful throughout settings and onboarding.
- Make staff-invite delivery failures explicit while keeping identity and token issuance atomic, serialized, and safe to retry.
- Move GitHub Actions to Node 24 and run the reminder-policy integration against real PostgreSQL in CI.

## Safety

- Automatic reminders remain off for every existing clinic after migration.
- This change does not enable SMS, purchase a number, submit carrier registration, or send participant outreach.
- Provider and suppression state is checked just-in-time before external email delivery.

## Verification

- `pnpm type-check`
- `pnpm test` — 3,461 passed; two expected database integrations skipped locally
- `pnpm build`
- staged and commit-range Gitleaks scans — no leaks
- two independent release reviews — GO

CI is expected to run both database integrations against PostgreSQL before merge.