### PR TITLE
Operate controlled clinic pilots

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -16,6 +16,7 @@ import { trpc } from "@/lib/trpc";
 import { EmptyState } from "@/components/common/empty-state";
 import { PageLoading } from "@/components/common/loading";
 import { SmsRecoveryConsole } from "@/components/admin/sms-recovery-console";
+import { ClinicPilotConsole } from "@/components/admin/clinic-pilot-console";
 
 const EMPTY_UUID = "00000000-0000-4000-8000-000000000000";
 const MESSAGING_HISTORY_LIMIT = 50;
@@ -292,6 +293,8 @@ export default function AdminPage() {
           );
         })}
       </div>
+
+      <ClinicPilotConsole practices={data.practices} />
 
       {/* SMS operations health */}
       <div className="mt-6 rounded-lg border border-border bg-card p-5">

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(async () => ({ success: true, id: "email_123" })),
   computeActivationFunnel: vi.fn(),
   computeJourneyFunnel: vi.fn(),
+  loadClinicPilotQueue: vi.fn(async () => []),
 }));
 
 vi.mock("@openpims/db/client", () => ({
@@ -40,9 +41,16 @@ vi.mock("@/lib/admin/journey-funnel", () => ({
   computeJourneyFunnel: mocks.computeJourneyFunnel,
 }));
 
+vi.mock("@/lib/admin/clinic-pilots", () => ({
+  loadClinicPilotQueue: mocks.loadClinicPilotQueue,
+}));
+
 const { GET } = await import("./route");
 
-function funnel(days: number, totals: Partial<ActivationFunnel["totals"]> = {}): ActivationFunnel {
+function funnel(
+  days: number,
+  totals: Partial<ActivationFunnel["totals"]> = {},
+): ActivationFunnel {
   return {
     days,
     weeks: [],
@@ -108,6 +116,7 @@ function journey(days: number): JourneyFunnel {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.clearAllMocks();
+  mocks.loadClinicPilotQueue.mockResolvedValue([]);
 });
 
 describe("activation digest cron", () => {
@@ -116,11 +125,11 @@ describe("activation digest cron", () => {
       new Response(JSON.stringify({ error: "Unauthorized" }), {
         status: 401,
         headers: { "content-type": "application/json" },
-      }) as never
+      }) as never,
     );
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/activation-digest")
+      new Request("https://openvpm.test/api/cron/activation-digest"),
     );
 
     expect(response.status).toBe(401);
@@ -133,7 +142,7 @@ describe("activation digest cron", () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "");
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/activation-digest")
+      new Request("https://openvpm.test/api/cron/activation-digest"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -152,19 +161,32 @@ describe("activation digest cron", () => {
   });
 
   it("emails the 7-day and 30-day funnel to every platform admin", async () => {
-    vi.stubEnv(
-      "PLATFORM_ADMIN_EMAILS",
-      "founder@openvpm.com, ops@openvpm.com"
-    );
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "founder@openvpm.com, ops@openvpm.com");
     mocks.computeActivationFunnel.mockImplementation(
-      async (_db: unknown, days: number) => funnel(days)
+      async (_db: unknown, days: number) => funnel(days),
     );
     mocks.computeJourneyFunnel.mockImplementation(
-      async (_db: unknown, days: number) => journey(days)
+      async (_db: unknown, days: number) => journey(days),
     );
+    mocks.loadClinicPilotQueue.mockResolvedValueOnce([
+      {
+        practiceName: "North <Clinic>",
+        stage: "visit_validation",
+        decision: "approved",
+        nextAction: "complete_first_visit",
+        nextReviewAt: new Date("2026-08-11T12:00:00.000Z"),
+        blockerCodes: [],
+        evidence: {
+          firstVisitCompletedAt: new Date("2026-08-10T12:00:00.000Z"),
+          distinctClinicDays: 1,
+          paymentMethodCollectedAt: null,
+          firstPositivePaymentAt: null,
+        },
+      },
+    ] as never);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/activation-digest")
+      new Request("https://openvpm.test/api/cron/activation-digest"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -176,38 +198,51 @@ describe("activation digest cron", () => {
     expect(mocks.computeActivationFunnel).toHaveBeenCalledWith(mocks.db, 30);
     expect(mocks.computeJourneyFunnel).toHaveBeenCalledWith(mocks.db, 7);
     expect(mocks.computeJourneyFunnel).toHaveBeenCalledWith(mocks.db, 30);
+    expect(mocks.loadClinicPilotQueue).toHaveBeenCalledWith(mocks.db);
     expect(mocks.sendEmail).toHaveBeenCalledTimes(2);
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         to: "founder@openvpm.com",
         subject: "OpenVPM trial funnel: 5 signups, 2 activated this week",
         html: expect.stringContaining("Past 30 days"),
-      })
+      }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         html: expect.stringContaining("Payment method"),
-      })
+      }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         html: expect.stringContaining("First visit done"),
-      })
+      }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         html: expect.stringContaining(
-          "its rate is measured from activated clinics"
+          "its rate is measured from activated clinics",
         ),
-      })
+      }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         html: expect.stringContaining("Production journey · past 30 days"),
-      })
+      }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "ops@openvpm.com" })
+      expect.objectContaining({
+        html: expect.stringContaining("Supported clinic cohort"),
+      }),
+    );
+    const html =
+      (
+        mocks.sendEmail.mock.calls as unknown as Array<[{ html: string }]>
+      )[0]?.[0].html ?? "";
+    expect(html).not.toContain("North &lt;Clinic&gt;");
+    expect(html).not.toContain("North <Clinic>");
+    expect(html).toContain("aggregate-only");
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "ops@openvpm.com" }),
     );
     expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
       job: "activation-digest",
