### PR TITLE
Restore Vercel analytics proxy

### DIFF
--- a/apps/web/middleware.test.ts
+++ b/apps/web/middleware.test.ts
@@ -204,8 +204,21 @@ describe("middleware security headers", () => {
     expectSecurityHeaders(response);
   });
 
-  it("runs on dynamic public and API routes so headers are global", () => {
-    expect(config.matcher).toEqual(["/((?!_next).*)"]);
+  it("runs on application routes but leaves Vercel analytics at the edge", () => {
+    expect(config.matcher).toEqual([
+      "/((?!_next|_vercel/insights|[a-f0-9]{16}/(?:script\\.js|view|event|session)).*)",
+    ]);
+
+    const matcher = new RegExp(`^${config.matcher[0]}$`);
+    expect(matcher.test("/register")).toBe(true);
+    expect(matcher.test("/api/health")).toBe(true);
+    expect(matcher.test("/_next/static/chunk.js")).toBe(false);
+    expect(matcher.test("/_vercel/insights/script.js")).toBe(false);
+    expect(matcher.test("/5691167a7e0cfa40/script.js")).toBe(false);
+    expect(matcher.test("/5691167a7e0cfa40/view")).toBe(false);
+    expect(matcher.test("/5691167a7e0cfa40/event")).toBe(false);
+    expect(matcher.test("/5691167a7e0cfa40/session")).toBe(false);
+    expect(matcher.test("/5691167a7e0cfa40/clinic-route")).toBe(true);
   });
 
   it("also configures app-wide headers for static and framework assets", async () => {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -75,5 +75,11 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next).*)"],
+  // Do not invoke Next middleware for Vercel's analytics proxy. Vercel rewrites
+  // /_vercel/insights to a deployment-specific 16-hex path in production; if
+  // middleware handles that rewritten path, the analytics script falls through
+  // to the app 404 instead of the platform proxy.
+  matcher: [
+    "/((?!_next|_vercel/insights|[a-f0-9]{16}/(?:script\\.js|view|event|session)).*)",
+  ],
 };


### PR DESCRIPTION
## Outcome

Restores Vercel page analytics on hosted routes by keeping both canonical and deployment-specific analytics proxy paths out of Next middleware.

## Evidence

Production smoke on `/register` showed:
- `/<16-hex>/script.js` returned the app 404 HTML
- the browser refused that HTML as JavaScript
- the current catch-all middleware matcher handled the Vercel-rewritten proxy path

This change excludes:
- `/_vercel/insights/*`
- `/<16-hex>/{script.js,view,event,session}`

All ordinary application and API routes continue through security middleware. Global security headers remain configured in `next.config.js`.

## Verification

- middleware suite: 18 passing
- web type-check passed
- production Next build passed
- staged Gitleaks scan: no leaks found

After merge, production acceptance is a 200 JavaScript response for the rewritten analytics script with zero browser console errors on `/register`.