### PR TITLE
Preserve clinic-fit funnel attribution

### DIFF
--- a/apps/web/app/clinic-fit/page.tsx
+++ b/apps/web/app/clinic-fit/page.tsx
@@ -11,7 +11,10 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PawMark } from "@/components/brand/paw-mark";
-import { buildCloudSignupUrl } from "@/lib/funnel-analytics";
+import {
+  buildClinicFitDemoUrl,
+  buildClinicFitSignupUrl,
+} from "@/lib/funnel-analytics";
 
 export const metadata: Metadata = {
   title: "Clinic fit and pilot readiness | OpenVPM",
@@ -40,13 +43,31 @@ const NOT_YET = [
   "Automated state or federal regulatory reporting",
 ];
 
-const CLINIC_FIT_SIGNUP_URL = buildCloudSignupUrl({
-  source: "clinic_fit",
-  medium: "product",
-  campaign: "clinic_fit",
-});
+type ClinicFitPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
 
-export default function ClinicFitPage() {
+function toUrlSearchParams(
+  values: Record<string, string | string[] | undefined>,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [name, value] of Object.entries(values)) {
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(name, item);
+    } else if (value !== undefined) {
+      params.set(name, value);
+    }
+  }
+  return params;
+}
+
+export default async function ClinicFitPage({
+  searchParams,
+}: ClinicFitPageProps) {
+  const inboundAttribution = toUrlSearchParams(await searchParams);
+  const clinicFitSignupUrl = buildClinicFitSignupUrl(inboundAttribution);
+  const clinicFitDemoUrl = buildClinicFitDemoUrl(inboundAttribution);
+
   return (
     <div className="min-h-screen bg-slate-50 text-slate-950">
       <header className="border-b border-slate-200 bg-white">
@@ -62,10 +83,10 @@ export default function ClinicFitPage() {
           </Link>
           <div className="flex items-center gap-2">
             <Button variant="ghost" size="sm" asChild>
-              <Link href="https://demo.openvpm.com/login">Open demo</Link>
+              <Link href={clinicFitDemoUrl}>Open demo</Link>
             </Button>
             <Button size="sm" asChild>
-              <Link href={CLINIC_FIT_SIGNUP_URL}>
+              <Link href={clinicFitSignupUrl}>
                 Start free
                 <ArrowRight className="ml-1.5 h-4 w-4" />
               </Link>
@@ -92,15 +113,13 @@ export default function ClinicFitPage() {
             </p>
             <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
               <Button size="lg" asChild>
-                <Link href={CLINIC_FIT_SIGNUP_URL}>
+                <Link href={clinicFitSignupUrl}>
                   Start a 14-day trial
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
               <Button size="lg" variant="outline" asChild>
-                <Link href="https://demo.openvpm.com/login">
-                  Open the live demo
-                </Link>
+                <Link href={clinicFitDemoUrl}>Open the live demo</Link>
               </Button>
             </div>
             <p className="mt-3 text-xs text-slate-500">
@@ -204,7 +223,7 @@ export default function ClinicFitPage() {
               </a>
             </Button>
             <Button variant="outline" asChild>
-              <Link href={CLINIC_FIT_SIGNUP_URL}>Start with sample data</Link>
+              <Link href={clinicFitSignupUrl}>Start with sample data</Link>
             </Button>
           </div>
           <p className="mt-4 text-xs text-slate-500">

--- a/apps/web/lib/__tests__/clinic-fit-ui.test.ts
+++ b/apps/web/lib/__tests__/clinic-fit-ui.test.ts
@@ -15,8 +15,11 @@ describe("public clinic fit guidance", () => {
     expect(page).toContain("Production multi-location rollout");
     expect(page).toContain("Hosted texting");
     expect(page).toContain("Do not attach clinic exports");
-    expect(page).toContain('source: "clinic_fit"');
-    expect(page).toContain('campaign: "clinic_fit"');
+    expect(page).toContain("buildClinicFitSignupUrl");
+    expect(page).toContain("buildClinicFitDemoUrl");
+    expect(page).toContain("await searchParams");
+    expect(page.match(/href={clinicFitSignupUrl}/g)).toHaveLength(3);
+    expect(page.match(/href={clinicFitDemoUrl}/g)).toHaveLength(2);
   });
 
   it("keeps the fit check optional and reachable before signup", () => {

--- a/apps/web/lib/__tests__/funnel-analytics.test.ts
+++ b/apps/web/lib/__tests__/funnel-analytics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { acquisitionFromSearchParams } from "@/lib/acquisition";
 import {
+  buildClinicFitDemoUrl,
+  buildClinicFitSignupUrl,
   buildCloudSignupUrl,
   FUNNEL_EVENTS,
   funnelToolFromPath,
@@ -39,7 +42,7 @@ describe("buildCloudSignupUrl", () => {
       campaign: "demo_login",
     });
     expect(url).toBe(
-      "https://app.openvpm.com/register?intent=cloud&source=demo&utm_source=demo&utm_medium=product&utm_campaign=demo_login"
+      "https://app.openvpm.com/register?intent=cloud&source=demo&utm_source=demo&utm_medium=product&utm_campaign=demo_login",
     );
   });
 
@@ -49,7 +52,7 @@ describe("buildCloudSignupUrl", () => {
     });
     const params = new URLSearchParams(url.slice("/register?".length));
     expect(params.get("funnel_id")).toBe(
-      "123e4567-e89b-42d3-a456-426614174000"
+      "123e4567-e89b-42d3-a456-426614174000",
     );
   });
 
@@ -59,6 +62,83 @@ describe("buildCloudSignupUrl", () => {
       source: "demo",
     });
     expect(url.startsWith("/register?")).toBe(true);
+  });
+});
+
+describe("buildClinicFitSignupUrl", () => {
+  it("preserves validated attribution across clinic fit and registration", () => {
+    const url = buildClinicFitSignupUrl(
+      new URLSearchParams({
+        source: "homepage_pricing",
+        funnel_id: "123E4567-E89B-42D3-A456-426614174000",
+        utm_source: "google",
+        utm_medium: "cpc",
+        utm_campaign: "clinic_launch-2026",
+      }),
+    );
+    const params = new URL(url, "https://app.openvpm.com").searchParams;
+
+    expect(url.startsWith("/register?")).toBe(true);
+    expect(Object.fromEntries(params)).toEqual({
+      intent: "cloud",
+      source: "homepage_pricing",
+      utm_source: "google",
+      utm_medium: "cpc",
+      utm_campaign: "clinic_launch-2026",
+      funnel_id: "123e4567-e89b-42d3-a456-426614174000",
+    });
+    expect(acquisitionFromSearchParams(params)).toEqual({
+      source: "homepage_pricing",
+      medium: "cpc",
+      campaign: "clinic_launch-2026",
+      funnelId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+  });
+
+  it("uses clinic fit as the source fallback and rejects unsafe input", () => {
+    const url = buildClinicFitSignupUrl(
+      new URLSearchParams({
+        source: "doctor@example.com",
+        funnel_id: "not-a-uuid",
+        utm_campaign: "contains spaces",
+        utm_term: "patient-name",
+        email: "doctor@example.com",
+        next: "https://attacker.example",
+        redirect: "/dashboard",
+      }),
+    );
+    const params = new URL(url, "https://app.openvpm.com").searchParams;
+
+    expect(Object.fromEntries(params)).toEqual({
+      intent: "cloud",
+      source: "clinic_fit",
+    });
+    expect(url).not.toContain("doctor");
+    expect(url).not.toContain("attacker");
+    expect(url).not.toContain("patient-name");
+  });
+
+  it("preserves the same safe attribution when clinic fit opens the demo", () => {
+    const url = new URL(
+      buildClinicFitDemoUrl(
+        new URLSearchParams({
+          source: "homepage_pricing",
+          funnel_id: "123E4567-E89B-42D3-A456-426614174000",
+          utm_campaign: "clinic_launch-2026",
+          email: "doctor@example.com",
+          next: "https://attacker.example",
+        }),
+      ),
+    );
+
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://demo.openvpm.com/login",
+    );
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      source: "homepage_pricing",
+      utm_campaign: "clinic_launch-2026",
+      funnel_id: "123e4567-e89b-42d3-a456-426614174000",
+    });
   });
 });
 