@@ -221,10 +256,10 @@ describe("activation digest cron", () => {
   it("counts send failures, alerts ops, and reports a degraded heartbeat", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "founder@openvpm.com");
     mocks.computeActivationFunnel.mockImplementation(
-      async (_db: unknown, days: number) => funnel(days)
+      async (_db: unknown, days: number) => funnel(days),
     );
     mocks.computeJourneyFunnel.mockImplementation(
-      async (_db: unknown, days: number) => journey(days)
+      async (_db: unknown, days: number) => journey(days),
     );
     mocks.sendEmail.mockResolvedValueOnce({
       success: false,
@@ -232,7 +267,7 @@ describe("activation digest cron", () => {
     } as never);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/activation-digest")
+      new Request("https://openvpm.test/api/cron/activation-digest"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -242,7 +277,7 @@ describe("activation digest cron", () => {
     });
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Activation digest had send failures",
-      "1 of 1 digest emails failed to send."
+      "1 of 1 digest emails failed to send.",
     );
     expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
       job: "activation-digest",
@@ -255,11 +290,11 @@ describe("activation digest cron", () => {
   it("never throws when the funnel query fails; it alerts ops instead", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "founder@openvpm.com");
     mocks.computeActivationFunnel.mockRejectedValue(
-      new Error("relation practices does not exist")
+      new Error("relation practices does not exist"),
     );
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/activation-digest")
+      new Request("https://openvpm.test/api/cron/activation-digest"),
     );
 
     expect(response.status).toBe(200);
@@ -270,7 +305,7 @@ describe("activation digest cron", () => {
     expect(mocks.sendEmail).not.toHaveBeenCalled();
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Activation digest cron failed",
-      "relation practices does not exist"
+      "relation practices does not exist",
     );
     expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
       job: "activation-digest",

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -13,6 +13,7 @@ import {
   computeJourneyFunnel,
   type JourneyFunnel,
 } from "@/lib/admin/journey-funnel";
+import { loadClinicPilotQueue } from "@/lib/admin/clinic-pilots";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -38,15 +39,16 @@ export async function GET(request: Request) {
       return NextResponse.json({ recipients: 0, sent: 0, failed: 0 });
     }
 
-    const [week, month, journeyWeek, journeyMonth] = await Promise.all([
+    const [week, month, journeyWeek, journeyMonth, pilots] = await Promise.all([
       computeActivationFunnel(db, 7),
       computeActivationFunnel(db, 30),
       computeJourneyFunnel(db, 7),
       computeJourneyFunnel(db, 30),
+      loadClinicPilotQueue(db),
     ]);
 
     const subject = `OpenVPM trial funnel: ${week.totals.signups} signups, ${week.totals.activated} activated this week`;
-    const html = digestHtml(week, month, journeyWeek, journeyMonth);
+    const html = digestHtml(week, month, journeyWeek, journeyMonth, pilots);
 
     let sent = 0;
     let failed = 0;
@@ -62,7 +64,7 @@ export async function GET(request: Request) {
     if (failed > 0) {
       void alertOps(
         "Activation digest had send failures",
-        `${failed} of ${recipients.length} digest emails failed to send.`
+        `${failed} of ${recipients.length} digest emails failed to send.`,
       );
     }
 
@@ -172,11 +174,27 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
 <p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>`;
 }
 
+type ClinicPilotQueue = Awaited<ReturnType<typeof loadClinicPilotQueue>>;
+
+function pilotSection(pilots: ClinicPilotQueue, now = new Date()): string {
+  const active = pilots.filter(
+    (pilot) => !["completed", "closed"].includes(pilot.stage),
+  );
+  const overdue = active.filter(
+    (pilot) =>
+      pilot.nextReviewAt && pilot.nextReviewAt.getTime() < now.getTime(),
+  );
+  return `<h2 style="margin:24px 0 8px;font-size:16px;color:#111827;">Supported clinic cohort</h2>
+<p style="margin:0 0 8px;color:#6b7280;font-size:13px;line-height:1.5;">${pilots.length} enrolled · ${pilots.filter((pilot) => pilot.decision === "eligible").length} eligible · ${pilots.filter((pilot) => pilot.decision === "approved").length} approved · ${active.length} active · ${pilots.filter((pilot) => pilot.evidence.firstVisitCompletedAt).length} first visit observed · ${pilots.filter((pilot) => pilot.evidence.distinctClinicDays >= 5).length} five clinic days observed · ${pilots.filter((pilot) => pilot.evidence.paymentMethodCollectedAt).length} payment method · ${pilots.filter((pilot) => pilot.evidence.firstPositivePaymentAt).length} first positive payment · ${overdue.length} overdue review(s) · ${pilots.reduce((sum, pilot) => sum + pilot.blockerCodes.length, 0)} open blocker code(s).</p>
+<p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Open Platform Admin for the restricted clinic-level queue. Operator stages do not replace canonical product or payment evidence. This digest is aggregate-only: it contains no clinic names, contact addresses, participant messages, free-form notes, or blocker detail.</p>`;
+}
+
 function digestHtml(
   week: ActivationFunnel,
   month: ActivationFunnel,
   journeyWeek: JourneyFunnel,
-  journeyMonth: JourneyFunnel
+  journeyMonth: JourneyFunnel,
+  pilots: ClinicPilotQueue,
 ): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -201,6 +219,7 @@ function digestHtml(
               ${journeySection("Production journey · past 30 days", journeyMonth)}
               ${funnelSection("Past 7 days", week)}
               ${funnelSection("Past 30 days", month)}
+              ${pilotSection(pilots)}
               <p style="margin:24px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Activated = added a real client and booked a real visit. First visit done = completed the clinical and billing closeout; its rate is measured from activated clinics. Payment method = signed subscription Checkout completion with collection required. First positive payment = signed positive subscription invoice payment. Currently active is current billing state, not a historical milestone. Legacy business-stage rows are excluded; demo data never counts.</p>
             </td>
           </tr>

--- a/apps/web/components/admin/clinic-pilot-console.tsx
+++ b/apps/web/components/admin/clinic-pilot-console.tsx
@@ -1,0 +1,1037 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  FlaskConical,
+} from "lucide-react";
+import { trpc } from "@/lib/trpc";
+
+type PracticeOption = {
+  id: string;
+  name: string;
+  analyticsExcluded: boolean;
+};
+
+const qualificationLabels = {
+  supportedClinicType: "Supported clinic type",
+  supportedJurisdictionConfirmed: "US pilot jurisdiction confirmed",
+  singleLocation: "One-location scope",
+  connectedModeAccepted: "Connected mode accepted",
+  parallelRunAccepted: "Parallel run accepted",
+  championConfirmed: "Clinic champion confirmed",
+  supportedWorkflowConfirmed: "Target workflow supported",
+  noUnsupportedMustHave: "No unsupported must-have",
+} as const;
+
+const readinessLabels = {
+  rolesAndDevicesValidated: "Roles and devices validated",
+  migrationPlanAccepted: "Migration plan accepted",
+  sampleValidationAccepted: "Sample validation accepted",
+  firstVisitScheduled: "First real visit scheduled",
+  exportAndRollbackConfirmed: "Export and rollback confirmed",
+  supportCadenceConfirmed: "Support cadence confirmed",
+} as const;
+
+const blockerLabels = {
+  workflow_fit: "Workflow fit",
+  data_import: "Data import",
+  staff_training: "Staff training",
+  record_accuracy: "Record accuracy",
+  billing: "Billing",
+  payments: "Payments",
+  email: "Email",
+  sms: "SMS",
+  permissions: "Permissions",
+  device_connectivity: "Device/connectivity",
+  backup_export: "Backup/export",
+  support_coverage: "Support coverage",
+} as const;
+
+const stageOptions = [
+  "candidate",
+  "parallel_setup",
+  "visit_validation",
+  "pilot_week",
+  "graduation_review",
+  "completed",
+  "closed",
+] as const;
+const decisionOptions = [
+  "pending",
+  "eligible",
+  "approved",
+  "paused",
+  "not_a_fit",
+  "graduated",
+] as const;
+const nextActionOptions = [
+  "confirm_fit",
+  "schedule_setup",
+  "validate_import",
+  "complete_first_visit",
+  "review_communications",
+  "configure_payment",
+  "review_clinic_week",
+  "resolve_blockers",
+  "decide_graduation",
+  "support_retention",
+  "revisit_fit",
+] as const;
+const reasonOptions = [
+  "initial_review",
+  "clinic_feedback",
+  "product_evidence",
+  "support_review",
+  "blocker_review",
+  "graduation_decision",
+] as const;
+const contactOutcomeOptions = [
+  "replied",
+  "no_reply",
+  "scheduled",
+  "completed",
+  "declined",
+] as const;
+
+type Qualification = Record<keyof typeof qualificationLabels, boolean>;
+type Readiness = Record<keyof typeof readinessLabels, boolean>;
+type Blocker = keyof typeof blockerLabels;
+
+type DraftEvidence = {
+  verifiedAdmin: boolean;
+  activeLocationCount: number;
+  setupComplete: boolean;
+  activatedAt: Date | string | null;
+  firstVisitCompletedAt: Date | string | null;
+  distinctClinicDays: number;
+  paymentMethodCollectedAt: Date | string | null;
+  firstPositivePaymentAt: Date | string | null;
+  hostedFullAccess: boolean;
+  country: string;
+};
+
+type Draft = {
+  practiceId: string;
+  practiceName: string;
+  expectedVersion: number | null;
+  cohortKey: string;
+  workflow: "general_practice" | "house_call";
+  stage: (typeof stageOptions)[number];
+  decision: (typeof decisionOptions)[number];
+  qualificationChecklist: Qualification;
+  readinessChecklist: Readiness;
+  blockerCodes: Blocker[];
+  nextAction: (typeof nextActionOptions)[number];
+  supportCadence: "daily" | "twice_weekly" | "weekly";
+  communicationMode: "email_only" | "email_and_sms";
+  communicationTested: boolean;
+  firstVisitValidated: boolean;
+  clinicUseValidated: boolean;
+  clinicAcceptanceConfirmed: boolean;
+  clinicAcceptanceByUserId: string;
+  verifiedAdmins: Array<{ id: string; name: string; email: string }>;
+  evidence: DraftEvidence | null;
+  smsStatus:
+    | "not_configured"
+    | "pending"
+    | "action_required"
+    | "carrier_approved_sending_off"
+    | "ready";
+  lastContactAt: string;
+  lastContactOutcome: (typeof contactOutcomeOptions)[number] | "";
+  targetStartOn: string;
+  nextReviewAt: string;
+  reason: (typeof reasonOptions)[number];
+};
+
+const stateDefaults: Record<
+  Draft["stage"],
+  { decision: Draft["decision"]; nextAction: Draft["nextAction"] }
+> = {
+  candidate: { decision: "pending", nextAction: "confirm_fit" },
+  parallel_setup: { decision: "eligible", nextAction: "schedule_setup" },
+  visit_validation: {
+    decision: "approved",
+    nextAction: "complete_first_visit",
+  },
+  pilot_week: { decision: "approved", nextAction: "review_clinic_week" },
+  graduation_review: {
+    decision: "approved",
+    nextAction: "decide_graduation",
+  },
+  completed: { decision: "graduated", nextAction: "support_retention" },
+  closed: { decision: "not_a_fit", nextAction: "revisit_fit" },
+};
+
+function validDecisions(draft: Draft): Draft["decision"][] {
+  const primary = stateDefaults[draft.stage].decision;
+  return !["candidate", "completed", "closed"].includes(draft.stage) &&
+    draft.blockerCodes.length > 0
+    ? [primary, "paused"]
+    : [primary];
+}
+
+function validNextActions(draft: Draft): Draft["nextAction"][] {
+  if (["completed", "closed"].includes(draft.stage)) {
+    return [stateDefaults[draft.stage].nextAction];
+  }
+  if (draft.blockerCodes.length > 0) return ["resolve_blockers"];
+  if (draft.decision === "paused") return ["resolve_blockers"];
+  const actions: Record<Draft["stage"], Draft["nextAction"][]> = {
+    candidate: ["confirm_fit"],
+    parallel_setup: ["schedule_setup", "validate_import"],
+    visit_validation: ["complete_first_visit", "review_communications"],
+    pilot_week: [
+      "review_clinic_week",
+      "review_communications",
+      "configure_payment",
+    ],
+    graduation_review: ["decide_graduation", "configure_payment"],
+    completed: ["support_retention"],
+    closed: ["revisit_fit"],
+  };
+  return actions[draft.stage];
+}
+
+function stageRequirements(draft: Draft, stage: Draft["stage"]): string[] {
+  if (stage === "candidate" || stage === "closed") return [];
+  const issues: string[] = [];
+  const evidence = draft.evidence;
+  if (!Object.values(draft.qualificationChecklist).every(Boolean)) {
+    issues.push("complete clinic fit");
+  }
+  if (stage === "parallel_setup") return issues;
+  if (!Object.values(draft.readinessChecklist).every(Boolean)) {
+    issues.push("complete launch readiness");
+  }
+  if (!evidence?.verifiedAdmin) issues.push("verify a clinic admin");
+  if (evidence?.activeLocationCount !== 1) issues.push("scope one location");
+  if (!evidence?.setupComplete) issues.push("complete guided setup");
+  if (evidence?.country !== "US") issues.push("use a US clinic");
+  if (draft.blockerCodes.length > 0) issues.push("resolve blockers");
+  if (stage === "visit_validation") return issues;
+  if (!evidence?.activatedAt) issues.push("record activation");
+  if (!evidence?.firstVisitCompletedAt)
+    issues.push("observe a completed visit");
+  if (!draft.firstVisitValidated) issues.push("validate the real visit");
+  if (!draft.communicationTested) issues.push("test communications");
+  if (
+    draft.communicationMode === "email_and_sms" &&
+    draft.smsStatus !== "ready"
+  ) {
+    issues.push("make SMS operational");
+  }
+  if (stage === "pilot_week") return issues;
+  if ((evidence?.distinctClinicDays ?? 0) < 5) {
+    issues.push("observe five clinic days");
+  }
+  if (!draft.clinicUseValidated) issues.push("validate five real clinic days");
+  if (stage === "graduation_review") return issues;
+  if (!evidence?.paymentMethodCollectedAt)
+    issues.push("collect a payment method");
+  if (!evidence?.hostedFullAccess) issues.push("restore current hosted access");
+  if (!draft.clinicAcceptanceConfirmed || !draft.clinicAcceptanceByUserId) {
+    issues.push("record clinic-admin acceptance");
+  }
+  return issues;
+}
+
+function humanize(value: string) {
+  return value.replaceAll("_", " ");
+}
+
+function cohortKey(now = new Date()) {
+  return `pilot-${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function localDateTime(value: Date | string | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+function defaultReviewAt() {
+  return localDateTime(new Date(Date.now() + 24 * 60 * 60 * 1000));
+}
+
+function maxReviewAt(cadence: Draft["supportCadence"]) {
+  const days = cadence === "daily" ? 1 : cadence === "twice_weekly" ? 4 : 7;
+  return localDateTime(new Date(Date.now() + days * 24 * 60 * 60 * 1000));
+}
+
+function emptyQualification(): Qualification {
+  return Object.fromEntries(
+    Object.keys(qualificationLabels).map((key) => [key, false]),
+  ) as Qualification;
+}
+
+function emptyReadiness(): Readiness {
+  return Object.fromEntries(
+    Object.keys(readinessLabels).map((key) => [key, false]),
+  ) as Readiness;
+}
+
+function newDraft(practice: PracticeOption): Draft {
+  return {
+    practiceId: practice.id,
+    practiceName: practice.name,
+    expectedVersion: null,
+    cohortKey: cohortKey(),
+    workflow: "general_practice",
+    stage: "candidate",
+    decision: "pending",
+    qualificationChecklist: emptyQualification(),
+    readinessChecklist: emptyReadiness(),
+    blockerCodes: [],
+    nextAction: "confirm_fit",
+    supportCadence: "daily",
+    communicationMode: "email_only",
+    communicationTested: false,
+    firstVisitValidated: false,
+    clinicUseValidated: false,
+    clinicAcceptanceConfirmed: false,
+    clinicAcceptanceByUserId: "",
+    verifiedAdmins: [],
+    evidence: null,
+    smsStatus: "not_configured",
+    lastContactAt: "",
+    lastContactOutcome: "",
+    targetStartOn: "",
+    nextReviewAt: defaultReviewAt(),
+    reason: "initial_review",
+  };
+}
+
+function EvidenceItem({ label, done }: { label: string; done: boolean }) {
+  const Icon = done ? CheckCircle2 : Circle;
+  return (
+    <span className={done ? "text-emerald-700" : "text-muted-foreground"}>
+      <Icon className="mr-1 inline h-3.5 w-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+export function ClinicPilotConsole({
+  practices,
+}: {
+  practices: PracticeOption[];
+}) {
+  const utils = trpc.useUtils();
+  const {
+    data: pilots,
+    error,
+    isLoading,
+  } = trpc.admin.clinicPilotQueue.useQuery(undefined, { retry: false });
+  const [candidateId, setCandidateId] = useState("");
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const save = trpc.admin.saveClinicPilot.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.admin.clinicPilotQueue.invalidate(),
+        utils.admin.activationRecovery.invalidate(),
+      ]);
+      setDraft(null);
+    },
+  });
+
+  const enrolledIds = new Set(pilots?.map((pilot) => pilot.practiceId) ?? []);
+  const candidates = practices.filter(
+    (practice) => !practice.analyticsExcluded && !enrolledIds.has(practice.id),
+  );
+  const draftStageIssues = draft ? stageRequirements(draft, draft.stage) : [];
+
+  const editPilot = (pilot: NonNullable<typeof pilots>[number]) => {
+    setDraft({
+      practiceId: pilot.practiceId,
+      practiceName: pilot.practiceName,
+      expectedVersion: pilot.version,
+      cohortKey: pilot.cohortKey,
+      workflow: pilot.workflow,
+      stage: pilot.stage,
+      decision: pilot.decision,
+      qualificationChecklist: pilot.qualificationChecklist,
+      readinessChecklist: pilot.readinessChecklist,
+      blockerCodes: pilot.blockerCodes,
+      nextAction: pilot.nextAction,
+      supportCadence: pilot.supportCadence,
+      communicationMode: pilot.communicationMode,
+      communicationTested: Boolean(pilot.communicationTestedAt),
+      firstVisitValidated: pilot.firstVisitValidationCurrent,
+      clinicUseValidated: pilot.clinicUseValidationCurrent,
+      clinicAcceptanceConfirmed: Boolean(pilot.clinicAcceptanceAt),
+      clinicAcceptanceByUserId: pilot.clinicAcceptanceByUserId ?? "",
+      verifiedAdmins: pilot.verifiedAdmins,
+      evidence: pilot.evidence,
+      smsStatus: pilot.smsStatus,
+      lastContactAt: localDateTime(pilot.lastContactAt),
+      lastContactOutcome: pilot.lastContactOutcome ?? "",
+      targetStartOn: pilot.targetStartOn ?? "",
+      nextReviewAt: localDateTime(pilot.nextReviewAt),
+      reason: "support_review",
+    });
+    save.reset();
+  };
+
+  const submit = () => {
+    if (!draft) return;
+    const terminal = draft.stage === "completed" || draft.stage === "closed";
+    save.mutate({
+      practiceId: draft.practiceId,
+      operationId: crypto.randomUUID(),
+      expectedVersion: draft.expectedVersion,
+      cohortKey: draft.cohortKey,
+      workflow: draft.workflow,
+      stage: draft.stage,
+      decision: draft.decision,
+      qualificationChecklist: draft.qualificationChecklist,
+      readinessChecklist: draft.readinessChecklist,
+      blockerCodes: draft.blockerCodes,
+      nextAction: draft.nextAction,
+      supportCadence: draft.supportCadence,
+      communicationMode: draft.communicationMode,
+      communicationTested: draft.communicationTested,
+      firstVisitValidated: draft.firstVisitValidated,
+      clinicUseValidated: draft.clinicUseValidated,
+      clinicAcceptanceConfirmed: draft.clinicAcceptanceConfirmed,
+      clinicAcceptanceByUserId:
+        draft.clinicAcceptanceConfirmed && draft.clinicAcceptanceByUserId
+          ? draft.clinicAcceptanceByUserId
+          : null,
+      lastContactAt: draft.lastContactAt
+        ? new Date(draft.lastContactAt).toISOString()
+        : null,
+      lastContactOutcome: draft.lastContactOutcome || null,
+      targetStartOn: draft.targetStartOn || null,
+      nextReviewAt:
+        terminal || !draft.nextReviewAt
+          ? null
+          : new Date(draft.nextReviewAt).toISOString(),
+      reason: draft.reason,
+    });
+  };
+
+  return (
+    <section className="mt-6 rounded-lg border border-border bg-card p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <FlaskConical className="h-4 w-4" />
+            <span className="text-sm">First supported clinic cohort</span>
+          </div>
+          <p className="mt-2 max-w-3xl text-xs text-muted-foreground">
+            Operator decisions are separate from product evidence. Saving here
+            records an immutable, PHI-free snapshot; it never emails a clinic,
+            enables texting, changes billing, or calls a provider.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <select
+            aria-label="Clinic to review for the pilot"
+            value={candidateId}
+            onChange={(event) => setCandidateId(event.target.value)}
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+          >
+            <option value="">Select a registered clinic…</option>
+            {candidates.map((practice) => (
+              <option key={practice.id} value={practice.id}>
+                {practice.name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            disabled={!candidateId}
+            onClick={() => {
+              const practice = candidates.find(
+                (candidate) => candidate.id === candidateId,
+              );
+              if (practice) {
+                setDraft(newDraft(practice));
+                save.reset();
+              }
+            }}
+            className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            Review for pilot
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="mt-4 text-sm text-destructive">
+          Could not load the pilot cohort: {error.message}
+        </p>
+      ) : isLoading ? (
+        <p className="mt-4 text-sm text-muted-foreground">
+          Loading pilot operations…
+        </p>
+      ) : pilots && pilots.length > 0 ? (
+        <div className="mt-5 grid gap-3">
+          {pilots.map((pilot) => {
+            const overdue =
+              pilot.nextReviewAt &&
+              new Date(pilot.nextReviewAt).getTime() < Date.now() &&
+              !["completed", "closed"].includes(pilot.stage);
+            return (
+              <article
+                key={pilot.id}
+                className={`rounded-md border p-4 ${
+                  overdue ? "border-amber-400 bg-amber-50/40" : "border-border"
+                }`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium">{pilot.practiceName}</p>
+                    <p className="mt-1 text-xs capitalize text-muted-foreground">
+                      {pilot.cohortKey} · {humanize(pilot.workflow)} · operator
+                      stage {humanize(pilot.stage)} · decision{" "}
+                      {humanize(pilot.decision)}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => editPilot(pilot)}
+                    className="rounded border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-muted"
+                  >
+                    Review
+                  </button>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs">
+                  <EvidenceItem
+                    label={`Setup: ${pilot.setupStage}`}
+                    done={pilot.evidence.setupComplete}
+                  />
+                  <EvidenceItem
+                    label="Activated"
+                    done={Boolean(pilot.evidence.activatedAt)}
+                  />
+                  <EvidenceItem
+                    label="First visit"
+                    done={Boolean(pilot.evidence.firstVisitCompletedAt)}
+                  />
+                  <EvidenceItem
+                    label={`${pilot.evidence.distinctClinicDays}/5 clinic days`}
+                    done={pilot.evidence.distinctClinicDays >= 5}
+                  />
+                  <EvidenceItem
+                    label="Payment method"
+                    done={Boolean(pilot.evidence.paymentMethodCollectedAt)}
+                  />
+                  <EvidenceItem
+                    label="First positive payment"
+                    done={Boolean(pilot.evidence.firstPositivePaymentAt)}
+                  />
+                  <EvidenceItem
+                    label={`Current access: ${pilot.billingStatus}`}
+                    done={pilot.evidence.hostedFullAccess}
+                  />
+                  <span className="capitalize text-muted-foreground">
+                    SMS: {humanize(pilot.smsStatus)}
+                  </span>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                  <span className="capitalize">
+                    Next: {humanize(pilot.nextAction)}
+                  </span>
+                  <span>
+                    Review:{" "}
+                    {pilot.nextReviewAt
+                      ? new Date(pilot.nextReviewAt).toLocaleString()
+                      : "closed"}
+                  </span>
+                  <span>Blockers: {pilot.blockerCodes.length}</span>
+                  <span>
+                    Audit: {new Date(pilot.lastChangedAt).toLocaleString()} by{" "}
+                    {pilot.lastChangedBy}
+                  </span>
+                  <span>Owner: {pilot.ownerIdentity}</span>
+                </div>
+                {pilot.gateIssues.length > 0 ? (
+                  <div className="mt-3 rounded border border-amber-300/70 bg-amber-50 p-2 text-xs text-amber-900">
+                    <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
+                    {pilot.gateIssues.join(" ")}
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-muted-foreground">
+          No clinic has been enrolled in the controlled cohort. Qualification is
+          intentionally deliberate.
+        </p>
+      )}
+
+      {draft ? (
+        <div className="mt-5 rounded-md border border-primary/30 bg-muted/20 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="font-medium">Pilot review · {draft.practiceName}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Record only operational facts. Never enter client, patient,
+                clinical, payment-card, or credential data here.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setDraft(null)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <label className="text-xs font-medium">
+              Workflow
+              <select
+                value={draft.workflow}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    workflow: event.target.value as Draft["workflow"],
+                  })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm"
+              >
+                <option value="general_practice">General practice</option>
+                <option value="house_call">House call</option>
+              </select>
+            </label>
+            <label className="text-xs font-medium">
+              Stage
+              <select
+                value={draft.stage}
+                onChange={(event) => {
+                  const stage = event.target.value as Draft["stage"];
+                  const state = stateDefaults[stage];
+                  setDraft({
+                    ...draft,
+                    stage,
+                    decision: state.decision,
+                    nextAction: state.nextAction,
+                    nextReviewAt:
+                      stage === "completed" || stage === "closed"
+                        ? ""
+                        : draft.nextReviewAt || defaultReviewAt(),
+                  });
+                }}
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm capitalize"
+              >
+                {stageOptions.map((option) => (
+                  <option
+                    key={option}
+                    value={option}
+                    disabled={stageRequirements(draft, option).length > 0}
+                  >
+                    {humanize(option)}
+                    {stageRequirements(draft, option).length > 0
+                      ? " · gated"
+                      : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-medium">
+              Readiness decision
+              <select
+                value={draft.decision}
+                onChange={(event) => {
+                  const decision = event.target.value as Draft["decision"];
+                  setDraft({
+                    ...draft,
+                    decision,
+                    nextAction:
+                      decision === "paused"
+                        ? "resolve_blockers"
+                        : stateDefaults[draft.stage].nextAction,
+                  });
+                }}
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm capitalize"
+              >
+                {validDecisions(draft).map((option) => (
+                  <option key={option} value={option}>
+                    {humanize(option)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-medium">
+              Support cadence
+              <select
+                value={draft.supportCadence}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    supportCadence: event.target
+                      .value as Draft["supportCadence"],
+                  })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm capitalize"
+              >
+                <option value="daily">Daily</option>
+                <option value="twice_weekly">Twice weekly</option>
+                <option value="weekly">Weekly</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="mt-4 grid gap-4 lg:grid-cols-2">
+            <fieldset className="rounded border border-border p-3">
+              <legend className="px-1 text-xs font-semibold">
+                Clinic fit · all required to qualify
+              </legend>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {Object.entries(qualificationLabels).map(([key, label]) => (
+                  <label key={key} className="flex gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      disabled={
+                        draft.stage === "completed" || draft.stage === "closed"
+                      }
+                      checked={
+                        draft.qualificationChecklist[key as keyof Qualification]
+                      }
+                      onChange={(event) =>
+                        setDraft({
+                          ...draft,
+                          qualificationChecklist: {
+                            ...draft.qualificationChecklist,
+                            [key]: event.target.checked,
+                          },
+                        })
+                      }
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+            <fieldset className="rounded border border-border p-3">
+              <legend className="px-1 text-xs font-semibold">
+                Launch readiness · all required to approve
+              </legend>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {Object.entries(readinessLabels).map(([key, label]) => (
+                  <label key={key} className="flex gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      checked={draft.readinessChecklist[key as keyof Readiness]}
+                      onChange={(event) =>
+                        setDraft({
+                          ...draft,
+                          readinessChecklist: {
+                            ...draft.readinessChecklist,
+                            [key]: event.target.checked,
+                          },
+                        })
+                      }
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+
+          <fieldset className="mt-4 rounded border border-border p-3">
+            <legend className="px-1 text-xs font-semibold">
+              Evidence attestations
+            </legend>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="text-xs font-medium">
+                Client communication path
+                <select
+                  value={draft.communicationMode}
+                  onChange={(event) =>
+                    setDraft({
+                      ...draft,
+                      communicationMode: event.target
+                        .value as Draft["communicationMode"],
+                      communicationTested: false,
+                    })
+                  }
+                  className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm"
+                >
+                  <option value="email_only">Verified email fallback</option>
+                  <option value="email_and_sms">
+                    Email and operational SMS
+                  </option>
+                </select>
+              </label>
+              <div className="grid gap-2 text-xs">
+                <label className="flex gap-2">
+                  <input
+                    type="checkbox"
+                    checked={draft.communicationTested}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        communicationTested: event.target.checked,
+                      })
+                    }
+                  />
+                  Selected communication path was tested successfully
+                </label>
+                <label className="flex gap-2">
+                  <input
+                    type="checkbox"
+                    checked={draft.firstVisitValidated}
+                    disabled={
+                      !draft.expectedVersion ||
+                      !draft.evidence?.firstVisitCompletedAt
+                    }
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        firstVisitValidated: event.target.checked,
+                      })
+                    }
+                  />
+                  Operator confirmed the observed visit was real clinic work
+                </label>
+                <label className="flex gap-2">
+                  <input
+                    type="checkbox"
+                    checked={draft.clinicUseValidated}
+                    disabled={
+                      !draft.expectedVersion ||
+                      (draft.evidence?.distinctClinicDays ?? 0) < 5
+                    }
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        clinicUseValidated: event.target.checked,
+                      })
+                    }
+                  />
+                  Operator reviewed five distinct days as real clinic use
+                </label>
+                <label className="flex gap-2">
+                  <input
+                    type="checkbox"
+                    checked={draft.clinicAcceptanceConfirmed}
+                    disabled={
+                      draft.verifiedAdmins.length === 0 ||
+                      (draft.evidence?.distinctClinicDays ?? 0) < 5 ||
+                      !draft.clinicUseValidated
+                    }
+                    onChange={(event) => {
+                      const confirmed = event.target.checked;
+                      setDraft({
+                        ...draft,
+                        clinicAcceptanceConfirmed: confirmed,
+                        clinicAcceptanceByUserId: confirmed
+                          ? draft.clinicAcceptanceByUserId ||
+                            draft.verifiedAdmins[0]?.id ||
+                            ""
+                          : "",
+                      });
+                    }}
+                  />
+                  Clinic explicitly accepted the golden day and go-live
+                </label>
+              </div>
+              {draft.clinicAcceptanceConfirmed ? (
+                <label className="text-xs font-medium md:col-start-2">
+                  Accepting clinic administrator
+                  <select
+                    value={draft.clinicAcceptanceByUserId}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        clinicAcceptanceByUserId: event.target.value,
+                      })
+                    }
+                    className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm"
+                  >
+                    {draft.verifiedAdmins.map((admin) => (
+                      <option key={admin.id} value={admin.id}>
+                        {admin.name} · {admin.email}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+            </div>
+          </fieldset>
+
+          <fieldset className="mt-4 rounded border border-border p-3">
+            <legend className="px-1 text-xs font-semibold">
+              Open blockers
+            </legend>
+            <div className="flex flex-wrap gap-x-4 gap-y-2">
+              {Object.entries(blockerLabels).map(([key, label]) => {
+                const blocker = key as Blocker;
+                return (
+                  <label key={key} className="flex gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      disabled={
+                        draft.stage === "completed" || draft.stage === "closed"
+                      }
+                      checked={draft.blockerCodes.includes(blocker)}
+                      onChange={(event) => {
+                        const blockerCodes = event.target.checked
+                          ? [...draft.blockerCodes, blocker]
+                          : draft.blockerCodes.filter(
+                              (item) => item !== blocker,
+                            );
+                        setDraft({
+                          ...draft,
+                          blockerCodes,
+                          decision:
+                            blockerCodes.length > 0 &&
+                            draft.stage !== "candidate"
+                              ? "paused"
+                              : blockerCodes.length === 0 &&
+                                  draft.decision === "paused"
+                                ? stateDefaults[draft.stage].decision
+                                : draft.decision,
+                          nextAction:
+                            blockerCodes.length > 0
+                              ? "resolve_blockers"
+                              : stateDefaults[draft.stage].nextAction,
+                        });
+                      }}
+                    />
+                    {label}
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <label className="text-xs font-medium">
+              Next action
+              <select
+                value={draft.nextAction}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    nextAction: event.target.value as Draft["nextAction"],
+                  })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm capitalize"
+              >
+                {validNextActions(draft).map((option) => (
+                  <option key={option} value={option}>
+                    {humanize(option)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-medium">
+              Target start
+              <input
+                type="date"
+                value={draft.targetStartOn}
+                onChange={(event) =>
+                  setDraft({ ...draft, targetStartOn: event.target.value })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm"
+              />
+            </label>
+            <label className="text-xs font-medium">
+              Next review
+              <input
+                type="datetime-local"
+                disabled={
+                  draft.stage === "completed" || draft.stage === "closed"
+                }
+                value={draft.nextReviewAt}
+                min={localDateTime(new Date())}
+                max={maxReviewAt(draft.supportCadence)}
+                onChange={(event) =>
+                  setDraft({ ...draft, nextReviewAt: event.target.value })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm disabled:opacity-50"
+              />
+            </label>
+            <label className="text-xs font-medium">
+              Change reason
+              <select
+                value={draft.reason}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    reason: event.target.value as Draft["reason"],
+                  })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm capitalize"
+              >
+                {reasonOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {humanize(option)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-medium">
+              Last contact
+              <input
+                type="datetime-local"
+                value={draft.lastContactAt}
+                onChange={(event) =>
+                  setDraft({ ...draft, lastContactAt: event.target.value })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm"
+              />
+            </label>
+            <label className="text-xs font-medium">
+              Contact outcome
+              <select
+                value={draft.lastContactOutcome}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    lastContactOutcome: event.target
+                      .value as Draft["lastContactOutcome"],
+                  })
+                }
+                className="mt-1 block w-full rounded border border-input bg-background px-2 py-2 text-sm capitalize"
+              >
+                <option value="">Not recorded</option>
+                {contactOutcomeOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {humanize(option)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          {save.error ? (
+            <p className="mt-4 text-sm text-destructive">
+              Could not save pilot review: {save.error.message}
+            </p>
+          ) : null}
+          {draftStageIssues.length > 0 ? (
+            <p className="mt-4 rounded border border-amber-300/70 bg-amber-50 p-2 text-xs text-amber-900">
+              <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
+              This stage is gated: {draftStageIssues.join(", ")}.
+            </p>
+          ) : null}
+          <div className="mt-4 flex justify-end">
+            <button
+              type="button"
+              disabled={save.isPending || draftStageIssues.length > 0}
+              onClick={submit}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {save.isPending ? "Saving…" : "Save audited review"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/__tests__/clinic-pilot-security.test.ts
+++ b/apps/web/lib/__tests__/clinic-pilot-security.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(
+  "../../packages/db/schema/clinic-pilots.ts",
+  "utf8",
+);
+const rls = readFileSync("../../packages/db/rls/enable-rls.sql", "utf8");
+const migration = readFileSync(
+  "../../packages/db/drizzle/0072_lucky_kate_bishop.sql",
+  "utf8",
+);
+const evidenceBindingMigration = readFileSync(
+  "../../packages/db/drizzle/0073_omniscient_phil_sheldon.sql",
+  "utf8",
+);
+const service = readFileSync("lib/admin/clinic-pilots.ts", "utf8");
+const router = readFileSync("server/routers/admin.ts", "utf8");
+const ui = readFileSync("components/admin/clinic-pilot-console.tsx", "utf8");
+
+describe("clinic pilot operating boundary", () => {
+  it("uses bounded PHI-free state plus immutable snapshots", () => {
+    expect(schema).toContain('"clinic_pilots"');
+    expect(schema).toContain('"clinic_pilot_events"');
+    expect(schema).toContain('payloadHash: varchar("payload_hash"');
+    expect(schema).toContain("qualificationChecklist");
+    expect(schema).toContain("readinessChecklist");
+    expect(schema).toContain("blockerCodes");
+    expect(schema).not.toContain("patientId");
+    expect(schema).not.toContain("clientId");
+    expect(schema).not.toContain("notes:");
+  });
+
+  it("keeps both tables system-only and the event ledger append-only", () => {
+    expect(rls).toContain(
+      "ALTER TABLE clinic_pilots ENABLE ROW LEVEL SECURITY",
+    );
+    expect(rls).toContain(
+      "ALTER TABLE clinic_pilot_events ENABLE ROW LEVEL SECURITY",
+    );
+    expect(rls).toContain("GRANT SELECT, INSERT, UPDATE ON clinic_pilots");
+    expect(rls).toContain("GRANT SELECT, INSERT ON clinic_pilot_events");
+    expect(rls).not.toContain(
+      "GRANT SELECT, INSERT, UPDATE ON clinic_pilot_events",
+    );
+    expect(rls).not.toContain(
+      "GRANT SELECT, INSERT, DELETE ON clinic_pilot_events",
+    );
+    expect(rls).toContain("clinic_pilots_require_event");
+    expect(rls).toContain("clinic_pilot_events_immutable");
+  });
+
+  it("ships the schema as a real migration with lifecycle constraints", () => {
+    expect(migration).toContain('CREATE TABLE "clinic_pilots"');
+    expect(migration).toContain('CREATE TABLE "clinic_pilot_events"');
+    expect(migration).toContain('CONSTRAINT "clinic_pilots_lifecycle_check"');
+    expect(migration).toContain('"payload_hash" varchar(64) NOT NULL');
+    expect(migration).toContain(
+      "ALTER TABLE clinic_pilots ENABLE ROW LEVEL SECURITY",
+    );
+    expect(migration).toContain("clinic_pilots_require_event");
+    expect(evidenceBindingMigration).toContain(
+      '"first_visit_validated_closeout_id"',
+    );
+    expect(evidenceBindingMigration).toContain('"clinic_use_validated_hash"');
+    expect(evidenceBindingMigration).toContain(
+      "CREATE OR REPLACE FUNCTION enforce_clinic_pilot_projection_audit()",
+    );
+  });
+
+  it("separates exact product evidence from operator state", () => {
+    expect(service).toContain("from practice_conversion_milestones");
+    expect(service).toContain("from visit_closeouts vc");
+    expect(service).toContain("distinct_clinic_days");
+    expect(service).toContain("payment_method_collected");
+    expect(service).toContain("first_positive_payment");
+    expect(service).toContain("pg_advisory_xact_lock");
+    expect(service).toContain("payloadHash !== hash");
+    expect(service).toContain("firstVisitValidationCurrent");
+    expect(service).toContain("clinicUseValidationCurrent");
+  });
+
+  it("uses platform-admin-only strict inputs and has no side-effect action", () => {
+    expect(router).toContain("clinicPilotSaveInput");
+    expect(router).toContain(".strict()");
+    expect(router).toContain("saveClinicPilot: platformAdminProcedure");
+    expect(ui).toContain("it never emails a clinic");
+    expect(ui).toContain("enables texting");
+    expect(ui).not.toContain("sendEmail");
+    expect(ui).not.toContain("assignMessagingNumbers");
+    expect(ui).not.toContain("checkout");
+    expect(ui).toContain("stageRequirements");
+    expect(ui).toContain("This stage is gated");
+  });
+});

--- a/apps/web/lib/__tests__/clinic-pilot-security.test.ts
+++ b/apps/web/lib/__tests__/clinic-pilot-security.test.ts
@@ -59,6 +59,15 @@ describe("clinic pilot operating boundary", () => {
       "ALTER TABLE clinic_pilots ENABLE ROW LEVEL SECURITY",
     );
     expect(migration).toContain("clinic_pilots_require_event");
+    expect(
+      migration.indexOf(
+        'CREATE UNIQUE INDEX "clinic_pilots_id_practice_uq"',
+      ),
+    ).toBeLessThan(
+      migration.indexOf(
+        'ADD CONSTRAINT "clinic_pilot_events_pilot_practice_fk"',
+      ),
+    );
     expect(evidenceBindingMigration).toContain(
       '"first_visit_validated_closeout_id"',
     );

--- a/apps/web/lib/admin/__tests__/clinic-pilots.test.ts
+++ b/apps/web/lib/admin/__tests__/clinic-pilots.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+import {
+  clinicPilotCohortKey,
+  clinicPilotGateIssues,
+  type ClinicPilotEvidence,
+  type SaveClinicPilotInput,
+} from "../clinic-pilots";
+
+const completeQualification = {
+  supportedClinicType: true,
+  supportedJurisdictionConfirmed: true,
+  singleLocation: true,
+  connectedModeAccepted: true,
+  parallelRunAccepted: true,
+  championConfirmed: true,
+  supportedWorkflowConfirmed: true,
+  noUnsupportedMustHave: true,
+};
+
+const completeReadiness = {
+  rolesAndDevicesValidated: true,
+  migrationPlanAccepted: true,
+  sampleValidationAccepted: true,
+  firstVisitScheduled: true,
+  exportAndRollbackConfirmed: true,
+  supportCadenceConfirmed: true,
+};
+
+function input(
+  overrides: Partial<SaveClinicPilotInput> = {},
+): Omit<SaveClinicPilotInput, "operationId" | "expectedVersion" | "reason"> {
+  const full: SaveClinicPilotInput = {
+    practiceId: "00000000-0000-0000-0000-000000000001",
+    operationId: "00000000-0000-0000-0000-000000000002",
+    expectedVersion: null,
+    cohortKey: "pilot-2026-08",
+    workflow: "general_practice",
+    stage: "candidate",
+    decision: "pending",
+    qualificationChecklist: {
+      ...completeQualification,
+      championConfirmed: false,
+    },
+    readinessChecklist: {
+      ...completeReadiness,
+      firstVisitScheduled: false,
+    },
+    blockerCodes: [],
+    nextAction: "confirm_fit",
+    supportCadence: "daily",
+    communicationMode: "email_only",
+    communicationTested: false,
+    firstVisitValidated: false,
+    clinicUseValidated: false,
+    clinicAcceptanceConfirmed: false,
+    clinicAcceptanceByUserId: null,
+    lastContactAt: null,
+    lastContactOutcome: null,
+    targetStartOn: null,
+    nextReviewAt: "2026-08-11T11:00:00.000Z",
+    reason: "initial_review",
+    ...overrides,
+  };
+  const {
+    operationId: _operationId,
+    expectedVersion: _version,
+    reason: _reason,
+    ...gateInput
+  } = full;
+  return gateInput;
+}
+
+function evidence(
+  overrides: Partial<ClinicPilotEvidence> = {},
+): ClinicPilotEvidence {
+  return {
+    verifiedAdmin: true,
+    verifiedAdmins: [
+      {
+        id: "00000000-0000-0000-0000-000000000003",
+        name: "Clinic Admin",
+        email: "clinic@example.com",
+      },
+    ],
+    verifiedAdminUserIds: ["00000000-0000-0000-0000-000000000003"],
+    activeLocationCount: 1,
+    activeLocationIds: ["00000000-0000-0000-0000-000000000004"],
+    setupComplete: true,
+    setupCompletedAt: new Date("2026-08-01T10:00:00.000Z"),
+    activatedEvidenceKey: "client:a|appointment:b",
+    activatedAt: new Date("2026-08-01T12:00:00.000Z"),
+    firstVisitCloseoutId: "00000000-0000-0000-0000-000000000006",
+    firstVisitCompletedAt: new Date("2026-08-02T12:00:00.000Z"),
+    distinctClinicDays: 5,
+    clinicUseDays: [],
+    paymentMethodEvidenceKey: "stripe:checkout-1",
+    paymentMethodCollectedAt: new Date("2026-08-07T12:00:00.000Z"),
+    firstPositivePaymentEvidenceKey: null,
+    firstPositivePaymentAt: null,
+    billingStatus: "trialing",
+    subscriptionTier: "cloud",
+    trialEndsAt: new Date("2026-08-20T12:00:00.000Z"),
+    hostedFullAccess: true,
+    country: "US",
+    smsStatus: "not_configured",
+    ...overrides,
+  };
+}
+
+describe("clinic pilot gates", () => {
+  const now = new Date("2026-08-10T12:00:00.000Z");
+
+  it("allows an incomplete candidate only when the next review is scheduled", () => {
+    expect(clinicPilotGateIssues(input(), evidence(), now)).toEqual([]);
+    expect(
+      clinicPilotGateIssues(input({ nextReviewAt: null }), evidence(), now),
+    ).toContain("Schedule the next review before saving an active pilot.");
+  });
+
+  it("requires every fit check before marking a clinic eligible", () => {
+    expect(
+      clinicPilotGateIssues(
+        input({
+          stage: "parallel_setup",
+          decision: "eligible",
+          nextAction: "schedule_setup",
+        }),
+        evidence(),
+        now,
+      ),
+    ).toContain(
+      "Complete every clinic-fit check before qualifying this pilot.",
+    );
+  });
+
+  it("requires objective admin, location, readiness, and blocker evidence for approval", () => {
+    const approved = input({
+      stage: "visit_validation",
+      decision: "approved",
+      nextAction: "complete_first_visit",
+      qualificationChecklist: completeQualification,
+      readinessChecklist: completeReadiness,
+    });
+    expect(clinicPilotGateIssues(approved, evidence(), now)).toEqual([]);
+    expect(
+      clinicPilotGateIssues(
+        {
+          ...approved,
+          blockerCodes: ["billing"],
+          nextAction: "resolve_blockers",
+        },
+        evidence({
+          verifiedAdmin: false,
+          verifiedAdmins: [],
+          verifiedAdminUserIds: [],
+          activeLocationCount: 2,
+        }),
+        now,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "A verified clinic administrator is required.",
+        "The controlled pilot must have exactly one active location.",
+        "Resolve every blocker before approving readiness.",
+      ]),
+    );
+  });
+
+  it("does not let an operator fabricate the clinic week or payment-method evidence", () => {
+    const completed = input({
+      stage: "completed",
+      decision: "graduated",
+      qualificationChecklist: completeQualification,
+      readinessChecklist: completeReadiness,
+      nextAction: "support_retention",
+      communicationTested: true,
+      firstVisitValidated: true,
+      clinicUseValidated: true,
+      clinicAcceptanceConfirmed: true,
+      clinicAcceptanceByUserId: "00000000-0000-0000-0000-000000000003",
+      nextReviewAt: null,
+    });
+    expect(
+      clinicPilotGateIssues(
+        completed,
+        evidence({
+          firstVisitCompletedAt: null,
+          distinctClinicDays: 1,
+          paymentMethodCollectedAt: null,
+        }),
+        now,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "Complete activation and explicitly validate one real visit before the pilot week.",
+        "Five distinct clinic-use days are required before graduation review.",
+        "Collect a payment method before graduating the pilot.",
+      ]),
+    );
+  });
+
+  it("allows graduation during a legitimate trial without fabricating paid", () => {
+    expect(
+      clinicPilotGateIssues(
+        input({
+          stage: "completed",
+          decision: "graduated",
+          qualificationChecklist: completeQualification,
+          readinessChecklist: completeReadiness,
+          nextAction: "support_retention",
+          communicationTested: true,
+          firstVisitValidated: true,
+          clinicUseValidated: true,
+          clinicAcceptanceConfirmed: true,
+          clinicAcceptanceByUserId: "00000000-0000-0000-0000-000000000003",
+          nextReviewAt: null,
+        }),
+        evidence({ firstPositivePaymentAt: null }),
+        now,
+      ),
+    ).toEqual([]);
+  });
+
+  it("requires a bounded blocker action and paired contact evidence", () => {
+    expect(
+      clinicPilotGateIssues(
+        input({
+          blockerCodes: ["data_import"],
+          lastContactAt: "2026-08-10T12:00:00.000Z",
+        }),
+        evidence(),
+        now,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "Open blockers require Resolve blockers as the next action.",
+        "Record the contact time and outcome together.",
+      ]),
+    );
+  });
+
+  it("requires current hosted access and explicit clinic acceptance to graduate", () => {
+    const completed = input({
+      stage: "completed",
+      decision: "graduated",
+      qualificationChecklist: completeQualification,
+      readinessChecklist: completeReadiness,
+      nextAction: "support_retention",
+      communicationTested: true,
+      firstVisitValidated: true,
+      clinicUseValidated: true,
+      nextReviewAt: null,
+    });
+    expect(
+      clinicPilotGateIssues(
+        completed,
+        evidence({ hostedFullAccess: false, billingStatus: "past_due" }),
+        now,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "The clinic must have current hosted write access before graduation.",
+        "Record explicit acceptance from a verified clinic administrator.",
+      ]),
+    );
+  });
+
+  it("creates stable monthly cohort keys in UTC", () => {
+    expect(clinicPilotCohortKey(new Date("2026-08-31T23:59:00.000Z"))).toBe(
+      "pilot-2026-08",
+    );
+  });
+});

--- a/apps/web/lib/admin/clinic-pilots.ts
+++ b/apps/web/lib/admin/clinic-pilots.ts
@@ -1,0 +1,1303 @@
+import { createHash } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import type { Database } from "@openpims/db/client";
+import {
+  clinicPilotEvents,
+  clinicPilots,
+  type ClinicPilotEvidenceSnapshot,
+  type ClinicPilotQualificationChecklist,
+  type ClinicPilotReadinessChecklist,
+} from "@openpims/db";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import { recoverySetupState } from "@/lib/admin/activation-recovery";
+import { hasHostedFullAccess } from "@/lib/billing/plans";
+import { withSystem } from "@/lib/tenant-db";
+
+export const CLINIC_PILOT_WORKFLOWS = [
+  "general_practice",
+  "house_call",
+] as const;
+export const CLINIC_PILOT_STAGES = [
+  "candidate",
+  "parallel_setup",
+  "visit_validation",
+  "pilot_week",
+  "graduation_review",
+  "completed",
+  "closed",
+] as const;
+export const CLINIC_PILOT_DECISIONS = [
+  "pending",
+  "eligible",
+  "approved",
+  "paused",
+  "not_a_fit",
+  "graduated",
+] as const;
+export const CLINIC_PILOT_BLOCKERS = [
+  "workflow_fit",
+  "data_import",
+  "staff_training",
+  "record_accuracy",
+  "billing",
+  "payments",
+  "email",
+  "sms",
+  "permissions",
+  "device_connectivity",
+  "backup_export",
+  "support_coverage",
+] as const;
+export const CLINIC_PILOT_NEXT_ACTIONS = [
+  "confirm_fit",
+  "schedule_setup",
+  "validate_import",
+  "complete_first_visit",
+  "review_communications",
+  "configure_payment",
+  "review_clinic_week",
+  "resolve_blockers",
+  "decide_graduation",
+  "support_retention",
+  "revisit_fit",
+] as const;
+export const CLINIC_PILOT_SUPPORT_CADENCES = [
+  "daily",
+  "twice_weekly",
+  "weekly",
+] as const;
+export const CLINIC_PILOT_CONTACT_OUTCOMES = [
+  "replied",
+  "no_reply",
+  "scheduled",
+  "completed",
+  "declined",
+] as const;
+export const CLINIC_PILOT_COMMUNICATION_MODES = [
+  "email_only",
+  "email_and_sms",
+] as const;
+export const CLINIC_PILOT_REASONS = [
+  "initial_review",
+  "clinic_feedback",
+  "product_evidence",
+  "support_review",
+  "blocker_review",
+  "graduation_decision",
+] as const;
+
+export const CLINIC_PILOT_QUALIFICATION_KEYS = [
+  "supportedClinicType",
+  "supportedJurisdictionConfirmed",
+  "singleLocation",
+  "connectedModeAccepted",
+  "parallelRunAccepted",
+  "championConfirmed",
+  "supportedWorkflowConfirmed",
+  "noUnsupportedMustHave",
+] as const satisfies readonly (keyof ClinicPilotQualificationChecklist)[];
+
+export const CLINIC_PILOT_READINESS_KEYS = [
+  "rolesAndDevicesValidated",
+  "migrationPlanAccepted",
+  "sampleValidationAccepted",
+  "firstVisitScheduled",
+  "exportAndRollbackConfirmed",
+  "supportCadenceConfirmed",
+] as const satisfies readonly (keyof ClinicPilotReadinessChecklist)[];
+
+export type ClinicPilotWorkflow = (typeof CLINIC_PILOT_WORKFLOWS)[number];
+export type ClinicPilotStage = (typeof CLINIC_PILOT_STAGES)[number];
+export type ClinicPilotDecision = (typeof CLINIC_PILOT_DECISIONS)[number];
+export type ClinicPilotBlocker = (typeof CLINIC_PILOT_BLOCKERS)[number];
+export type ClinicPilotNextAction = (typeof CLINIC_PILOT_NEXT_ACTIONS)[number];
+export type ClinicPilotSupportCadence =
+  (typeof CLINIC_PILOT_SUPPORT_CADENCES)[number];
+export type ClinicPilotContactOutcome =
+  (typeof CLINIC_PILOT_CONTACT_OUTCOMES)[number];
+export type ClinicPilotCommunicationMode =
+  (typeof CLINIC_PILOT_COMMUNICATION_MODES)[number];
+export type ClinicPilotReason = (typeof CLINIC_PILOT_REASONS)[number];
+
+export type ClinicPilotSmsStatus =
+  | "not_configured"
+  | "pending"
+  | "action_required"
+  | "carrier_approved_sending_off"
+  | "ready";
+
+export interface ClinicPilotEvidence {
+  verifiedAdmin: boolean;
+  verifiedAdmins: Array<{ id: string; name: string; email: string }>;
+  verifiedAdminUserIds: string[];
+  activeLocationCount: number;
+  activeLocationIds: string[];
+  setupComplete: boolean;
+  setupCompletedAt: Date | null;
+  activatedEvidenceKey: string | null;
+  activatedAt: Date | null;
+  firstVisitCloseoutId: string | null;
+  firstVisitCompletedAt: Date | null;
+  distinctClinicDays: number;
+  clinicUseDays: Array<{
+    closeoutId: string;
+    completedAt: string;
+    localDate: string;
+  }>;
+  paymentMethodEvidenceKey: string | null;
+  paymentMethodCollectedAt: Date | null;
+  firstPositivePaymentEvidenceKey: string | null;
+  firstPositivePaymentAt: Date | null;
+  billingStatus: string;
+  subscriptionTier: string;
+  trialEndsAt: Date | null;
+  hostedFullAccess: boolean;
+  country: string;
+  smsStatus: ClinicPilotSmsStatus;
+}
+
+export interface SaveClinicPilotInput {
+  practiceId: string;
+  operationId: string;
+  expectedVersion: number | null;
+  cohortKey: string;
+  workflow: ClinicPilotWorkflow;
+  stage: ClinicPilotStage;
+  decision: ClinicPilotDecision;
+  qualificationChecklist: ClinicPilotQualificationChecklist;
+  readinessChecklist: ClinicPilotReadinessChecklist;
+  blockerCodes: ClinicPilotBlocker[];
+  nextAction: ClinicPilotNextAction;
+  supportCadence: ClinicPilotSupportCadence;
+  communicationMode: ClinicPilotCommunicationMode;
+  communicationTested: boolean;
+  firstVisitValidated: boolean;
+  clinicUseValidated: boolean;
+  clinicAcceptanceConfirmed: boolean;
+  clinicAcceptanceByUserId: string | null;
+  lastContactAt: string | null;
+  lastContactOutcome: ClinicPilotContactOutcome | null;
+  targetStartOn: string | null;
+  nextReviewAt: string | null;
+  reason: ClinicPilotReason;
+}
+
+export class ClinicPilotConflictError extends Error {}
+export class ClinicPilotEligibilityError extends Error {}
+export class ClinicPilotNotFoundError extends Error {}
+
+interface ClinicPilotQueueRow {
+  id: string;
+  practiceId: string;
+  practiceName: string;
+  cohortKey: string;
+  workflow: ClinicPilotWorkflow;
+  stage: ClinicPilotStage;
+  decision: ClinicPilotDecision;
+  qualificationChecklist: ClinicPilotQualificationChecklist;
+  readinessChecklist: ClinicPilotReadinessChecklist;
+  blockerCodes: ClinicPilotBlocker[];
+  nextAction: ClinicPilotNextAction;
+  supportCadence: ClinicPilotSupportCadence;
+  ownerIdentity: string;
+  communicationMode: ClinicPilotCommunicationMode;
+  communicationTestedAt: Date | string | null;
+  firstVisitValidatedAt: Date | string | null;
+  firstVisitValidatedCloseoutId: string | null;
+  clinicUseValidatedAt: Date | string | null;
+  clinicUseValidatedHash: string | null;
+  clinicAcceptanceAt: Date | string | null;
+  clinicAcceptanceByUserId: string | null;
+  lastContactAt: Date | string | null;
+  lastContactOutcome: ClinicPilotContactOutcome | null;
+  targetStartOn: string | null;
+  nextReviewAt: Date | string | null;
+  version: number | string;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+  billingStatus: string;
+  subscriptionTier: string;
+  trialEndsAt: Date | string | null;
+  country: string;
+  settings: unknown;
+  verifiedAdmins: Array<{ id: string; name: string; email: string }> | null;
+  activeLocationIds: string[] | null;
+  activeLocationCount: number | string;
+  activatedEvidenceKey: string | null;
+  activatedAt: Date | string | null;
+  paymentMethodEvidenceKey: string | null;
+  paymentMethodCollectedAt: Date | string | null;
+  firstPositivePaymentEvidenceKey: string | null;
+  firstPositivePaymentAt: Date | string | null;
+  firstVisitCloseoutId: string | null;
+  firstVisitCompletedAt: Date | string | null;
+  distinctClinicDays: number | string;
+  clinicUseDays: ClinicPilotEvidence["clinicUseDays"] | null;
+  smsStatus: ClinicPilotSmsStatus;
+  lastChangedAt: Date | string;
+  lastChangedBy: string;
+  lastChangeReason: ClinicPilotReason;
+}
+
+function asDate(value: Date | string | null): Date | null {
+  if (!value) return null;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function checklistComplete<T extends object>(
+  checklist: T,
+  keys: readonly (keyof T)[],
+): boolean {
+  return keys.every((key) => checklist[key] === true);
+}
+
+export function clinicPilotGateIssues(
+  input: Omit<
+    SaveClinicPilotInput,
+    "operationId" | "expectedVersion" | "reason"
+  >,
+  evidence: ClinicPilotEvidence,
+  now: Date = new Date(),
+): string[] {
+  const issues: string[] = [];
+  const qualificationComplete = checklistComplete(
+    input.qualificationChecklist,
+    CLINIC_PILOT_QUALIFICATION_KEYS,
+  );
+  const readinessComplete = checklistComplete(
+    input.readinessChecklist,
+    CLINIC_PILOT_READINESS_KEYS,
+  );
+  const needsApprovedReadiness = ["approved", "graduated"].includes(
+    input.decision,
+  );
+  const allowedStates: Record<
+    ClinicPilotStage,
+    Partial<Record<ClinicPilotDecision, readonly ClinicPilotNextAction[]>>
+  > = {
+    candidate: { pending: ["confirm_fit", "resolve_blockers"] },
+    parallel_setup: {
+      eligible: ["schedule_setup", "validate_import"],
+      paused: ["resolve_blockers"],
+    },
+    visit_validation: {
+      approved: ["complete_first_visit", "review_communications"],
+      paused: ["resolve_blockers"],
+    },
+    pilot_week: {
+      approved: [
+        "review_clinic_week",
+        "review_communications",
+        "configure_payment",
+      ],
+      paused: ["resolve_blockers"],
+    },
+    graduation_review: {
+      approved: ["decide_graduation", "configure_payment"],
+      paused: ["resolve_blockers"],
+    },
+    completed: { graduated: ["support_retention"] },
+    closed: { not_a_fit: ["revisit_fit"] },
+  };
+  const allowedActions = allowedStates[input.stage][input.decision];
+  if (!allowedActions?.includes(input.nextAction)) {
+    issues.push(
+      "Choose a stage, decision, and next action that belong together.",
+    );
+  }
+  if (input.decision === "paused" && input.blockerCodes.length === 0) {
+    issues.push("A paused pilot must identify at least one bounded blocker.");
+  }
+
+  if (
+    ["eligible", "approved", "graduated"].includes(input.decision) &&
+    !qualificationComplete
+  ) {
+    issues.push(
+      "Complete every clinic-fit check before qualifying this pilot.",
+    );
+  }
+  if (needsApprovedReadiness && !readinessComplete) {
+    issues.push("Complete every launch-readiness check before approval.");
+  }
+  if (needsApprovedReadiness && !evidence.setupComplete) {
+    issues.push("Complete guided clinic setup before approval.");
+  }
+  if (needsApprovedReadiness && evidence.country !== "US") {
+    issues.push(
+      "The first controlled clinic cohort is limited to the United States.",
+    );
+  }
+  if (needsApprovedReadiness && !evidence.verifiedAdmin) {
+    issues.push("A verified clinic administrator is required.");
+  }
+  if (needsApprovedReadiness && evidence.activeLocationCount !== 1) {
+    issues.push("The controlled pilot must have exactly one active location.");
+  }
+  if (
+    input.blockerCodes.length > 0 &&
+    input.stage !== "closed" &&
+    input.nextAction !== "resolve_blockers"
+  ) {
+    issues.push("Open blockers require Resolve blockers as the next action.");
+  }
+  if (needsApprovedReadiness && input.blockerCodes.length > 0) {
+    issues.push("Resolve every blocker before approving readiness.");
+  }
+  if (
+    ["visit_validation", "pilot_week", "graduation_review"].includes(
+      input.stage,
+    ) &&
+    !["approved", "paused"].includes(input.decision)
+  ) {
+    issues.push(
+      "This stage requires an approved or paused readiness decision.",
+    );
+  }
+  if (
+    ["pilot_week", "graduation_review", "completed"].includes(input.stage) &&
+    (!evidence.activatedAt ||
+      !evidence.firstVisitCompletedAt ||
+      !input.firstVisitValidated)
+  ) {
+    issues.push(
+      "Complete activation and explicitly validate one real visit before the pilot week.",
+    );
+  }
+  if (input.firstVisitValidated && !evidence.firstVisitCloseoutId) {
+    issues.push("A real visit closeout must be observed before validating it.");
+  }
+  if (
+    ["pilot_week", "graduation_review", "completed"].includes(input.stage) &&
+    !input.communicationTested
+  ) {
+    issues.push(
+      "Verify the selected client communication path before the pilot week.",
+    );
+  }
+  if (
+    ["pilot_week", "graduation_review", "completed"].includes(input.stage) &&
+    input.communicationMode === "email_and_sms" &&
+    evidence.smsStatus !== "ready"
+  ) {
+    issues.push(
+      "SMS must be operational before it is included in the pilot workflow.",
+    );
+  }
+  if (
+    ["graduation_review", "completed"].includes(input.stage) &&
+    evidence.distinctClinicDays < 5
+  ) {
+    issues.push(
+      "Five distinct clinic-use days are required before graduation review.",
+    );
+  }
+  if (
+    ["graduation_review", "completed"].includes(input.stage) &&
+    !input.clinicUseValidated
+  ) {
+    issues.push("Validate the five clinic-use days as real operating work.");
+  }
+  if (input.clinicUseValidated && evidence.distinctClinicDays < 5) {
+    issues.push(
+      "Five observed clinic-use days are required before validation.",
+    );
+  }
+  if (input.decision === "graduated" && !evidence.paymentMethodCollectedAt) {
+    issues.push("Collect a payment method before graduating the pilot.");
+  }
+  if (input.decision === "graduated" && !evidence.hostedFullAccess) {
+    issues.push(
+      "The clinic must have current hosted write access before graduation.",
+    );
+  }
+  if (input.decision === "graduated") {
+    if (!input.clinicAcceptanceConfirmed || !input.clinicAcceptanceByUserId) {
+      issues.push(
+        "Record explicit acceptance from a verified clinic administrator.",
+      );
+    } else if (
+      !evidence.verifiedAdminUserIds.includes(input.clinicAcceptanceByUserId)
+    ) {
+      issues.push(
+        "Clinic acceptance must be attributed to a current verified administrator.",
+      );
+    }
+  }
+  if (
+    input.clinicAcceptanceConfirmed &&
+    !["graduation_review", "completed"].includes(input.stage)
+  ) {
+    issues.push("Record clinic acceptance only after the five-day review.");
+  }
+  if ((input.stage === "completed") !== (input.decision === "graduated")) {
+    issues.push(
+      "Completed stage and graduated decision must be recorded together.",
+    );
+  }
+  if ((input.stage === "closed") !== (input.decision === "not_a_fit")) {
+    issues.push(
+      "Closed stage and not-a-fit decision must be recorded together.",
+    );
+  }
+  const isTerminal = ["completed", "closed"].includes(input.stage);
+  if (isTerminal !== (input.nextReviewAt === null)) {
+    issues.push(
+      isTerminal
+        ? "Clear the next review when closing a pilot."
+        : "Schedule the next review before saving an active pilot.",
+    );
+  }
+  if ((input.lastContactAt === null) !== (input.lastContactOutcome === null)) {
+    issues.push("Record the contact time and outcome together.");
+  }
+  if (!isTerminal && input.nextReviewAt) {
+    const reviewAt = new Date(input.nextReviewAt);
+    const cadenceMs: Record<ClinicPilotSupportCadence, number> = {
+      daily: 24 * 60 * 60 * 1000,
+      twice_weekly: 4 * 24 * 60 * 60 * 1000,
+      weekly: 7 * 24 * 60 * 60 * 1000,
+    };
+    if (reviewAt.getTime() <= now.getTime()) {
+      issues.push("Schedule the next review in the future.");
+    } else if (
+      reviewAt.getTime() >
+      now.getTime() + cadenceMs[input.supportCadence]
+    ) {
+      issues.push(
+        "The next review cannot be later than the selected support cadence.",
+      );
+    }
+  }
+  return issues;
+}
+
+export function clinicPilotCohortKey(now: Date = new Date()): string {
+  return `pilot-${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function payloadHash(input: SaveClinicPilotInput): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        ...input,
+        blockerCodes: [...new Set(input.blockerCodes)].sort(),
+      }),
+    )
+    .digest("hex");
+}
+
+function evidenceSnapshot(
+  evidence: ClinicPilotEvidence,
+): ClinicPilotEvidenceSnapshot {
+  return {
+    verifiedAdminUserIds: evidence.verifiedAdminUserIds,
+    activeLocationIds: evidence.activeLocationIds,
+    setupCompletedAt: evidence.setupCompletedAt?.toISOString() ?? null,
+    activatedEvidenceKey: evidence.activatedEvidenceKey,
+    activatedAt: evidence.activatedAt?.toISOString() ?? null,
+    firstVisitCloseoutId: evidence.firstVisitCloseoutId,
+    firstVisitCompletedAt:
+      evidence.firstVisitCompletedAt?.toISOString() ?? null,
+    clinicUseDays: evidence.clinicUseDays,
+    paymentMethodEvidenceKey: evidence.paymentMethodEvidenceKey,
+    paymentMethodCollectedAt:
+      evidence.paymentMethodCollectedAt?.toISOString() ?? null,
+    firstPositivePaymentEvidenceKey: evidence.firstPositivePaymentEvidenceKey,
+    firstPositivePaymentAt:
+      evidence.firstPositivePaymentAt?.toISOString() ?? null,
+    billingStatus: evidence.billingStatus,
+    subscriptionTier: evidence.subscriptionTier,
+    trialEndsAt: evidence.trialEndsAt?.toISOString() ?? null,
+    hostedFullAccess: evidence.hostedFullAccess,
+    country: evidence.country,
+    smsStatus: evidence.smsStatus,
+  };
+}
+
+function clinicUseEvidenceHash(evidence: ClinicPilotEvidence): string | null {
+  if (evidence.clinicUseDays.length < 5) return null;
+  return createHash("sha256")
+    .update(JSON.stringify(evidence.clinicUseDays.slice(0, 5)))
+    .digest("hex");
+}
+
+export async function loadClinicPilotQueue(db: Database) {
+  return withSystem(db, async (tx) => {
+    const result = await tx.execute(sql`
+      with verified_admins as (
+        select
+          u.practice_id,
+          jsonb_agg(
+            jsonb_build_object('id', u.id, 'name', u.name, 'email', u.email)
+            order by u.created_at, u.id
+          ) as verified_admins
+        from users u
+        where u.role = 'admin'
+          and u.deleted_at is null
+          and u.email_verified_at is not null
+        group by u.practice_id
+      ), location_evidence as (
+        select
+          l.practice_id,
+          count(*)::int as active_location_count,
+          array_agg(l.id order by l.id) as active_location_ids
+        from locations l
+        where l.deleted_at is null
+        group by l.practice_id
+      ), milestone_evidence as (
+        select
+          pcm.practice_id,
+          max(pcm.evidence_key) filter (
+            where pcm.milestone = 'activated'
+          ) as activated_evidence_key,
+          min(pcm.occurred_at) filter (
+            where pcm.milestone = 'activated'
+          ) as activated_at,
+          max(pcm.evidence_key) filter (
+            where pcm.milestone = 'payment_method_collected'
+          ) as payment_method_evidence_key,
+          min(pcm.occurred_at) filter (
+            where pcm.milestone = 'payment_method_collected'
+          ) as payment_method_collected_at,
+          max(pcm.evidence_key) filter (
+            where pcm.milestone = 'first_positive_payment'
+          ) as first_positive_payment_evidence_key,
+          min(pcm.occurred_at) filter (
+            where pcm.milestone = 'first_positive_payment'
+          ) as first_positive_payment_at
+        from practice_conversion_milestones pcm
+        group by pcm.practice_id
+      ), eligible_closeouts as (
+        select
+          vc.practice_id,
+          vc.id as closeout_id,
+          vc.completed_at,
+          (vc.completed_at at time zone p.timezone)::date as local_date
+        from visit_closeouts vc
+        join appointments a
+          on a.id = vc.appointment_id
+         and a.practice_id = vc.practice_id
+         and a.deleted_at is null
+        join practices p
+          on p.id = vc.practice_id
+         and p.deleted_at is null
+        join clinic_pilots pilot
+          on pilot.practice_id = vc.practice_id
+        where vc.status = 'completed'
+          and vc.completed_at is not null
+          and vc.completed_at >= pilot.created_at
+          and vc.deleted_at is null
+          and a.created_at >= p.created_at
+          and not (
+            coalesce(p.settings -> 'demoData' -> 'appointmentIds', '[]'::jsonb)
+              @> to_jsonb(a.id::text)
+          )
+      ), clinic_use_days as (
+        select distinct on (practice_id, local_date)
+          practice_id, closeout_id, completed_at, local_date
+        from eligible_closeouts
+        order by practice_id, local_date, completed_at, closeout_id
+      ), ranked_clinic_use_days as (
+        select
+          clinic_use_days.*,
+          row_number() over (
+            partition by practice_id order by completed_at, closeout_id
+          ) as day_rank
+        from clinic_use_days
+      ), clinic_use as (
+        select
+          practice_id,
+          (array_agg(closeout_id order by completed_at, closeout_id))[1]
+            as first_visit_closeout_id,
+          min(completed_at) as first_visit_completed_at,
+          count(*)::int as distinct_clinic_days,
+          jsonb_agg(
+            jsonb_build_object(
+              'closeoutId', closeout_id,
+              'completedAt', completed_at,
+              'localDate', local_date
+            ) order by completed_at, closeout_id
+          ) filter (where day_rank <= 5) as clinic_use_days
+        from ranked_clinic_use_days
+        group by practice_id
+      )
+      select
+        cp.id,
+        cp.practice_id as "practiceId",
+        p.name as "practiceName",
+        cp.cohort_key as "cohortKey",
+        cp.workflow,
+        cp.stage,
+        cp.decision,
+        cp.qualification_checklist as "qualificationChecklist",
+        cp.readiness_checklist as "readinessChecklist",
+        cp.blocker_codes as "blockerCodes",
+        cp.next_action as "nextAction",
+        cp.support_cadence as "supportCadence",
+        cp.owner_identity as "ownerIdentity",
+        cp.communication_mode as "communicationMode",
+        cp.communication_tested_at as "communicationTestedAt",
+        cp.first_visit_validated_at as "firstVisitValidatedAt",
+        cp.first_visit_validated_closeout_id as "firstVisitValidatedCloseoutId",
+        cp.clinic_use_validated_at as "clinicUseValidatedAt",
+        cp.clinic_use_validated_hash as "clinicUseValidatedHash",
+        cp.clinic_acceptance_at as "clinicAcceptanceAt",
+        cp.clinic_acceptance_by_user_id as "clinicAcceptanceByUserId",
+        cp.last_contact_at as "lastContactAt",
+        cp.last_contact_outcome as "lastContactOutcome",
+        cp.target_start_on as "targetStartOn",
+        cp.next_review_at as "nextReviewAt",
+        cp.version,
+        cp.created_at as "createdAt",
+        cp.updated_at as "updatedAt",
+        p.billing_status as "billingStatus",
+        p.subscription_tier as "subscriptionTier",
+        p.trial_ends_at as "trialEndsAt",
+        p.country,
+        p.settings,
+        va.verified_admins as "verifiedAdmins",
+        coalesce(le.active_location_count, 0)::int as "activeLocationCount",
+        coalesce(le.active_location_ids, ARRAY[]::uuid[]) as "activeLocationIds",
+        me.activated_evidence_key as "activatedEvidenceKey",
+        me.activated_at as "activatedAt",
+        me.payment_method_evidence_key as "paymentMethodEvidenceKey",
+        me.payment_method_collected_at as "paymentMethodCollectedAt",
+        me.first_positive_payment_evidence_key as "firstPositivePaymentEvidenceKey",
+        me.first_positive_payment_at as "firstPositivePaymentAt",
+        cu.first_visit_closeout_id as "firstVisitCloseoutId",
+        cu.first_visit_completed_at as "firstVisitCompletedAt",
+        coalesce(cu.distinct_clinic_days, 0)::int as "distinctClinicDays",
+        coalesce(cu.clinic_use_days, '[]'::jsonb) as "clinicUseDays",
+        case
+          when exists (
+            select 1 from location_messaging lm
+            where lm.practice_id = cp.practice_id
+              and lm.deleted_at is null
+              and lm.registration_status = 'active'
+              and lm.provider_profile_ready = true
+              and lm.enabled = true
+          ) then 'ready'
+          when exists (
+            select 1 from location_messaging lm
+            where lm.practice_id = cp.practice_id
+              and lm.deleted_at is null
+              and lm.registration_status = 'active'
+          ) then 'carrier_approved_sending_off'
+          when exists (
+            select 1 from messaging_registrations mr
+            where mr.practice_id = cp.practice_id
+              and mr.deleted_at is null
+              and mr.status in ('action_required', 'failed', 'suspended')
+          ) then 'action_required'
+          when exists (
+            select 1 from messaging_registrations mr
+            where mr.practice_id = cp.practice_id
+              and mr.deleted_at is null
+          ) then 'pending'
+          else 'not_configured'
+        end as "smsStatus",
+        latest.created_at as "lastChangedAt",
+        latest.actor_identity as "lastChangedBy",
+        latest.reason as "lastChangeReason"
+      from clinic_pilots cp
+      join practices p
+        on p.id = cp.practice_id
+       and p.deleted_at is null
+       and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+      join lateral (
+        select e.created_at, e.actor_identity, e.reason
+        from clinic_pilot_events e
+        where e.clinic_pilot_id = cp.id
+          and e.practice_id = cp.practice_id
+        order by e.created_at desc, e.id desc
+        limit 1
+      ) latest on true
+      left join verified_admins va on va.practice_id = cp.practice_id
+      left join location_evidence le on le.practice_id = cp.practice_id
+      left join milestone_evidence me on me.practice_id = cp.practice_id
+      left join clinic_use cu on cu.practice_id = cp.practice_id
+      order by
+        case when cp.stage in ('completed', 'closed') then 1 else 0 end,
+        cp.next_review_at asc nulls last,
+        cp.created_at asc,
+        cp.practice_id
+    `);
+
+    return rowsFromExecute<ClinicPilotQueueRow>(result).map((row) => {
+      const setup = recoverySetupState(row.settings);
+      const verifiedAdmins = row.verifiedAdmins ?? [];
+      const trialEndsAt = asDate(row.trialEndsAt);
+      const evidence: ClinicPilotEvidence = {
+        verifiedAdmin: verifiedAdmins.length > 0,
+        verifiedAdmins,
+        verifiedAdminUserIds: verifiedAdmins.map((admin) => admin.id),
+        activeLocationCount: Number(row.activeLocationCount) || 0,
+        activeLocationIds: row.activeLocationIds ?? [],
+        setupComplete: setup.completed,
+        setupCompletedAt: setup.completedAt,
+        activatedEvidenceKey: row.activatedEvidenceKey,
+        activatedAt: asDate(row.activatedAt),
+        firstVisitCloseoutId: row.firstVisitCloseoutId,
+        firstVisitCompletedAt: asDate(row.firstVisitCompletedAt),
+        distinctClinicDays: Number(row.distinctClinicDays) || 0,
+        clinicUseDays: row.clinicUseDays ?? [],
+        paymentMethodEvidenceKey: row.paymentMethodEvidenceKey,
+        paymentMethodCollectedAt: asDate(row.paymentMethodCollectedAt),
+        firstPositivePaymentEvidenceKey: row.firstPositivePaymentEvidenceKey,
+        firstPositivePaymentAt: asDate(row.firstPositivePaymentAt),
+        billingStatus: row.billingStatus,
+        subscriptionTier: row.subscriptionTier,
+        trialEndsAt,
+        hostedFullAccess: hasHostedFullAccess(
+          row.subscriptionTier,
+          row.billingStatus,
+          trialEndsAt,
+          new Date(),
+          true,
+        ),
+        country: row.country,
+        smsStatus: row.smsStatus,
+      };
+      const firstVisitValidationCurrent = Boolean(
+        row.firstVisitValidatedAt &&
+        row.firstVisitValidatedCloseoutId &&
+        row.firstVisitValidatedCloseoutId === evidence.firstVisitCloseoutId,
+      );
+      const clinicUseValidationCurrent = Boolean(
+        row.clinicUseValidatedAt &&
+        row.clinicUseValidatedHash &&
+        row.clinicUseValidatedHash === clinicUseEvidenceHash(evidence),
+      );
+      const {
+        settings: _settings,
+        activeLocationCount: _activeLocationCount,
+        activeLocationIds: _activeLocationIds,
+        activatedEvidenceKey: _activatedEvidenceKey,
+        activatedAt: _activatedAt,
+        paymentMethodEvidenceKey: _paymentMethodEvidenceKey,
+        paymentMethodCollectedAt: _paymentMethodCollectedAt,
+        firstPositivePaymentEvidenceKey: _firstPositivePaymentEvidenceKey,
+        firstPositivePaymentAt: _firstPositivePaymentAt,
+        firstVisitCloseoutId: _firstVisitCloseoutId,
+        firstVisitCompletedAt: _firstVisitCompletedAt,
+        distinctClinicDays: _distinctClinicDays,
+        clinicUseDays: _clinicUseDays,
+        firstVisitValidatedCloseoutId: _firstVisitValidatedCloseoutId,
+        clinicUseValidatedHash: _clinicUseValidatedHash,
+        ...pilot
+      } = row;
+      return {
+        ...pilot,
+        verifiedAdmins,
+        version: Number(row.version),
+        lastContactAt: asDate(row.lastContactAt),
+        nextReviewAt: asDate(row.nextReviewAt),
+        trialEndsAt,
+        createdAt: asDate(row.createdAt)!,
+        updatedAt: asDate(row.updatedAt)!,
+        communicationTestedAt: asDate(row.communicationTestedAt),
+        firstVisitValidatedAt: asDate(row.firstVisitValidatedAt),
+        clinicUseValidatedAt: asDate(row.clinicUseValidatedAt),
+        clinicAcceptanceAt: asDate(row.clinicAcceptanceAt),
+        lastChangedAt: asDate(row.lastChangedAt)!,
+        setupStage: setup.stage,
+        firstVisitValidationCurrent,
+        clinicUseValidationCurrent,
+        evidence: {
+          verifiedAdmin: evidence.verifiedAdmin,
+          activeLocationCount: evidence.activeLocationCount,
+          setupComplete: evidence.setupComplete,
+          activatedAt: evidence.activatedAt,
+          firstVisitCompletedAt: evidence.firstVisitCompletedAt,
+          distinctClinicDays: evidence.distinctClinicDays,
+          paymentMethodCollectedAt: evidence.paymentMethodCollectedAt,
+          firstPositivePaymentAt: evidence.firstPositivePaymentAt,
+          hostedFullAccess: evidence.hostedFullAccess,
+          country: evidence.country,
+        },
+        gateIssues: clinicPilotGateIssues(
+          {
+            practiceId: row.practiceId,
+            cohortKey: row.cohortKey,
+            workflow: row.workflow,
+            stage: row.stage,
+            decision: row.decision,
+            qualificationChecklist: row.qualificationChecklist,
+            readinessChecklist: row.readinessChecklist,
+            blockerCodes: row.blockerCodes,
+            nextAction: row.nextAction,
+            supportCadence: row.supportCadence,
+            communicationMode: row.communicationMode,
+            communicationTested: Boolean(row.communicationTestedAt),
+            firstVisitValidated: firstVisitValidationCurrent,
+            clinicUseValidated: clinicUseValidationCurrent,
+            clinicAcceptanceConfirmed: Boolean(row.clinicAcceptanceAt),
+            clinicAcceptanceByUserId: row.clinicAcceptanceByUserId,
+            lastContactAt: row.lastContactAt
+              ? (asDate(row.lastContactAt)?.toISOString() ?? null)
+              : null,
+            lastContactOutcome: row.lastContactOutcome,
+            targetStartOn: row.targetStartOn,
+            nextReviewAt: row.nextReviewAt
+              ? (asDate(row.nextReviewAt)?.toISOString() ?? null)
+              : null,
+          },
+          evidence,
+        ),
+      };
+    });
+  });
+}
+
+async function loadGateEvidence(
+  tx: Database,
+  practiceId: string,
+): Promise<ClinicPilotEvidence> {
+  const result = await tx.execute(sql`
+    with practice_scope as (
+      select
+        p.id,
+        p.settings,
+        p.timezone,
+        p.billing_status,
+        p.subscription_tier,
+        p.trial_ends_at,
+        p.country
+      from practices p
+      where p.id = ${practiceId}
+        and p.deleted_at is null
+        and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+      for update
+    ), eligible_closeouts as (
+      select
+        vc.id as closeout_id,
+        vc.completed_at,
+        (vc.completed_at at time zone p.timezone)::date as local_date
+      from practice_scope p
+      join visit_closeouts vc on vc.practice_id = p.id
+      join appointments a
+        on a.id = vc.appointment_id
+       and a.practice_id = p.id
+       and a.deleted_at is null
+      left join clinic_pilots pilot on pilot.practice_id = p.id
+      where vc.status = 'completed'
+        and vc.completed_at is not null
+        and vc.completed_at >= coalesce(pilot.created_at, now())
+        and vc.deleted_at is null
+        and not (
+          coalesce(p.settings -> 'demoData' -> 'appointmentIds', '[]'::jsonb)
+            @> to_jsonb(a.id::text)
+        )
+    ), clinic_use_days as (
+      select distinct on (local_date)
+        closeout_id, completed_at, local_date
+      from eligible_closeouts
+      order by local_date, completed_at, closeout_id
+    ), ranked_clinic_use_days as (
+      select
+        clinic_use_days.*,
+        row_number() over (order by completed_at, closeout_id) as day_rank
+      from clinic_use_days
+    ), clinic_use as (
+      select
+        (array_agg(closeout_id order by completed_at, closeout_id))[1]
+          as first_visit_closeout_id,
+        min(completed_at) as first_visit_completed_at,
+        count(*)::int as distinct_clinic_days,
+        jsonb_agg(
+          jsonb_build_object(
+            'closeoutId', closeout_id,
+            'completedAt', completed_at,
+            'localDate', local_date
+          ) order by completed_at, closeout_id
+        ) filter (where day_rank <= 5) as clinic_use_days
+      from ranked_clinic_use_days
+    )
+    select
+      coalesce((
+        select jsonb_agg(
+          jsonb_build_object('id', u.id, 'name', u.name, 'email', u.email)
+          order by u.created_at, u.id
+        ) from users u
+        where u.practice_id = p.id
+          and u.role = 'admin'
+          and u.email_verified_at is not null
+          and u.deleted_at is null
+      ), '[]'::jsonb) as "verifiedAdmins",
+      coalesce((
+        select array_agg(l.id order by l.id) from locations l
+        where l.practice_id = p.id and l.deleted_at is null
+      ), ARRAY[]::uuid[]) as "activeLocationIds",
+      p.settings,
+      (
+        select pcm.evidence_key
+        from practice_conversion_milestones pcm
+        where pcm.practice_id = p.id and pcm.milestone = 'activated'
+        limit 1
+      ) as "activatedEvidenceKey",
+      (
+        select pcm.occurred_at
+        from practice_conversion_milestones pcm
+        where pcm.practice_id = p.id and pcm.milestone = 'activated'
+        limit 1
+      ) as "activatedAt",
+      (
+        select pcm.evidence_key
+        from practice_conversion_milestones pcm
+        where pcm.practice_id = p.id
+          and pcm.milestone = 'payment_method_collected'
+        limit 1
+      ) as "paymentMethodEvidenceKey",
+      (
+        select pcm.occurred_at
+        from practice_conversion_milestones pcm
+        where pcm.practice_id = p.id
+          and pcm.milestone = 'payment_method_collected'
+        limit 1
+      ) as "paymentMethodCollectedAt",
+      (
+        select pcm.evidence_key
+        from practice_conversion_milestones pcm
+        where pcm.practice_id = p.id
+          and pcm.milestone = 'first_positive_payment'
+        limit 1
+      ) as "firstPositivePaymentEvidenceKey",
+      (
+        select pcm.occurred_at
+        from practice_conversion_milestones pcm
+        where pcm.practice_id = p.id
+          and pcm.milestone = 'first_positive_payment'
+        limit 1
+      ) as "firstPositivePaymentAt",
+      cu.first_visit_closeout_id as "firstVisitCloseoutId",
+      cu.first_visit_completed_at as "firstVisitCompletedAt",
+      coalesce(cu.distinct_clinic_days, 0)::int as "distinctClinicDays",
+      coalesce(cu.clinic_use_days, '[]'::jsonb) as "clinicUseDays",
+      p.billing_status as "billingStatus",
+      p.subscription_tier as "subscriptionTier",
+      p.trial_ends_at as "trialEndsAt",
+      p.country,
+      case
+        when exists (
+          select 1 from location_messaging lm
+          where lm.practice_id = p.id
+            and lm.deleted_at is null
+            and lm.registration_status = 'active'
+            and lm.provider_profile_ready = true
+            and lm.enabled = true
+        ) then 'ready'
+        when exists (
+          select 1 from location_messaging lm
+          where lm.practice_id = p.id
+            and lm.deleted_at is null
+            and lm.registration_status = 'active'
+        ) then 'carrier_approved_sending_off'
+        when exists (
+          select 1 from messaging_registrations mr
+          where mr.practice_id = p.id
+            and mr.deleted_at is null
+            and mr.status in ('action_required', 'failed', 'suspended')
+        ) then 'action_required'
+        when exists (
+          select 1 from messaging_registrations mr
+          where mr.practice_id = p.id and mr.deleted_at is null
+        ) then 'pending'
+        else 'not_configured'
+      end as "smsStatus"
+    from practice_scope p
+    cross join clinic_use cu
+  `);
+  const row = rowsFromExecute<{
+    verifiedAdmins: Array<{ id: string; name: string; email: string }>;
+    activeLocationIds: string[];
+    settings: unknown;
+    activatedEvidenceKey: string | null;
+    activatedAt: Date | string | null;
+    firstVisitCloseoutId: string | null;
+    firstVisitCompletedAt: Date | string | null;
+    distinctClinicDays: number | string;
+    clinicUseDays: ClinicPilotEvidence["clinicUseDays"];
+    paymentMethodEvidenceKey: string | null;
+    paymentMethodCollectedAt: Date | string | null;
+    firstPositivePaymentEvidenceKey: string | null;
+    firstPositivePaymentAt: Date | string | null;
+    billingStatus: string;
+    subscriptionTier: string;
+    trialEndsAt: Date | string | null;
+    country: string;
+    smsStatus: ClinicPilotSmsStatus;
+  }>(result)[0];
+  if (!row) {
+    throw new ClinicPilotNotFoundError(
+      "The practice does not exist or is excluded from clinic operations.",
+    );
+  }
+  const setup = recoverySetupState(row.settings);
+  const trialEndsAt = asDate(row.trialEndsAt);
+  return {
+    verifiedAdmin: row.verifiedAdmins.length > 0,
+    verifiedAdmins: row.verifiedAdmins,
+    verifiedAdminUserIds: row.verifiedAdmins.map((admin) => admin.id),
+    activeLocationCount: row.activeLocationIds.length,
+    activeLocationIds: row.activeLocationIds,
+    setupComplete: setup.completed,
+    setupCompletedAt: setup.completedAt,
+    activatedEvidenceKey: row.activatedEvidenceKey,
+    activatedAt: asDate(row.activatedAt),
+    firstVisitCloseoutId: row.firstVisitCloseoutId,
+    firstVisitCompletedAt: asDate(row.firstVisitCompletedAt),
+    distinctClinicDays: Number(row.distinctClinicDays) || 0,
+    clinicUseDays: row.clinicUseDays,
+    paymentMethodEvidenceKey: row.paymentMethodEvidenceKey,
+    paymentMethodCollectedAt: asDate(row.paymentMethodCollectedAt),
+    firstPositivePaymentEvidenceKey: row.firstPositivePaymentEvidenceKey,
+    firstPositivePaymentAt: asDate(row.firstPositivePaymentAt),
+    billingStatus: row.billingStatus,
+    subscriptionTier: row.subscriptionTier,
+    trialEndsAt,
+    hostedFullAccess: hasHostedFullAccess(
+      row.subscriptionTier,
+      row.billingStatus,
+      trialEndsAt,
+      new Date(),
+      true,
+    ),
+    country: row.country,
+    smsStatus: row.smsStatus,
+  };
+}
+
+export async function saveClinicPilot(
+  db: Database,
+  input: SaveClinicPilotInput,
+  actorIdentity: string,
+) {
+  const cleanBlockers = [...new Set(input.blockerCodes)].sort();
+  const normalized: SaveClinicPilotInput = {
+    ...input,
+    blockerCodes: cleanBlockers,
+  };
+  const hash = payloadHash(normalized);
+  const actor = actorIdentity.trim().toLowerCase();
+
+  return withSystem(db, async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${`clinic-pilot:${input.practiceId}`}, 0))`,
+    );
+
+    const replay = await tx
+      .select({
+        practiceId: clinicPilotEvents.practiceId,
+        payloadHash: clinicPilotEvents.payloadHash,
+        projectionVersion: clinicPilotEvents.projectionVersion,
+      })
+      .from(clinicPilotEvents)
+      .where(eq(clinicPilotEvents.operationId, input.operationId))
+      .limit(1);
+    if (replay[0]) {
+      if (
+        replay[0].practiceId !== input.practiceId ||
+        replay[0].payloadHash !== hash
+      ) {
+        throw new ClinicPilotConflictError(
+          "This operation id was already used for a different pilot change.",
+        );
+      }
+      return {
+        practiceId: replay[0].practiceId,
+        version: replay[0].projectionVersion,
+        replayed: true,
+      };
+    }
+
+    const current = await tx
+      .select({
+        id: clinicPilots.id,
+        version: clinicPilots.version,
+        communicationTestedAt: clinicPilots.communicationTestedAt,
+        firstVisitValidatedAt: clinicPilots.firstVisitValidatedAt,
+        firstVisitValidatedCloseoutId:
+          clinicPilots.firstVisitValidatedCloseoutId,
+        clinicUseValidatedAt: clinicPilots.clinicUseValidatedAt,
+        clinicUseValidatedHash: clinicPilots.clinicUseValidatedHash,
+        clinicAcceptanceAt: clinicPilots.clinicAcceptanceAt,
+        clinicAcceptanceByUserId: clinicPilots.clinicAcceptanceByUserId,
+      })
+      .from(clinicPilots)
+      .where(eq(clinicPilots.practiceId, input.practiceId))
+      .limit(1);
+
+    const evidence = await loadGateEvidence(tx, input.practiceId);
+    const changedAt = new Date();
+    const communicationTestedAt = normalized.communicationTested
+      ? (current[0]?.communicationTestedAt ?? changedAt)
+      : null;
+    const firstVisitValidatedCloseoutId = normalized.firstVisitValidated
+      ? evidence.firstVisitCloseoutId
+      : null;
+    const firstVisitValidatedAt = firstVisitValidatedCloseoutId
+      ? current[0]?.firstVisitValidatedCloseoutId ===
+          firstVisitValidatedCloseoutId && current[0]?.firstVisitValidatedAt
+        ? current[0].firstVisitValidatedAt
+        : changedAt
+      : null;
+    const clinicUseValidatedHash = normalized.clinicUseValidated
+      ? clinicUseEvidenceHash(evidence)
+      : null;
+    const clinicUseValidatedAt = clinicUseValidatedHash
+      ? current[0]?.clinicUseValidatedHash === clinicUseValidatedHash &&
+        current[0]?.clinicUseValidatedAt
+        ? current[0].clinicUseValidatedAt
+        : changedAt
+      : null;
+    const clinicAcceptanceAt = normalized.clinicAcceptanceConfirmed
+      ? current[0]?.clinicAcceptanceByUserId ===
+          normalized.clinicAcceptanceByUserId && current[0]?.clinicAcceptanceAt
+        ? current[0].clinicAcceptanceAt
+        : changedAt
+      : null;
+    const issues = clinicPilotGateIssues(
+      {
+        practiceId: normalized.practiceId,
+        cohortKey: normalized.cohortKey,
+        workflow: normalized.workflow,
+        stage: normalized.stage,
+        decision: normalized.decision,
+        qualificationChecklist: normalized.qualificationChecklist,
+        readinessChecklist: normalized.readinessChecklist,
+        blockerCodes: normalized.blockerCodes,
+        nextAction: normalized.nextAction,
+        supportCadence: normalized.supportCadence,
+        communicationMode: normalized.communicationMode,
+        communicationTested: Boolean(communicationTestedAt),
+        firstVisitValidated: normalized.firstVisitValidated,
+        clinicUseValidated: normalized.clinicUseValidated,
+        clinicAcceptanceConfirmed: Boolean(clinicAcceptanceAt),
+        clinicAcceptanceByUserId: normalized.clinicAcceptanceByUserId,
+        lastContactAt: normalized.lastContactAt,
+        lastContactOutcome: normalized.lastContactOutcome,
+        targetStartOn: normalized.targetStartOn,
+        nextReviewAt: normalized.nextReviewAt,
+      },
+      evidence,
+    );
+    if (issues.length > 0) {
+      throw new ClinicPilotEligibilityError(issues.join(" "));
+    }
+
+    const values = {
+      cohortKey: normalized.cohortKey,
+      workflow: normalized.workflow,
+      stage: normalized.stage,
+      decision: normalized.decision,
+      qualificationChecklist: normalized.qualificationChecklist,
+      readinessChecklist: normalized.readinessChecklist,
+      blockerCodes: normalized.blockerCodes,
+      nextAction: normalized.nextAction,
+      supportCadence: normalized.supportCadence,
+      ownerIdentity: actor,
+      communicationMode: normalized.communicationMode,
+      communicationTestedAt,
+      firstVisitValidatedAt,
+      firstVisitValidatedCloseoutId,
+      clinicUseValidatedAt,
+      clinicUseValidatedHash,
+      clinicAcceptanceAt,
+      clinicAcceptanceByUserId: clinicAcceptanceAt
+        ? normalized.clinicAcceptanceByUserId
+        : null,
+      lastContactAt: normalized.lastContactAt
+        ? new Date(normalized.lastContactAt)
+        : null,
+      lastContactOutcome: normalized.lastContactOutcome,
+      targetStartOn: normalized.targetStartOn,
+      nextReviewAt: normalized.nextReviewAt
+        ? new Date(normalized.nextReviewAt)
+        : null,
+    };
+
+    let pilot: { id: string; version: number } | undefined;
+    let eventType: "enrolled" | "updated";
+    if (!current[0]) {
+      if (input.expectedVersion !== null) {
+        throw new ClinicPilotConflictError(
+          "The pilot changed before enrollment. Refresh and try again.",
+        );
+      }
+      [pilot] = await tx
+        .insert(clinicPilots)
+        .values({ practiceId: input.practiceId, ...values })
+        .returning({ id: clinicPilots.id, version: clinicPilots.version });
+      eventType = "enrolled";
+    } else {
+      if (input.expectedVersion !== current[0].version) {
+        throw new ClinicPilotConflictError(
+          "The pilot changed in another session. Refresh and try again.",
+        );
+      }
+      [pilot] = await tx
+        .update(clinicPilots)
+        .set({
+          ...values,
+          version: current[0].version + 1,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(clinicPilots.id, current[0].id),
+            eq(clinicPilots.practiceId, input.practiceId),
+            eq(clinicPilots.version, current[0].version),
+          ),
+        )
+        .returning({ id: clinicPilots.id, version: clinicPilots.version });
+      eventType = "updated";
+    }
+    if (!pilot) {
+      throw new ClinicPilotConflictError(
+        "The pilot changed in another session. Refresh and try again.",
+      );
+    }
+
+    await tx.insert(clinicPilotEvents).values({
+      clinicPilotId: pilot.id,
+      practiceId: input.practiceId,
+      operationId: input.operationId,
+      payloadHash: hash,
+      eventType,
+      reason: input.reason,
+      cohortKey: values.cohortKey,
+      workflow: values.workflow,
+      stage: values.stage,
+      decision: values.decision,
+      qualificationChecklist: values.qualificationChecklist,
+      readinessChecklist: values.readinessChecklist,
+      blockerCodes: values.blockerCodes,
+      nextAction: values.nextAction,
+      supportCadence: values.supportCadence,
+      ownerIdentity: values.ownerIdentity,
+      communicationMode: values.communicationMode,
+      communicationTestedAt: values.communicationTestedAt,
+      firstVisitValidatedAt: values.firstVisitValidatedAt,
+      firstVisitValidatedCloseoutId: values.firstVisitValidatedCloseoutId,
+      clinicUseValidatedAt: values.clinicUseValidatedAt,
+      clinicUseValidatedHash: values.clinicUseValidatedHash,
+      clinicAcceptanceAt: values.clinicAcceptanceAt,
+      clinicAcceptanceByUserId: values.clinicAcceptanceByUserId,
+      lastContactAt: values.lastContactAt,
+      lastContactOutcome: values.lastContactOutcome,
+      targetStartOn: values.targetStartOn,
+      nextReviewAt: values.nextReviewAt,
+      projectionVersion: pilot.version,
+      actorIdentity: actor,
+      evidenceSnapshot: evidenceSnapshot(evidence),
+    });
+
+    return {
+      practiceId: input.practiceId,
+      version: pilot.version,
+      replayed: false,
+    };
+  });
+}

--- a/apps/web/server/__tests__/admin-clinic-pilots.test.ts
+++ b/apps/web/server/__tests__/admin-clinic-pilots.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class ClinicPilotConflictError extends Error {}
+  class ClinicPilotEligibilityError extends Error {}
+  class ClinicPilotNotFoundError extends Error {}
+  return {
+    db: { execute: vi.fn(async () => []) },
+    loadClinicPilotQueue: vi.fn(async () => []),
+    saveClinicPilot: vi.fn(async () => ({
+      practiceId: "00000000-0000-0000-0000-0000000000aa",
+      version: 1,
+      replayed: false,
+    })),
+    ClinicPilotConflictError,
+    ClinicPilotEligibilityError,
+    ClinicPilotNotFoundError,
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({ db: mocks.db }));
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/tenant-db", () => ({
+  withTenant: vi.fn(
+    async (
+      database: unknown,
+      _practiceId: string,
+      fn: (tx: unknown) => Promise<unknown>,
+    ) => fn(database),
+  ),
+  withSystem: vi.fn(
+    async (database: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+      fn(database),
+  ),
+}));
+vi.mock("@/lib/admin/clinic-pilots", () => ({
+  CLINIC_PILOT_BLOCKERS: [
+    "workflow_fit",
+    "data_import",
+    "staff_training",
+    "record_accuracy",
+    "billing",
+    "payments",
+    "email",
+    "sms",
+    "permissions",
+    "device_connectivity",
+    "backup_export",
+    "support_coverage",
+  ],
+  CLINIC_PILOT_CONTACT_OUTCOMES: [
+    "replied",
+    "no_reply",
+    "scheduled",
+    "completed",
+    "declined",
+  ],
+  CLINIC_PILOT_COMMUNICATION_MODES: ["email_only", "email_and_sms"],
+  CLINIC_PILOT_DECISIONS: [
+    "pending",
+    "eligible",
+    "approved",
+    "paused",
+    "not_a_fit",
+    "graduated",
+  ],
+  CLINIC_PILOT_NEXT_ACTIONS: [
+    "confirm_fit",
+    "schedule_setup",
+    "validate_import",
+    "complete_first_visit",
+    "review_communications",
+    "configure_payment",
+    "review_clinic_week",
+    "resolve_blockers",
+    "decide_graduation",
+    "support_retention",
+    "revisit_fit",
+  ],
+  CLINIC_PILOT_REASONS: [
+    "initial_review",
+    "clinic_feedback",
+    "product_evidence",
+    "support_review",
+    "blocker_review",
+    "graduation_decision",
+  ],
+  CLINIC_PILOT_STAGES: [
+    "candidate",
+    "parallel_setup",
+    "visit_validation",
+    "pilot_week",
+    "graduation_review",
+    "completed",
+    "closed",
+  ],
+  CLINIC_PILOT_SUPPORT_CADENCES: ["daily", "twice_weekly", "weekly"],
+  CLINIC_PILOT_WORKFLOWS: ["general_practice", "house_call"],
+  ClinicPilotConflictError: mocks.ClinicPilotConflictError,
+  ClinicPilotEligibilityError: mocks.ClinicPilotEligibilityError,
+  ClinicPilotNotFoundError: mocks.ClinicPilotNotFoundError,
+  loadClinicPilotQueue: mocks.loadClinicPilotQueue,
+  saveClinicPilot: mocks.saveClinicPilot,
+}));
+
+const { adminRouter } = await import("../routers/admin");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+
+function caller(email = "ops@example.com") {
+  return adminRouter.createCaller({
+    db: mocks.db,
+    session: {
+      user: {
+        id: "00000000-0000-0000-0000-000000000001",
+        email,
+        name: "Ops",
+        role: "admin",
+        practiceId: PRACTICE_ID,
+      },
+    },
+  } as never);
+}
+
+function input() {
+  return {
+    practiceId: PRACTICE_ID,
+    operationId: "00000000-0000-0000-0000-000000000002",
+    expectedVersion: null,
+    cohortKey: "pilot-2026-08",
+    workflow: "general_practice" as const,
+    stage: "candidate" as const,
+    decision: "pending" as const,
+    qualificationChecklist: {
+      supportedClinicType: false,
+      supportedJurisdictionConfirmed: false,
+      singleLocation: false,
+      connectedModeAccepted: false,
+      parallelRunAccepted: false,
+      championConfirmed: false,
+      supportedWorkflowConfirmed: false,
+      noUnsupportedMustHave: false,
+    },
+    readinessChecklist: {
+      rolesAndDevicesValidated: false,
+      migrationPlanAccepted: false,
+      sampleValidationAccepted: false,
+      firstVisitScheduled: false,
+      exportAndRollbackConfirmed: false,
+      supportCadenceConfirmed: false,
+    },
+    blockerCodes: [],
+    nextAction: "confirm_fit" as const,
+    supportCadence: "daily" as const,
+    communicationMode: "email_only" as const,
+    communicationTested: false,
+    firstVisitValidated: false,
+    clinicUseValidated: false,
+    clinicAcceptanceConfirmed: false,
+    clinicAcceptanceByUserId: null,
+    lastContactAt: null,
+    lastContactOutcome: null,
+    targetStartOn: null,
+    nextReviewAt: "2026-08-11T12:00:00.000Z",
+    reason: "initial_review" as const,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  mocks.saveClinicPilot.mockResolvedValue({
+    practiceId: PRACTICE_ID,
+    version: 1,
+    replayed: false,
+  });
+});
+
+describe("admin clinic pilot operations", () => {
+  it("rejects clinic admins before reading or mutating the cohort", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    await expect(
+      caller("clinic@example.com").clinicPilotQueue(),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    await expect(
+      caller("clinic@example.com").saveClinicPilot(input()),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.loadClinicPilotQueue).not.toHaveBeenCalled();
+    expect(mocks.saveClinicPilot).not.toHaveBeenCalled();
+  });
+
+  it("accepts only the bounded PHI-free payload and attributes the operator", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    await expect(caller().saveClinicPilot(input())).resolves.toMatchObject({
+      practiceId: PRACTICE_ID,
+      version: 1,
+    });
+    expect(mocks.saveClinicPilot).toHaveBeenCalledWith(
+      mocks.db,
+      input(),
+      "ops@example.com",
+    );
+
+    await expect(
+      caller().saveClinicPilot({
+        ...input(),
+        notes: "Patient or participant detail must never be accepted",
+      } as never),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("maps stale and failed gate decisions without hiding the reason", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.saveClinicPilot.mockRejectedValueOnce(
+      new mocks.ClinicPilotConflictError("Refresh and try again."),
+    );
+    await expect(caller().saveClinicPilot(input())).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Refresh and try again.",
+    });
+
+    mocks.saveClinicPilot.mockRejectedValueOnce(
+      new mocks.ClinicPilotEligibilityError("Complete the readiness checks."),
+    );
+    await expect(caller().saveClinicPilot(input())).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Complete the readiness checks.",
+    });
+  });
+});

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -24,6 +24,22 @@ import { computeActivationFunnel } from "@/lib/admin/activation-funnel";
 import { computeJourneyFunnel } from "@/lib/admin/journey-funnel";
 import { computeActivationRecovery } from "@/lib/admin/activation-recovery";
 import {
+  CLINIC_PILOT_BLOCKERS,
+  CLINIC_PILOT_COMMUNICATION_MODES,
+  CLINIC_PILOT_CONTACT_OUTCOMES,
+  CLINIC_PILOT_DECISIONS,
+  CLINIC_PILOT_NEXT_ACTIONS,
+  CLINIC_PILOT_REASONS,
+  CLINIC_PILOT_STAGES,
+  CLINIC_PILOT_SUPPORT_CADENCES,
+  CLINIC_PILOT_WORKFLOWS,
+  ClinicPilotConflictError,
+  ClinicPilotEligibilityError,
+  ClinicPilotNotFoundError,
+  loadClinicPilotQueue,
+  saveClinicPilot,
+} from "@/lib/admin/clinic-pilots";
+import {
   CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
   CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
   getPlan,
@@ -92,6 +108,61 @@ const platformAdminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
 const MESSAGING_SUBMISSION_LOCK_STALE_MS = 15 * 60 * 1000;
 const MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
 const WITHHELD_PHONE_LIKE_OPERATIONAL_ID = "[withheld: phone-like identifier]";
+
+const clinicPilotQualificationInput = z
+  .object({
+    supportedClinicType: z.boolean(),
+    supportedJurisdictionConfirmed: z.boolean(),
+    singleLocation: z.boolean(),
+    connectedModeAccepted: z.boolean(),
+    parallelRunAccepted: z.boolean(),
+    championConfirmed: z.boolean(),
+    supportedWorkflowConfirmed: z.boolean(),
+    noUnsupportedMustHave: z.boolean(),
+  })
+  .strict();
+
+const clinicPilotReadinessInput = z
+  .object({
+    rolesAndDevicesValidated: z.boolean(),
+    migrationPlanAccepted: z.boolean(),
+    sampleValidationAccepted: z.boolean(),
+    firstVisitScheduled: z.boolean(),
+    exportAndRollbackConfirmed: z.boolean(),
+    supportCadenceConfirmed: z.boolean(),
+  })
+  .strict();
+
+const clinicPilotSaveInput = z
+  .object({
+    practiceId: z.string().uuid(),
+    operationId: z.string().uuid(),
+    expectedVersion: z.number().int().positive().nullable(),
+    cohortKey: z.string().regex(/^pilot-[0-9]{4}-[0-9]{2}$/),
+    workflow: z.enum(CLINIC_PILOT_WORKFLOWS),
+    stage: z.enum(CLINIC_PILOT_STAGES),
+    decision: z.enum(CLINIC_PILOT_DECISIONS),
+    qualificationChecklist: clinicPilotQualificationInput,
+    readinessChecklist: clinicPilotReadinessInput,
+    blockerCodes: z.array(z.enum(CLINIC_PILOT_BLOCKERS)).max(12),
+    nextAction: z.enum(CLINIC_PILOT_NEXT_ACTIONS),
+    supportCadence: z.enum(CLINIC_PILOT_SUPPORT_CADENCES),
+    communicationMode: z.enum(CLINIC_PILOT_COMMUNICATION_MODES),
+    communicationTested: z.boolean(),
+    firstVisitValidated: z.boolean(),
+    clinicUseValidated: z.boolean(),
+    clinicAcceptanceConfirmed: z.boolean(),
+    clinicAcceptanceByUserId: z.string().uuid().nullable(),
+    lastContactAt: z.string().datetime({ offset: true }).nullable(),
+    lastContactOutcome: z.enum(CLINIC_PILOT_CONTACT_OUTCOMES).nullable(),
+    targetStartOn: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .nullable(),
+    nextReviewAt: z.string().datetime({ offset: true }).nullable(),
+    reason: z.enum(CLINIC_PILOT_REASONS),
+  })
+  .strict();
 
 function safeOperationalProviderId(value: string | null): string | null {
   if (!value) return null;
@@ -2632,6 +2703,46 @@ export const adminRouter = createRouter({
   activationRecovery: platformAdminProcedure.query(() =>
     computeActivationRecovery(db, new Date()),
   ),
+
+  /** Audited operating queue for the deliberately bounded clinic pilot. */
+  clinicPilotQueue: platformAdminProcedure.query(() => {
+    noStore();
+    return loadClinicPilotQueue(db);
+  }),
+
+  /**
+   * Save one bounded pilot decision and its immutable snapshot atomically.
+   * This never sends a message, enables SMS, changes billing, or calls an
+   * external provider.
+   */
+  saveClinicPilot: platformAdminProcedure
+    .input(clinicPilotSaveInput)
+    .mutation(async ({ ctx, input }) => {
+      const actorIdentity = ctx.session?.user?.email?.trim();
+      if (!actorIdentity) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "A verified platform operator identity is required.",
+        });
+      }
+      try {
+        return await saveClinicPilot(db, input, actorIdentity);
+      } catch (error) {
+        if (error instanceof ClinicPilotConflictError) {
+          throw new TRPCError({ code: "CONFLICT", message: error.message });
+        }
+        if (error instanceof ClinicPilotEligibilityError) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: error.message,
+          });
+        }
+        if (error instanceof ClinicPilotNotFoundError) {
+          throw new TRPCError({ code: "NOT_FOUND", message: error.message });
+        }
+        throw error;
+      }
+    }),
 
   /** Privacy-safe first-touch cohorts spanning visit through paid. */
   journeyFunnel: platformAdminProcedure

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -144,6 +144,7 @@ const HOSTED_READ_ONLY_MUTATION_ALLOWLIST = new Set([
   // practice trial has lapsed; the procedure itself gates on the
   // PLATFORM_ADMIN_EMAILS allowlist.
   "admin.extendTrial",
+  "admin.saveClinicPilot",
   "admin.submitMessagingBrand",
   "admin.submitMessagingCampaign",
   "admin.assignMessagingNumbers",
@@ -166,27 +167,29 @@ function practiceNotFound(): TRPCError {
  * They have no tenant session and do their own scoping (tokens, email, rate
  * limits), so they run in a system DB context that bypasses tenant RLS.
  */
-export const publicProcedure = t.procedure.use(async ({ ctx, next, type, path }) => {
-  const effects: PostCommitEffect[] = [];
-  const result = await withSystem(ctx.db, (tx) =>
-    next({
-      ctx: {
-        ...ctx,
-        db: tx,
-        postCommitEffect: (effect: PostCommitEffect) => {
-          if (type !== "mutation") {
-            throw new Error("Post-commit effects are mutation-only.");
-          }
-          effects.push(effect);
+export const publicProcedure = t.procedure.use(
+  async ({ ctx, next, type, path }) => {
+    const effects: PostCommitEffect[] = [];
+    const result = await withSystem(ctx.db, (tx) =>
+      next({
+        ctx: {
+          ...ctx,
+          db: tx,
+          postCommitEffect: (effect: PostCommitEffect) => {
+            if (type !== "mutation") {
+              throw new Error("Post-commit effects are mutation-only.");
+            }
+            effects.push(effect);
+          },
         },
-      },
-    }),
-  );
-  if (result.ok) {
-    await runPostCommitEffects(ctx.db, effects, path);
-  }
-  return result;
-});
+      }),
+    );
+    if (result.ok) {
+      await runPostCommitEffects(ctx.db, effects, path);
+    }
+    return result;
+  },
+);
 
 /** Requires an authenticated session */
 export const protectedProcedure = t.procedure.use(

--- a/docs/clinic-pilot-operations.md
+++ b/docs/clinic-pilot-operations.md
@@ -1,0 +1,163 @@
+# Controlled clinic pilot operations
+
+This runbook turns the [clinic pilot readiness boundary](clinic-pilot-readiness.md)
+into a repeatable operating process. The first cohort is limited to connected,
+single-location United States general-practice and house-call pilots. It is not
+approval to market OpenVPM as a universal PIMS replacement.
+
+The platform-admin pilot workspace keeps two kinds of evidence separate:
+
+- **Product evidence** is derived from the underlying records: setup,
+  activation, completed visit closeout, distinct clinic-use days, payment
+  method, positive payment, and messaging readiness. An operator cannot edit
+  these facts.
+- **Operating decisions** are bounded, PHI-free fit checks, readiness checks,
+  blocker codes, support cadence, next action, review time, and the pilot
+  decision. Every change creates an immutable snapshot.
+
+Saving a pilot review never sends a message, enables texting, buys or assigns a
+number, changes a subscription, adds a payment method, or charges a clinic.
+
+## 1. Qualify within one business day
+
+Confirm every clinic-fit check before marking a candidate eligible:
+
+1. The clinic is a supported general-practice or house-call workflow.
+2. The clinic operates in the United States and accepts the first-cohort
+   jurisdiction boundary.
+3. One location is in scope.
+4. The clinic accepts that a reliable internet connection is required.
+5. The clinic will keep its existing PIMS authoritative during validation.
+6. A clinic owner and a day-to-day champion are confirmed.
+7. The target workflow is explicit and supported.
+8. No unsupported feature is a must-have for the pilot.
+
+Choose `not a fit` when a must-have depends on offline use, multi-location
+production, herd/group medicine, automated regulatory reporting, or an
+unavailable vendor integration. Record only the blocker category. Never paste
+messages, patient or client details, credentials, payment data, or clinical
+notes into pilot operations.
+
+## 2. Approve readiness before real clinic work
+
+All readiness checks, a verified clinic administrator, exactly one active
+location, and zero open blockers are required before approval:
+
+1. Test each in-scope staff role and device.
+2. Agree on assisted migration or manual-entry scope.
+3. Dry-run and reconcile a small representative sample.
+4. Schedule the first real visit and name the staff involved.
+5. Confirm export, backup, and rollback responsibilities.
+6. Set the support cadence and next review time.
+
+Select and successfully test the client communication path. Keep SMS out of
+scope unless the separate carrier registration, consent, provider verification,
+and exact clinic/location allowlist are complete. A tested email path is the
+fallback while texting is unavailable.
+
+## 3. Validate one golden clinic day
+
+Run one real visit through the complete supported handoff:
+
+1. Create or verify the client and patient.
+2. Schedule and check in the appointment.
+3. Record vitals and the encounter.
+4. Finalize clinical documentation.
+5. Record applicable services, vaccines, prescriptions, manual lab work, and
+   consumables.
+6. Complete billing or document the no-charge reason.
+7. Complete discharge instructions, follow-up, and client handoff.
+8. Export or retrieve the resulting record and confirm the rollback path.
+
+The platform observes a candidate only when the non-seeded appointment has a
+completed visit closeout. An operator must then explicitly validate that the
+observed closeout represents real clinic work; system activity alone cannot
+advance the pilot week. Creating a client and appointment is activation, not
+proof of a completed clinic day.
+
+Pause immediately for patient-safety, record-integrity, billing-integrity,
+tenant-isolation, or unrecoverable workflow problems. Keep the prior PIMS as
+the source of truth while the issue is investigated.
+
+## 4. Run five clinic days
+
+After the first visit succeeds, run the agreed workflow on five distinct local
+clinic dates. Use a daily support cadence during this phase unless the clinic
+and operator deliberately choose otherwise.
+
+At each review:
+
+- confirm the prior day's visits and billing closed correctly;
+- inspect record, lab, follow-up, email, payment, and export exceptions;
+- record only bounded blocker categories and the next action;
+- set the next review time; and
+- preserve the clinic's independent rollback path.
+
+Five dates measure repeated use, not volume. A high appointment count on one
+day does not substitute for a pilot week. Before graduation review, the
+operator must attest that the five observed dates were real clinic operations,
+not staff-created test work.
+
+## 5. Decide within two business days
+
+Graduation requires:
+
+- completed clinic-fit and readiness checks;
+- a verified administrator and one active location;
+- no open blockers;
+- activation and an operator-validated completed real visit;
+- five distinct, operator-validated clinic-use days;
+- a successfully tested email path, plus operational SMS when SMS is in scope;
+- a payment method collected through signed subscription Checkout evidence;
+- current hosted write access through an unexpired trial or active paid tier;
+  and
+- explicit golden-day and go-live acceptance attributed to a current verified
+  clinic administrator.
+
+Positive payment remains a separate signed Stripe milestone and is never
+entered manually. A clinic can graduate while a legitimate free trial is still
+running; the workspace must continue to show payment pending until a positive
+subscription invoice succeeds.
+
+Use these outcomes:
+
+- **Graduated:** the supported workflow is accepted and the clinic can move to
+  the agreed production scope.
+- **Paused:** a safe, owned blocker has a clear next review date.
+- **Not a fit:** a required workflow is outside the supported boundary. Close
+  the pilot without implying that missing evidence is zero.
+
+Do not extend a pilot to hide an undefined problem. An extension needs a
+bounded blocker, an owner outside the patient record, a next action, and a
+review date.
+
+## 6. Evidence and retention
+
+Retain the source export until migration acceptance, preserve reconciliation
+counts, and take an OpenVPM export after acceptance. Pilot operations should
+contain only non-sensitive codes and timestamps. Product records, billing
+evidence, and provider evidence remain in their authoritative ledgers.
+
+Platform operators may correct the current pilot projection through the admin
+workspace. Every projection version must have a matching event at database
+commit; each event preserves a PHI-free snapshot of the canonical source IDs,
+timestamps, current billing access, and messaging state that passed the gate.
+The application role cannot rewrite or delete event history. Ordinary clinic
+sessions cannot read any pilot-cohort state.
+
+## Escalation
+
+- **Patient or record safety:** pause clinic work in OpenVPM and preserve all
+  evidence.
+- **Billing or payment integrity:** stop the affected checkout flow; do not
+  retry charges blindly.
+- **Data isolation or security:** treat as an incident and follow the security
+  process.
+- **Connectivity:** use the agreed connected-mode fallback; OpenVPM does not
+  offer offline charting.
+- **SMS:** disable clinic sending and use email until carrier and consent
+  evidence are reviewed.
+
+No dashboard can replace clinic sign-off. Graduation is a documented operating
+decision supported by exact product evidence, an accepted workflow, recoverable
+data, and a team that knows the fallback.

--- a/docs/clinic-pilot-readiness.md
+++ b/docs/clinic-pilot-readiness.md
@@ -1,5 +1,9 @@
 # Clinic pilot readiness
 
+Platform operators should use the
+[controlled clinic pilot operations runbook](clinic-pilot-operations.md) to
+qualify, validate, support, and graduate each clinic consistently.
+
 OpenVPM is ready for a controlled, connected-mode clinic pilot. It should not
 yet be sold as a universal replacement for every veterinary workflow. This
 page defines the boundary so a clinic can make a clear decision before moving

--- a/docs/conversion-observability.md
+++ b/docs/conversion-observability.md
@@ -5,14 +5,18 @@ canonical repairable projection is `practice_conversion_milestones`; browser
 journey telemetry remains in `funnel_events` and is not a business-stage source
 of truth.
 
+The [controlled clinic pilot operations runbook](clinic-pilot-operations.md)
+adds a separate, audited operating layer for qualified clinics. Pilot stages
+and decisions never replace the canonical conversion evidence below.
+
 ## Canonical definitions
 
-| Milestone | Exact source | Occurrence time |
-| --- | --- | --- |
-| Registered | committed `practices` row | `practices.created_at` |
-| Activated | earliest non-demo client plus earliest non-demo appointment | later of practice, client, and appointment creation |
-| Payment method collected | signed subscription `checkout.session.completed` with `mode=subscription`, `payment_method_collection=always`, and a subscription id | signed Stripe `event.created` |
-| First positive payment | signed subscription `invoice.payment_succeeded` with `amount_paid > 0`, valid currency, and a subscription id | signed Stripe `event.created` |
+| Milestone                | Exact source                                                                                                                         | Occurrence time                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| Registered               | committed `practices` row                                                                                                            | `practices.created_at`                              |
+| Activated                | earliest non-demo client plus earliest non-demo appointment                                                                          | later of practice, client, and appointment creation |
+| Payment method collected | signed subscription `checkout.session.completed` with `mode=subscription`, `payment_method_collection=always`, and a subscription id | signed Stripe `event.created`                       |
+| First positive payment   | signed subscription `invoice.payment_succeeded` with `amount_paid > 0`, valid currency, and a subscription id                        | signed Stripe `event.created`                       |
 
 `observed_at` is when the projection first saw evidence. It is never used as a
 conversion timestamp. Reconciliation may repair `occurred_at` to an earlier

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -1,5 +1,9 @@
 # OpenVPM Cloud Production Runbook
 
+Clinic onboarding and graduation are governed by the
+[controlled clinic pilot operations runbook](clinic-pilot-operations.md) and
+the [clinic readiness boundary](clinic-pilot-readiness.md).
+
 OpenVPM has two operating modes:
 
 - **Self-host / OSS:** leave `HOSTED_BILLING_ENABLED` unset. Hosted billing gates and usage metering are disabled, and Stripe subscription envs are optional.

--- a/packages/db/drizzle/0072_lucky_kate_bishop.sql
+++ b/packages/db/drizzle/0072_lucky_kate_bishop.sql
@@ -1,0 +1,252 @@
+CREATE TYPE "public"."clinic_pilot_communication_mode" AS ENUM('email_only', 'email_and_sms');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_contact_outcome" AS ENUM('replied', 'no_reply', 'scheduled', 'completed', 'declined');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_decision" AS ENUM('pending', 'eligible', 'approved', 'paused', 'not_a_fit', 'graduated');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_event_type" AS ENUM('enrolled', 'updated');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_next_action" AS ENUM('confirm_fit', 'schedule_setup', 'validate_import', 'complete_first_visit', 'review_communications', 'configure_payment', 'review_clinic_week', 'resolve_blockers', 'decide_graduation', 'support_retention', 'revisit_fit');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_reason" AS ENUM('initial_review', 'clinic_feedback', 'product_evidence', 'support_review', 'blocker_review', 'graduation_decision');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_stage" AS ENUM('candidate', 'parallel_setup', 'visit_validation', 'pilot_week', 'graduation_review', 'completed', 'closed');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_support_cadence" AS ENUM('daily', 'twice_weekly', 'weekly');--> statement-breakpoint
+CREATE TYPE "public"."clinic_pilot_workflow" AS ENUM('general_practice', 'house_call');--> statement-breakpoint
+CREATE TABLE "clinic_pilot_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"clinic_pilot_id" uuid NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"operation_id" uuid NOT NULL,
+	"payload_hash" varchar(64) NOT NULL,
+	"event_type" "clinic_pilot_event_type" NOT NULL,
+	"reason" "clinic_pilot_reason" NOT NULL,
+	"cohort_key" varchar(32) NOT NULL,
+	"workflow" "clinic_pilot_workflow" NOT NULL,
+	"stage" "clinic_pilot_stage" NOT NULL,
+	"decision" "clinic_pilot_decision" NOT NULL,
+	"qualification_checklist" jsonb NOT NULL,
+	"readiness_checklist" jsonb NOT NULL,
+	"blocker_codes" text[] NOT NULL,
+	"next_action" "clinic_pilot_next_action" NOT NULL,
+	"support_cadence" "clinic_pilot_support_cadence" NOT NULL,
+	"owner_identity" varchar(255) NOT NULL,
+	"communication_mode" "clinic_pilot_communication_mode" NOT NULL,
+	"communication_tested_at" timestamp with time zone,
+	"first_visit_validated_at" timestamp with time zone,
+	"clinic_use_validated_at" timestamp with time zone,
+	"clinic_acceptance_at" timestamp with time zone,
+	"clinic_acceptance_by_user_id" uuid,
+	"last_contact_at" timestamp with time zone,
+	"last_contact_outcome" "clinic_pilot_contact_outcome",
+	"target_start_on" date,
+	"next_review_at" timestamp with time zone,
+	"projection_version" integer NOT NULL,
+	"actor_identity" varchar(255) NOT NULL,
+	"evidence_snapshot" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "clinic_pilot_events_snapshot_check" CHECK ("clinic_pilot_events"."projection_version" > 0
+        and "clinic_pilot_events"."payload_hash" ~ '^[a-f0-9]{64}$'
+        and "clinic_pilot_events"."actor_identity" = btrim("clinic_pilot_events"."actor_identity")
+        and length("clinic_pilot_events"."actor_identity") between 3 and 255
+        and "clinic_pilot_events"."owner_identity" = btrim("clinic_pilot_events"."owner_identity")
+        and length("clinic_pilot_events"."owner_identity") between 3 and 255
+        and "clinic_pilot_events"."cohort_key" ~ '^pilot-[0-9]{4}-[0-9]{2}$'
+        and jsonb_typeof("clinic_pilot_events"."qualification_checklist") = 'object'
+        and jsonb_typeof("clinic_pilot_events"."readiness_checklist") = 'object'
+        and jsonb_typeof("clinic_pilot_events"."evidence_snapshot") = 'object'
+        and ("clinic_pilot_events"."last_contact_at" is null) = ("clinic_pilot_events"."last_contact_outcome" is null)
+        and ("clinic_pilot_events"."clinic_acceptance_at" is null) = ("clinic_pilot_events"."clinic_acceptance_by_user_id" is null)
+        and "clinic_pilot_events"."blocker_codes" <@ ARRAY[
+          'workflow_fit',
+          'data_import',
+          'staff_training',
+          'record_accuracy',
+          'billing',
+          'payments',
+          'email',
+          'sms',
+          'permissions',
+          'device_connectivity',
+          'backup_export',
+          'support_coverage'
+        ]::text[]
+        and cardinality("clinic_pilot_events"."blocker_codes") <= 12
+        and array_position("clinic_pilot_events"."blocker_codes", null) is null)
+);
+--> statement-breakpoint
+CREATE TABLE "clinic_pilots" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"cohort_key" varchar(32) NOT NULL,
+	"workflow" "clinic_pilot_workflow" NOT NULL,
+	"stage" "clinic_pilot_stage" DEFAULT 'candidate' NOT NULL,
+	"decision" "clinic_pilot_decision" DEFAULT 'pending' NOT NULL,
+	"qualification_checklist" jsonb DEFAULT '{"supportedClinicType":false,"supportedJurisdictionConfirmed":false,"singleLocation":false,"connectedModeAccepted":false,"parallelRunAccepted":false,"championConfirmed":false,"supportedWorkflowConfirmed":false,"noUnsupportedMustHave":false}'::jsonb NOT NULL,
+	"readiness_checklist" jsonb DEFAULT '{"rolesAndDevicesValidated":false,"migrationPlanAccepted":false,"sampleValidationAccepted":false,"firstVisitScheduled":false,"exportAndRollbackConfirmed":false,"supportCadenceConfirmed":false}'::jsonb NOT NULL,
+	"blocker_codes" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+	"next_action" "clinic_pilot_next_action" DEFAULT 'confirm_fit' NOT NULL,
+	"support_cadence" "clinic_pilot_support_cadence" DEFAULT 'daily' NOT NULL,
+	"owner_identity" varchar(255) NOT NULL,
+	"communication_mode" "clinic_pilot_communication_mode" DEFAULT 'email_only' NOT NULL,
+	"communication_tested_at" timestamp with time zone,
+	"first_visit_validated_at" timestamp with time zone,
+	"clinic_use_validated_at" timestamp with time zone,
+	"clinic_acceptance_at" timestamp with time zone,
+	"clinic_acceptance_by_user_id" uuid,
+	"last_contact_at" timestamp with time zone,
+	"last_contact_outcome" "clinic_pilot_contact_outcome",
+	"target_start_on" date,
+	"next_review_at" timestamp with time zone,
+	"version" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "clinic_pilots_version_check" CHECK ("clinic_pilots"."version" > 0),
+	CONSTRAINT "clinic_pilots_operating_shape_check" CHECK ("clinic_pilots"."cohort_key" ~ '^pilot-[0-9]{4}-[0-9]{2}$'
+        and jsonb_typeof("clinic_pilots"."qualification_checklist") = 'object'
+        and jsonb_typeof("clinic_pilots"."readiness_checklist") = 'object'
+        and "clinic_pilots"."owner_identity" = btrim("clinic_pilots"."owner_identity")
+        and length("clinic_pilots"."owner_identity") between 3 and 255
+        and ("clinic_pilots"."last_contact_at" is null) = ("clinic_pilots"."last_contact_outcome" is null)
+        and ("clinic_pilots"."clinic_acceptance_at" is null) = ("clinic_pilots"."clinic_acceptance_by_user_id" is null)),
+	CONSTRAINT "clinic_pilots_blocker_codes_check" CHECK ("clinic_pilots"."blocker_codes" <@ ARRAY[
+          'workflow_fit',
+          'data_import',
+          'staff_training',
+          'record_accuracy',
+          'billing',
+          'payments',
+          'email',
+          'sms',
+          'permissions',
+          'device_connectivity',
+          'backup_export',
+          'support_coverage'
+        ]::text[]
+        and cardinality("clinic_pilots"."blocker_codes") <= 12
+        and array_position("clinic_pilots"."blocker_codes", null) is null),
+	CONSTRAINT "clinic_pilots_lifecycle_check" CHECK ((
+          "clinic_pilots"."stage" = 'completed'
+          and "clinic_pilots"."decision" = 'graduated'
+          and cardinality("clinic_pilots"."blocker_codes") = 0
+          and "clinic_pilots"."next_action" = 'support_retention'
+          and "clinic_pilots"."next_review_at" is null
+        ) or (
+          "clinic_pilots"."stage" = 'closed'
+          and "clinic_pilots"."decision" = 'not_a_fit'
+          and "clinic_pilots"."next_action" = 'revisit_fit'
+          and "clinic_pilots"."next_review_at" is null
+        ) or (
+          "clinic_pilots"."stage" not in ('completed', 'closed')
+          and "clinic_pilots"."decision" not in ('graduated', 'not_a_fit')
+          and "clinic_pilots"."next_review_at" is not null
+        ))
+);
+--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk" FOREIGN KEY ("clinic_pilot_id") REFERENCES "public"."clinic_pilots"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_pilot_practice_fk" FOREIGN KEY ("clinic_pilot_id","practice_id") REFERENCES "public"."clinic_pilots"("id","practice_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_acceptance_user_practice_fk" FOREIGN KEY ("practice_id","clinic_acceptance_by_user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clinic_pilots" ADD CONSTRAINT "clinic_pilots_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clinic_pilots" ADD CONSTRAINT "clinic_pilots_acceptance_user_practice_fk" FOREIGN KEY ("practice_id","clinic_acceptance_by_user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "clinic_pilot_events_operation_uq" ON "clinic_pilot_events" USING btree ("operation_id");--> statement-breakpoint
+CREATE INDEX "clinic_pilot_events_history_idx" ON "clinic_pilot_events" USING btree ("practice_id","created_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "clinic_pilots_practice_uq" ON "clinic_pilots" USING btree ("practice_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "clinic_pilots_id_practice_uq" ON "clinic_pilots" USING btree ("id","practice_id");--> statement-breakpoint
+CREATE INDEX "clinic_pilots_review_idx" ON "clinic_pilots" USING btree ("stage","next_review_at","practice_id");--> statement-breakpoint
+
+-- Install system-only access in the same transaction that creates these
+-- cross-tenant tables, so there is no fail-open interval before db:rls runs.
+CREATE OR REPLACE FUNCTION app_rls_bypass() RETURNS boolean
+  LANGUAGE sql STABLE
+  SET search_path = ''
+  AS
+$fn$ SELECT coalesce(current_setting('app.rls_bypass', true), '') = 'on' $fn$;--> statement-breakpoint
+ALTER TABLE clinic_pilots ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY system_only ON clinic_pilots
+  USING (app_rls_bypass())
+  WITH CHECK (app_rls_bypass());--> statement-breakpoint
+ALTER TABLE clinic_pilot_events ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY system_read ON clinic_pilot_events
+  FOR SELECT USING (app_rls_bypass());--> statement-breakpoint
+CREATE POLICY system_insert ON clinic_pilot_events
+  FOR INSERT WITH CHECK (app_rls_bypass());--> statement-breakpoint
+DO $$
+DECLARE r text;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+    REVOKE ALL ON clinic_pilots, clinic_pilot_events FROM openpims_app;
+    GRANT SELECT, INSERT, UPDATE ON clinic_pilots TO openpims_app;
+    GRANT SELECT, INSERT ON clinic_pilot_events TO openpims_app;
+  END IF;
+  FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
+      EXECUTE format(
+        'REVOKE ALL ON clinic_pilots, clinic_pilot_events FROM %I', r
+      );
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+
+-- An event ledger is an invariant, not an application convention. Projection
+-- writes and event inserts are checked together at transaction commit.
+CREATE OR REPLACE FUNCTION enforce_clinic_pilot_projection_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.clinic_pilot_events e
+    WHERE e.clinic_pilot_id = NEW.id
+      AND e.practice_id = NEW.practice_id
+      AND e.projection_version = NEW.version
+      AND e.cohort_key = NEW.cohort_key
+      AND e.workflow = NEW.workflow
+      AND e.stage = NEW.stage
+      AND e.decision = NEW.decision
+      AND e.qualification_checklist = NEW.qualification_checklist
+      AND e.readiness_checklist = NEW.readiness_checklist
+      AND e.blocker_codes = NEW.blocker_codes
+      AND e.next_action = NEW.next_action
+      AND e.support_cadence = NEW.support_cadence
+      AND e.owner_identity = NEW.owner_identity
+      AND e.communication_mode = NEW.communication_mode
+      AND e.communication_tested_at IS NOT DISTINCT FROM NEW.communication_tested_at
+      AND e.first_visit_validated_at IS NOT DISTINCT FROM NEW.first_visit_validated_at
+      AND e.clinic_use_validated_at IS NOT DISTINCT FROM NEW.clinic_use_validated_at
+      AND e.clinic_acceptance_at IS NOT DISTINCT FROM NEW.clinic_acceptance_at
+      AND e.clinic_acceptance_by_user_id IS NOT DISTINCT FROM NEW.clinic_acceptance_by_user_id
+      AND e.last_contact_at IS NOT DISTINCT FROM NEW.last_contact_at
+      AND e.last_contact_outcome IS NOT DISTINCT FROM NEW.last_contact_outcome
+      AND e.target_start_on IS NOT DISTINCT FROM NEW.target_start_on
+      AND e.next_review_at IS NOT DISTINCT FROM NEW.next_review_at
+  ) THEN
+    RAISE EXCEPTION 'clinic pilot projection version % requires a matching immutable event', NEW.version;
+  END IF;
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE CONSTRAINT TRIGGER clinic_pilots_require_event
+AFTER INSERT OR UPDATE ON clinic_pilots
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION enforce_clinic_pilot_projection_audit();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION reject_clinic_pilot_event_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+    AND current_user = (
+      SELECT pg_catalog.pg_get_userbyid(class.relowner)
+      FROM pg_catalog.pg_class class
+      JOIN pg_catalog.pg_namespace namespace ON namespace.oid = class.relnamespace
+      WHERE namespace.nspname = TG_TABLE_SCHEMA AND class.relname = TG_TABLE_NAME
+    )
+  THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+  END IF;
+  RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'Clinic pilot events are immutable.';
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER clinic_pilot_events_immutable
+BEFORE UPDATE OR DELETE ON clinic_pilot_events
+FOR EACH ROW EXECUTE FUNCTION reject_clinic_pilot_event_mutation();

--- a/packages/db/drizzle/0072_lucky_kate_bishop.sql
+++ b/packages/db/drizzle/0072_lucky_kate_bishop.sql
@@ -137,6 +137,7 @@ CREATE TABLE "clinic_pilots" (
         ))
 );
 --> statement-breakpoint
+CREATE UNIQUE INDEX "clinic_pilots_id_practice_uq" ON "clinic_pilots" USING btree ("id","practice_id");--> statement-breakpoint
 ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk" FOREIGN KEY ("clinic_pilot_id") REFERENCES "public"."clinic_pilots"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_pilot_practice_fk" FOREIGN KEY ("clinic_pilot_id","practice_id") REFERENCES "public"."clinic_pilots"("id","practice_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
@@ -146,7 +147,6 @@ ALTER TABLE "clinic_pilots" ADD CONSTRAINT "clinic_pilots_acceptance_user_practi
 CREATE UNIQUE INDEX "clinic_pilot_events_operation_uq" ON "clinic_pilot_events" USING btree ("operation_id");--> statement-breakpoint
 CREATE INDEX "clinic_pilot_events_history_idx" ON "clinic_pilot_events" USING btree ("practice_id","created_at","id");--> statement-breakpoint
 CREATE UNIQUE INDEX "clinic_pilots_practice_uq" ON "clinic_pilots" USING btree ("practice_id");--> statement-breakpoint
-CREATE UNIQUE INDEX "clinic_pilots_id_practice_uq" ON "clinic_pilots" USING btree ("id","practice_id");--> statement-breakpoint
 CREATE INDEX "clinic_pilots_review_idx" ON "clinic_pilots" USING btree ("stage","next_review_at","practice_id");--> statement-breakpoint
 
 -- Install system-only access in the same transaction that creates these

--- a/packages/db/drizzle/0073_omniscient_phil_sheldon.sql
+++ b/packages/db/drizzle/0073_omniscient_phil_sheldon.sql
@@ -1,0 +1,92 @@
+ALTER TABLE "clinic_pilot_events" DROP CONSTRAINT "clinic_pilot_events_snapshot_check";--> statement-breakpoint
+ALTER TABLE "clinic_pilots" DROP CONSTRAINT "clinic_pilots_operating_shape_check";--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD COLUMN "first_visit_validated_closeout_id" uuid;--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD COLUMN "clinic_use_validated_hash" varchar(64);--> statement-breakpoint
+ALTER TABLE "clinic_pilots" ADD COLUMN "first_visit_validated_closeout_id" uuid;--> statement-breakpoint
+ALTER TABLE "clinic_pilots" ADD COLUMN "clinic_use_validated_hash" varchar(64);--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_first_visit_validated_closeout_id_visit_closeouts_id_fk" FOREIGN KEY ("first_visit_validated_closeout_id") REFERENCES "public"."visit_closeouts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clinic_pilots" ADD CONSTRAINT "clinic_pilots_first_visit_validated_closeout_id_visit_closeouts_id_fk" FOREIGN KEY ("first_visit_validated_closeout_id") REFERENCES "public"."visit_closeouts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "clinic_pilot_events" ADD CONSTRAINT "clinic_pilot_events_snapshot_check" CHECK ("clinic_pilot_events"."projection_version" > 0
+        and "clinic_pilot_events"."payload_hash" ~ '^[a-f0-9]{64}$'
+        and "clinic_pilot_events"."actor_identity" = btrim("clinic_pilot_events"."actor_identity")
+        and length("clinic_pilot_events"."actor_identity") between 3 and 255
+        and "clinic_pilot_events"."owner_identity" = btrim("clinic_pilot_events"."owner_identity")
+        and length("clinic_pilot_events"."owner_identity") between 3 and 255
+        and "clinic_pilot_events"."cohort_key" ~ '^pilot-[0-9]{4}-[0-9]{2}$'
+        and jsonb_typeof("clinic_pilot_events"."qualification_checklist") = 'object'
+        and jsonb_typeof("clinic_pilot_events"."readiness_checklist") = 'object'
+        and jsonb_typeof("clinic_pilot_events"."evidence_snapshot") = 'object'
+        and ("clinic_pilot_events"."last_contact_at" is null) = ("clinic_pilot_events"."last_contact_outcome" is null)
+        and ("clinic_pilot_events"."clinic_acceptance_at" is null) = ("clinic_pilot_events"."clinic_acceptance_by_user_id" is null)
+        and ("clinic_pilot_events"."first_visit_validated_at" is null) = ("clinic_pilot_events"."first_visit_validated_closeout_id" is null)
+        and ("clinic_pilot_events"."clinic_use_validated_at" is null) = ("clinic_pilot_events"."clinic_use_validated_hash" is null)
+        and ("clinic_pilot_events"."clinic_use_validated_hash" is null or "clinic_pilot_events"."clinic_use_validated_hash" ~ '^[a-f0-9]{64}$')
+        and "clinic_pilot_events"."blocker_codes" <@ ARRAY[
+          'workflow_fit',
+          'data_import',
+          'staff_training',
+          'record_accuracy',
+          'billing',
+          'payments',
+          'email',
+          'sms',
+          'permissions',
+          'device_connectivity',
+          'backup_export',
+          'support_coverage'
+        ]::text[]
+        and cardinality("clinic_pilot_events"."blocker_codes") <= 12
+        and array_position("clinic_pilot_events"."blocker_codes", null) is null);--> statement-breakpoint
+ALTER TABLE "clinic_pilots" ADD CONSTRAINT "clinic_pilots_operating_shape_check" CHECK ("clinic_pilots"."cohort_key" ~ '^pilot-[0-9]{4}-[0-9]{2}$'
+        and jsonb_typeof("clinic_pilots"."qualification_checklist") = 'object'
+        and jsonb_typeof("clinic_pilots"."readiness_checklist") = 'object'
+        and "clinic_pilots"."owner_identity" = btrim("clinic_pilots"."owner_identity")
+        and length("clinic_pilots"."owner_identity") between 3 and 255
+        and ("clinic_pilots"."last_contact_at" is null) = ("clinic_pilots"."last_contact_outcome" is null)
+        and ("clinic_pilots"."clinic_acceptance_at" is null) = ("clinic_pilots"."clinic_acceptance_by_user_id" is null)
+        and ("clinic_pilots"."first_visit_validated_at" is null) = ("clinic_pilots"."first_visit_validated_closeout_id" is null)
+        and ("clinic_pilots"."clinic_use_validated_at" is null) = ("clinic_pilots"."clinic_use_validated_hash" is null)
+        and ("clinic_pilots"."clinic_use_validated_hash" is null or "clinic_pilots"."clinic_use_validated_hash" ~ '^[a-f0-9]{64}$'));--> statement-breakpoint
+
+-- Extend the deferred projection/event invariant to the evidence bindings
+-- introduced above. An old attestation cannot validate replacement evidence.
+CREATE OR REPLACE FUNCTION enforce_clinic_pilot_projection_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.clinic_pilot_events e
+    WHERE e.clinic_pilot_id = NEW.id
+      AND e.practice_id = NEW.practice_id
+      AND e.projection_version = NEW.version
+      AND e.cohort_key = NEW.cohort_key
+      AND e.workflow = NEW.workflow
+      AND e.stage = NEW.stage
+      AND e.decision = NEW.decision
+      AND e.qualification_checklist = NEW.qualification_checklist
+      AND e.readiness_checklist = NEW.readiness_checklist
+      AND e.blocker_codes = NEW.blocker_codes
+      AND e.next_action = NEW.next_action
+      AND e.support_cadence = NEW.support_cadence
+      AND e.owner_identity = NEW.owner_identity
+      AND e.communication_mode = NEW.communication_mode
+      AND e.communication_tested_at IS NOT DISTINCT FROM NEW.communication_tested_at
+      AND e.first_visit_validated_at IS NOT DISTINCT FROM NEW.first_visit_validated_at
+      AND e.first_visit_validated_closeout_id IS NOT DISTINCT FROM NEW.first_visit_validated_closeout_id
+      AND e.clinic_use_validated_at IS NOT DISTINCT FROM NEW.clinic_use_validated_at
+      AND e.clinic_use_validated_hash IS NOT DISTINCT FROM NEW.clinic_use_validated_hash
+      AND e.clinic_acceptance_at IS NOT DISTINCT FROM NEW.clinic_acceptance_at
+      AND e.clinic_acceptance_by_user_id IS NOT DISTINCT FROM NEW.clinic_acceptance_by_user_id
+      AND e.last_contact_at IS NOT DISTINCT FROM NEW.last_contact_at
+      AND e.last_contact_outcome IS NOT DISTINCT FROM NEW.last_contact_outcome
+      AND e.target_start_on IS NOT DISTINCT FROM NEW.target_start_on
+      AND e.next_review_at IS NOT DISTINCT FROM NEW.next_review_at
+  ) THEN
+    RAISE EXCEPTION 'clinic pilot projection version % requires a matching immutable event', NEW.version;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/packages/db/drizzle/meta/0072_snapshot.json
+++ b/packages/db/drizzle/meta/0072_snapshot.json
@@ -1,0 +1,21821 @@
+{
+  "id": "f62f6211-b2a6-4d34-acea-17b2dd8c9b64",
+  "prevId": "93bb34b3-5cb4-4d4d-bd76-548baf4de293",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_reminders_enabled": {
+          "name": "appointment_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appointment_reminder_lead_hours": {
+          "name": "appointment_reminder_lead_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practices_appointment_reminder_lead_hours_check": {
+          "name": "practices_appointment_reminder_lead_hours_check",
+          "value": "\"practices\".\"appointment_reminder_lead_hours\" in (24, 48, 72)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "is_veterinarian": {
+          "name": "is_veterinarian",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_veterinarian_idx": {
+          "name": "users_veterinarian_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_veterinarian",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_location_time_idx": {
+          "name": "appointments_location_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_id_locations_id_fk": {
+          "name": "appointments_location_id_locations_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_tenant_fk": {
+          "name": "appointments_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_location_tenant_fk": {
+          "name": "appointments_room_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "practice_id",
+            "location_id",
+            "room_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "location_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "appointments_time_range_check": {
+          "name": "appointments_time_range_check",
+          "value": "\"appointments\".\"start_time\" < \"appointments\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_practice_location_id_uq": {
+          "name": "rooms_practice_location_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_tenant_fk": {
+          "name": "rooms_location_tenant_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_active_day_idx": {
+          "name": "staff_schedules_active_day_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"staff_schedules\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_window_uq": {
+          "name": "staff_schedules_active_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_null_location_window_uq": {
+          "name": "staff_schedules_active_null_location_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_tenant_fk": {
+          "name": "staff_schedules_user_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_tenant_fk": {
+          "name": "staff_schedules_location_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "staff_schedules_day_of_week_check": {
+          "name": "staff_schedules_day_of_week_check",
+          "value": "\"staff_schedules\".\"day_of_week\" between 0 and 6"
+        },
+        "staff_schedules_time_range_check": {
+          "name": "staff_schedules_time_range_check",
+          "value": "\"staff_schedules\".\"start_time\" < \"staff_schedules\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "finalized_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_soap_source_uq": {
+          "name": "clinical_record_corrections_practice_record_soap_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "lab_result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_note_replacements": {
+      "name": "soap_note_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_soap_note_id": {
+          "name": "source_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_soap_note_id": {
+          "name": "replacement_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_replacements_source_history_idx": {
+          "name": "soap_note_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_source_uq": {
+          "name": "soap_note_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_replacement_uq": {
+          "name": "soap_note_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_operation_uq": {
+          "name": "soap_note_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_replacements_practice_id_practices_id_fk": {
+          "name": "soap_note_replacements_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "soap_note_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_source_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_id_users_id_fk": {
+          "name": "soap_note_replacements_actor_id_users_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_tenant_fk": {
+          "name": "soap_note_replacements_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_tenant_fk": {
+          "name": "soap_note_replacements_replacement_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_source_tenant_fk": {
+          "name": "soap_note_replacements_correction_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "soap_note_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_tenant_fk": {
+          "name": "soap_note_replacements_actor_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_replacements_shape_check": {
+          "name": "soap_note_replacements_shape_check",
+          "value": "\"soap_note_replacements\".\"source_soap_note_id\" <> \"soap_note_replacements\".\"replacement_soap_note_id\"\n        and \"soap_note_replacements\".\"actor_name\" = btrim(\"soap_note_replacements\".\"actor_name\")\n        and length(btrim(\"soap_note_replacements\".\"actor_name\")) between 1 and 255\n        and \"soap_note_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": [
+            "original_webhook_id"
+          ],
+          "columnsTo": [
+            "webhook_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_practice_id_uq": {
+          "name": "messaging_registrations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registration_events": {
+      "name": "messaging_registration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "messaging_registration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "messaging_registration_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "messaging_registration_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messaging_registration_events_registration_history_idx": {
+          "name": "messaging_registration_events_registration_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_practice_time_idx": {
+          "name": "messaging_registration_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_operation_event_uq": {
+          "name": "messaging_registration_events_operation_event_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registration_events_practice_id_practices_id_fk": {
+          "name": "messaging_registration_events_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_id_messaging_registrations_id_fk": {
+          "name": "messaging_registration_events_registration_id_messaging_registrations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_id_locations_id_fk": {
+          "name": "messaging_registration_events_location_id_locations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_user_id_users_id_fk": {
+          "name": "messaging_registration_events_actor_user_id_users_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_tenant_fk": {
+          "name": "messaging_registration_events_registration_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "practice_id",
+            "registration_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_tenant_fk": {
+          "name": "messaging_registration_events_location_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_tenant_fk": {
+          "name": "messaging_registration_events_actor_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registration_events_shape_check": {
+          "name": "messaging_registration_events_shape_check",
+          "value": "\"messaging_registration_events\".\"provider\" in ('telnyx', 'twilio')\n        and \"messaging_registration_events\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and \"messaging_registration_events\".\"actor_name\" = btrim(\"messaging_registration_events\".\"actor_name\")\n        and length(\"messaging_registration_events\".\"actor_name\") between 1 and 255\n        and (\n          (\"messaging_registration_events\".\"actor_type\" = 'clinic_user'\n            and \"messaging_registration_events\".\"actor_user_id\" is not null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n          or (\"messaging_registration_events\".\"actor_type\" = 'platform_operator'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and length(btrim(coalesce(\"messaging_registration_events\".\"actor_identity\", ''))) between 1 and 255)\n          or (\"messaging_registration_events\".\"actor_type\" = 'system'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n        )\n        and (\"messaging_registration_events\".\"provider_brand_id\" is null or (\n          \"messaging_registration_events\".\"provider_brand_id\" = btrim(\"messaging_registration_events\".\"provider_brand_id\")\n          and length(\"messaging_registration_events\".\"provider_brand_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_campaign_id\" is null or (\n          \"messaging_registration_events\".\"provider_campaign_id\" = btrim(\"messaging_registration_events\".\"provider_campaign_id\")\n          and length(\"messaging_registration_events\".\"provider_campaign_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"messaging_profile_id\" is null or (\n          \"messaging_registration_events\".\"messaging_profile_id\" = btrim(\"messaging_registration_events\".\"messaging_profile_id\")\n          and length(\"messaging_registration_events\".\"messaging_profile_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_brand_status\" is null\n          or length(\"messaging_registration_events\".\"provider_brand_status\") between 1 and 64)\n        and (\"messaging_registration_events\".\"provider_campaign_status\" is null\n          or length(\"messaging_registration_events\".\"provider_campaign_status\") between 1 and 64)\n        and (\n          (\"messaging_registration_events\".\"event_type\" = 'details_saved'\n            and \"messaging_registration_events\".\"operation\" = 'registration_details')\n          or (\"messaging_registration_events\".\"event_type\" in (\n              'provider_operation_started',\n              'provider_operation_succeeded',\n              'provider_operation_failed'\n            ) and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'number_assignment'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_state_observed'\n            and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'registration_reconciliation'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_ids_attached'\n            and \"messaging_registration_events\".\"operation\" = 'provider_id_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'stale_lock_cleared'\n            and \"messaging_registration_events\".\"operation\" = 'submission_lock_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_enabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_activation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_disabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_deactivation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_verified'\n            and \"messaging_registration_events\".\"operation\" = 'profile_verification'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": [
+            "delivery_event_id",
+            "reviewed_history_id"
+          ],
+          "columnsTo": [
+            "delivery_event_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_email_identity": {
+      "name": "platform_email_identity",
+      "schema": "",
+      "columns": {
+        "key_slot": {
+          "name": "key_slot",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_identity_singleton_check": {
+          "name": "platform_email_identity_singleton_check",
+          "value": "\"platform_email_identity\".\"key_slot\" = 1"
+        },
+        "platform_email_identity_fingerprint_check": {
+          "name": "platform_email_identity_fingerprint_check",
+          "value": "\"platform_email_identity\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preference_events": {
+      "name": "platform_email_preference_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_marketing_enabled": {
+          "name": "requested_marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_key_hash": {
+          "name": "provider_event_key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preference_events_recipient_timeline_idx": {
+          "name": "platform_email_preference_events_recipient_timeline_idx",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preference_events_provider_event_key_uq": {
+          "name": "platform_email_preference_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider_event_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preference_events_email_hash_check": {
+          "name": "platform_email_preference_events_email_hash_check",
+          "value": "\"platform_email_preference_events\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_identity_fingerprint_check": {
+          "name": "platform_email_preference_events_identity_fingerprint_check",
+          "value": "\"platform_email_preference_events\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_provider_event_key_hash_check": {
+          "name": "platform_email_preference_events_provider_event_key_hash_check",
+          "value": "\"platform_email_preference_events\".\"provider_event_key_hash\" IS NULL OR \"platform_email_preference_events\".\"provider_event_key_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_source_check": {
+          "name": "platform_email_preference_events_source_check",
+          "value": "\"platform_email_preference_events\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preference_events_reason_check": {
+          "name": "platform_email_preference_events_reason_check",
+          "value": "\"platform_email_preference_events\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preference_events_request_state_check": {
+          "name": "platform_email_preference_events_request_state_check",
+          "value": "(\"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preferences": {
+      "name": "platform_email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing_enabled": {
+          "name": "marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preferences_email_hash_uq": {
+          "name": "platform_email_preferences_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preferences_identity_fingerprint_idx": {
+          "name": "platform_email_preferences_identity_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "identity_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preferences_email_hash_check": {
+          "name": "platform_email_preferences_email_hash_check",
+          "value": "\"platform_email_preferences\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_identity_fingerprint_check": {
+          "name": "platform_email_preferences_identity_fingerprint_check",
+          "value": "\"platform_email_preferences\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_source_check": {
+          "name": "platform_email_preferences_source_check",
+          "value": "\"platform_email_preferences\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preferences_reason_check": {
+          "name": "platform_email_preferences_reason_check",
+          "value": "\"platform_email_preferences\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preferences_state_check": {
+          "name": "platform_email_preferences_state_check",
+          "value": "(\"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilot_events": {
+      "name": "clinic_pilot_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clinic_pilot_id": {
+          "name": "clinic_pilot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "clinic_pilot_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "clinic_pilot_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_version": {
+          "name": "projection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_snapshot": {
+          "name": "evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilot_events_operation_uq": {
+          "name": "clinic_pilot_events_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilot_events_history_idx": {
+          "name": "clinic_pilot_events_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk": {
+          "name": "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": [
+            "clinic_pilot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_practice_id_practices_id_fk": {
+          "name": "clinic_pilot_events_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_pilot_practice_fk": {
+          "name": "clinic_pilot_events_pilot_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": [
+            "clinic_pilot_id",
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id",
+            "practice_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_acceptance_user_practice_fk": {
+          "name": "clinic_pilot_events_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "clinic_acceptance_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilot_events_snapshot_check": {
+          "name": "clinic_pilot_events_snapshot_check",
+          "value": "\"clinic_pilot_events\".\"projection_version\" > 0\n        and \"clinic_pilot_events\".\"payload_hash\" ~ '^[a-f0-9]{64}$'\n        and \"clinic_pilot_events\".\"actor_identity\" = btrim(\"clinic_pilot_events\".\"actor_identity\")\n        and length(\"clinic_pilot_events\".\"actor_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"owner_identity\" = btrim(\"clinic_pilot_events\".\"owner_identity\")\n        and length(\"clinic_pilot_events\".\"owner_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilot_events\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"readiness_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"evidence_snapshot\") = 'object'\n        and (\"clinic_pilot_events\".\"last_contact_at\" is null) = (\"clinic_pilot_events\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilot_events\".\"clinic_acceptance_at\" is null) = (\"clinic_pilot_events\".\"clinic_acceptance_by_user_id\" is null)\n        and \"clinic_pilot_events\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilot_events\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilot_events\".\"blocker_codes\", null) is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilots": {
+      "name": "clinic_pilots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"supportedClinicType\":false,\"supportedJurisdictionConfirmed\":false,\"singleLocation\":false,\"connectedModeAccepted\":false,\"parallelRunAccepted\":false,\"championConfirmed\":false,\"supportedWorkflowConfirmed\":false,\"noUnsupportedMustHave\":false}'::jsonb"
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"rolesAndDevicesValidated\":false,\"migrationPlanAccepted\":false,\"sampleValidationAccepted\":false,\"firstVisitScheduled\":false,\"exportAndRollbackConfirmed\":false,\"supportCadenceConfirmed\":false}'::jsonb"
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirm_fit'"
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email_only'"
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilots_practice_uq": {
+          "name": "clinic_pilots_practice_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_id_practice_uq": {
+          "name": "clinic_pilots_id_practice_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_review_idx": {
+          "name": "clinic_pilots_review_idx",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilots_practice_id_practices_id_fk": {
+          "name": "clinic_pilots_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilots_acceptance_user_practice_fk": {
+          "name": "clinic_pilots_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "clinic_acceptance_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilots_version_check": {
+          "name": "clinic_pilots_version_check",
+          "value": "\"clinic_pilots\".\"version\" > 0"
+        },
+        "clinic_pilots_operating_shape_check": {
+          "name": "clinic_pilots_operating_shape_check",
+          "value": "\"clinic_pilots\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilots\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilots\".\"readiness_checklist\") = 'object'\n        and \"clinic_pilots\".\"owner_identity\" = btrim(\"clinic_pilots\".\"owner_identity\")\n        and length(\"clinic_pilots\".\"owner_identity\") between 3 and 255\n        and (\"clinic_pilots\".\"last_contact_at\" is null) = (\"clinic_pilots\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilots\".\"clinic_acceptance_at\" is null) = (\"clinic_pilots\".\"clinic_acceptance_by_user_id\" is null)"
+        },
+        "clinic_pilots_blocker_codes_check": {
+          "name": "clinic_pilots_blocker_codes_check",
+          "value": "\"clinic_pilots\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilots\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilots\".\"blocker_codes\", null) is null"
+        },
+        "clinic_pilots_lifecycle_check": {
+          "name": "clinic_pilots_lifecycle_check",
+          "value": "(\n          \"clinic_pilots\".\"stage\" = 'completed'\n          and \"clinic_pilots\".\"decision\" = 'graduated'\n          and cardinality(\"clinic_pilots\".\"blocker_codes\") = 0\n          and \"clinic_pilots\".\"next_action\" = 'support_retention'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" = 'closed'\n          and \"clinic_pilots\".\"decision\" = 'not_a_fit'\n          and \"clinic_pilots\".\"next_action\" = 'revisit_fit'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" not in ('completed', 'closed')\n          and \"clinic_pilots\".\"decision\" not in ('graduated', 'not_a_fit')\n          and \"clinic_pilots\".\"next_review_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": [
+        "not_required",
+        "open",
+        "completed"
+      ]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "normal",
+        "abnormal",
+        "critical"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "finalized"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": [
+        "registration",
+        "authenticated_resend"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.messaging_registration_actor_type": {
+      "name": "messaging_registration_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator",
+        "system"
+      ]
+    },
+    "public.messaging_registration_event_type": {
+      "name": "messaging_registration_event_type",
+      "schema": "public",
+      "values": [
+        "details_saved",
+        "provider_operation_started",
+        "provider_operation_succeeded",
+        "provider_operation_failed",
+        "provider_state_observed",
+        "provider_ids_attached",
+        "stale_lock_cleared",
+        "provider_profile_enabled",
+        "provider_profile_disabled",
+        "provider_profile_verified"
+      ]
+    },
+    "public.messaging_registration_operation": {
+      "name": "messaging_registration_operation",
+      "schema": "public",
+      "values": [
+        "registration_details",
+        "brand_submission",
+        "campaign_submission",
+        "number_assignment",
+        "registration_reconciliation",
+        "provider_id_recovery",
+        "submission_lock_recovery",
+        "profile_activation",
+        "profile_deactivation",
+        "profile_verification"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "sent",
+        "failed",
+        "delivered"
+      ]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": [
+        "automatic",
+        "operator_reconciliation"
+      ]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    },
+    "public.clinic_pilot_communication_mode": {
+      "name": "clinic_pilot_communication_mode",
+      "schema": "public",
+      "values": [
+        "email_only",
+        "email_and_sms"
+      ]
+    },
+    "public.clinic_pilot_contact_outcome": {
+      "name": "clinic_pilot_contact_outcome",
+      "schema": "public",
+      "values": [
+        "replied",
+        "no_reply",
+        "scheduled",
+        "completed",
+        "declined"
+      ]
+    },
+    "public.clinic_pilot_decision": {
+      "name": "clinic_pilot_decision",
+      "schema": "public",
+      "values": [
+        "pending",
+        "eligible",
+        "approved",
+        "paused",
+        "not_a_fit",
+        "graduated"
+      ]
+    },
+    "public.clinic_pilot_event_type": {
+      "name": "clinic_pilot_event_type",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "updated"
+      ]
+    },
+    "public.clinic_pilot_next_action": {
+      "name": "clinic_pilot_next_action",
+      "schema": "public",
+      "values": [
+        "confirm_fit",
+        "schedule_setup",
+        "validate_import",
+        "complete_first_visit",
+        "review_communications",
+        "configure_payment",
+        "review_clinic_week",
+        "resolve_blockers",
+        "decide_graduation",
+        "support_retention",
+        "revisit_fit"
+      ]
+    },
+    "public.clinic_pilot_reason": {
+      "name": "clinic_pilot_reason",
+      "schema": "public",
+      "values": [
+        "initial_review",
+        "clinic_feedback",
+        "product_evidence",
+        "support_review",
+        "blocker_review",
+        "graduation_decision"
+      ]
+    },
+    "public.clinic_pilot_stage": {
+      "name": "clinic_pilot_stage",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "parallel_setup",
+        "visit_validation",
+        "pilot_week",
+        "graduation_review",
+        "completed",
+        "closed"
+      ]
+    },
+    "public.clinic_pilot_support_cadence": {
+      "name": "clinic_pilot_support_cadence",
+      "schema": "public",
+      "values": [
+        "daily",
+        "twice_weekly",
+        "weekly"
+      ]
+    },
+    "public.clinic_pilot_workflow": {
+      "name": "clinic_pilot_workflow",
+      "schema": "public",
+      "values": [
+        "general_practice",
+        "house_call"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0073_snapshot.json
+++ b/packages/db/drizzle/meta/0073_snapshot.json
@@ -1,0 +1,21871 @@
+{
+  "id": "756fe2d6-6da4-41df-82b9-54295e3d27d1",
+  "prevId": "f62f6211-b2a6-4d34-acea-17b2dd8c9b64",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_reminders_enabled": {
+          "name": "appointment_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appointment_reminder_lead_hours": {
+          "name": "appointment_reminder_lead_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practices_appointment_reminder_lead_hours_check": {
+          "name": "practices_appointment_reminder_lead_hours_check",
+          "value": "\"practices\".\"appointment_reminder_lead_hours\" in (24, 48, 72)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "is_veterinarian": {
+          "name": "is_veterinarian",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_veterinarian_idx": {
+          "name": "users_veterinarian_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_veterinarian",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_location_time_idx": {
+          "name": "appointments_location_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_id_locations_id_fk": {
+          "name": "appointments_location_id_locations_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_tenant_fk": {
+          "name": "appointments_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_location_tenant_fk": {
+          "name": "appointments_room_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "practice_id",
+            "location_id",
+            "room_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "location_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "appointments_time_range_check": {
+          "name": "appointments_time_range_check",
+          "value": "\"appointments\".\"start_time\" < \"appointments\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_practice_location_id_uq": {
+          "name": "rooms_practice_location_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_tenant_fk": {
+          "name": "rooms_location_tenant_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_active_day_idx": {
+          "name": "staff_schedules_active_day_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"staff_schedules\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_window_uq": {
+          "name": "staff_schedules_active_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_null_location_window_uq": {
+          "name": "staff_schedules_active_null_location_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_tenant_fk": {
+          "name": "staff_schedules_user_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_tenant_fk": {
+          "name": "staff_schedules_location_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "staff_schedules_day_of_week_check": {
+          "name": "staff_schedules_day_of_week_check",
+          "value": "\"staff_schedules\".\"day_of_week\" between 0 and 6"
+        },
+        "staff_schedules_time_range_check": {
+          "name": "staff_schedules_time_range_check",
+          "value": "\"staff_schedules\".\"start_time\" < \"staff_schedules\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "finalized_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_soap_source_uq": {
+          "name": "clinical_record_corrections_practice_record_soap_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "lab_result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_note_replacements": {
+      "name": "soap_note_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_soap_note_id": {
+          "name": "source_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_soap_note_id": {
+          "name": "replacement_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_replacements_source_history_idx": {
+          "name": "soap_note_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_source_uq": {
+          "name": "soap_note_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_replacement_uq": {
+          "name": "soap_note_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_operation_uq": {
+          "name": "soap_note_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_replacements_practice_id_practices_id_fk": {
+          "name": "soap_note_replacements_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "soap_note_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_source_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_id_users_id_fk": {
+          "name": "soap_note_replacements_actor_id_users_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_tenant_fk": {
+          "name": "soap_note_replacements_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_tenant_fk": {
+          "name": "soap_note_replacements_replacement_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_source_tenant_fk": {
+          "name": "soap_note_replacements_correction_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "soap_note_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_tenant_fk": {
+          "name": "soap_note_replacements_actor_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_replacements_shape_check": {
+          "name": "soap_note_replacements_shape_check",
+          "value": "\"soap_note_replacements\".\"source_soap_note_id\" <> \"soap_note_replacements\".\"replacement_soap_note_id\"\n        and \"soap_note_replacements\".\"actor_name\" = btrim(\"soap_note_replacements\".\"actor_name\")\n        and length(btrim(\"soap_note_replacements\".\"actor_name\")) between 1 and 255\n        and \"soap_note_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": [
+            "original_webhook_id"
+          ],
+          "columnsTo": [
+            "webhook_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_practice_id_uq": {
+          "name": "messaging_registrations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registration_events": {
+      "name": "messaging_registration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "messaging_registration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "messaging_registration_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "messaging_registration_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messaging_registration_events_registration_history_idx": {
+          "name": "messaging_registration_events_registration_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_practice_time_idx": {
+          "name": "messaging_registration_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_operation_event_uq": {
+          "name": "messaging_registration_events_operation_event_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registration_events_practice_id_practices_id_fk": {
+          "name": "messaging_registration_events_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_id_messaging_registrations_id_fk": {
+          "name": "messaging_registration_events_registration_id_messaging_registrations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_id_locations_id_fk": {
+          "name": "messaging_registration_events_location_id_locations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_user_id_users_id_fk": {
+          "name": "messaging_registration_events_actor_user_id_users_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_tenant_fk": {
+          "name": "messaging_registration_events_registration_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "practice_id",
+            "registration_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_tenant_fk": {
+          "name": "messaging_registration_events_location_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_tenant_fk": {
+          "name": "messaging_registration_events_actor_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registration_events_shape_check": {
+          "name": "messaging_registration_events_shape_check",
+          "value": "\"messaging_registration_events\".\"provider\" in ('telnyx', 'twilio')\n        and \"messaging_registration_events\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and \"messaging_registration_events\".\"actor_name\" = btrim(\"messaging_registration_events\".\"actor_name\")\n        and length(\"messaging_registration_events\".\"actor_name\") between 1 and 255\n        and (\n          (\"messaging_registration_events\".\"actor_type\" = 'clinic_user'\n            and \"messaging_registration_events\".\"actor_user_id\" is not null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n          or (\"messaging_registration_events\".\"actor_type\" = 'platform_operator'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and length(btrim(coalesce(\"messaging_registration_events\".\"actor_identity\", ''))) between 1 and 255)\n          or (\"messaging_registration_events\".\"actor_type\" = 'system'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n        )\n        and (\"messaging_registration_events\".\"provider_brand_id\" is null or (\n          \"messaging_registration_events\".\"provider_brand_id\" = btrim(\"messaging_registration_events\".\"provider_brand_id\")\n          and length(\"messaging_registration_events\".\"provider_brand_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_campaign_id\" is null or (\n          \"messaging_registration_events\".\"provider_campaign_id\" = btrim(\"messaging_registration_events\".\"provider_campaign_id\")\n          and length(\"messaging_registration_events\".\"provider_campaign_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"messaging_profile_id\" is null or (\n          \"messaging_registration_events\".\"messaging_profile_id\" = btrim(\"messaging_registration_events\".\"messaging_profile_id\")\n          and length(\"messaging_registration_events\".\"messaging_profile_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_brand_status\" is null\n          or length(\"messaging_registration_events\".\"provider_brand_status\") between 1 and 64)\n        and (\"messaging_registration_events\".\"provider_campaign_status\" is null\n          or length(\"messaging_registration_events\".\"provider_campaign_status\") between 1 and 64)\n        and (\n          (\"messaging_registration_events\".\"event_type\" = 'details_saved'\n            and \"messaging_registration_events\".\"operation\" = 'registration_details')\n          or (\"messaging_registration_events\".\"event_type\" in (\n              'provider_operation_started',\n              'provider_operation_succeeded',\n              'provider_operation_failed'\n            ) and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'number_assignment'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_state_observed'\n            and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'registration_reconciliation'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_ids_attached'\n            and \"messaging_registration_events\".\"operation\" = 'provider_id_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'stale_lock_cleared'\n            and \"messaging_registration_events\".\"operation\" = 'submission_lock_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_enabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_activation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_disabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_deactivation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_verified'\n            and \"messaging_registration_events\".\"operation\" = 'profile_verification'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": [
+            "delivery_event_id",
+            "reviewed_history_id"
+          ],
+          "columnsTo": [
+            "delivery_event_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_email_identity": {
+      "name": "platform_email_identity",
+      "schema": "",
+      "columns": {
+        "key_slot": {
+          "name": "key_slot",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_identity_singleton_check": {
+          "name": "platform_email_identity_singleton_check",
+          "value": "\"platform_email_identity\".\"key_slot\" = 1"
+        },
+        "platform_email_identity_fingerprint_check": {
+          "name": "platform_email_identity_fingerprint_check",
+          "value": "\"platform_email_identity\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preference_events": {
+      "name": "platform_email_preference_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_marketing_enabled": {
+          "name": "requested_marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_key_hash": {
+          "name": "provider_event_key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preference_events_recipient_timeline_idx": {
+          "name": "platform_email_preference_events_recipient_timeline_idx",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preference_events_provider_event_key_uq": {
+          "name": "platform_email_preference_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider_event_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preference_events_email_hash_check": {
+          "name": "platform_email_preference_events_email_hash_check",
+          "value": "\"platform_email_preference_events\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_identity_fingerprint_check": {
+          "name": "platform_email_preference_events_identity_fingerprint_check",
+          "value": "\"platform_email_preference_events\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_provider_event_key_hash_check": {
+          "name": "platform_email_preference_events_provider_event_key_hash_check",
+          "value": "\"platform_email_preference_events\".\"provider_event_key_hash\" IS NULL OR \"platform_email_preference_events\".\"provider_event_key_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_source_check": {
+          "name": "platform_email_preference_events_source_check",
+          "value": "\"platform_email_preference_events\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preference_events_reason_check": {
+          "name": "platform_email_preference_events_reason_check",
+          "value": "\"platform_email_preference_events\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preference_events_request_state_check": {
+          "name": "platform_email_preference_events_request_state_check",
+          "value": "(\"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preferences": {
+      "name": "platform_email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing_enabled": {
+          "name": "marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preferences_email_hash_uq": {
+          "name": "platform_email_preferences_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preferences_identity_fingerprint_idx": {
+          "name": "platform_email_preferences_identity_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "identity_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preferences_email_hash_check": {
+          "name": "platform_email_preferences_email_hash_check",
+          "value": "\"platform_email_preferences\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_identity_fingerprint_check": {
+          "name": "platform_email_preferences_identity_fingerprint_check",
+          "value": "\"platform_email_preferences\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_source_check": {
+          "name": "platform_email_preferences_source_check",
+          "value": "\"platform_email_preferences\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preferences_reason_check": {
+          "name": "platform_email_preferences_reason_check",
+          "value": "\"platform_email_preferences\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preferences_state_check": {
+          "name": "platform_email_preferences_state_check",
+          "value": "(\"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilot_events": {
+      "name": "clinic_pilot_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clinic_pilot_id": {
+          "name": "clinic_pilot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "clinic_pilot_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "clinic_pilot_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_closeout_id": {
+          "name": "first_visit_validated_closeout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_hash": {
+          "name": "clinic_use_validated_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_version": {
+          "name": "projection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_snapshot": {
+          "name": "evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilot_events_operation_uq": {
+          "name": "clinic_pilot_events_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilot_events_history_idx": {
+          "name": "clinic_pilot_events_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk": {
+          "name": "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": [
+            "clinic_pilot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_practice_id_practices_id_fk": {
+          "name": "clinic_pilot_events_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_first_visit_validated_closeout_id_visit_closeouts_id_fk": {
+          "name": "clinic_pilot_events_first_visit_validated_closeout_id_visit_closeouts_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "visit_closeouts",
+          "columnsFrom": [
+            "first_visit_validated_closeout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_pilot_practice_fk": {
+          "name": "clinic_pilot_events_pilot_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": [
+            "clinic_pilot_id",
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id",
+            "practice_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_acceptance_user_practice_fk": {
+          "name": "clinic_pilot_events_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "clinic_acceptance_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilot_events_snapshot_check": {
+          "name": "clinic_pilot_events_snapshot_check",
+          "value": "\"clinic_pilot_events\".\"projection_version\" > 0\n        and \"clinic_pilot_events\".\"payload_hash\" ~ '^[a-f0-9]{64}$'\n        and \"clinic_pilot_events\".\"actor_identity\" = btrim(\"clinic_pilot_events\".\"actor_identity\")\n        and length(\"clinic_pilot_events\".\"actor_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"owner_identity\" = btrim(\"clinic_pilot_events\".\"owner_identity\")\n        and length(\"clinic_pilot_events\".\"owner_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilot_events\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"readiness_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"evidence_snapshot\") = 'object'\n        and (\"clinic_pilot_events\".\"last_contact_at\" is null) = (\"clinic_pilot_events\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilot_events\".\"clinic_acceptance_at\" is null) = (\"clinic_pilot_events\".\"clinic_acceptance_by_user_id\" is null)\n        and (\"clinic_pilot_events\".\"first_visit_validated_at\" is null) = (\"clinic_pilot_events\".\"first_visit_validated_closeout_id\" is null)\n        and (\"clinic_pilot_events\".\"clinic_use_validated_at\" is null) = (\"clinic_pilot_events\".\"clinic_use_validated_hash\" is null)\n        and (\"clinic_pilot_events\".\"clinic_use_validated_hash\" is null or \"clinic_pilot_events\".\"clinic_use_validated_hash\" ~ '^[a-f0-9]{64}$')\n        and \"clinic_pilot_events\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilot_events\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilot_events\".\"blocker_codes\", null) is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilots": {
+      "name": "clinic_pilots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"supportedClinicType\":false,\"supportedJurisdictionConfirmed\":false,\"singleLocation\":false,\"connectedModeAccepted\":false,\"parallelRunAccepted\":false,\"championConfirmed\":false,\"supportedWorkflowConfirmed\":false,\"noUnsupportedMustHave\":false}'::jsonb"
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"rolesAndDevicesValidated\":false,\"migrationPlanAccepted\":false,\"sampleValidationAccepted\":false,\"firstVisitScheduled\":false,\"exportAndRollbackConfirmed\":false,\"supportCadenceConfirmed\":false}'::jsonb"
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirm_fit'"
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email_only'"
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_closeout_id": {
+          "name": "first_visit_validated_closeout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_hash": {
+          "name": "clinic_use_validated_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilots_practice_uq": {
+          "name": "clinic_pilots_practice_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_id_practice_uq": {
+          "name": "clinic_pilots_id_practice_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_review_idx": {
+          "name": "clinic_pilots_review_idx",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilots_practice_id_practices_id_fk": {
+          "name": "clinic_pilots_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilots_first_visit_validated_closeout_id_visit_closeouts_id_fk": {
+          "name": "clinic_pilots_first_visit_validated_closeout_id_visit_closeouts_id_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "visit_closeouts",
+          "columnsFrom": [
+            "first_visit_validated_closeout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilots_acceptance_user_practice_fk": {
+          "name": "clinic_pilots_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "clinic_acceptance_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilots_version_check": {
+          "name": "clinic_pilots_version_check",
+          "value": "\"clinic_pilots\".\"version\" > 0"
+        },
+        "clinic_pilots_operating_shape_check": {
+          "name": "clinic_pilots_operating_shape_check",
+          "value": "\"clinic_pilots\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilots\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilots\".\"readiness_checklist\") = 'object'\n        and \"clinic_pilots\".\"owner_identity\" = btrim(\"clinic_pilots\".\"owner_identity\")\n        and length(\"clinic_pilots\".\"owner_identity\") between 3 and 255\n        and (\"clinic_pilots\".\"last_contact_at\" is null) = (\"clinic_pilots\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilots\".\"clinic_acceptance_at\" is null) = (\"clinic_pilots\".\"clinic_acceptance_by_user_id\" is null)\n        and (\"clinic_pilots\".\"first_visit_validated_at\" is null) = (\"clinic_pilots\".\"first_visit_validated_closeout_id\" is null)\n        and (\"clinic_pilots\".\"clinic_use_validated_at\" is null) = (\"clinic_pilots\".\"clinic_use_validated_hash\" is null)\n        and (\"clinic_pilots\".\"clinic_use_validated_hash\" is null or \"clinic_pilots\".\"clinic_use_validated_hash\" ~ '^[a-f0-9]{64}$')"
+        },
+        "clinic_pilots_blocker_codes_check": {
+          "name": "clinic_pilots_blocker_codes_check",
+          "value": "\"clinic_pilots\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilots\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilots\".\"blocker_codes\", null) is null"
+        },
+        "clinic_pilots_lifecycle_check": {
+          "name": "clinic_pilots_lifecycle_check",
+          "value": "(\n          \"clinic_pilots\".\"stage\" = 'completed'\n          and \"clinic_pilots\".\"decision\" = 'graduated'\n          and cardinality(\"clinic_pilots\".\"blocker_codes\") = 0\n          and \"clinic_pilots\".\"next_action\" = 'support_retention'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" = 'closed'\n          and \"clinic_pilots\".\"decision\" = 'not_a_fit'\n          and \"clinic_pilots\".\"next_action\" = 'revisit_fit'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" not in ('completed', 'closed')\n          and \"clinic_pilots\".\"decision\" not in ('graduated', 'not_a_fit')\n          and \"clinic_pilots\".\"next_review_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": [
+        "not_required",
+        "open",
+        "completed"
+      ]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "normal",
+        "abnormal",
+        "critical"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "finalized"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": [
+        "registration",
+        "authenticated_resend"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.messaging_registration_actor_type": {
+      "name": "messaging_registration_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator",
+        "system"
+      ]
+    },
+    "public.messaging_registration_event_type": {
+      "name": "messaging_registration_event_type",
+      "schema": "public",
+      "values": [
+        "details_saved",
+        "provider_operation_started",
+        "provider_operation_succeeded",
+        "provider_operation_failed",
+        "provider_state_observed",
+        "provider_ids_attached",
+        "stale_lock_cleared",
+        "provider_profile_enabled",
+        "provider_profile_disabled",
+        "provider_profile_verified"
+      ]
+    },
+    "public.messaging_registration_operation": {
+      "name": "messaging_registration_operation",
+      "schema": "public",
+      "values": [
+        "registration_details",
+        "brand_submission",
+        "campaign_submission",
+        "number_assignment",
+        "registration_reconciliation",
+        "provider_id_recovery",
+        "submission_lock_recovery",
+        "profile_activation",
+        "profile_deactivation",
+        "profile_verification"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "sent",
+        "failed",
+        "delivered"
+      ]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": [
+        "automatic",
+        "operator_reconciliation"
+      ]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    },
+    "public.clinic_pilot_communication_mode": {
+      "name": "clinic_pilot_communication_mode",
+      "schema": "public",
+      "values": [
+        "email_only",
+        "email_and_sms"
+      ]
+    },
+    "public.clinic_pilot_contact_outcome": {
+      "name": "clinic_pilot_contact_outcome",
+      "schema": "public",
+      "values": [
+        "replied",
+        "no_reply",
+        "scheduled",
+        "completed",
+        "declined"
+      ]
+    },
+    "public.clinic_pilot_decision": {
+      "name": "clinic_pilot_decision",
+      "schema": "public",
+      "values": [
+        "pending",
+        "eligible",
+        "approved",
+        "paused",
+        "not_a_fit",
+        "graduated"
+      ]
+    },
+    "public.clinic_pilot_event_type": {
+      "name": "clinic_pilot_event_type",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "updated"
+      ]
+    },
+    "public.clinic_pilot_next_action": {
+      "name": "clinic_pilot_next_action",
+      "schema": "public",
+      "values": [
+        "confirm_fit",
+        "schedule_setup",
+        "validate_import",
+        "complete_first_visit",
+        "review_communications",
+        "configure_payment",
+        "review_clinic_week",
+        "resolve_blockers",
+        "decide_graduation",
+        "support_retention",
+        "revisit_fit"
+      ]
+    },
+    "public.clinic_pilot_reason": {
+      "name": "clinic_pilot_reason",
+      "schema": "public",
+      "values": [
+        "initial_review",
+        "clinic_feedback",
+        "product_evidence",
+        "support_review",
+        "blocker_review",
+        "graduation_decision"
+      ]
+    },
+    "public.clinic_pilot_stage": {
+      "name": "clinic_pilot_stage",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "parallel_setup",
+        "visit_validation",
+        "pilot_week",
+        "graduation_review",
+        "completed",
+        "closed"
+      ]
+    },
+    "public.clinic_pilot_support_cadence": {
+      "name": "clinic_pilot_support_cadence",
+      "schema": "public",
+      "values": [
+        "daily",
+        "twice_weekly",
+        "weekly"
+      ]
+    },
+    "public.clinic_pilot_workflow": {
+      "name": "clinic_pilot_workflow",
+      "schema": "public",
+      "values": [
+        "general_practice",
+        "house_call"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -505,6 +505,20 @@
       "when": 1786343344347,
       "tag": "0071_boring_devos",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1786359466768,
+      "tag": "0072_lucky_kate_bishop",
+      "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1786360245682,
+      "tag": "0073_omniscient_phil_sheldon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -262,6 +262,100 @@ CREATE POLICY system_only ON practice_conversion_milestones
   USING (app_rls_bypass())
   WITH CHECK (app_rls_bypass());
 
+-- Controlled clinic-pilot state spans tenants and belongs only to platform
+-- operators. Clinics cannot inspect cohort decisions, other practices, or the
+-- immutable operator audit trail through a tenant session.
+ALTER TABLE clinic_pilots ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS system_only ON clinic_pilots;
+CREATE POLICY system_only ON clinic_pilots
+  USING (app_rls_bypass())
+  WITH CHECK (app_rls_bypass());
+
+ALTER TABLE clinic_pilot_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS system_read ON clinic_pilot_events;
+CREATE POLICY system_read ON clinic_pilot_events
+  FOR SELECT USING (app_rls_bypass());
+DROP POLICY IF EXISTS system_insert ON clinic_pilot_events;
+CREATE POLICY system_insert ON clinic_pilot_events
+  FOR INSERT WITH CHECK (app_rls_bypass());
+
+REVOKE ALL ON clinic_pilots, clinic_pilot_events FROM openpims_app;
+GRANT SELECT, INSERT, UPDATE ON clinic_pilots TO openpims_app;
+GRANT SELECT, INSERT ON clinic_pilot_events TO openpims_app;
+
+-- Keep the operator projection and immutable evidence ledger inseparable even
+-- if a future system-context path bypasses the application helper.
+CREATE OR REPLACE FUNCTION enforce_clinic_pilot_projection_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.clinic_pilot_events e
+    WHERE e.clinic_pilot_id = NEW.id
+      AND e.practice_id = NEW.practice_id
+      AND e.projection_version = NEW.version
+      AND e.cohort_key = NEW.cohort_key
+      AND e.workflow = NEW.workflow
+      AND e.stage = NEW.stage
+      AND e.decision = NEW.decision
+      AND e.qualification_checklist = NEW.qualification_checklist
+      AND e.readiness_checklist = NEW.readiness_checklist
+      AND e.blocker_codes = NEW.blocker_codes
+      AND e.next_action = NEW.next_action
+      AND e.support_cadence = NEW.support_cadence
+      AND e.owner_identity = NEW.owner_identity
+      AND e.communication_mode = NEW.communication_mode
+      AND e.communication_tested_at IS NOT DISTINCT FROM NEW.communication_tested_at
+      AND e.first_visit_validated_at IS NOT DISTINCT FROM NEW.first_visit_validated_at
+      AND e.first_visit_validated_closeout_id IS NOT DISTINCT FROM NEW.first_visit_validated_closeout_id
+      AND e.clinic_use_validated_at IS NOT DISTINCT FROM NEW.clinic_use_validated_at
+      AND e.clinic_use_validated_hash IS NOT DISTINCT FROM NEW.clinic_use_validated_hash
+      AND e.clinic_acceptance_at IS NOT DISTINCT FROM NEW.clinic_acceptance_at
+      AND e.clinic_acceptance_by_user_id IS NOT DISTINCT FROM NEW.clinic_acceptance_by_user_id
+      AND e.last_contact_at IS NOT DISTINCT FROM NEW.last_contact_at
+      AND e.last_contact_outcome IS NOT DISTINCT FROM NEW.last_contact_outcome
+      AND e.target_start_on IS NOT DISTINCT FROM NEW.target_start_on
+      AND e.next_review_at IS NOT DISTINCT FROM NEW.next_review_at
+  ) THEN
+    RAISE EXCEPTION 'clinic pilot projection version % requires a matching immutable event', NEW.version;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS clinic_pilots_require_event ON clinic_pilots;
+CREATE CONSTRAINT TRIGGER clinic_pilots_require_event
+AFTER INSERT OR UPDATE ON clinic_pilots
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW EXECUTE FUNCTION enforce_clinic_pilot_projection_audit();
+
+CREATE OR REPLACE FUNCTION reject_clinic_pilot_event_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+    AND current_user = (
+      SELECT pg_catalog.pg_get_userbyid(class.relowner)
+      FROM pg_catalog.pg_class class
+      JOIN pg_catalog.pg_namespace namespace ON namespace.oid = class.relnamespace
+      WHERE namespace.nspname = TG_TABLE_SCHEMA AND class.relname = TG_TABLE_NAME
+    )
+  THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+  END IF;
+  RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'Clinic pilot events are immutable.';
+END;
+$$;
+DROP TRIGGER IF EXISTS clinic_pilot_events_immutable ON clinic_pilot_events;
+CREATE TRIGGER clinic_pilot_events_immutable
+BEFORE UPDATE OR DELETE ON clinic_pilot_events
+FOR EACH ROW EXECUTE FUNCTION reject_clinic_pilot_event_mutation();
+
 -- Durable rate-limit buckets are also global/system state.
 ALTER TABLE rate_limit_buckets ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS system_only ON rate_limit_buckets;
@@ -330,7 +424,7 @@ BEGIN
   FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
       EXECUTE format(
-        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, messaging_registration_events, patient_merge_events, platform_email_identity, platform_email_preference_events, platform_email_preferences, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
+        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_provider_identity_conflicts, auth_email_webhook_conflicts, auth_tokens, clinic_pilot_events, clinic_pilots, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, messaging_registration_events, patient_merge_events, platform_email_identity, platform_email_preference_events, platform_email_preferences, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
       );
     END IF;
   END LOOP;

--- a/packages/db/schema/clinic-pilots.ts
+++ b/packages/db/schema/clinic-pilots.ts
@@ -1,0 +1,421 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  date,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { practices } from "./practices";
+import { users } from "./users";
+import { visitCloseouts } from "./visit-closeouts";
+
+export const clinicPilotStageEnum = pgEnum("clinic_pilot_stage", [
+  "candidate",
+  "parallel_setup",
+  "visit_validation",
+  "pilot_week",
+  "graduation_review",
+  "completed",
+  "closed",
+]);
+
+export const clinicPilotDecisionEnum = pgEnum("clinic_pilot_decision", [
+  "pending",
+  "eligible",
+  "approved",
+  "paused",
+  "not_a_fit",
+  "graduated",
+]);
+
+export const clinicPilotWorkflowEnum = pgEnum("clinic_pilot_workflow", [
+  "general_practice",
+  "house_call",
+]);
+
+export const clinicPilotSupportCadenceEnum = pgEnum(
+  "clinic_pilot_support_cadence",
+  ["daily", "twice_weekly", "weekly"],
+);
+
+export const clinicPilotContactOutcomeEnum = pgEnum(
+  "clinic_pilot_contact_outcome",
+  ["replied", "no_reply", "scheduled", "completed", "declined"],
+);
+
+export const clinicPilotCommunicationModeEnum = pgEnum(
+  "clinic_pilot_communication_mode",
+  ["email_only", "email_and_sms"],
+);
+
+export const clinicPilotNextActionEnum = pgEnum("clinic_pilot_next_action", [
+  "confirm_fit",
+  "schedule_setup",
+  "validate_import",
+  "complete_first_visit",
+  "review_communications",
+  "configure_payment",
+  "review_clinic_week",
+  "resolve_blockers",
+  "decide_graduation",
+  "support_retention",
+  "revisit_fit",
+]);
+
+export const clinicPilotReasonEnum = pgEnum("clinic_pilot_reason", [
+  "initial_review",
+  "clinic_feedback",
+  "product_evidence",
+  "support_review",
+  "blocker_review",
+  "graduation_decision",
+]);
+
+export const clinicPilotEventTypeEnum = pgEnum("clinic_pilot_event_type", [
+  "enrolled",
+  "updated",
+]);
+
+export type ClinicPilotQualificationChecklist = {
+  supportedClinicType: boolean;
+  supportedJurisdictionConfirmed: boolean;
+  singleLocation: boolean;
+  connectedModeAccepted: boolean;
+  parallelRunAccepted: boolean;
+  championConfirmed: boolean;
+  supportedWorkflowConfirmed: boolean;
+  noUnsupportedMustHave: boolean;
+};
+
+export type ClinicPilotEvidenceSnapshot = {
+  verifiedAdminUserIds: string[];
+  activeLocationIds: string[];
+  setupCompletedAt: string | null;
+  activatedEvidenceKey: string | null;
+  activatedAt: string | null;
+  firstVisitCloseoutId: string | null;
+  firstVisitCompletedAt: string | null;
+  clinicUseDays: Array<{
+    closeoutId: string;
+    completedAt: string;
+    localDate: string;
+  }>;
+  paymentMethodEvidenceKey: string | null;
+  paymentMethodCollectedAt: string | null;
+  firstPositivePaymentEvidenceKey: string | null;
+  firstPositivePaymentAt: string | null;
+  billingStatus: string;
+  subscriptionTier: string;
+  trialEndsAt: string | null;
+  hostedFullAccess: boolean;
+  country: string;
+  smsStatus: string;
+};
+
+export type ClinicPilotReadinessChecklist = {
+  rolesAndDevicesValidated: boolean;
+  migrationPlanAccepted: boolean;
+  sampleValidationAccepted: boolean;
+  firstVisitScheduled: boolean;
+  exportAndRollbackConfirmed: boolean;
+  supportCadenceConfirmed: boolean;
+};
+
+export const emptyClinicPilotQualification: ClinicPilotQualificationChecklist =
+  {
+    supportedClinicType: false,
+    supportedJurisdictionConfirmed: false,
+    singleLocation: false,
+    connectedModeAccepted: false,
+    parallelRunAccepted: false,
+    championConfirmed: false,
+    supportedWorkflowConfirmed: false,
+    noUnsupportedMustHave: false,
+  };
+
+export const emptyClinicPilotReadiness: ClinicPilotReadinessChecklist = {
+  rolesAndDevicesValidated: false,
+  migrationPlanAccepted: false,
+  sampleValidationAccepted: false,
+  firstVisitScheduled: false,
+  exportAndRollbackConfirmed: false,
+  supportCadenceConfirmed: false,
+};
+
+/**
+ * Current operator-owned projection for a controlled clinic pilot.
+ *
+ * This deliberately stores no free-form notes or duplicated clinic contact
+ * details. Product progress remains authoritative in its source tables; this
+ * row records only bounded operating decisions and the next review cadence.
+ */
+export const clinicPilots = pgTable(
+  "clinic_pilots",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    cohortKey: varchar("cohort_key", { length: 32 }).notNull(),
+    workflow: clinicPilotWorkflowEnum("workflow").notNull(),
+    stage: clinicPilotStageEnum("stage").notNull().default("candidate"),
+    decision: clinicPilotDecisionEnum("decision").notNull().default("pending"),
+    qualificationChecklist: jsonb("qualification_checklist")
+      .$type<ClinicPilotQualificationChecklist>()
+      .notNull()
+      .default(emptyClinicPilotQualification),
+    readinessChecklist: jsonb("readiness_checklist")
+      .$type<ClinicPilotReadinessChecklist>()
+      .notNull()
+      .default(emptyClinicPilotReadiness),
+    blockerCodes: text("blocker_codes")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+    nextAction: clinicPilotNextActionEnum("next_action")
+      .notNull()
+      .default("confirm_fit"),
+    supportCadence: clinicPilotSupportCadenceEnum("support_cadence")
+      .notNull()
+      .default("daily"),
+    ownerIdentity: varchar("owner_identity", { length: 255 }).notNull(),
+    communicationMode: clinicPilotCommunicationModeEnum("communication_mode")
+      .notNull()
+      .default("email_only"),
+    communicationTestedAt: timestamp("communication_tested_at", {
+      withTimezone: true,
+    }),
+    firstVisitValidatedAt: timestamp("first_visit_validated_at", {
+      withTimezone: true,
+    }),
+    firstVisitValidatedCloseoutId: uuid(
+      "first_visit_validated_closeout_id",
+    ).references(() => visitCloseouts.id),
+    clinicUseValidatedAt: timestamp("clinic_use_validated_at", {
+      withTimezone: true,
+    }),
+    clinicUseValidatedHash: varchar("clinic_use_validated_hash", {
+      length: 64,
+    }),
+    clinicAcceptanceAt: timestamp("clinic_acceptance_at", {
+      withTimezone: true,
+    }),
+    clinicAcceptanceByUserId: uuid("clinic_acceptance_by_user_id"),
+    lastContactAt: timestamp("last_contact_at", { withTimezone: true }),
+    lastContactOutcome: clinicPilotContactOutcomeEnum("last_contact_outcome"),
+    targetStartOn: date("target_start_on"),
+    nextReviewAt: timestamp("next_review_at", { withTimezone: true }),
+    version: integer("version").notNull().default(1),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => ({
+    practiceUq: uniqueIndex("clinic_pilots_practice_uq").on(table.practiceId),
+    pilotPracticeUq: uniqueIndex("clinic_pilots_id_practice_uq").on(
+      table.id,
+      table.practiceId,
+    ),
+    reviewIdx: index("clinic_pilots_review_idx").on(
+      table.stage,
+      table.nextReviewAt,
+      table.practiceId,
+    ),
+    acceptanceTenantFk: foreignKey({
+      columns: [table.practiceId, table.clinicAcceptanceByUserId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "clinic_pilots_acceptance_user_practice_fk",
+    }),
+    versionCheck: check(
+      "clinic_pilots_version_check",
+      sql`${table.version} > 0`,
+    ),
+    operatingShapeCheck: check(
+      "clinic_pilots_operating_shape_check",
+      sql`${table.cohortKey} ~ '^pilot-[0-9]{4}-[0-9]{2}$'
+        and jsonb_typeof(${table.qualificationChecklist}) = 'object'
+        and jsonb_typeof(${table.readinessChecklist}) = 'object'
+        and ${table.ownerIdentity} = btrim(${table.ownerIdentity})
+        and length(${table.ownerIdentity}) between 3 and 255
+        and (${table.lastContactAt} is null) = (${table.lastContactOutcome} is null)
+        and (${table.clinicAcceptanceAt} is null) = (${table.clinicAcceptanceByUserId} is null)
+        and (${table.firstVisitValidatedAt} is null) = (${table.firstVisitValidatedCloseoutId} is null)
+        and (${table.clinicUseValidatedAt} is null) = (${table.clinicUseValidatedHash} is null)
+        and (${table.clinicUseValidatedHash} is null or ${table.clinicUseValidatedHash} ~ '^[a-f0-9]{64}$')`,
+    ),
+    blockerCodesCheck: check(
+      "clinic_pilots_blocker_codes_check",
+      sql`${table.blockerCodes} <@ ARRAY[
+          'workflow_fit',
+          'data_import',
+          'staff_training',
+          'record_accuracy',
+          'billing',
+          'payments',
+          'email',
+          'sms',
+          'permissions',
+          'device_connectivity',
+          'backup_export',
+          'support_coverage'
+        ]::text[]
+        and cardinality(${table.blockerCodes}) <= 12
+        and array_position(${table.blockerCodes}, null) is null`,
+    ),
+    lifecycleCheck: check(
+      "clinic_pilots_lifecycle_check",
+      sql`(
+          ${table.stage} = 'completed'
+          and ${table.decision} = 'graduated'
+          and cardinality(${table.blockerCodes}) = 0
+          and ${table.nextAction} = 'support_retention'
+          and ${table.nextReviewAt} is null
+        ) or (
+          ${table.stage} = 'closed'
+          and ${table.decision} = 'not_a_fit'
+          and ${table.nextAction} = 'revisit_fit'
+          and ${table.nextReviewAt} is null
+        ) or (
+          ${table.stage} not in ('completed', 'closed')
+          and ${table.decision} not in ('graduated', 'not_a_fit')
+          and ${table.nextReviewAt} is not null
+        )`,
+    ),
+  }),
+);
+
+/**
+ * Immutable, PHI-free snapshots of every pilot projection change. The event
+ * history is the audit trail; the current row above may be updated by an
+ * authenticated platform operator under explicit system context.
+ */
+export const clinicPilotEvents = pgTable(
+  "clinic_pilot_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    clinicPilotId: uuid("clinic_pilot_id")
+      .notNull()
+      .references(() => clinicPilots.id),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    operationId: uuid("operation_id").notNull(),
+    payloadHash: varchar("payload_hash", { length: 64 }).notNull(),
+    eventType: clinicPilotEventTypeEnum("event_type").notNull(),
+    reason: clinicPilotReasonEnum("reason").notNull(),
+    cohortKey: varchar("cohort_key", { length: 32 }).notNull(),
+    workflow: clinicPilotWorkflowEnum("workflow").notNull(),
+    stage: clinicPilotStageEnum("stage").notNull(),
+    decision: clinicPilotDecisionEnum("decision").notNull(),
+    qualificationChecklist: jsonb("qualification_checklist")
+      .$type<ClinicPilotQualificationChecklist>()
+      .notNull(),
+    readinessChecklist: jsonb("readiness_checklist")
+      .$type<ClinicPilotReadinessChecklist>()
+      .notNull(),
+    blockerCodes: text("blocker_codes").array().notNull(),
+    nextAction: clinicPilotNextActionEnum("next_action").notNull(),
+    supportCadence: clinicPilotSupportCadenceEnum("support_cadence").notNull(),
+    ownerIdentity: varchar("owner_identity", { length: 255 }).notNull(),
+    communicationMode:
+      clinicPilotCommunicationModeEnum("communication_mode").notNull(),
+    communicationTestedAt: timestamp("communication_tested_at", {
+      withTimezone: true,
+    }),
+    firstVisitValidatedAt: timestamp("first_visit_validated_at", {
+      withTimezone: true,
+    }),
+    firstVisitValidatedCloseoutId: uuid(
+      "first_visit_validated_closeout_id",
+    ).references(() => visitCloseouts.id),
+    clinicUseValidatedAt: timestamp("clinic_use_validated_at", {
+      withTimezone: true,
+    }),
+    clinicUseValidatedHash: varchar("clinic_use_validated_hash", {
+      length: 64,
+    }),
+    clinicAcceptanceAt: timestamp("clinic_acceptance_at", {
+      withTimezone: true,
+    }),
+    clinicAcceptanceByUserId: uuid("clinic_acceptance_by_user_id"),
+    lastContactAt: timestamp("last_contact_at", { withTimezone: true }),
+    lastContactOutcome: clinicPilotContactOutcomeEnum("last_contact_outcome"),
+    targetStartOn: date("target_start_on"),
+    nextReviewAt: timestamp("next_review_at", { withTimezone: true }),
+    projectionVersion: integer("projection_version").notNull(),
+    actorIdentity: varchar("actor_identity", { length: 255 }).notNull(),
+    evidenceSnapshot: jsonb("evidence_snapshot")
+      .$type<ClinicPilotEvidenceSnapshot>()
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    operationUq: uniqueIndex("clinic_pilot_events_operation_uq").on(
+      table.operationId,
+    ),
+    historyIdx: index("clinic_pilot_events_history_idx").on(
+      table.practiceId,
+      table.createdAt,
+      table.id,
+    ),
+    pilotTenantFk: foreignKey({
+      columns: [table.clinicPilotId, table.practiceId],
+      foreignColumns: [clinicPilots.id, clinicPilots.practiceId],
+      name: "clinic_pilot_events_pilot_practice_fk",
+    }),
+    acceptanceTenantFk: foreignKey({
+      columns: [table.practiceId, table.clinicAcceptanceByUserId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "clinic_pilot_events_acceptance_user_practice_fk",
+    }),
+    snapshotCheck: check(
+      "clinic_pilot_events_snapshot_check",
+      sql`${table.projectionVersion} > 0
+        and ${table.payloadHash} ~ '^[a-f0-9]{64}$'
+        and ${table.actorIdentity} = btrim(${table.actorIdentity})
+        and length(${table.actorIdentity}) between 3 and 255
+        and ${table.ownerIdentity} = btrim(${table.ownerIdentity})
+        and length(${table.ownerIdentity}) between 3 and 255
+        and ${table.cohortKey} ~ '^pilot-[0-9]{4}-[0-9]{2}$'
+        and jsonb_typeof(${table.qualificationChecklist}) = 'object'
+        and jsonb_typeof(${table.readinessChecklist}) = 'object'
+        and jsonb_typeof(${table.evidenceSnapshot}) = 'object'
+        and (${table.lastContactAt} is null) = (${table.lastContactOutcome} is null)
+        and (${table.clinicAcceptanceAt} is null) = (${table.clinicAcceptanceByUserId} is null)
+        and (${table.firstVisitValidatedAt} is null) = (${table.firstVisitValidatedCloseoutId} is null)
+        and (${table.clinicUseValidatedAt} is null) = (${table.clinicUseValidatedHash} is null)
+        and (${table.clinicUseValidatedHash} is null or ${table.clinicUseValidatedHash} ~ '^[a-f0-9]{64}$')
+        and ${table.blockerCodes} <@ ARRAY[
+          'workflow_fit',
+          'data_import',
+          'staff_training',
+          'record_accuracy',
+          'billing',
+          'payments',
+          'email',
+          'sms',
+          'permissions',
+          'device_connectivity',
+          'backup_export',
+          'support_coverage'
+        ]::text[]
+        and cardinality(${table.blockerCodes}) <= 12
+        and array_position(${table.blockerCodes}, null) is null`,
+    ),
+  }),
+);

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -36,3 +36,4 @@ export * from "./conversion-milestones";
 export * from "./migrations";
 export * from "./visit-closeouts";
 export * from "./visit-work-items";
+export * from "./clinic-pilots";

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -172,6 +172,9 @@ const systemPlatformEmailPreferenceEventId = randomUUID();
 const platformEmailHash = "c".repeat(64);
 const platformEmailIdentityFingerprint = "d".repeat(64);
 const conversionEvidenceKey = `practice:${aId}`;
+const clinicPilotId = randomUUID();
+const clinicPilotEventId = randomUUID();
+const clinicPilotOperationId = randomUUID();
 const aSoapCorrectionReason =
   "Original note was documented on the wrong encounter.";
 const bSoapCorrectionReason =
@@ -420,6 +423,30 @@ try {
   await owner`insert into practice_conversion_milestones
     (practice_id, milestone, occurred_at, evidence_source, evidence_key)
     values (${aId}, 'registered', now(), 'practice_created', ${conversionEvidenceKey})`;
+  await owner.begin(async (tx) => {
+    const seed = tx as unknown as typeof owner;
+    await seed`insert into clinic_pilots
+      (id, practice_id, cohort_key, workflow, stage, decision, next_action,
+        owner_identity, next_review_at)
+      values (${clinicPilotId}, ${aId}, 'pilot-2026-08', 'general_practice',
+        'candidate', 'pending', 'confirm_fit', 'rls-operator@example.com',
+        now() + interval '1 day')`;
+    await seed`insert into clinic_pilot_events
+      (id, clinic_pilot_id, practice_id, operation_id, payload_hash, event_type,
+        reason, cohort_key, workflow, stage, decision, qualification_checklist,
+        readiness_checklist, blocker_codes, next_action, support_cadence,
+        owner_identity, communication_mode, next_review_at, projection_version,
+        actor_identity, evidence_snapshot)
+      values (${clinicPilotEventId}, ${clinicPilotId}, ${aId},
+        ${clinicPilotOperationId}, ${"a".repeat(64)}, 'enrolled',
+        'initial_review', 'pilot-2026-08', 'general_practice', 'candidate',
+        'pending',
+        '{"supportedClinicType":false,"supportedJurisdictionConfirmed":false,"singleLocation":false,"connectedModeAccepted":false,"parallelRunAccepted":false,"championConfirmed":false,"supportedWorkflowConfirmed":false,"noUnsupportedMustHave":false}'::jsonb,
+        '{"rolesAndDevicesValidated":false,"migrationPlanAccepted":false,"sampleValidationAccepted":false,"firstVisitScheduled":false,"exportAndRollbackConfirmed":false,"supportCadenceConfirmed":false}'::jsonb,
+        ARRAY[]::text[], 'confirm_fit', 'daily',
+        'rls-operator@example.com', 'email_only', now() + interval '1 day', 1,
+        'rls-operator@example.com', '{}'::jsonb)`;
+  });
   await owner`insert into appointments (id, practice_id, location_id, room_id, client_id, start_time, end_time)
     select ${aAppointment}::uuid, ${aId}::uuid, ${aLocation}::uuid, ${aRoom}::uuid, id, now(), now() + interval '30 minutes'
     from clients where practice_id = ${aId}
@@ -2319,6 +2346,22 @@ try {
     "tenant context cannot read system-only conversion milestones",
     hiddenConversionRows.length === 0,
   );
+  const hiddenClinicPilots = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id from clinic_pilots where id = ${clinicPilotId}`;
+  });
+  check(
+    "tenant context cannot read system-only clinic pilot state",
+    hiddenClinicPilots.length === 0,
+  );
+  const hiddenClinicPilotEvents = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id from clinic_pilot_events where id = ${clinicPilotEventId}`;
+  });
+  check(
+    "tenant context cannot read clinic pilot audit events",
+    hiddenClinicPilotEvents.length === 0,
+  );
   const hiddenPlatformEmailPreferences = await appTransaction(async (tx) => {
     await tx`select set_config('app.current_practice_id', ${aId}, true)`;
     return tx`select id from platform_email_preferences where id = ${platformEmailPreferenceId}`;
@@ -2406,6 +2449,64 @@ try {
   check(
     "system bypass can read conversion milestones",
     systemConversionRows.length === 1,
+  );
+  const systemClinicPilots = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id from clinic_pilots where id = ${clinicPilotId}`;
+  });
+  check(
+    "system bypass can read clinic pilot state",
+    systemClinicPilots.length === 1,
+  );
+  const systemClinicPilotEvents = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id from clinic_pilot_events where id = ${clinicPilotEventId}`;
+  });
+  check(
+    "system bypass can read clinic pilot audit events",
+    systemClinicPilotEvents.length === 1,
+  );
+  let bypassCannotRewriteClinicPilotEvent = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`update clinic_pilot_events set reason = 'support_review'
+        where id = ${clinicPilotEventId}`;
+    });
+  } catch {
+    bypassCannotRewriteClinicPilotEvent = true;
+  }
+  check(
+    "application role cannot rewrite clinic pilot audit events",
+    bypassCannotRewriteClinicPilotEvent,
+  );
+  let bypassCannotDeleteClinicPilotEvent = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`delete from clinic_pilot_events where id = ${clinicPilotEventId}`;
+    });
+  } catch {
+    bypassCannotDeleteClinicPilotEvent = true;
+  }
+  check(
+    "application role cannot delete clinic pilot audit events",
+    bypassCannotDeleteClinicPilotEvent,
+  );
+  let bypassCannotRewritePilotWithoutEvidence = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`update clinic_pilots
+        set version = version + 1, updated_at = now()
+        where id = ${clinicPilotId}`;
+    });
+  } catch {
+    bypassCannotRewritePilotWithoutEvidence = true;
+  }
+  check(
+    "application role cannot rewrite clinic pilot state without a matching event",
+    bypassCannotRewritePilotWithoutEvidence,
   );
   const systemPlatformEmailPreferences = await appTransaction(async (tx) => {
     await tx`select set_config('app.rls_bypass', 'on', true)`;
@@ -2835,6 +2936,8 @@ try {
     await cleanup`delete from visit_closeouts where id in (${aCloseout}, ${bCloseout})`;
     await cleanup`delete from funnel_events where id = ${funnelEventId}`;
     await cleanup`delete from practice_conversion_milestones where practice_id = ${aId}`;
+    await cleanup`delete from clinic_pilot_events where id = ${clinicPilotEventId}`;
+    await cleanup`delete from clinic_pilots where id = ${clinicPilotId}`;
     await cleanup`delete from invoices where id in (${aInvoice}, ${bInvoice})`;
     await cleanup`delete from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
     await cleanup`delete from appointments where id in (${aAppointment}, ${bAppointment}, ${aSoapLegalAppointment}, ${bSoapLegalAppointment}, ${aSoapDraftFinalAppointment}, ${aSoapDoubleFinalAppointment}, ${aSoapDiscardAppointment})`;


### PR DESCRIPTION
## Outcome

Adds a restricted, audited operating system for the first controlled US clinic cohort without claiming universal clinic readiness.

## What changes

- platform-admin clinic pilot queue with bounded qualification, readiness, cadence, blocker, and graduation controls
- immutable PHI-free event history with exact evidence binding and tenant-deny RLS
- canonical activation, completed-visit, five-day-use, messaging, payment-method, billing-access, and acceptance gates
- aggregate-only pilot status in the activation digest
- controlled clinic pilot runbook and linked readiness/production guidance
- no automatic outreach, SMS enablement, number purchase, billing change, payment collection, or external-provider calls

## Verification

- `pnpm --filter @openpims/db type-check`
- `pnpm --filter @openpims/web type-check`
- focused clinic-pilot suite: 70 passing
- full suite: 343 files passed, 2 skipped; 3,510 tests passed, 2 integration skipped
- `pnpm --filter @openpims/web build`
- `git diff --check`
- staged Gitleaks scan: no leaks found
- three independent readiness/security reviews: GO

Local Docker was unavailable, so CI remains the required live migration/RLS gate before merge.

Tracks [OPENVPM-56](https://get-talky.atlassian.net/browse/OPENVPM-56).