### PR TITLE
Prepare connected mobile clinic workflow

### DIFF
--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -985,6 +985,7 @@ function InvoiceRow({
     dueDate: string | null;
     createdAt: Date | string | null;
     isEstimate: boolean;
+    appointmentId: string | null;
     clientFirstName: string | null;
     clientLastName: string | null;
     patientName: string | null;
@@ -1128,6 +1129,16 @@ function InvoiceRow({
               </div>
             ) : detail.data ? (
               <div className="space-y-4">
+                {detail.data.appointmentId ? (
+                  <Button variant="outline" size="sm" asChild>
+                    <Link
+                      href={`/encounters/${encodeURIComponent(detail.data.appointmentId)}#charge-capture`}
+                    >
+                      Back to visit
+                    </Link>
+                  </Button>
+                ) : null}
+
                 {/* Estimate Approval Card */}
                 {invoice.isEstimate && (
                   <div className="flex items-center justify-between rounded-lg border border-purple-200 bg-purple-50 p-4 dark:border-purple-900 dark:bg-purple-950/30">
@@ -1645,17 +1656,23 @@ function PaymentSection({
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h4 className="text-sm font-medium">Payments &amp; Adjustments</h4>
         {canCollect && (
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={handleOpenForm}>
+          <div className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-3">
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={handleOpenForm}
+            >
               <DollarSign className="mr-1 h-3.5 w-3.5" />
               Record Payment
             </Button>
             <Button
               variant="outline"
               size="sm"
+              className="w-full sm:w-auto"
               disabled={
                 cardCheckout.isPending ||
                 cardPaymentStatus.isLoading ||
@@ -1678,6 +1695,7 @@ function PaymentSection({
             <Button
               variant="outline"
               size="sm"
+              className="w-full sm:w-auto"
               onClick={handleOpenAdjustmentForm}
             >
               <DollarSign className="mr-1 h-3.5 w-3.5" />
@@ -1702,7 +1720,7 @@ function PaymentSection({
       {/* Payment form */}
       {showPaymentForm && (
         <div className="rounded-lg border border-border bg-background p-4 space-y-3">
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             <div>
               <label className="block text-xs font-medium text-muted-foreground mb-1">
                 Amount
@@ -1745,9 +1763,10 @@ function PaymentSection({
               />
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
             <Button
               size="sm"
+              className="w-full sm:w-auto"
               onClick={handleRecordPayment}
               disabled={!canRecordPayment}
             >
@@ -1756,6 +1775,7 @@ function PaymentSection({
             <Button
               variant="ghost"
               size="sm"
+              className="w-full sm:w-auto"
               onClick={() => {
                 paymentOperationId.current = null;
                 setShowPaymentForm(false);
@@ -1774,7 +1794,7 @@ function PaymentSection({
 
       {showAdjustmentForm && (
         <div className="space-y-3 rounded-lg border border-border bg-background p-4">
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             <div>
               <label className="block text-xs font-medium text-muted-foreground mb-1">
                 Type
@@ -1816,9 +1836,10 @@ function PaymentSection({
               />
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
             <Button
               size="sm"
+              className="w-full sm:w-auto"
               onClick={handleApplyAdjustment}
               disabled={!canApplyAdjustment}
             >
@@ -1827,6 +1848,7 @@ function PaymentSection({
             <Button
               variant="ghost"
               size="sm"
+              className="w-full sm:w-auto"
               onClick={() => {
                 adjustmentOperationId.current = null;
                 setShowAdjustmentForm(false);

--- a/apps/web/app/(dashboard)/clients/page.tsx
+++ b/apps/web/app/(dashboard)/clients/page.tsx
@@ -42,7 +42,7 @@ export default function ClientsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="font-heading text-xl font-semibold">Clients</h2>
           <p className="text-sm text-muted-foreground">
@@ -50,26 +50,29 @@ export default function ClientsPage() {
           </p>
         </div>
         {canManageClients && (
-          <Button onClick={() => router.push("/clients/new")}>
+          <Button
+            onClick={() => router.push("/clients/new")}
+            className="h-11 w-full sm:h-10 sm:w-auto"
+          >
             <Plus className="mr-2 h-4 w-4" />
             New Client
           </Button>
         )}
       </div>
 
-      <div className="mt-6 flex items-center gap-4">
-        <div className="relative flex-1 max-w-sm">
+      <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <div className="relative w-full min-w-0 sm:max-w-sm sm:flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search clients..."
             value={search}
             maxLength={CLIENT_SEARCH_MAX_LENGTH}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-9"
+            className="h-11 pl-9 sm:h-10"
           />
         </div>
         {verifiedClientList && (
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-muted-foreground sm:shrink-0">
             {verifiedClientList.total} client
             {verifiedClientList.total !== 1 ? "s" : ""}
           </p>
@@ -83,7 +86,49 @@ export default function ClientsPage() {
       ) : isLoading ? (
         <TableSkeleton rows={8} cols={5} />
       ) : verifiedClientList && verifiedClientList.items.length > 0 ? (
-        <div className="mt-6 overflow-x-auto rounded-lg border border-border">
+        <>
+          <div className="mt-6 space-y-3 sm:hidden">
+            {verifiedClientList.items.map((client) => {
+              const fullName = `${client.firstName} ${client.lastName}`;
+
+              return (
+                <button
+                  key={client.id}
+                  type="button"
+                  onClick={() => router.push(`/clients/${client.id}`)}
+                  aria-label={`Open client ${fullName}`}
+                  className="min-h-11 w-full min-w-0 overflow-hidden rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-muted/30 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                >
+                  <span className="block truncate text-sm font-semibold text-foreground">
+                    {fullName}
+                  </span>
+                  <span className="mt-2 block min-w-0 space-y-1 text-sm text-muted-foreground">
+                    <span className="block truncate">
+                      {client.phone || "No phone on file"}
+                    </span>
+                    <span className="block truncate">
+                      {client.email || "No email on file"}
+                    </span>
+                    <span className="flex min-w-0 items-center justify-between gap-3 text-xs">
+                      <span className="truncate">
+                        {client.city || "City not listed"}
+                      </span>
+                      <span className="shrink-0">
+                        Added{" "}
+                        {formatClinicalDate(
+                          client.createdAt,
+                          clientListTimeZone,
+                          "—"
+                        )}
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="mt-6 hidden overflow-x-auto rounded-lg border border-border sm:block">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border bg-muted/50">
@@ -134,7 +179,8 @@ export default function ClientsPage() {
               ))}
             </tbody>
           </table>
-        </div>
+          </div>
+        </>
       ) : (
         <EmptyState
           className="mt-6"

--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useCallback,
   useDeferredValue,
   useEffect,
   useMemo,
@@ -45,6 +46,8 @@ import {
 import { centsToMoney, moneyToCents } from "@/lib/billing/invoice-balance";
 import { tryCalculateInvoiceTaxTotals } from "@/lib/billing/invoice-tax";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
+import { useUnsavedChangesGuard } from "@/lib/use-unsaved-changes-guard";
+import { useOnlineStatus } from "@/lib/use-online-status";
 import {
   APPOINTMENT_PATIENT_SEARCH_MAX_LENGTH,
   isAppointmentPatientSearchInputValid,
@@ -90,6 +93,51 @@ type ChargeItem = {
   sourcePrescriptionId?: string;
   sourceDispenseChargeId?: string;
 };
+
+type ClinicalDraftFields = {
+  diagnosisSummary: string;
+  dischargeInstructions: string;
+  warningSigns: string;
+  noInstructionsReason: string;
+  prescriptionDisposition: "" | "prescribed" | "not_needed";
+  followUpDisposition: "" | "none" | "needed" | "scheduled";
+  followUpNotes: string;
+  followUpAppointmentId: string;
+  followUpDueDate: string;
+  followUpAssignedTo: string;
+  documentationExceptionReason: string;
+};
+
+function chargeItemsFingerprint(items: ChargeItem[]): string {
+  return JSON.stringify(
+    items.map((item) => [
+      item.description,
+      item.quantity,
+      item.unitPrice,
+      item.itemType,
+      item.itemId ?? null,
+      item.taxable,
+      item.sourcePrescriptionId ?? null,
+      item.sourceDispenseChargeId ?? null,
+    ]),
+  );
+}
+
+function clinicalDraftFingerprint(fields: ClinicalDraftFields): string {
+  return JSON.stringify([
+    fields.diagnosisSummary,
+    fields.dischargeInstructions,
+    fields.warningSigns,
+    fields.noInstructionsReason,
+    fields.prescriptionDisposition,
+    fields.followUpDisposition,
+    fields.followUpNotes,
+    fields.followUpAppointmentId,
+    fields.followUpDueDate,
+    fields.followUpAssignedTo,
+    fields.documentationExceptionReason,
+  ]);
+}
 
 const APPOINTMENT_STATUS_LABELS: Record<string, string> = {
   scheduled: "Scheduled",
@@ -810,6 +858,7 @@ function VisitCloseout({
   invoicesQuery: InvoiceQueryState;
 }) {
   const utils = trpc.useUtils();
+  const isOnline = useOnlineStatus();
   const data = closeoutQuery.data;
   const closeout = data?.closeout ?? null;
   const activeInvoice = data?.invoices[0] ?? null;
@@ -845,30 +894,112 @@ function VisitCloseout({
   >("");
   const [resolutionAppointmentId, setResolutionAppointmentId] = useState("");
   const [resolutionNotes, setResolutionNotes] = useState("");
+  const [draftSaveState, setDraftSaveState] = useState<
+    "idle" | "unsaved" | "saving" | "saved" | "error" | "conflict"
+  >("idle");
+  const [lastDraftSavedAt, setLastDraftSavedAt] = useState<Date | null>(null);
+  const [conflictRevision, setConflictRevision] = useState<number | null>(null);
+  const draftInitializedRef = useRef(false);
+  const revisionRef = useRef(0);
+  const lastSavedFingerprintRef = useRef("");
+  const savePromiseRef = useRef<Promise<unknown> | null>(null);
+  const autosaveTimerRef = useRef<number | null>(null);
+  const conflictRef = useRef(false);
+  const fieldsRef = useRef<ClinicalDraftFields>({
+    diagnosisSummary,
+    dischargeInstructions,
+    warningSigns,
+    noInstructionsReason,
+    prescriptionDisposition,
+    followUpDisposition,
+    followUpNotes,
+    followUpAppointmentId,
+    followUpDueDate,
+    followUpAssignedTo,
+    documentationExceptionReason,
+  });
+  fieldsRef.current = {
+    diagnosisSummary,
+    dischargeInstructions,
+    warningSigns,
+    noInstructionsReason,
+    prescriptionDisposition,
+    followUpDisposition,
+    followUpNotes,
+    followUpAppointmentId,
+    followUpDueDate,
+    followUpAssignedTo,
+    documentationExceptionReason,
+  };
+
+  const applyClinicalFields = useCallback((fields: ClinicalDraftFields) => {
+    setDiagnosisSummary(fields.diagnosisSummary);
+    setDischargeInstructions(fields.dischargeInstructions);
+    setWarningSigns(fields.warningSigns);
+    setNoInstructionsReason(fields.noInstructionsReason);
+    setPrescriptionDisposition(fields.prescriptionDisposition);
+    setFollowUpDisposition(fields.followUpDisposition);
+    setFollowUpNotes(fields.followUpNotes);
+    setFollowUpAppointmentId(fields.followUpAppointmentId);
+    setFollowUpDueDate(fields.followUpDueDate);
+    setFollowUpAssignedTo(fields.followUpAssignedTo);
+    setDocumentationExceptionReason(fields.documentationExceptionReason);
+    fieldsRef.current = fields;
+  }, []);
 
   useEffect(() => {
     if (!data) return;
     const key = closeout ? `${closeout.id}:${closeout.revision}` : "empty";
     if (hydratedRevision.current === key) return;
     const clinicalSource = closeout?.amendmentDraft ?? closeout;
-    setDiagnosisSummary(clinicalSource?.diagnosisSummary ?? "");
-    setDischargeInstructions(clinicalSource?.dischargeInstructions ?? "");
-    setWarningSigns(clinicalSource?.warningSigns ?? "");
-    setNoInstructionsReason(clinicalSource?.noInstructionsReason ?? "");
-    setPrescriptionDisposition(clinicalSource?.prescriptionDisposition ?? "");
-    setFollowUpDisposition(clinicalSource?.followUpDisposition ?? "");
-    setFollowUpNotes(clinicalSource?.followUpNotes ?? "");
-    setFollowUpAppointmentId(clinicalSource?.followUpAppointmentId ?? "");
-    setFollowUpDueDate(clinicalSource?.followUpDueDate ?? "");
-    setFollowUpAssignedTo(clinicalSource?.followUpAssignedTo ?? "");
-    setDocumentationExceptionReason(
-      clinicalSource?.documentationExceptionReason ?? "",
-    );
+    const serverFields: ClinicalDraftFields = {
+      diagnosisSummary: clinicalSource?.diagnosisSummary ?? "",
+      dischargeInstructions: clinicalSource?.dischargeInstructions ?? "",
+      warningSigns: clinicalSource?.warningSigns ?? "",
+      noInstructionsReason: clinicalSource?.noInstructionsReason ?? "",
+      prescriptionDisposition: clinicalSource?.prescriptionDisposition ?? "",
+      followUpDisposition: clinicalSource?.followUpDisposition ?? "",
+      followUpNotes: clinicalSource?.followUpNotes ?? "",
+      followUpAppointmentId: clinicalSource?.followUpAppointmentId ?? "",
+      followUpDueDate: clinicalSource?.followUpDueDate ?? "",
+      followUpAssignedTo: clinicalSource?.followUpAssignedTo ?? "",
+      documentationExceptionReason:
+        clinicalSource?.documentationExceptionReason ?? "",
+    };
+    const serverRevision = closeout?.revision ?? 0;
+    const localDirty =
+      clinicalDraftFingerprint(fieldsRef.current) !==
+      lastSavedFingerprintRef.current;
+    if (
+      draftInitializedRef.current &&
+      serverRevision > revisionRef.current &&
+      (localDirty || savePromiseRef.current)
+    ) {
+      conflictRef.current = true;
+      setConflictRevision(serverRevision);
+      setDraftSaveState("conflict");
+      return;
+    }
+    if (
+      draftInitializedRef.current &&
+      serverRevision <= revisionRef.current
+    ) {
+      hydratedRevision.current = key;
+      return;
+    }
+    applyClinicalFields(serverFields);
+    revisionRef.current = serverRevision;
+    lastSavedFingerprintRef.current = clinicalDraftFingerprint(serverFields);
+    setLastDraftSavedAt(closeout?.updatedAt ?? null);
+    setDraftSaveState(closeout ? "saved" : "idle");
+    conflictRef.current = false;
+    setConflictRevision(null);
+    draftInitializedRef.current = true;
     setChargeDisposition(closeout?.chargeDisposition ?? "");
     setNoChargeReason(closeout?.noChargeReason ?? "");
     setHandoffMethod(closeout?.handoffMethod ?? "");
     hydratedRevision.current = key;
-  }, [closeout, data]);
+  }, [applyClinicalFields, closeout, data]);
 
   useEffect(() => {
     if (!data) return;
@@ -896,19 +1027,32 @@ function VisitCloseout({
     ]);
   };
 
-  const saveDraft = trpc.encounters.saveDraft.useMutation({
-    onSuccess: async () => {
-      toast.success("Clinical closeout draft saved");
-      await refresh();
-    },
-    onError: (error) => toast.error(error.message),
-  });
+  const saveDraft = trpc.encounters.saveDraft.useMutation();
+  const saveDraftRef = useRef(saveDraft.mutateAsync);
+  saveDraftRef.current = saveDraft.mutateAsync;
   const finalizeClinical = trpc.encounters.finalizeClinical.useMutation({
     onSuccess: async () => {
+      conflictRef.current = false;
+      setConflictRevision(null);
+      setDraftSaveState("saved");
       toast.success("Clinical handoff finalized");
       await refresh();
     },
-    onError: (error) => toast.error(error.message),
+    onError: async (error) => {
+      if ((error as { data?: { code?: string } }).data?.code === "CONFLICT") {
+        conflictRef.current = true;
+        try {
+          const latest = await utils.encounters.getCloseout.fetch({
+            appointmentId,
+          });
+          setConflictRevision(latest.closeout?.revision ?? 0);
+        } catch {
+          setConflictRevision(null);
+        }
+        setDraftSaveState("conflict");
+      }
+      toast.error(error.message);
+    },
   });
   const completeVisit = trpc.encounters.completeVisit.useMutation({
     onSuccess: async () => {
@@ -952,21 +1096,224 @@ function VisitCloseout({
   const amendingClinical = Boolean(closeout?.amendmentDraft);
   const clinicalLocked = signedClinical && !amendingClinical;
   const isCompleted = closeout?.status === "completed";
-  const clinicalInput = {
-    appointmentId,
-    expectedRevision: closeout?.revision ?? 0,
-    diagnosisSummary: diagnosisSummary || null,
-    dischargeInstructions: dischargeInstructions || null,
-    warningSigns: warningSigns || null,
-    noInstructionsReason: noInstructionsReason || null,
-    prescriptionDisposition: prescriptionDisposition || null,
-    followUpDisposition: followUpDisposition || null,
-    followUpNotes: followUpNotes || null,
-    followUpAppointmentId: followUpAppointmentId || null,
-    followUpDueDate: followUpDueDate || null,
-    followUpAssignedTo: followUpAssignedTo || null,
-    documentationExceptionReason: documentationExceptionReason || null,
-  } as const;
+  const persistCloseoutDraft = useCallback(async () => {
+    if (!draftInitializedRef.current || clinicalLocked || !canDraftClinical) {
+      return null;
+    }
+    while (true) {
+      if (conflictRef.current) return null;
+      if (!window.navigator.onLine) {
+        setDraftSaveState("unsaved");
+        return null;
+      }
+      if (savePromiseRef.current) {
+        await savePromiseRef.current.catch(() => null);
+        continue;
+      }
+      const fields = { ...fieldsRef.current };
+      const fingerprint = clinicalDraftFingerprint(fields);
+      if (fingerprint === lastSavedFingerprintRef.current) {
+        return { revision: revisionRef.current };
+      }
+      setDraftSaveState("saving");
+      const request = saveDraftRef.current({
+        appointmentId,
+        expectedRevision: revisionRef.current,
+        diagnosisSummary: fields.diagnosisSummary || null,
+        dischargeInstructions: fields.dischargeInstructions || null,
+        warningSigns: fields.warningSigns || null,
+        noInstructionsReason: fields.noInstructionsReason || null,
+        prescriptionDisposition: fields.prescriptionDisposition || null,
+        followUpDisposition: fields.followUpDisposition || null,
+        followUpNotes: fields.followUpNotes || null,
+        followUpAppointmentId: fields.followUpAppointmentId || null,
+        followUpDueDate: fields.followUpDueDate || null,
+        followUpAssignedTo: fields.followUpAssignedTo || null,
+        documentationExceptionReason:
+          fields.documentationExceptionReason || null,
+      });
+      savePromiseRef.current = request;
+      try {
+        const result = await request;
+        revisionRef.current = result.revision;
+        lastSavedFingerprintRef.current = fingerprint;
+        setLastDraftSavedAt(result.updatedAt ?? new Date());
+        setDraftSaveState("saved");
+        await utils.encounters.getCloseout.invalidate({ appointmentId });
+      } catch (error) {
+        const code = (error as { data?: { code?: string } })?.data?.code;
+        if (code === "CONFLICT") {
+          conflictRef.current = true;
+          try {
+            const latest = await utils.encounters.getCloseout.fetch({
+              appointmentId,
+            });
+            setConflictRevision(latest.closeout?.revision ?? 0);
+          } catch {
+            setConflictRevision(null);
+          }
+          setDraftSaveState("conflict");
+          toast.error(
+            "Closeout changed in another session. Your local work is still here.",
+          );
+        } else {
+          setDraftSaveState("error");
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Clinical closeout draft could not be saved",
+          );
+        }
+        return null;
+      } finally {
+        if (savePromiseRef.current === request) savePromiseRef.current = null;
+      }
+    }
+  }, [appointmentId, canDraftClinical, clinicalLocked, utils.encounters.getCloseout]);
+
+  const closeoutNeedsLeaveGuard = useCallback(() => {
+    if (!draftInitializedRef.current || clinicalLocked) return false;
+    return (
+      conflictRef.current ||
+      savePromiseRef.current !== null ||
+      clinicalDraftFingerprint(fieldsRef.current) !==
+        lastSavedFingerprintRef.current
+    );
+  }, [clinicalLocked]);
+
+  useEffect(() => {
+    if (!draftInitializedRef.current || clinicalLocked || conflictRef.current) {
+      return;
+    }
+    const fingerprint = clinicalDraftFingerprint(fieldsRef.current);
+    if (fingerprint === lastSavedFingerprintRef.current) return;
+    setDraftSaveState("unsaved");
+    if (!isOnline) return;
+    const timer = window.setTimeout(
+      () => void persistCloseoutDraft(),
+      1_200,
+    );
+    autosaveTimerRef.current = timer;
+    return () => {
+      window.clearTimeout(timer);
+      if (autosaveTimerRef.current === timer) autosaveTimerRef.current = null;
+    };
+  }, [
+    clinicalLocked,
+    diagnosisSummary,
+    dischargeInstructions,
+    documentationExceptionReason,
+    followUpAppointmentId,
+    followUpAssignedTo,
+    followUpDisposition,
+    followUpDueDate,
+    followUpNotes,
+    isOnline,
+    noInstructionsReason,
+    persistCloseoutDraft,
+    prescriptionDisposition,
+    warningSigns,
+  ]);
+
+  useEffect(() => {
+    if (!isOnline || conflictRef.current || !closeoutNeedsLeaveGuard()) return;
+    void persistCloseoutDraft();
+  }, [closeoutNeedsLeaveGuard, isOnline, persistCloseoutDraft]);
+
+  useUnsavedChangesGuard(
+    closeoutNeedsLeaveGuard(),
+    "This closeout has changes that are not saved on the server. Leave and lose those changes?",
+  );
+
+  async function finalizeClinicalHandoff() {
+    if (autosaveTimerRef.current !== null) {
+      window.clearTimeout(autosaveTimerRef.current);
+      autosaveTimerRef.current = null;
+    }
+    const saved = await persistCloseoutDraft();
+    if (!saved || conflictRef.current || !window.navigator.onLine) return;
+    const fields = { ...fieldsRef.current };
+    finalizeClinical.mutate({
+      appointmentId,
+      expectedRevision: revisionRef.current,
+      diagnosisSummary: fields.diagnosisSummary || null,
+      dischargeInstructions: fields.dischargeInstructions || null,
+      warningSigns: fields.warningSigns || null,
+      noInstructionsReason: fields.noInstructionsReason || null,
+      prescriptionDisposition: fields.prescriptionDisposition || null,
+      followUpDisposition: fields.followUpDisposition || null,
+      followUpNotes: fields.followUpNotes || null,
+      followUpAppointmentId: fields.followUpAppointmentId || null,
+      followUpDueDate: fields.followUpDueDate || null,
+      followUpAssignedTo: fields.followUpAssignedTo || null,
+      documentationExceptionReason:
+        fields.documentationExceptionReason || null,
+    });
+  }
+
+  const fieldsFromPayload = (
+    payload: NonNullable<CloseoutQueryState["data"]>,
+  ): ClinicalDraftFields => {
+    const source = payload.closeout?.amendmentDraft ?? payload.closeout;
+    return {
+      diagnosisSummary: source?.diagnosisSummary ?? "",
+      dischargeInstructions: source?.dischargeInstructions ?? "",
+      warningSigns: source?.warningSigns ?? "",
+      noInstructionsReason: source?.noInstructionsReason ?? "",
+      prescriptionDisposition: source?.prescriptionDisposition ?? "",
+      followUpDisposition: source?.followUpDisposition ?? "",
+      followUpNotes: source?.followUpNotes ?? "",
+      followUpAppointmentId: source?.followUpAppointmentId ?? "",
+      followUpDueDate: source?.followUpDueDate ?? "",
+      followUpAssignedTo: source?.followUpAssignedTo ?? "",
+      documentationExceptionReason:
+        source?.documentationExceptionReason ?? "",
+    };
+  };
+
+  async function useServerCloseoutDraft() {
+    try {
+      const latest = await utils.encounters.getCloseout.fetch({ appointmentId });
+      const serverFields = fieldsFromPayload(latest);
+      applyClinicalFields(serverFields);
+      revisionRef.current = latest.closeout?.revision ?? 0;
+      lastSavedFingerprintRef.current = clinicalDraftFingerprint(serverFields);
+      setLastDraftSavedAt(latest.closeout?.updatedAt ?? null);
+      conflictRef.current = false;
+      setConflictRevision(null);
+      setDraftSaveState(latest.closeout ? "saved" : "idle");
+      await utils.encounters.getCloseout.invalidate({ appointmentId });
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "The server closeout could not be loaded",
+      );
+    }
+  }
+
+  async function overwriteServerCloseoutDraft() {
+    if (!window.navigator.onLine) {
+      toast.error("Reconnect before replacing the server closeout draft");
+      return;
+    }
+    try {
+      const latest = await utils.encounters.getCloseout.fetch({ appointmentId });
+      const serverFields = fieldsFromPayload(latest);
+      revisionRef.current = latest.closeout?.revision ?? conflictRevision ?? 0;
+      lastSavedFingerprintRef.current = clinicalDraftFingerprint(serverFields);
+      conflictRef.current = false;
+      setConflictRevision(null);
+      setDraftSaveState("unsaved");
+      await persistCloseoutDraft();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "The local closeout could not replace the server draft",
+      );
+    }
+  }
   const clientName = [appointment.clientFirstName, appointment.clientLastName]
     .filter(Boolean)
     .join(" ");
@@ -1208,11 +1555,16 @@ function VisitCloseout({
               followUpAssignees={data.followUpAssignees}
               timeZone={data.practice.timezone}
               isAmendment={amendingClinical}
+              saveState={draftSaveState}
+              lastSavedAt={lastDraftSavedAt}
+              isOnline={isOnline}
               isSaving={saveDraft.isPending || finalizeClinical.isPending}
               isFinalizing={finalizeClinical.isPending}
               canFinalize={canFinalizeClinical}
-              onSave={() => saveDraft.mutate(clinicalInput)}
-              onFinalize={() => finalizeClinical.mutate(clinicalInput)}
+              onSave={() => void persistCloseoutDraft()}
+              onUseServer={() => void useServerCloseoutDraft()}
+              onOverwrite={() => void overwriteServerCloseoutDraft()}
+              onFinalize={() => void finalizeClinicalHandoff()}
             />
           ) : (
             <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
@@ -1614,10 +1966,15 @@ type ClinicalCloseoutFormProps = {
   }>;
   timeZone?: string | null;
   isAmendment: boolean;
+  saveState: "idle" | "unsaved" | "saving" | "saved" | "error" | "conflict";
+  lastSavedAt: Date | null;
+  isOnline: boolean;
   isSaving: boolean;
   isFinalizing: boolean;
   canFinalize: boolean;
   onSave: () => void;
+  onUseServer: () => void;
+  onOverwrite: () => void;
   onFinalize: () => void;
 };
 
@@ -1653,7 +2010,31 @@ function ClinicalCloseoutForm(props: ClinicalCloseoutFormProps) {
       : null,
   ].filter((issue): issue is string => Boolean(issue));
   const canFinalizeNow =
-    props.canFinalize && finalizationIssues.length === 0 && !props.isSaving;
+    props.canFinalize &&
+    props.isOnline &&
+    props.saveState !== "conflict" &&
+    finalizationIssues.length === 0 &&
+    !props.isSaving;
+  const saveStatus = !props.isOnline
+    ? "Offline — changes are only on this device until you reconnect."
+    : props.saveState === "saving"
+      ? "Saving closeout draft to the server..."
+      : props.saveState === "saved"
+        ? `Saved to the server${
+            props.lastSavedAt
+              ? ` at ${props.lastSavedAt.toLocaleTimeString([], {
+                  hour: "numeric",
+                  minute: "2-digit",
+                })}`
+              : ""
+          }.`
+        : props.saveState === "error"
+          ? "Draft save failed. Your changes remain on this device; retry before leaving."
+          : props.saveState === "conflict"
+            ? "Another session changed this closeout. Your local version remains visible."
+            : props.saveState === "unsaved"
+              ? "Changes have not reached the server yet."
+              : "Server draft recovery is ready.";
 
   return (
     <div className="space-y-4 rounded-md border border-border p-4">
@@ -1667,6 +2048,36 @@ function ClinicalCloseoutForm(props: ClinicalCloseoutFormProps) {
             : "Finalized content becomes the durable discharge record and cannot be silently edited."}
         </p>
       </div>
+      <div
+        className={`rounded-md border px-3 py-2 text-xs ${
+          !props.isOnline || props.saveState === "error"
+            ? "border-amber-500/40 bg-amber-500/10 text-amber-950 dark:text-amber-100"
+            : props.saveState === "conflict"
+              ? "border-destructive/40 bg-destructive/10 text-destructive"
+              : "border-border bg-muted/20 text-muted-foreground"
+        }`}
+        role="status"
+        aria-live="polite"
+      >
+        {saveStatus}
+      </div>
+      {props.saveState === "conflict" ? (
+        <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+          <p className="text-sm font-medium">Choose which closeout to keep</p>
+          <p className="text-xs text-muted-foreground">
+            Use the newest server version, or deliberately replace it with the
+            local fields still visible below. Nothing is overwritten silently.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" size="sm" variant="outline" onClick={props.onUseServer}>
+              Use server version
+            </Button>
+            <Button type="button" size="sm" onClick={props.onOverwrite}>
+              Overwrite with local version
+            </Button>
+          </div>
+        </div>
+      ) : null}
       <div>
         <label className="text-sm font-medium" htmlFor="closeout-diagnosis">
           Diagnosis or visit summary{" "}
@@ -1951,7 +2362,9 @@ function ClinicalCloseoutForm(props: ClinicalCloseoutFormProps) {
       <div className="flex flex-wrap justify-end gap-2">
         <Button
           variant="outline"
-          disabled={props.isSaving}
+          disabled={
+            props.isSaving || !props.isOnline || props.saveState === "conflict"
+          }
           onClick={props.onSave}
         >
           <Save className="mr-2 h-4 w-4" />
@@ -2782,10 +3195,14 @@ function ChargeCapture({
   }>;
 }) {
   const utils = trpc.useUtils();
+  const isOnline = useOnlineStatus();
   const [selectedCatalogId, setSelectedCatalogId] = useState("");
   const [quantity, setQuantity] = useState(1);
   const [items, setItems] = useState<ChargeItem[]>([]);
   const [loadedInvoiceId, setLoadedInvoiceId] = useState<string | null>(null);
+  const lastSavedItemsFingerprintRef = useRef(
+    chargeItemsFingerprint([]),
+  );
   const configQuery = trpc.billing.getTaxConfig.useQuery(undefined, {
     staleTime: 5 * 60 * 1000,
   });
@@ -2822,6 +3239,7 @@ function ChargeCapture({
     if (!activeInvoice) {
       if (loadedInvoiceId) {
         setItems([]);
+        lastSavedItemsFingerprintRef.current = chargeItemsFingerprint([]);
         setLoadedInvoiceId(null);
       }
       return;
@@ -2831,8 +3249,7 @@ function ChargeCapture({
       invoiceDetailQuery.data?.id === activeInvoice.id &&
       loadedInvoiceId !== activeInvoice.id
     ) {
-      setItems(
-        invoiceDetailQuery.data.items.map((item) => ({
+      const loadedItems = invoiceDetailQuery.data.items.map((item) => ({
           key: item.id,
           description: item.description,
           quantity: item.quantity,
@@ -2842,8 +3259,10 @@ function ChargeCapture({
           taxable: item.taxable,
           sourcePrescriptionId: item.sourcePrescriptionId ?? undefined,
           sourceDispenseChargeId: item.sourceDispenseChargeId ?? undefined,
-        })),
-      );
+        }));
+      setItems(loadedItems);
+      lastSavedItemsFingerprintRef.current =
+        chargeItemsFingerprint(loadedItems);
       setLoadedInvoiceId(activeInvoice.id);
     }
   }, [
@@ -2947,6 +3366,7 @@ function ChargeCapture({
     items.length < BILLING_INVOICE_MAX_ITEMS;
   const canSubmit =
     Boolean(clientId && patientId) &&
+    isOnline &&
     items.length > 0 &&
     items.every((item) =>
       isBillingInvoiceLineTotalValid(item.unitPrice, item.quantity),
@@ -2962,6 +3382,7 @@ function ChargeCapture({
     onSuccess: () => {
       toast.success("Visit charges saved as a draft invoice");
       setItems([]);
+      lastSavedItemsFingerprintRef.current = chargeItemsFingerprint([]);
       setSelectedCatalogId("");
       setQuantity(1);
       utils.billing.listInvoices.invalidate({
@@ -2976,6 +3397,7 @@ function ChargeCapture({
   const updateInvoiceItems = trpc.billing.updateInvoiceItems.useMutation({
     onSuccess: () => {
       toast.success("Visit invoice charges updated");
+      lastSavedItemsFingerprintRef.current = chargeItemsFingerprint(items);
       utils.billing.listInvoices.invalidate({
         appointmentId,
         limit: 25,
@@ -2989,6 +3411,12 @@ function ChargeCapture({
     onError: (error) => toast.error(error.message),
   });
   const isSaving = createInvoice.isPending || updateInvoiceItems.isPending;
+  const hasUnsavedCharges =
+    chargeItemsFingerprint(items) !== lastSavedItemsFingerprintRef.current;
+  useUnsavedChangesGuard(
+    hasUnsavedCharges,
+    "Visit charges have not been saved on the server. Leave and lose these changes?",
+  );
 
   function addSelectedItem() {
     if (!selected || !canAdd) return;
@@ -3131,6 +3559,15 @@ function ChargeCapture({
           />
         ) : (
           <div className="flex flex-col gap-4">
+            {!isOnline ? (
+              <div
+                className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-950 dark:text-amber-100"
+                role="status"
+              >
+                Offline — charges stay only in this form. Reconnect before
+                creating or updating the visit invoice.
+              </div>
+            ) : null}
             <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_90px_auto] lg:grid-cols-1 xl:grid-cols-[minmax(0,1fr)_80px_auto]">
               <ServicePicker
                 services={catalog}

--- a/apps/web/app/(dashboard)/patients/page.tsx
+++ b/apps/web/app/(dashboard)/patients/page.tsx
@@ -83,25 +83,29 @@ export default function PatientsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="font-heading text-xl font-semibold">Patients</h2>
           <p className="text-sm text-muted-foreground">
             Manage patient records
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
           {canReviewDuplicates ? (
             <Button
               variant="outline"
               onClick={() => router.push("/patients/duplicates")}
+              className="h-11 w-full sm:h-10 sm:w-auto"
             >
               <GitMerge className="mr-2 h-4 w-4" />
               Review duplicates
             </Button>
           ) : null}
           {canManagePatients && (
-            <Button onClick={() => router.push("/patients/new")}>
+            <Button
+              onClick={() => router.push("/patients/new")}
+              className="h-11 w-full sm:h-10 sm:w-auto"
+            >
               <Plus className="mr-2 h-4 w-4" />
               New Patient
             </Button>
@@ -109,21 +113,21 @@ export default function PatientsPage() {
         </div>
       </div>
 
-      <div className="mt-6 flex items-center gap-4">
-        <div className="relative flex-1 max-w-sm">
+      <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <div className="relative w-full min-w-0 sm:max-w-sm sm:flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search patients..."
             value={search}
             maxLength={PATIENT_SEARCH_MAX_LENGTH}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-9"
+            className="h-11 pl-9 sm:h-10"
           />
         </div>
         <select
           value={species}
           onChange={(e) => setSpecies(e.target.value as SpeciesFilter)}
-          className="h-10 rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="h-11 w-full rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-10 sm:w-auto"
         >
           {speciesOptions.map((opt) => (
             <option key={opt.value} value={opt.value}>
@@ -132,7 +136,7 @@ export default function PatientsPage() {
           ))}
         </select>
         {data && (
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-muted-foreground sm:shrink-0">
             {data.total} patient{data.total !== 1 ? "s" : ""}
           </p>
         )}
@@ -145,7 +149,58 @@ export default function PatientsPage() {
       ) : isLoading ? (
         <TableSkeleton rows={8} cols={5} />
       ) : data && data.items.length > 0 ? (
-        <div className="mt-6 overflow-x-auto rounded-lg border border-border">
+        <>
+          <div className="mt-6 space-y-3 sm:hidden">
+            {data.items.map((patient) => {
+              const ownerName =
+                patient.clientFirstName && patient.clientLastName
+                  ? `${patient.clientFirstName} ${patient.clientLastName}`
+                  : "Owner not listed";
+
+              return (
+                <button
+                  key={patient.id}
+                  type="button"
+                  onClick={() => router.push(`/patients/${patient.id}`)}
+                  aria-label={`Open patient ${patient.name}`}
+                  className="min-h-11 w-full min-w-0 overflow-hidden rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-muted/30 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                >
+                  <span className="flex min-w-0 items-start justify-between gap-3">
+                    <span className="min-w-0 truncate text-sm font-semibold text-foreground">
+                      <span className="mr-1.5" aria-hidden="true">
+                        {speciesEmoji[patient.species ?? "other"] ?? "🐾"}
+                      </span>
+                      {patient.name}
+                    </span>
+                    <span
+                      className={`inline-flex shrink-0 items-center rounded-full px-2 py-1 text-xs font-medium ${
+                        patient.status === "active"
+                          ? "bg-emerald-100 text-emerald-700"
+                          : patient.status === "deceased"
+                            ? "bg-gray-100 text-gray-600"
+                            : "bg-amber-100 text-amber-700"
+                      }`}
+                    >
+                      {patient.status ?? "active"}
+                    </span>
+                  </span>
+                  <span className="mt-2 block min-w-0 space-y-1 text-sm text-muted-foreground">
+                    <span className="block truncate">
+                      {[patient.breed, patient.species]
+                        .filter(Boolean)
+                        .join(" · ") || "Breed and species not listed"}
+                    </span>
+                    <span className="block truncate">Owner: {ownerName}</span>
+                    <span className="block text-xs">
+                      Sex: {formatSex(patient.sex)}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="mt-6 hidden overflow-x-auto rounded-lg border border-border sm:block">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border bg-muted/50">
@@ -207,7 +262,8 @@ export default function PatientsPage() {
               ))}
             </tbody>
           </table>
-        </div>
+          </div>
+        </>
       ) : (
         <EmptyState
           className="mt-6"

--- a/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
+++ b/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
@@ -14,6 +14,7 @@ import {
   Save,
   ShieldAlert,
   Sparkles,
+  WifiOff,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
@@ -37,6 +38,7 @@ import {
   runSoapSafeLeave,
   soapEditorNeedsLeaveGuard,
 } from "@/lib/records/soap-navigation";
+import { useOnlineStatus } from "@/lib/use-online-status";
 
 const SoapNoteEditor = dynamic(
   () =>
@@ -75,6 +77,15 @@ type SoapEditorSections = {
   assessment: string;
   plan: string;
 };
+
+type SoapDraftSaveState =
+  | "idle"
+  | "offline"
+  | "unsaved"
+  | "saving"
+  | "saved"
+  | "error"
+  | "conflict";
 
 function soapDraftFingerprint(sections: SoapEditorSections): string {
   return JSON.stringify({
@@ -170,9 +181,11 @@ export default function NewSoapNotePage() {
   const discardMutation = trpc.records.discardSoapDraft.useMutation();
   const [draftInitialized, setDraftInitialized] = useState(false);
   const draftInitializedRef = useRef(false);
-  const [saveState, setSaveState] = useState<
-    "idle" | "unsaved" | "saving" | "saved" | "error" | "conflict"
-  >("idle");
+  const [saveState, setSaveState] = useState<SoapDraftSaveState>("idle");
+  const isOnline = useOnlineStatus();
+  const onlineStatusRef = useRef(isOnline);
+  onlineStatusRef.current = isOnline;
+  const wasOnlineRef = useRef(isOnline);
   const [finalizedElsewhere, setFinalizedElsewhere] = useState(false);
   const [localTextCopied, setLocalTextCopied] = useState(false);
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
@@ -247,9 +260,18 @@ export default function NewSoapNotePage() {
     )
       return null;
 
+    if (!onlineStatusRef.current) {
+      setSaveState("offline");
+      return null;
+    }
+
     while (true) {
       if (finalizedElsewhereRef.current) return null;
       if (conflictRef.current) return null;
+      if (!onlineStatusRef.current) {
+        setSaveState("offline");
+        return null;
+      }
       if (savePromiseRef.current) {
         await savePromiseRef.current.catch(() => null);
         continue;
@@ -291,12 +313,16 @@ export default function NewSoapNotePage() {
         setLastSavedAt(result.draft.updatedAt);
         setSaveState("saved");
       } catch (error) {
-        setSaveState("error");
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "SOAP draft could not be saved",
-        );
+        if (!onlineStatusRef.current) {
+          setSaveState("offline");
+        } else {
+          setSaveState("error");
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "SOAP draft could not be saved",
+          );
+        }
         return null;
       } finally {
         if (savePromiseRef.current === request) savePromiseRef.current = null;
@@ -305,14 +331,42 @@ export default function NewSoapNotePage() {
   }, [appointmentId, draftInitialized, params.patientId]);
 
   useEffect(() => {
+    const wasOnline = wasOnlineRef.current;
+    wasOnlineRef.current = isOnline;
     if (
-      finalizedElsewhere ||
       !draftInitialized ||
+      finalizedElsewhereRef.current ||
       conflictRef.current
-    )
+    ) {
       return;
+    }
+    if (!isOnline) {
+      setSaveState("offline");
+      return;
+    }
+    if (wasOnline) return;
+
+    const fingerprint = soapDraftFingerprint(sectionsRef.current);
+    if (fingerprint === lastSavedFingerprintRef.current) {
+      setSaveState(draftIdRef.current ? "saved" : "idle");
+      return;
+    }
+
+    // Retry only the in-memory SOAP draft through the existing revision guard.
+    // No clinical content is written to browser persistence while offline.
+    setSaveState("unsaved");
+    void persistDraft();
+  }, [draftInitialized, isOnline, persistDraft]);
+
+  useEffect(() => {
+    if (finalizedElsewhere || !draftInitialized || conflictRef.current) return;
     const fingerprint = soapDraftFingerprint(sectionsRef.current);
     if (fingerprint === lastSavedFingerprintRef.current) return;
+    if (!isOnline) {
+      setSaveState("offline");
+      return;
+    }
+    if (savePromiseRef.current) return;
     setSaveState("unsaved");
     const timer = window.setTimeout(() => void persistDraft(), 1_200);
     return () => window.clearTimeout(timer);
@@ -320,6 +374,7 @@ export default function NewSoapNotePage() {
     assessment,
     draftInitialized,
     finalizedElsewhere,
+    isOnline,
     objective,
     persistDraft,
     plan,
@@ -849,7 +904,7 @@ export default function NewSoapNotePage() {
               variant="outline"
               size="sm"
               onClick={handleDraftWithAi}
-              disabled={!aiConfigured || draftWithAi.isPending}
+              disabled={!isOnline || !aiConfigured || draftWithAi.isPending}
             >
               {draftWithAi.isPending ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -873,7 +928,9 @@ export default function NewSoapNotePage() {
           aria-live="polite"
         >
           <div className="flex items-center gap-2 text-sm">
-            {saveState === "saving" ? (
+            {saveState === "offline" ? (
+              <WifiOff className="h-4 w-4 text-amber-600" />
+            ) : saveState === "saving" ? (
               <Loader2 className="h-4 w-4 animate-spin text-primary" />
             ) : saveState === "saved" ? (
               <CheckCircle2 className="h-4 w-4 text-emerald-600" />
@@ -885,19 +942,21 @@ export default function NewSoapNotePage() {
             <span>
               {saveState === "saving"
                 ? "Saving draft..."
-                : saveState === "saved"
-                  ? `Draft saved${lastSavedAt ? ` at ${lastSavedAt.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : ""}`
-                  : saveState === "error"
-                    ? "Draft could not be saved"
-                    : saveState === "conflict"
-                      ? "A newer draft exists in another session"
-                      : saveState === "unsaved"
-                        ? "Changes not saved yet"
-                        : "Draft will save after you begin typing"}
+                : saveState === "offline"
+                  ? "Offline — autosave is paused"
+                  : saveState === "saved"
+                    ? `Draft saved${lastSavedAt ? ` at ${lastSavedAt.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : ""}`
+                    : saveState === "error"
+                      ? "Draft could not be saved"
+                      : saveState === "conflict"
+                        ? "A newer draft exists in another session"
+                        : saveState === "unsaved"
+                          ? "Changes not saved yet"
+                          : "Draft will save after you begin typing"}
             </span>
           </div>
           <div className="flex gap-2">
-            {(saveState === "error" || saveState === "unsaved") && (
+            {isOnline && (saveState === "error" || saveState === "unsaved") ? (
               <Button
                 type="button"
                 variant="outline"
@@ -906,14 +965,18 @@ export default function NewSoapNotePage() {
               >
                 Retry save
               </Button>
-            )}
+            ) : null}
             {draftIdRef.current ? (
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
                 className="text-destructive hover:text-destructive"
-                disabled={discardMutation.isPending || saveState === "saving"}
+                disabled={
+                  !isOnline ||
+                  discardMutation.isPending ||
+                  saveState === "saving"
+                }
                 onClick={() => void handleDiscardDraft()}
               >
                 {discardMutation.isPending ? "Discarding..." : "Discard draft"}
@@ -921,6 +984,17 @@ export default function NewSoapNotePage() {
             ) : null}
           </div>
         </div>
+
+        {saveState === "offline" ? (
+          <div
+            role="status"
+            className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
+          >
+            Keep this tab open. New SOAP changes remain only in this tab, and
+            OpenVPM will retry the same revision-checked draft automatically
+            when the connection returns.
+          </div>
+        ) : null}
 
         {conflictDraft ? (
           <div
@@ -1074,6 +1148,7 @@ export default function NewSoapNotePage() {
             onClick={() => void handleFinalize()}
             disabled={
               finalizeMutation.isPending ||
+              !isOnline ||
               saveState === "saving" ||
               saveState === "error" ||
               saveState === "conflict" ||

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -24,6 +24,8 @@ import {
 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
+import { useOnlineStatus } from "@/lib/use-online-status";
+import { useUnsavedChangesGuard } from "@/lib/use-unsaved-changes-guard";
 import { formatClinicalDateTime } from "@/lib/records/clinical-dates";
 import { soapSectionText } from "@/lib/records/soap-content";
 import { Button } from "@/components/ui/button";
@@ -599,6 +601,7 @@ function RecordsPageContent() {
   const utils = trpc.useUtils();
   const searchParams = useSearchParams();
   const { data: session } = useSession();
+  const isOnline = useOnlineStatus();
   const linkedPatientId = searchParams.get("patientId") ?? "";
   const linkedAppointmentId = searchParams.get("appointmentId") ?? "";
   const requestedTab = searchParams.get("tab");
@@ -753,6 +756,24 @@ function RecordsPageContent() {
   const recordsPracticePhone = verifiedRecordsSettings
     ? verifiedRecordsSettings.phone
     : undefined;
+  const hasUnsavedRecordForm =
+    (showVaccinationForm &&
+      JSON.stringify(vaccinationForm) !==
+        JSON.stringify(initialVaccinationForm())) ||
+    (showProblemForm &&
+      JSON.stringify(problemForm) !== JSON.stringify(initialProblemForm())) ||
+    (showLabForm &&
+      JSON.stringify(labForm) !== JSON.stringify(initialLabResultForm())) ||
+    (showProcedureForm &&
+      JSON.stringify(procedureForm) !==
+        JSON.stringify(initialProcedureForm())) ||
+    (showPrescriptionForm &&
+      JSON.stringify(prescriptionForm) !==
+        JSON.stringify(initialPrescriptionForm(recordsTimeZone)));
+  useUnsavedChangesGuard(
+    hasUnsavedRecordForm,
+    "This clinical record has not been saved on the server. Leave and lose these values?"
+  );
 
   const {
     data: soapNotes,
@@ -1139,6 +1160,7 @@ function RecordsPageContent() {
   });
   const canSubmitVaccination =
     Boolean(patientId) &&
+    isOnline &&
     visitContextMatchesPatient &&
     isVaccinationRequiredTextInputValid(
       vaccinationForm.vaccineName,
@@ -1156,6 +1178,7 @@ function RecordsPageContent() {
     !createVaccination.isPending;
   const canSubmitProblem =
     Boolean(patientId) &&
+    isOnline &&
     isProblemRequiredTextInputValid(
       problemForm.description,
       PROBLEM_DESCRIPTION_MAX_LENGTH
@@ -1165,6 +1188,7 @@ function RecordsPageContent() {
     !createProblem.isPending;
   const canSubmitLabResult =
     Boolean(patientId) &&
+    isOnline &&
     visitContextMatchesPatient &&
     (!linkedAppointmentId || !replacesLabResultId) &&
     (!replacesLabResultId || Boolean(replacementPatient)) &&
@@ -1184,6 +1208,7 @@ function RecordsPageContent() {
     !createLabResult.isPending;
   const canSubmitProcedure =
     Boolean(patientId) &&
+    isOnline &&
     visitContextMatchesPatient &&
     isProcedureRequiredTextInputValid(
       procedureForm.name,
@@ -1205,6 +1230,7 @@ function RecordsPageContent() {
     !createProcedure.isPending;
   const canSubmitPrescription =
     Boolean(patientId) &&
+    isOnline &&
     visitContextMatchesPatient &&
     isPrescriptionRequiredTextInputValid(
       prescriptionForm.medicationName,
@@ -1262,7 +1288,7 @@ function RecordsPageContent() {
               setSearchQuery(e.target.value);
               if (!e.target.value) setSelectedPatient(null);
             }}
-            className="pl-10"
+            className="h-11 pl-10 sm:h-10"
           />
         </div>
 
@@ -1333,10 +1359,12 @@ function RecordsPageContent() {
 
       {/* Selected Patient Banner */}
       {selectedPatient && (
-        <div className="mt-4 flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3">
-          <div className="text-sm">
-            <span className="font-medium">{selectedPatient.name}</span>
-            <span className="ml-2 text-muted-foreground">
+        <div className="mt-4 flex flex-col items-stretch gap-3 rounded-lg border border-border bg-card px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0 text-sm">
+            <span className="block truncate font-medium sm:inline">
+              {selectedPatient.name}
+            </span>
+            <span className="block truncate text-muted-foreground sm:ml-2 sm:inline">
               {selectedPatient.species
                 ? selectedPatient.species.charAt(0).toUpperCase() +
                   selectedPatient.species.slice(1)
@@ -1344,7 +1372,7 @@ function RecordsPageContent() {
               {selectedPatient.breed ? ` - ${selectedPatient.breed}` : ""}
             </span>
             {selectedPatient.clientFirstName && (
-              <span className="ml-3 text-muted-foreground">
+              <span className="block truncate text-muted-foreground sm:ml-3 sm:inline">
                 Owner: {selectedPatient.clientFirstName}{" "}
                 {selectedPatient.clientLastName}
               </span>
@@ -1354,6 +1382,7 @@ function RecordsPageContent() {
             <Button
               variant="ghost"
               size="sm"
+              className="h-11 w-full sm:h-9 sm:w-auto"
               onClick={() => {
                 setSelectedPatient(null);
                 setSearchQuery("");
@@ -1387,12 +1416,22 @@ function RecordsPageContent() {
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button size="sm" variant="outline" asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-11 flex-1 sm:h-9 sm:flex-none"
+              asChild
+            >
               <Link href={`/encounters/${linkedAppointmentId}`}>
                 Back to visit
               </Link>
             </Button>
-            <Button size="sm" variant="ghost" asChild>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-11 flex-1 sm:h-9 sm:flex-none"
+              asChild
+            >
               <Link
                 href={`/records?patientId=${encodeURIComponent(linkedPatientId)}&tab=${encodeURIComponent(requestedTab ?? "soap")}`}
               >
@@ -1403,19 +1442,30 @@ function RecordsPageContent() {
         </div>
       ) : null}
 
+      {selectedPatient && !isOnline ? (
+        <div
+          className="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-950 dark:text-amber-100"
+          role="status"
+        >
+          Offline — clinical forms stay only on this device. Keep this page
+          open and reconnect before saving a record.
+        </div>
+      ) : null}
+
       {/* Tabs */}
       {selectedPatient && (
         <>
-          <div className="mt-6 border-b border-border">
-            <div className="flex gap-0">
+          <div className="mt-6 max-w-full overflow-x-auto border-b border-border">
+            <div className="flex min-w-max gap-0">
               {visibleTabs.map((tab) => {
                 const Icon = tab.icon;
                 return (
                   <button
                     key={tab.id}
+                    type="button"
                     onClick={() => setActiveTab(tab.id)}
                     className={cn(
-                      "relative flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors",
+                      "relative flex min-h-11 shrink-0 items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors",
                       currentTab === tab.id
                         ? "text-primary"
                         : "text-muted-foreground hover:text-foreground"
@@ -1826,6 +1876,7 @@ function RecordsPageContent() {
                   <div className="mb-4 flex justify-end">
                     <Button
                       size="sm"
+                      className="h-11 w-full sm:h-9 sm:w-auto"
                       variant={showVaccinationForm ? "outline" : "default"}
                       onClick={() => {
                         if (showVaccinationForm) {
@@ -1859,8 +1910,8 @@ function RecordsPageContent() {
                       });
                     }}
                   >
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="col-span-2 sm:col-span-1">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                      <div>
                         <label className="block text-xs font-medium text-muted-foreground mb-1">
                           Vaccine *
                         </label>
@@ -1938,6 +1989,7 @@ function RecordsPageContent() {
                       <Button
                         type="submit"
                         size="sm"
+                        className="h-11 sm:h-9"
                         disabled={!canSubmitVaccination}
                       >
                         {createVaccination.isPending ? "Saving..." : "Save"}
@@ -1946,6 +1998,7 @@ function RecordsPageContent() {
                         type="button"
                         variant="ghost"
                         size="sm"
+                        className="h-11 sm:h-9"
                         onClick={() => {
                           setShowVaccinationForm(false);
                           setVaccinationForm(initialVaccinationForm());
@@ -2093,6 +2146,7 @@ function RecordsPageContent() {
                   <div className="mb-4 flex justify-end">
                     <Button
                       size="sm"
+                      className="h-11 w-full sm:h-9 sm:w-auto"
                       variant={showPrescriptionForm ? "outline" : "default"}
                       onClick={() => {
                         if (showPrescriptionForm) {
@@ -2401,6 +2455,7 @@ function RecordsPageContent() {
                       <Button
                         type="submit"
                         size="sm"
+                        className="h-11 sm:h-9"
                         disabled={!canSubmitPrescription}
                       >
                         {createPrescription.isPending ? (
@@ -2412,6 +2467,7 @@ function RecordsPageContent() {
                         type="button"
                         variant="ghost"
                         size="sm"
+                        className="h-11 sm:h-9"
                         onClick={() => {
                           prescriptionOperationId.current = null;
                           setShowPrescriptionForm(false);
@@ -2597,6 +2653,7 @@ function RecordsPageContent() {
                   <div className="mb-4 flex justify-end">
                     <Button
                       size="sm"
+                      className="h-11 w-full sm:h-9 sm:w-auto"
                       variant={showProblemForm ? "outline" : "default"}
                       onClick={() => {
                         if (showProblemForm) {
@@ -2625,8 +2682,8 @@ function RecordsPageContent() {
                       });
                     }}
                   >
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="col-span-2">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                      <div className="sm:col-span-2">
                         <label className="block text-xs font-medium text-muted-foreground mb-1">
                           Problem *
                         </label>
@@ -2692,6 +2749,7 @@ function RecordsPageContent() {
                       <Button
                         type="submit"
                         size="sm"
+                        className="h-11 sm:h-9"
                         disabled={!canSubmitProblem}
                       >
                         {createProblem.isPending ? "Saving..." : "Save"}
@@ -2700,6 +2758,7 @@ function RecordsPageContent() {
                         type="button"
                         variant="ghost"
                         size="sm"
+                        className="h-11 sm:h-9"
                         onClick={() => {
                           setShowProblemForm(false);
                           setProblemForm(initialProblemForm());
@@ -2847,6 +2906,7 @@ function RecordsPageContent() {
                   {canManageLabResults && (
                     <Button
                       size="sm"
+                      className="h-11 w-full sm:h-9 sm:w-auto"
                       onClick={() => {
                         if (showLabForm) setLabForm(initialLabResultForm());
                         setReplacesLabResultId(null);
@@ -2979,8 +3039,8 @@ function RecordsPageContent() {
                         </div>
                       </div>
                     ) : null}
-                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-                      <div className="col-span-2 sm:col-span-1">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                      <div>
                         <label className="block text-xs font-medium text-muted-foreground mb-1">
                           Test Name *
                         </label>
@@ -3121,6 +3181,7 @@ function RecordsPageContent() {
                       <Button
                         type="submit"
                         size="sm"
+                        className="h-11 sm:h-9"
                         disabled={!canSubmitLabResult}
                       >
                         {createLabResult.isPending ? "Saving..." : "Save"}
@@ -3129,6 +3190,7 @@ function RecordsPageContent() {
                         type="button"
                         variant="ghost"
                         size="sm"
+                        className="h-11 sm:h-9"
                         onClick={() => {
                           setShowLabForm(false);
                           setLabForm(initialLabResultForm());
@@ -3466,6 +3528,7 @@ function RecordsPageContent() {
                   <div className="flex justify-end mb-4">
                     <Button
                       size="sm"
+                      className="h-11 w-full sm:h-9 sm:w-auto"
                       onClick={() => {
                         if (showProcedureForm) {
                           setProcedureForm(initialProcedureForm());
@@ -3502,8 +3565,8 @@ function RecordsPageContent() {
                       });
                     }}
                   >
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="col-span-2 sm:col-span-1">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                      <div>
                         <label className="block text-xs font-medium text-muted-foreground mb-1">
                           Name *
                         </label>
@@ -3546,7 +3609,7 @@ function RecordsPageContent() {
                           placeholder="e.g. 45"
                         />
                       </div>
-                      <div className="col-span-2">
+                      <div className="sm:col-span-2">
                         <label className="block text-xs font-medium text-muted-foreground mb-1">
                           Description
                         </label>
@@ -3580,7 +3643,7 @@ function RecordsPageContent() {
                           placeholder="e.g. Isoflurane"
                         />
                       </div>
-                      <div className="col-span-2">
+                      <div className="sm:col-span-2">
                         <label className="block text-xs font-medium text-muted-foreground mb-1">
                           Notes
                         </label>
@@ -3602,6 +3665,7 @@ function RecordsPageContent() {
                       <Button
                         type="submit"
                         size="sm"
+                        className="h-11 sm:h-9"
                         disabled={!canSubmitProcedure}
                       >
                         {createProcedure.isPending ? "Saving..." : "Save"}
@@ -3610,6 +3674,7 @@ function RecordsPageContent() {
                         type="button"
                         variant="ghost"
                         size="sm"
+                        className="h-11 sm:h-9"
                         onClick={() => {
                           setShowProcedureForm(false);
                           setProcedureForm(initialProcedureForm());

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -628,6 +628,149 @@ function DayCalendar({
   );
 }
 
+function PhoneAgenda({
+  appointments,
+  timeZone,
+  view,
+  onAppointmentClick,
+}: {
+  appointments: Appointment[];
+  timeZone?: string | null;
+  view: CalendarView;
+  onAppointmentClick: (appointment: Appointment) => void;
+}) {
+  const appointmentsByDay = new Map<string, Appointment[]>();
+
+  for (const appointment of appointments) {
+    const dateKey = toISODate(new Date(appointment.startTime), timeZone);
+    const dayAppointments = appointmentsByDay.get(dateKey);
+    if (dayAppointments) {
+      dayAppointments.push(appointment);
+    } else {
+      appointmentsByDay.set(dateKey, [appointment]);
+    }
+  }
+
+  const rangeLabel =
+    view === "day" ? "Day" : view === "week" ? "Week" : "Month";
+
+  return (
+    <section
+      aria-label={`${rangeLabel} appointment agenda`}
+      className="mt-4 max-w-full space-y-4 overflow-hidden sm:hidden"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h4 className="text-sm font-semibold">{rangeLabel} agenda</h4>
+        <span className="text-xs text-muted-foreground">
+          {appointments.length} appointment
+          {appointments.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {appointments.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card px-4 py-8 text-center">
+          <Calendar className="mx-auto h-8 w-8 text-muted-foreground/40" />
+          <p className="mt-2 text-sm font-medium">No appointments</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            The selected {view} is clear.
+          </p>
+        </div>
+      ) : (
+        Array.from(appointmentsByDay.entries()).map(
+          ([dateKey, dayAppointments]) => (
+            <div key={dateKey} className="min-w-0 space-y-2">
+              {view !== "day" && (
+                <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {new Date(
+                    dayAppointments[0]!.startTime
+                  ).toLocaleDateString("en-US", {
+                    weekday: "long",
+                    month: "short",
+                    day: "numeric",
+                    timeZone: timeZone ?? undefined,
+                  })}
+                </h5>
+              )}
+              {dayAppointments.map((appointment) => {
+                const start = new Date(appointment.startTime);
+                const end = new Date(appointment.endTime);
+                const patientName =
+                  appointment.patientName || "Unknown Patient";
+                const clientName = [
+                  appointment.clientFirstName,
+                  appointment.clientLastName,
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                const careTeam = appointment.doctorName
+                  ? `Dr. ${appointment.doctorName}`
+                  : "Team";
+                const place = [
+                  appointment.locationName,
+                  appointment.roomName,
+                ]
+                  .filter(Boolean)
+                  .join(" · ");
+
+                return (
+                  <button
+                    key={appointment.id}
+                    type="button"
+                    onClick={() => onAppointmentClick(appointment)}
+                    aria-label={`Open ${patientName} appointment at ${formatTime(start, timeZone)}`}
+                    className="min-h-11 w-full overflow-hidden rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-muted/30 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                    style={{
+                      borderLeftColor: getAppointmentColor(appointment),
+                      borderLeftWidth: 3,
+                    }}
+                  >
+                    <span className="flex min-w-0 items-start justify-between gap-3">
+                      <span className="min-w-0">
+                        <span className="block text-xs font-medium text-muted-foreground">
+                          {formatTime(start, timeZone)}–
+                          {formatTime(end, timeZone)}
+                        </span>
+                        <span className="mt-0.5 block truncate text-sm font-semibold text-foreground">
+                          {patientName}
+                        </span>
+                      </span>
+                      <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-muted px-2 py-1 text-[11px] font-medium text-muted-foreground">
+                        <StatusDot status={appointment.status} />
+                        {appointmentStatusLabel(appointment)}
+                      </span>
+                    </span>
+                    <span className="mt-2 block min-w-0 space-y-1 text-xs text-muted-foreground">
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <User className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">
+                          {clientName || "Client not listed"}
+                          {appointment.patientSpecies
+                            ? ` · ${appointment.patientSpecies}`
+                            : ""}
+                        </span>
+                      </span>
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <Stethoscope className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">
+                          {careTeam}
+                          {place ? ` · ${place}` : ""}
+                        </span>
+                      </span>
+                      <span className="block truncate font-medium text-foreground">
+                        {appointment.typeName || "Appointment"}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )
+        )
+      )}
+    </section>
+  );
+}
+
 function WeekCalendar({
   days,
   appointmentsByDate,
@@ -2568,36 +2711,53 @@ export default function SchedulePage() {
       </div>
 
       {/* Toolbar */}
-      <div className="mt-4 flex flex-wrap items-center gap-3">
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
         {/* Date navigation */}
-        <div className="flex items-center gap-1">
-          <Button variant="outline" size="icon" onClick={goPrev} className="h-9 w-9">
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-          <Button
-            variant={isToday ? "secondary" : "outline"}
-            size="sm"
-            onClick={goToday}
-          >
-            Today
-          </Button>
-          <Button variant="outline" size="icon" onClick={goNext} className="h-9 w-9">
-            <ChevronRight className="h-4 w-4" />
-          </Button>
+        <div className="flex min-w-0 items-center justify-between gap-3 sm:justify-start">
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goPrev}
+              className="h-11 w-11 sm:h-9 sm:w-9"
+              aria-label="Previous date range"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant={isToday ? "secondary" : "outline"}
+              size="sm"
+              onClick={goToday}
+              className="h-11 sm:h-9"
+            >
+              Today
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={goNext}
+              className="h-11 w-11 sm:h-9 sm:w-9"
+              aria-label="Next date range"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <h3 className="min-w-0 truncate text-right text-sm font-medium sm:text-left">
+            {formatToolbarDate(currentDate, view)}
+          </h3>
         </div>
 
-        <h3 className="text-sm font-medium">{formatToolbarDate(currentDate, view)}</h3>
-
-        <div className="ml-auto flex items-center gap-2">
+        <div className="flex w-full min-w-0 flex-wrap items-center gap-2 sm:ml-auto sm:w-auto sm:flex-nowrap">
           {/* View toggle */}
-          <div className="flex rounded-md border border-border">
+          <div className="grid h-11 w-full grid-cols-3 rounded-md border border-border sm:flex sm:h-9 sm:w-auto">
             {viewOptions.map((option, index) => (
               <button
                 key={option.id}
                 type="button"
                 onClick={() => setView(option.id)}
                 className={cn(
-                  "px-3 py-1.5 text-xs font-medium transition-colors",
+                  "min-h-11 px-3 py-1.5 text-xs font-medium transition-colors sm:min-h-0",
                   index > 0 && "border-l border-border",
                   index === 0 && "rounded-l-md",
                   index === viewOptions.length - 1 && "rounded-r-md",
@@ -2613,7 +2773,7 @@ export default function SchedulePage() {
 
           {/* Doctor filter */}
           {scheduleLocations.length > 1 && (
-            <div className="relative">
+            <div className="relative min-w-0 flex-1 sm:flex-none">
               <MapPin className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground pointer-events-none" />
               <select
                 aria-label="Filter schedule by clinic location"
@@ -2622,7 +2782,7 @@ export default function SchedulePage() {
                   setLocationFilter(event.target.value);
                   setSelectedAppointment(null);
                 }}
-                className="h-9 appearance-none rounded-md border border-input bg-background pl-8 pr-8 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                className="h-11 w-full min-w-0 appearance-none rounded-md border border-input bg-background pl-8 pr-8 text-xs focus:outline-none focus:ring-2 focus:ring-ring sm:h-9 sm:w-auto"
               >
                 <option value="all">All Locations</option>
                 {scheduleLocations.map((location) => (
@@ -2634,12 +2794,12 @@ export default function SchedulePage() {
             </div>
           )}
 
-          <div className="relative">
+          <div className="relative min-w-0 flex-1 sm:flex-none">
             <Filter className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <select
               value={doctorFilter}
               onChange={(e) => setDoctorFilter(e.target.value)}
-              className="h-9 appearance-none rounded-md border border-input bg-background pl-8 pr-8 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+              className="h-11 w-full min-w-0 appearance-none rounded-md border border-input bg-background pl-8 pr-8 text-xs focus:outline-none focus:ring-2 focus:ring-ring sm:h-9 sm:w-auto"
             >
               <option value="all">All Doctors</option>
               {doctors?.map((doc) => (
@@ -2654,6 +2814,7 @@ export default function SchedulePage() {
           {canCreateAppointments && (
             <Button
               size="sm"
+              className="h-11 w-full sm:h-9 sm:w-auto"
               disabled={!canUseScheduleInteractions}
               onClick={() => {
                 openBookingForm(currentDate);
@@ -2677,7 +2838,16 @@ export default function SchedulePage() {
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading appointments...
         </div>
-      ) : view === "week" ? (
+      ) : (
+        <>
+          <PhoneAgenda
+            appointments={appointments}
+            timeZone={calendarTimeZone}
+            view={view}
+            onAppointmentClick={setSelectedAppointment}
+          />
+          <div className="hidden sm:block">
+          {view === "week" ? (
         appointments.length > 0 ? (
           <WeekCalendar
             days={weekDays}
@@ -2770,6 +2940,9 @@ export default function SchedulePage() {
           }
           onAppointmentClick={setSelectedAppointment}
         />
+          )}
+          </div>
+        </>
       )}
       </div>
 

--- a/apps/web/components/records/encounter-vitals-card.tsx
+++ b/apps/web/components/records/encounter-vitals-card.tsx
@@ -45,6 +45,8 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ClinicalCorrectionControl } from "@/components/records/clinical-correction-control";
 import { cn } from "@/lib/utils";
+import { useOnlineStatus } from "@/lib/use-online-status";
+import { useUnsavedChangesGuard } from "@/lib/use-unsaved-changes-guard";
 
 type VitalsFormState = {
   temperatureC: string;
@@ -161,6 +163,7 @@ export function EncounterVitalsCard({
   timeZone?: string | null;
 }) {
   const utils = trpc.useUtils();
+  const isOnline = useOnlineStatus();
   const [form, setForm] = useState<VitalsFormState>(() => ({
     ...EMPTY_VITALS_FORM,
   }));
@@ -200,9 +203,14 @@ export function EncounterVitalsCard({
   const hasContent = Object.values(form).some(
     (value) => value.trim().length > 0,
   );
+  useUnsavedChangesGuard(
+    hasContent,
+    "Vitals have not been recorded on the server. Leave and lose these values?",
+  );
   const vitalsReady = Boolean(vitalsQuery.data) && !vitalsQuery.error;
   const canSubmit =
     canRecord &&
+    isOnline &&
     vitalsReady &&
     hasContent &&
     isVitalsOptionalTemperatureInputValid(form.temperatureC) &&
@@ -257,6 +265,15 @@ export function EncounterVitalsCard({
       <CardContent className="space-y-4">
         {canRecord ? (
           <form onSubmit={submitVitals} className="space-y-3">
+            {!isOnline ? (
+              <div
+                className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-950 dark:text-amber-100"
+                role="status"
+              >
+                Offline — keep this page open. Vitals stay only in this form
+                until you reconnect and record them.
+              </div>
+            ) : null}
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
               <VitalNumberInput
                 label="Temp (C)"

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -203,6 +203,31 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("Take Card");
   });
 
+  it("keeps appointment-linked invoices connected to their visit", () => {
+    expect(source).toContain("detail.data.appointmentId");
+    expect(source).toContain("Back to visit");
+    expect(source).toContain(
+      "`/encounters/${encodeURIComponent(detail.data.appointmentId)}#charge-capture`"
+    );
+  });
+
+  it("stacks payment actions and forms at phone width", () => {
+    expect(source).toContain(
+      'className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"'
+    );
+    expect(source).toContain(
+      'className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-3"'
+    );
+    expect(source.match(/grid grid-cols-1 gap-3 sm:grid-cols-3/g)).toHaveLength(
+      2
+    );
+    expect(
+      source.match(
+        /flex flex-col-reverse gap-2 sm:flex-row sm:items-center/g
+      )
+    ).toHaveLength(2);
+  });
+
   it("offers invoice email only while a balance-bearing invoice is sent or overdue", () => {
     expect(source).toContain(
       '(invoice.status === "sent" ||\n                          invoice.status === "overdue")'

--- a/apps/web/lib/__tests__/consult-companion-ui.test.ts
+++ b/apps/web/lib/__tests__/consult-companion-ui.test.ts
@@ -102,7 +102,7 @@ describe("consult companion UI states", () => {
 
   it("hides the AI draft affordance behind configuration with a gentle note", () => {
     expect(soapPage).toContain("agentStatus.data?.configured ?? false");
-    expect(soapPage).toContain("disabled={!aiConfigured || draftWithAi.isPending}");
+    expect(soapPage).toContain("disabled={!isOnline || !aiConfigured || draftWithAi.isPending}");
     expect(soapPage).toContain(
       "AI is not set up yet. Ask your admin to add an AI key."
     );

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -150,7 +150,7 @@ describe("clinic encounter workspace", () => {
     expect(encounterVitalsSource).toContain(
       "const vitalsReady = Boolean(vitalsQuery.data) && !vitalsQuery.error",
     );
-    expect(encounterVitalsSource).toContain("canRecord &&\n    vitalsReady &&");
+    expect(encounterVitalsSource).toContain("canRecord &&\n    isOnline &&\n    vitalsReady &&");
     expect(encounterVitalsSource).toMatch(
       /recordVitals\.mutate\(\{\s+patientId,\s+appointmentId,/,
     );
@@ -278,5 +278,63 @@ describe("clinic encounter workspace", () => {
     expect(workspaceSource).toContain("No charge");
     expect(workspaceSource).toContain("Void/corrected");
     expect(workspaceSource).toContain("never bills a suggestion automatically");
+  });
+
+  it("autosaves revisioned closeout drafts and preserves local work on conflict", () => {
+    expect(workspaceSource).toContain("persistCloseoutDraft");
+    expect(workspaceSource).toContain("expectedRevision: revisionRef.current");
+    expect(workspaceSource).toContain("clinicalDraftFingerprint");
+    expect(workspaceSource).toContain("const timer = window.setTimeout(");
+    expect(workspaceSource).toContain('setDraftSaveState("conflict")');
+    expect(workspaceSource).toContain("Use server version");
+    expect(workspaceSource).toContain("Overwrite with local version");
+    expect(workspaceSource).toContain("async function finalizeClinicalHandoff()");
+    expect(workspaceSource).toContain("const saved = await persistCloseoutDraft()");
+    expect(workspaceSource).toContain("autosaveTimerRef.current");
+    expect(workspaceSource).toContain(
+      "Offline — changes are only on this device until you reconnect.",
+    );
+  });
+
+  it("guards unsaved vitals and charges without persisting clinical data in the browser", () => {
+    const guardSource = readFileSync("lib/use-unsaved-changes-guard.ts", "utf8");
+    expect(encounterVitalsSource).toContain("useUnsavedChangesGuard(");
+    expect(encounterVitalsSource).toContain("Offline — keep this page open.");
+    expect(workspaceSource).toContain("hasUnsavedCharges");
+    expect(workspaceSource).toContain(
+      "Visit charges have not been saved on the server.",
+    );
+    expect(recordsSource).toContain("const hasUnsavedRecordForm =");
+    expect(recordsSource).toContain(
+      "This clinical record has not been saved on the server.",
+    );
+    expect(recordsSource).toContain(
+      "Offline — clinical forms stay only on this device.",
+    );
+    expect(guardSource).toContain('window.addEventListener("beforeunload"');
+    expect(guardSource).toContain(
+      'document.addEventListener("click", handleDocumentClick, true)',
+    );
+    expect(guardSource).toContain(
+      'window.addEventListener("popstate", handlePopState, true)',
+    );
+    expect(guardSource).toContain("HISTORY_SENTINEL_KEY");
+    expect(guardSource).toContain('pendingPopAction = "restore"');
+    expect(guardSource).toContain('pendingPopAction = "leave"');
+    expect(guardSource).toContain("isSameDocumentHashNavigation(");
+    expect(guardSource).toContain('anchor.hasAttribute("download")');
+    expect(guardSource).not.toContain("window.history.pushState =");
+    for (const forbiddenStorage of [
+      "localStorage",
+      "sessionStorage",
+      "indexedDB",
+      "caches.open",
+      "serviceWorker",
+    ]) {
+      expect(workspaceSource).not.toContain(forbiddenStorage);
+      expect(encounterVitalsSource).not.toContain(forbiddenStorage);
+      expect(recordsSource).not.toContain(forbiddenStorage);
+      expect(guardSource).not.toContain(forbiddenStorage);
+    }
   });
 });

--- a/apps/web/lib/__tests__/mobile-clinic-day-ui.test.ts
+++ b/apps/web/lib/__tests__/mobile-clinic-day-ui.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const readDashboardPage = (name: string) =>
+  readFileSync(`app/(dashboard)/${name}/page.tsx`, "utf8");
+
+describe("mobile clinic-day UI", () => {
+  it("uses a touch-friendly phone agenda while preserving the full schedule at larger viewports", () => {
+    const source = readDashboardPage("schedule");
+
+    expect(source).toContain("function PhoneAgenda({");
+    expect(source).toContain("aria-label={`${rangeLabel} appointment agenda`}");
+    expect(source).toContain(
+      'className="mt-4 max-w-full space-y-4 overflow-hidden sm:hidden"'
+    );
+    expect(source).toContain('className="hidden sm:block"');
+    expect(source).toContain(
+      "aria-label={`Open ${patientName} appointment at ${formatTime(start, timeZone)}`}"
+    );
+    expect(source).toContain(
+      'className="min-h-11 w-full overflow-hidden rounded-lg border border-border bg-card p-3'
+    );
+    expect(source).toContain('className="h-11 w-full sm:h-9 sm:w-auto"');
+    expect(source).toContain(
+      'className="flex w-full min-w-0 flex-wrap items-center gap-2'
+    );
+  });
+
+  it("renders clients as full-width phone cards and keeps the desktop table", () => {
+    const source = readDashboardPage("clients");
+
+    expect(source).toContain('className="mt-6 space-y-3 sm:hidden"');
+    expect(source).toContain("aria-label={`Open client ${fullName}`}");
+    expect(source).toContain(
+      'className="min-h-11 w-full min-w-0 overflow-hidden rounded-lg border'
+    );
+    expect(source).toContain(
+      'className="mt-6 hidden overflow-x-auto rounded-lg border border-border sm:block"'
+    );
+    expect(source).toContain('className="h-11 pl-9 sm:h-10"');
+  });
+
+  it("renders patients as full-width phone cards with owner and status context", () => {
+    const source = readDashboardPage("patients");
+
+    expect(source).toContain('className="mt-6 space-y-3 sm:hidden"');
+    expect(source).toContain("aria-label={`Open patient ${patient.name}`}");
+    expect(source).toContain("Owner: {ownerName}");
+    expect(source).toContain(
+      'className="mt-6 hidden overflow-x-auto rounded-lg border border-border sm:block"'
+    );
+    expect(source).toContain(
+      'className="h-11 w-full rounded-md border border-input'
+    );
+  });
+
+  it("keeps record tabs reachable and clinical forms single-column on phones", () => {
+    const source = readDashboardPage("records");
+
+    expect(source).toContain(
+      'className="mt-6 max-w-full overflow-x-auto border-b border-border"'
+    );
+    expect(source).toContain('className="flex min-w-max gap-0"');
+    expect(source).toContain(
+      '"relative flex min-h-11 shrink-0 items-center gap-2 px-4 py-2.5'
+    );
+    expect(source).toContain(
+      'className="grid grid-cols-1 gap-4 sm:grid-cols-2"'
+    );
+    expect(source).toContain(
+      'className="grid grid-cols-1 gap-4 sm:grid-cols-3"'
+    );
+    expect(source).not.toContain('className="grid grid-cols-2 gap-4"');
+  });
+});

--- a/apps/web/lib/__tests__/online-status.test.ts
+++ b/apps/web/lib/__tests__/online-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  readOnlineStatus,
+  subscribeToOnlineStatus,
+  type OnlineStatusEventTarget,
+} from "../use-online-status";
+
+class TestOnlineStatusTarget implements OnlineStatusEventTarget {
+  private readonly listeners = new Map<"online" | "offline", EventListener>();
+
+  addEventListener(type: "online" | "offline", listener: EventListener): void {
+    this.listeners.set(type, listener);
+  }
+
+  removeEventListener(
+    type: "online" | "offline",
+    listener: EventListener,
+  ): void {
+    if (this.listeners.get(type) === listener) this.listeners.delete(type);
+  }
+
+  emit(type: "online" | "offline"): void {
+    this.listeners.get(type)?.(new Event(type));
+  }
+}
+
+describe("online status signal", () => {
+  it("reports browser connectivity and defaults safely for server rendering", () => {
+    expect(readOnlineStatus({ onLine: true })).toBe(true);
+    expect(readOnlineStatus({ onLine: false })).toBe(false);
+    expect(readOnlineStatus(null)).toBe(true);
+  });
+
+  it("subscribes to both connectivity events and cleans them up", () => {
+    const target = new TestOnlineStatusTarget();
+    const onStoreChange = vi.fn();
+    const unsubscribe = subscribeToOnlineStatus(onStoreChange, target);
+
+    target.emit("offline");
+    target.emit("online");
+    expect(onStoreChange).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    target.emit("offline");
+    target.emit("online");
+    expect(onStoreChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/__tests__/soap-editor-ui.test.ts
+++ b/apps/web/lib/__tests__/soap-editor-ui.test.ts
@@ -98,6 +98,43 @@ describe("SOAP note editor UX", () => {
     expect(source).toContain("normalizeSoapSection(sections.subjective)");
   });
 
+  it("recovers the revision-guarded SOAP draft after reconnect without browser persistence", () => {
+    const source = readFileSync(
+      "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
+      "utf8"
+    );
+    const onlineHook = readFileSync("lib/use-online-status.ts", "utf8");
+
+    expect(source).toContain(
+      'import { useOnlineStatus } from "@/lib/use-online-status"',
+    );
+    expect(source).toContain("const isOnline = useOnlineStatus()");
+    expect(source).toContain('| "offline"');
+    expect(source).toContain('setSaveState("offline")');
+    expect(source).toContain("Offline — autosave is paused");
+    expect(source).toContain(
+      "OpenVPM will retry the same revision-checked draft automatically",
+    );
+    expect(source).toContain("if (wasOnline) return;");
+    expect(source).toContain("void persistDraft()");
+    expect(source).toContain("noteId: draftIdRef.current ?? undefined");
+    expect(source).toContain("expectedRevision: revisionRef.current");
+    expect(source).toContain("conflictRef.current");
+    expect(source).toContain("soapEditorNeedsLeaveGuard({");
+    expect(source).toContain('window.addEventListener("beforeunload"');
+
+    for (const forbiddenStorage of [
+      "localStorage",
+      "sessionStorage",
+      "indexedDB",
+      "caches.open",
+      "serviceWorker",
+    ]) {
+      expect(source).not.toContain(forbiddenStorage);
+      expect(onlineHook).not.toContain(forbiddenStorage);
+    }
+  });
+
   it("offers structured SOAP templates without clobbering drafts by default", () => {
     const source = readFileSync(
       "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
@@ -219,7 +256,7 @@ describe("SOAP note editor UX", () => {
     expect(source).toContain("View signed patient chart");
     expect(source).toContain("if (finalizedElsewhereRef.current) return;");
     expect(source).toContain(
-      "finalizedElsewhere ||\n      !draftInitialized",
+      "finalizedElsewhere || !draftInitialized || conflictRef.current",
     );
     const alreadyFinalized = source.slice(
       source.indexOf('if (result.outcome === "already_finalized")'),

--- a/apps/web/lib/__tests__/unsaved-changes-guard.test.ts
+++ b/apps/web/lib/__tests__/unsaved-changes-guard.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSameDocumentHashNavigation,
+  resolveUnsavedPopEffect,
+  shouldReplaceGuardedHashNavigation,
+} from "../use-unsaved-changes-guard";
+
+describe("unsaved changes history guard", () => {
+  it("uses the same-URL sentinel as the decision point", () => {
+    expect(
+      resolveUnsavedPopEffect({
+        pendingAction: null,
+        guardActive: true,
+        sentinelActive: true,
+        confirmed: false,
+      }),
+    ).toBe("go-forward");
+    expect(
+      resolveUnsavedPopEffect({
+        pendingAction: null,
+        guardActive: true,
+        sentinelActive: true,
+        confirmed: true,
+      }),
+    ).toBe("go-back");
+  });
+
+  it("restores, leaves, and cleans up through explicit follow-up states", () => {
+    expect(
+      resolveUnsavedPopEffect({
+        pendingAction: "restore",
+        guardActive: true,
+        sentinelActive: false,
+        confirmed: false,
+      }),
+    ).toBe("restore-sentinel");
+    expect(
+      resolveUnsavedPopEffect({
+        pendingAction: "leave",
+        guardActive: true,
+        sentinelActive: false,
+        confirmed: false,
+      }),
+    ).toBe("leave-page");
+    expect(
+      resolveUnsavedPopEffect({
+        pendingAction: "cleanup",
+        guardActive: false,
+        sentinelActive: true,
+        confirmed: false,
+      }),
+    ).toBe("cleanup");
+    expect(
+      resolveUnsavedPopEffect({
+        pendingAction: "cleanup",
+        guardActive: true,
+        sentinelActive: true,
+        confirmed: false,
+      }),
+    ).toBe("rearm-sentinel");
+  });
+
+  it("allows ordinary history when no dirty guard is active", () => {
+    expect(
+      resolveUnsavedPopEffect({
+        pendingAction: null,
+        guardActive: false,
+        sentinelActive: false,
+        confirmed: false,
+      }),
+    ).toBe("allow");
+  });
+
+  it("replaces the active sentinel for same-document hashes instead of pushing above it", () => {
+    const current = "https://app.openvpm.com/encounters/visit-1?payment=success";
+    expect(
+      isSameDocumentHashNavigation(
+        "#visit-closeout",
+        current,
+      ),
+    ).toBe(true);
+    expect(
+      isSameDocumentHashNavigation(
+        "https://app.openvpm.com/encounters/visit-2#visit-closeout",
+        current,
+      ),
+    ).toBe(false);
+    expect(
+      isSameDocumentHashNavigation("/billing#invoice", current),
+    ).toBe(false);
+    expect(
+      shouldReplaceGuardedHashNavigation({
+        guardActive: true,
+        sentinelActive: true,
+        targetHref: "#visit-closeout",
+        currentHref: current,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReplaceGuardedHashNavigation({
+        guardActive: true,
+        sentinelActive: false,
+        targetHref: "#visit-closeout",
+        currentHref: current,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReplaceGuardedHashNavigation({
+        guardActive: false,
+        sentinelActive: true,
+        targetHref: "#visit-closeout",
+        currentHref: current,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/use-online-status.ts
+++ b/apps/web/lib/use-online-status.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export interface OnlineStatusEventTarget {
+  addEventListener(type: "online" | "offline", listener: EventListener): void;
+  removeEventListener(
+    type: "online" | "offline",
+    listener: EventListener,
+  ): void;
+}
+
+/**
+ * Subscribe to browser connectivity changes without retaining any application
+ * data. Exported separately so event cleanup can be verified without a DOM.
+ */
+export function subscribeToOnlineStatus(
+  onStoreChange: () => void,
+  target: OnlineStatusEventTarget | null = typeof window === "undefined"
+    ? null
+    : window,
+): () => void {
+  if (!target) return () => undefined;
+
+  const handleStatusChange: EventListener = () => onStoreChange();
+  target.addEventListener("online", handleStatusChange);
+  target.addEventListener("offline", handleStatusChange);
+  return () => {
+    target.removeEventListener("online", handleStatusChange);
+    target.removeEventListener("offline", handleStatusChange);
+  };
+}
+
+export function readOnlineStatus(
+  source: Pick<Navigator, "onLine"> | null = typeof navigator === "undefined"
+    ? null
+    : navigator,
+): boolean {
+  return source?.onLine ?? true;
+}
+
+function readServerOnlineStatus(): boolean {
+  return true;
+}
+
+/** Browser-reported connectivity. This is a signal for safe retry, not proof. */
+export function useOnlineStatus(): boolean {
+  return useSyncExternalStore(
+    subscribeToOnlineStatus,
+    readOnlineStatus,
+    readServerOnlineStatus,
+  );
+}

--- a/apps/web/lib/use-unsaved-changes-guard.ts
+++ b/apps/web/lib/use-unsaved-changes-guard.ts
@@ -1,0 +1,275 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const activeGuards = new Map<symbol, string>();
+const HISTORY_SENTINEL_KEY = "__openvpmUnsavedGuard";
+let listenersAttached = false;
+let originalPushState: History["pushState"] | null = null;
+let sentinelActive = false;
+let bypassBeforeUnload = false;
+let pendingPopAction: "leave" | "restore" | "cleanup" | null = null;
+
+export type UnsavedPopEffect =
+  | "allow"
+  | "cleanup"
+  | "rearm-sentinel"
+  | "restore-sentinel"
+  | "leave-page"
+  | "go-back"
+  | "go-forward";
+
+export function resolveUnsavedPopEffect(input: {
+  pendingAction: "leave" | "restore" | "cleanup" | null;
+  guardActive: boolean;
+  sentinelActive: boolean;
+  confirmed: boolean;
+}): UnsavedPopEffect {
+  if (input.pendingAction === "cleanup") {
+    return input.guardActive ? "rearm-sentinel" : "cleanup";
+  }
+  if (input.pendingAction === "restore") return "restore-sentinel";
+  if (input.pendingAction === "leave") return "leave-page";
+  if (!input.guardActive || !input.sentinelActive) return "allow";
+  return input.confirmed ? "go-back" : "go-forward";
+}
+
+export function isSameDocumentHashNavigation(
+  targetHref: string,
+  currentHref: string,
+): boolean {
+  const target = new URL(targetHref, currentHref);
+  const current = new URL(currentHref);
+  return (
+    Boolean(target.hash) &&
+    target.origin === current.origin &&
+    target.pathname === current.pathname &&
+    target.search === current.search
+  );
+}
+
+export function shouldReplaceGuardedHashNavigation(input: {
+  guardActive: boolean;
+  sentinelActive: boolean;
+  targetHref: string;
+  currentHref: string;
+}): boolean {
+  return (
+    input.guardActive &&
+    input.sentinelActive &&
+    isSameDocumentHashNavigation(input.targetHref, input.currentHref)
+  );
+}
+
+function replaceSentinelHash(targetHref: string) {
+  const oldUrl = window.location.href;
+  const target = new URL(targetHref, oldUrl);
+  const currentState =
+    window.history.state && typeof window.history.state === "object"
+      ? window.history.state
+      : {};
+
+  // Keep the sentinel as the current history entry. A native hash navigation
+  // would push a new entry above it, causing the first confirmed Back to land
+  // on the underlying encounter instead of actually leaving the page.
+  window.history.replaceState(
+    { ...currentState, [HISTORY_SENTINEL_KEY]: true },
+    "",
+    target.href,
+  );
+
+  const rawTargetId = target.hash.slice(1);
+  if (rawTargetId) {
+    const targetId = decodeURIComponent(rawTargetId);
+    const destination =
+      document.getElementById(targetId) ??
+      document.getElementsByName(targetId).item(0);
+    destination?.scrollIntoView();
+  }
+
+  window.dispatchEvent(
+    new HashChangeEvent("hashchange", {
+      oldURL: oldUrl,
+      newURL: target.href,
+    }),
+  );
+}
+
+function activeMessage(): string {
+  return (
+    activeGuards.values().next().value ??
+    "This page has changes that are not saved on the server. Leave and lose those changes?"
+  );
+}
+
+function handleBeforeUnload(event: BeforeUnloadEvent) {
+  if (activeGuards.size === 0 || bypassBeforeUnload) return;
+  event.preventDefault();
+  event.returnValue = "";
+}
+
+function handleDocumentClick(event: MouseEvent) {
+  if (activeGuards.size === 0) return;
+  const target = event.target;
+  const anchor =
+    target instanceof Element
+      ? target.closest<HTMLAnchorElement>("a[href]")
+      : null;
+  if (
+    !anchor ||
+    anchor.target === "_blank" ||
+    anchor.hasAttribute("download") ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return;
+  }
+  if (
+    shouldReplaceGuardedHashNavigation({
+      guardActive: activeGuards.size > 0,
+      sentinelActive,
+      targetHref: anchor.href,
+      currentHref: window.location.href,
+    })
+  ) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    replaceSentinelHash(anchor.href);
+    return;
+  }
+  if (window.confirm(activeMessage())) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    bypassBeforeUnload = true;
+    window.location.assign(anchor.href);
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handlePopState(event: PopStateEvent) {
+  const needsDecision =
+    pendingPopAction === null && activeGuards.size > 0 && sentinelActive;
+  const effect = resolveUnsavedPopEffect({
+    pendingAction: pendingPopAction,
+    guardActive: activeGuards.size > 0,
+    sentinelActive,
+    confirmed: needsDecision ? window.confirm(activeMessage()) : false,
+  });
+  if (effect === "cleanup") {
+    pendingPopAction = null;
+    sentinelActive = false;
+    event.stopImmediatePropagation();
+    removeListeners();
+    return;
+  }
+  if (effect === "rearm-sentinel") {
+    pendingPopAction = null;
+    sentinelActive = false;
+    event.stopImmediatePropagation();
+    pushSentinel();
+    return;
+  }
+  if (effect === "restore-sentinel") {
+    pendingPopAction = null;
+    sentinelActive = true;
+    event.stopImmediatePropagation();
+    return;
+  }
+  if (effect === "leave-page") {
+    pendingPopAction = null;
+    sentinelActive = false;
+    bypassBeforeUnload = true;
+    return;
+  }
+  if (effect === "allow") return;
+
+  // The sentinel duplicates the current Next.js history entry. The first Back
+  // therefore stays on the same URL and gives us a safe decision point before
+  // a second Back can leave the page.
+  sentinelActive = false;
+  event.stopImmediatePropagation();
+  if (effect === "go-back") {
+    pendingPopAction = "leave";
+    window.history.back();
+  } else {
+    pendingPopAction = "restore";
+    window.history.forward();
+  }
+}
+
+function removeListeners() {
+  if (!listenersAttached) return;
+  window.removeEventListener("beforeunload", handleBeforeUnload);
+  window.removeEventListener("popstate", handlePopState, true);
+  document.removeEventListener("click", handleDocumentClick, true);
+  originalPushState = null;
+  bypassBeforeUnload = false;
+  listenersAttached = false;
+}
+
+function pushSentinel() {
+  if (!originalPushState) return;
+  const currentState =
+    window.history.state && typeof window.history.state === "object"
+      ? window.history.state
+      : {};
+  originalPushState.call(
+    window.history,
+    { ...currentState, [HISTORY_SENTINEL_KEY]: true },
+    "",
+    window.location.href,
+  );
+  sentinelActive = true;
+}
+
+function attachListeners() {
+  if (listenersAttached || typeof window === "undefined") return;
+  originalPushState = window.history.pushState;
+  window.addEventListener("beforeunload", handleBeforeUnload);
+  window.addEventListener("popstate", handlePopState, true);
+  document.addEventListener("click", handleDocumentClick, true);
+  listenersAttached = true;
+  pushSentinel();
+}
+
+function detachListenersIfIdle() {
+  if (!listenersAttached || activeGuards.size > 0) return;
+  if (sentinelActive) {
+    pendingPopAction = "cleanup";
+    window.history.back();
+    return;
+  }
+  removeListeners();
+}
+
+/**
+ * Guards browser and anchor navigation while server-unacknowledged form state
+ * exists. Only an in-memory boolean and static warning are tracked; form data
+ * is never copied into browser storage.
+ */
+export function useUnsavedChangesGuard(dirty: boolean, message?: string) {
+  const tokenRef = useRef(Symbol("unsaved-change-guard"));
+
+  useEffect(() => {
+    const token = tokenRef.current;
+    if (!dirty) {
+      activeGuards.delete(token);
+      detachListenersIfIdle();
+      return;
+    }
+    activeGuards.set(
+      token,
+      message ??
+        "This page has changes that are not saved on the server. Leave and lose those changes?",
+    );
+    attachListeners();
+    return () => {
+      activeGuards.delete(token);
+      detachListenersIfIdle();
+    };
+  }, [dirty, message]);
+}

--- a/apps/web/server/__tests__/billing-card-checkout.test.ts
+++ b/apps/web/server/__tests__/billing-card-checkout.test.ts
@@ -60,13 +60,16 @@ const activeHostedPractice = {
   trialEndsAt: null,
 };
 
-function callerWithDb(db: Record<string, unknown>) {
+function callerWithDb(
+  db: Record<string, unknown>,
+  role: "admin" | "front_desk" | "veterinarian" = "front_desk"
+) {
   const session = {
     user: {
       id: USER_ID,
       email: "frontdesk@example.com",
       name: "Front Desk",
-      role: "front_desk",
+      role,
       practiceId: PRACTICE_ID,
     },
   };
@@ -118,6 +121,19 @@ afterEach(() => {
 });
 
 describe("billing card checkout", () => {
+  it("keeps card checkout limited to billing roles", async () => {
+    const { db, select } = createDb([[baseInvoice]]);
+
+    await expect(
+      callerWithDb(db, "veterinarian").createCardPaymentCheckout({
+        invoiceId: INVOICE_ID,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
   it("reports whether card payment checkout is configured", async () => {
     const { db } = createDb([]);
 
@@ -229,6 +245,32 @@ describe("billing card checkout", () => {
         currency: "usd",
         successUrl: `https://app.example.com/billing?payment=success&invoice=${INVOICE_ID}`,
         cancelUrl: `https://app.example.com/billing?payment=cancelled&invoice=${INVOICE_ID}`,
+      })
+    );
+  });
+
+  it("returns appointment-linked checkout to the same visit with payment status", async () => {
+    const visitInvoice = { ...baseInvoice, appointmentId: APPOINTMENT_ID };
+    const { db } = createDb([
+      [visitInvoice],
+      [{ id: APPOINTMENT_ID }],
+      [visitInvoice],
+      [{ status: "completed" }],
+      [],
+    ]);
+
+    await expect(
+      callerWithDb(db).createCardPaymentCheckout({ invoiceId: INVOICE_ID })
+    ).resolves.toEqual({ url: "https://stripe.example/checkout" });
+
+    expect(mocks.createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        successUrl:
+          `https://app.example.com/encounters/${APPOINTMENT_ID}` +
+          `?payment=success&invoice=${INVOICE_ID}#charge-capture`,
+        cancelUrl:
+          `https://app.example.com/encounters/${APPOINTMENT_ID}` +
+          `?payment=cancelled&invoice=${INVOICE_ID}#charge-capture`,
       })
     );
   });

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -160,6 +160,25 @@ function canTransitionInvoiceStatus(current: InvoiceStatus, next: InvoiceStatus)
   return current === next || allowedInvoiceStatusTransitions[current].includes(next);
 }
 
+function invoiceCheckoutReturnUrl({
+  base,
+  invoiceId,
+  appointmentId,
+  payment,
+}: {
+  base: string;
+  invoiceId: string;
+  appointmentId?: string | null;
+  payment: "success" | "cancelled";
+}) {
+  const params = new URLSearchParams({ payment, invoice: invoiceId });
+  if (!appointmentId) {
+    return `${base}/billing?${params.toString()}`;
+  }
+
+  return `${base}/encounters/${encodeURIComponent(appointmentId)}?${params.toString()}#charge-capture`;
+}
+
 type PaymentAccountRow = typeof practicePaymentAccounts.$inferSelect;
 
 const billingAdminProcedure = protectedProcedure.use(requireRole("admin"));
@@ -2418,6 +2437,7 @@ export const billingRouter = createRouter({
           tax: invoices.tax,
           total: invoices.total,
           paidAmount: invoices.paidAmount,
+          appointmentId: invoices.appointmentId,
           dueDate: invoices.dueDate,
           createdAt: invoices.createdAt,
           updatedAt: invoices.updatedAt,
@@ -3782,8 +3802,18 @@ export const billingRouter = createRouter({
         applicationFeeAmount: connectedAccount
           ? stripeConnectApplicationFeeAmount(balanceCents)
           : undefined,
-        successUrl: `${base}/billing?payment=success&invoice=${invoice.id}`,
-        cancelUrl: `${base}/billing?payment=cancelled&invoice=${invoice.id}`,
+        successUrl: invoiceCheckoutReturnUrl({
+          base,
+          invoiceId: invoice.id,
+          appointmentId: invoice.appointmentId,
+          payment: "success",
+        }),
+        cancelUrl: invoiceCheckoutReturnUrl({
+          base,
+          invoiceId: invoice.id,
+          appointmentId: invoice.appointmentId,
+          payment: "cancelled",
+        }),
       });
 
       const checkoutUrl = result?.url;


### PR DESCRIPTION
## Outcome

Makes the core clinic-day workflow usable on phones and iPads in connected environments, while protecting server-unacknowledged clinical work during connectivity loss and navigation.

## What changed

- Adds a mobile schedule agenda and responsive client, patient, records, billing, and clinical forms.
- Adds explicit connectivity and save-state feedback for SOAP notes and encounter closeout.
- Autosaves revision-checked encounter drafts, retries only safe draft writes after reconnect, and serializes finalization behind a successful save.
- Protects dirty SOAP, closeout, vitals, charges, and patient-record forms from accidental navigation without storing PHI in browser storage.
- Keeps append-only vitals, charges, and record creates manual after connectivity errors to prevent duplicate clinical or financial records.
- Returns appointment-linked Stripe Checkout sessions to the originating visit using only validated app origins and server-owned identifiers.
- Adds a direct billing-to-visit return path and phone-safe payment controls.

## Scope boundary

This release supports connected clinic and house-call workflows. It does not claim offline charting or herd/group workflows. Browser-reported offline status is a safety signal, not proof of server reachability.

## Verification

- Full suite: 338 files passed, 2 skipped; 3,478 tests passed, 2 skipped
- Final focused navigation/encounter suite: 21/21 passed
- Web TypeScript: passed
- Production build: passed
- `pnpm audit --prod --audit-level=low`: no known vulnerabilities
- `git diff --check`: passed
- staged gitleaks: no leaks
- independent responsive/billing review: GO
- independent clinical save/navigation review: GO

Authenticated rendered mobile QA was not available locally because no signed-in browser session/local auth database was connected. CI, preview deployment, and public smoke remain required before merge.