--- a/apps/web/lib/funnel-analytics.ts
+++ b/apps/web/lib/funnel-analytics.ts
@@ -53,6 +53,18 @@ const PATH_TOOL_MAP: Array<{ prefix: string; tool: FunnelToolId }> = [
   { prefix: "/", tool: "dashboard" },
 ];
 
+const FUNNEL_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const REGISTRATION_UTM_PARAMS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+] as const;
+
+type SearchParamsReader = {
+  get(name: string): string | null;
+};
+
 export function funnelToolFromPath(pathname: string): FunnelToolId {
   const path = pathname.split("?")[0] || "/";
   for (const { prefix, tool } of PATH_TOOL_MAP) {
@@ -67,8 +79,16 @@ export function funnelToolFromPath(pathname: string): FunnelToolId {
 
 function cleanParam(value: string | null | undefined): string | undefined {
   const trimmed = value?.trim();
-  if (!trimmed || trimmed.length > ACQUISITION_VALUE_MAX_LENGTH) return undefined;
+  if (!trimmed || trimmed.length > ACQUISITION_VALUE_MAX_LENGTH)
+    return undefined;
   return /^[a-zA-Z0-9._:/-]+$/.test(trimmed) ? trimmed : undefined;
+}
+
+function cleanFunnelId(value: string | null | undefined): string | undefined {
+  const visitorId = cleanParam(value);
+  return visitorId && FUNNEL_ID_RE.test(visitorId)
+    ? visitorId.toLowerCase()
+    : undefined;
 }
 
 export type CloudSignupUrlOptions = {
@@ -98,14 +118,9 @@ export function buildCloudSignupUrl(opts: CloudSignupUrlOptions = {}): string {
   params.set("utm_source", source);
   params.set("utm_medium", medium);
   params.set("utm_campaign", campaign);
-  const visitorId = cleanParam(opts.visitorId);
-  if (
-    visitorId &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      visitorId
-    )
-  ) {
-    params.set("funnel_id", visitorId.toLowerCase());
+  const visitorId = cleanFunnelId(opts.visitorId);
+  if (visitorId) {
+    params.set("funnel_id", visitorId);
   }
 
   const path = `/register?${params.toString()}`;
@@ -116,6 +131,47 @@ export function buildCloudSignupUrl(opts: CloudSignupUrlOptions = {}): string {
   } catch {
     return path;
   }
+}
+
+/**
+ * Carry the validated marketing journey through the public clinic-fit page.
+ * Only registration attribution fields are read, so contact data, redirect
+ * targets, and arbitrary query parameters cannot reach the signup URL.
+ */
+export function buildClinicFitSignupUrl(
+  searchParams: SearchParamsReader,
+): string {
+  const params = new URLSearchParams({ intent: "cloud" });
+  for (const [name, value] of clinicFitAttributionParams(searchParams)) {
+    params.set(name, value);
+  }
+  return `/register?${params.toString()}`;
+}
+
+/** Preserve the same safe journey fields when clinic-fit opens the demo. */
+export function buildClinicFitDemoUrl(
+  searchParams: SearchParamsReader,
+): string {
+  const params = clinicFitAttributionParams(searchParams);
+  return `https://demo.openvpm.com/login?${params.toString()}`;
+}
+
+function clinicFitAttributionParams(
+  searchParams: SearchParamsReader,
+): URLSearchParams {
+  const params = new URLSearchParams({
+    source: cleanParam(searchParams.get("source")) ?? "clinic_fit",
+  });
+
+  for (const name of REGISTRATION_UTM_PARAMS) {
+    const value = cleanParam(searchParams.get(name));
+    if (value) params.set(name, value);
+  }
+
+  const funnelId = cleanFunnelId(searchParams.get("funnel_id"));
+  if (funnelId) params.set("funnel_id", funnelId);
+
+  return params;
 }
 
 export function cloudSignupAppOrigin(): string | undefined {


### PR DESCRIPTION
## Summary
- preserve validated `source`, `funnel_id`, and allowlisted UTM fields through clinic-fit into registration
- preserve the same safe journey fields when clinic-fit opens the sample-data demo
- reject contact fields, arbitrary parameters, and redirect targets; use `source=clinic_fit` only as a fallback
- keep the public clinic-fit page server-rendered

## Validation
- 12 focused Vitest checks passed
- web type-check passed
- production build passed (45 static pages)
- Prettier and `git diff --check` passed
- staged gitleaks scan found no leaks
- independent read-only review: GO

This is the attribution prerequisite for the truthful market-readiness release in `openvpm-www`.