### PR TITLE
Make allergy corrections clinic-safe

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -640,15 +640,36 @@ export default function EncounterWorkspacePage() {
                             .join(" · ") || "Patient details unavailable"}
                         </p>
                       </div>
-                      {patient?.allergies.length ? (
-                        <Badge variant="destructive">
-                          {patient.allergies.length} allerg
-                          {patient.allergies.length === 1 ? "y" : "ies"}
-                        </Badge>
-                      ) : (
+                      {!patient?.allergies.length ? (
                         <Badge variant="secondary">No recorded allergies</Badge>
-                      )}
+                      ) : null}
                     </div>
+                    {patient?.allergies.length ? (
+                      <div
+                        className="mt-3 grid gap-2"
+                        role="alert"
+                        aria-label="Current allergy warnings"
+                      >
+                        {patient.allergies.map((allergy) => (
+                          <div
+                            key={allergy.id}
+                            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <span className="font-semibold text-destructive">
+                                {allergy.allergen}
+                              </span>
+                              <span className="text-xs font-semibold uppercase tracking-wide text-destructive">
+                                {allergy.severity}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-xs text-foreground">
+                              Reaction: {allergy.reaction || "Not documented"}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
 
                   <div className="flex flex-wrap gap-2">

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -23,7 +23,6 @@ import {
   Paperclip,
   Plus,
   Receipt,
-  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
@@ -413,9 +412,9 @@ export default function PatientDetailPage() {
     },
     onError: (err) => toast.error(err.message),
   });
-  const removeAllergy = trpc.patients.removeAllergy.useMutation({
+  const correctAllergy = trpc.patients.markAllergyEnteredInError.useMutation({
     onSuccess: () => {
-      toast.success("Allergy removed");
+      toast.success("Allergy correction recorded");
       void refreshPatientDetail();
     },
     onError: (err) => toast.error(err.message),
@@ -434,18 +433,6 @@ export default function PatientDetailPage() {
       severity: allergySeverity,
       reaction: allergyReaction.trim() || undefined,
     });
-  }
-
-  function handleRemoveAllergy(allergy: { id: string; allergen: string }) {
-    if (!patient || removeAllergy.isPending) return;
-    if (
-      !window.confirm(
-        `Remove the "${allergy.allergen}" allergy? Prescription safety checks will stop warning about it.`
-      )
-    ) {
-      return;
-    }
-    removeAllergy.mutate({ patientId: patient.id, id: allergy.id });
   }
 
   const loadError = error ?? recordsSettingsError;
@@ -537,6 +524,7 @@ export default function PatientDetailPage() {
         allergies: (patientData.allergies ?? []).map((a) => ({
           allergen: a.allergen,
           severity: a.severity ?? "unknown",
+          reaction: a.reaction ?? undefined,
         })),
         problems: problems.map((p) => ({
           description: p.description,
@@ -586,11 +574,36 @@ export default function PatientDetailPage() {
               ),
             })),
           })),
-        recordCorrections: soapNotes
-          .filter(
-            (note) => note.status === "finalized" && Boolean(note.correctionId),
-          )
-          .map((note) => ({
+        recordCorrections: [
+          ...(patientData.allergyHistory ?? [])
+            .filter(
+              (allergy) =>
+                Boolean(allergy.correctionId) &&
+                Boolean(allergy.correctionReason) &&
+                Boolean(allergy.correctedAt),
+            )
+            .map((allergy) => ({
+              recordLabel: `Allergy “${allergy.allergen}” recorded ${formatClinicalDate(
+                allergy.notedAt,
+                recordsTimeZone,
+                "Unknown date",
+              )}`,
+              reason: allergy.correctionReason ?? "Reason unavailable",
+              correctedByName:
+                allergy.correctedByName ?? "Unknown clinician",
+              correctedAt: allergy.correctedAt
+                ? formatClinicalDateTime(
+                    allergy.correctedAt,
+                    recordsTimeZone,
+                  )
+                : "Unknown time",
+            })),
+          ...soapNotes
+            .filter(
+              (note) =>
+                note.status === "finalized" && Boolean(note.correctionId),
+            )
+            .map((note) => ({
             recordLabel: `SOAP note dated ${formatClinicalDate(
               note.createdAt,
               recordsTimeZone,
@@ -613,9 +626,10 @@ export default function PatientDetailPage() {
                         "unknown date",
                       )}, finalized by ${replacement.finalizerName ?? "Unknown clinician"}`
                     : "Replacement SOAP retained in chart";
-                })()
+              })()
               : undefined,
-          })),
+            })),
+        ],
         prescriptions: prescriptions.map((rx) => ({
           medication: rx.medicationName,
           dosage: rx.dosage ?? "",
@@ -789,39 +803,47 @@ export default function PatientDetailPage() {
             <p className="text-sm font-semibold text-red-800 dark:text-red-300">
               Allergies
             </p>
-            <div className="mt-1 flex flex-wrap items-center gap-2">
+            <div className="mt-2 grid gap-2 md:grid-cols-2">
               {patient.allergies.map((allergy) => (
-                <span
+                <div
                   key={allergy.id}
-                  title={allergy.reaction ?? undefined}
                   className={cn(
-                    "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                    "rounded-md border px-3 py-2 text-sm",
                     allergy.severity === "severe"
-                      ? "bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-200"
+                      ? "border-red-300 bg-red-100 text-red-900 dark:border-red-800 dark:bg-red-950/60 dark:text-red-100"
                       : allergy.severity === "moderate"
-                        ? "bg-amber-200 text-amber-800 dark:bg-amber-900 dark:text-amber-200"
-                        : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+                        ? "border-amber-300 bg-amber-100 text-amber-900 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-100"
+                        : "border-yellow-300 bg-yellow-50 text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950/50 dark:text-yellow-100"
                   )}
                 >
-                  {allergy.allergen}
-                  {allergy.severity === "severe" ? (
-                    <span className="ml-1 text-[10px] font-semibold uppercase tracking-wide">
-                      severe
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-semibold">{allergy.allergen}</span>
+                    <span className="text-xs font-semibold uppercase tracking-wide">
+                      {allergy.severity}
                     </span>
-                  ) : null}
-                  {canManagePatientDetail ? (
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveAllergy(allergy)}
-                      disabled={removeAllergy.isPending}
-                      aria-label={`Remove ${allergy.allergen} allergy`}
-                      className="ml-1 rounded-full p-0.5 opacity-60 transition-opacity hover:opacity-100 disabled:cursor-not-allowed"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  ) : null}
-                </span>
+                  </div>
+                  <p className="mt-1 text-xs">
+                    Reaction: {allergy.reaction || "Not documented"}
+                  </p>
+                  <ClinicalCorrectionControl
+                    correction={null}
+                    canCorrect={canCorrectClinicalRecords}
+                    isPending={correctAllergy.isPending}
+                    triggerLabel="Mark allergy entered in error"
+                    description="The original allergy and this permanent reason remain in staff chart history. The allergy will stop feeding current alerts, prescription safety, AI context, PDF summaries, and the client portal."
+                    timeZone={recordsTimeZone}
+                    onCorrect={(reason) =>
+                      correctAllergy.mutateAsync({
+                        patientId: patient.id,
+                        recordId: allergy.id,
+                        reason,
+                      })
+                    }
+                  />
+                </div>
               ))}
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
               {canManagePatientDetail && !showAllergyForm ? (
                 <button
                   type="button"
@@ -878,6 +900,61 @@ export default function PatientDetailPage() {
             </div>
           )}
         </div>
+      ) : null}
+
+      {patient.allergyHistory.some(
+        (allergy) => Boolean(allergy.correctionId) || Boolean(allergy.deletedAt),
+      ) ? (
+        <details className="mt-3 rounded-lg border border-border bg-card px-4 py-3">
+          <summary className="cursor-pointer text-sm font-medium">
+            Allergy correction history
+          </summary>
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            {patient.allergyHistory
+              .filter(
+                (allergy) =>
+                  Boolean(allergy.correctionId) || Boolean(allergy.deletedAt),
+              )
+              .map((allergy) => (
+                <div
+                  key={allergy.id}
+                  className="rounded-md border border-border bg-muted/20 p-3 text-sm"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-semibold">{allergy.allergen}</span>
+                    <span className="text-xs uppercase text-muted-foreground">
+                      {allergy.severity}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Reaction: {allergy.reaction || "Not documented"}
+                  </p>
+                  {allergy.correctionId &&
+                  allergy.correctionReason &&
+                  allergy.correctedAt ? (
+                    <ClinicalCorrectionControl
+                      correction={{
+                        id: allergy.correctionId,
+                        reason: allergy.correctionReason,
+                        correctedAt: allergy.correctedAt,
+                        correctedByName: allergy.correctedByName,
+                      }}
+                      canCorrect={false}
+                      isPending={false}
+                      onCorrect={async () => undefined}
+                      timeZone={recordsTimeZone}
+                    />
+                  ) : (
+                    <div className="mt-3 rounded-md border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
+                      Legacy removal retained. This predates permanent allergy
+                      correction attribution, so no reason or clinician is
+                      available.
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        </details>
       ) : null}
 
       {/* Tab Navigation */}

--- a/apps/web/lib/__tests__/allergy-corrections-db-safety.test.ts
+++ b/apps/web/lib/__tests__/allergy-corrections-db-safety.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import { getTableConfig } from "drizzle-orm/pg-core";
 import { clinicalRecordCorrections, patientAllergies } from "@openpims/db";
 
-const MIGRATION = "packages/db/drizzle/0074_hesitant_franklin_richards.sql";
+const SCHEMA_MIGRATION =
+  "packages/db/drizzle/0074_hesitant_franklin_richards.sql";
+const PATIENTS_ROUTER = "apps/web/server/routers/patients.ts";
 
 function readRepoFile(path: string): string {
   return readFileSync(new URL(`../../../../${path}`, import.meta.url), "utf8");
@@ -50,7 +52,7 @@ describe("patient allergy correction database safety", () => {
   });
 
   it("ships a transaction-safe migration with ordered constraints", () => {
-    const migration = readRepoFile(MIGRATION);
+    const migration = readRepoFile(SCHEMA_MIGRATION);
     const journal = JSON.parse(
       readRepoFile("packages/db/drizzle/meta/_journal.json"),
     ) as { entries?: Array<{ tag?: string }> };
@@ -102,4 +104,14 @@ describe("patient allergy correction database safety", () => {
     expect(migration).toContain('"appointment_id" is null');
   });
 
+  it("does not require an UPDATE row lock to append a correction", () => {
+    const router = readRepoFile(PATIENTS_ROUTER);
+    const mutation = router.slice(
+      router.indexOf("markAllergyEnteredInError:"),
+      router.indexOf("previewMerge:"),
+    );
+
+    expect(mutation).toContain(".onConflictDoNothing()");
+    expect(mutation).not.toContain('.for("update")');
+  });
 });

--- a/apps/web/lib/__tests__/clinical-corrections-safety.test.ts
+++ b/apps/web/lib/__tests__/clinical-corrections-safety.test.ts
@@ -206,13 +206,15 @@ describe("clinical correction schema and migration", () => {
       'ALTER TYPE "public"."clinical_correction_record_type" RENAME TO "clinical_correction_record_type_old"',
     );
     expect(migration).toContain(
-      'CREATE TYPE "public"."clinical_correction_record_type" AS ENUM(\'soap_note\', \'vital_sign\', \'vaccination_record\')',
+      "CREATE TYPE \"public\".\"clinical_correction_record_type\" AS ENUM('soap_note', 'vital_sign', 'vaccination_record')",
     );
     expect(migration).toContain(
       'USING "record_type"::text::"public"."clinical_correction_record_type"',
     );
     expect(migration).not.toContain("ADD VALUE 'vaccination_record'");
-    expect(migration.indexOf("vaccination_records_practice_record_uq")).toBeLessThan(
+    expect(
+      migration.indexOf("vaccination_records_practice_record_uq"),
+    ).toBeLessThan(
       migration.indexOf("clinical_record_corrections_vaccination_source_fk"),
     );
     expect(migration).toContain(
@@ -227,9 +229,7 @@ describe("clinical correction schema and migration", () => {
     expect(migration).toContain(
       'and "clinical_record_corrections"."vital_sign_id" is null',
     );
-    expect(migration).toContain(
-      "ELSIF NEW.record_type = 'vaccination_record'",
-    );
+    expect(migration).toContain("ELSIF NEW.record_type = 'vaccination_record'");
     expect(migration).toContain("FROM public.vaccination_records source");
     expect(migration).toContain(
       "source.appointment_id IS NOT DISTINCT FROM NEW.appointment_id",
@@ -491,6 +491,40 @@ describe("clinical correction consumers", () => {
       expect(source).toContain("newer_correction.vaccination_record_id");
       expect(source).toContain("newer_vaccination.administered_at");
     }
+  });
+
+  it("retains corrected allergies while excluding them from current safety consumers", () => {
+    const patientsRouter = readRepoFile("apps/web/server/routers/patients.ts");
+    const records = readRepoFile("apps/web/server/routers/records.ts");
+    const ai = readRepoFile("apps/web/server/routers/ai.ts");
+    const portal = readRepoFile("apps/web/server/routers/portal.ts");
+    const patientPage = readRepoFile(
+      "apps/web/app/(dashboard)/patients/[id]/page.tsx",
+    );
+    const encounterPage = readRepoFile(
+      "apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx",
+    );
+    const backup = readRepoFile("apps/web/lib/backup/export.ts");
+
+    expect(patientsRouter).toContain("markAllergyEnteredInError");
+    expect(patientsRouter).toContain('recordType: "patient_allergy"');
+    expect(patientsRouter).toContain("allergyHistory");
+    for (const source of [records, ai, portal]) {
+      expect(source).toContain(
+        "allergy_correction.patient_allergy_id = ${patientAllergies.id}",
+      );
+    }
+    expect(patientPage).toContain("Allergy correction history");
+    expect(patientPage).toContain(
+      'triggerLabel="Mark allergy entered in error"',
+    );
+    for (const source of [patientPage, encounterPage]) {
+      expect(source).toContain(
+        'Reaction: {allergy.reaction || "Not documented"}',
+      );
+    }
+    expect(backup).toContain('"patientAllergyId"');
+    expect(backup).toContain('row.recordType === "patient_allergy"');
   });
 
   it("uses an accessible, explicit confirmation dialog for permanent corrections", () => {

--- a/apps/web/lib/__tests__/patient-detail-ui.test.ts
+++ b/apps/web/lib/__tests__/patient-detail-ui.test.ts
@@ -321,19 +321,20 @@ describe("patient detail UI states", () => {
     expect(source).toContain('toast.success("Weight recorded")');
   });
 
-  it("lets staff manage allergies from the alert bar, gated and confirmed", () => {
+  it("keeps allergy reactions visible and uses permanent clinician corrections", () => {
     const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
-    // Add + remove both refresh the same getById payload the bar renders from.
+    // Add + correction both refresh the same getById payload the bar renders from.
     expect(source).toContain("trpc.patients.addAllergy.useMutation");
-    expect(source).toContain("trpc.patients.removeAllergy.useMutation");
+    expect(source).toContain(
+      "trpc.patients.markAllergyEnteredInError.useMutation"
+    );
     const refreshes = source.match(/void refreshPatientDetail\(\)/g);
     expect(refreshes && refreshes.length).toBeGreaterThanOrEqual(4);
-    // Removal is destructive to safety checks; it must be confirmed and
-    // both controls stay behind the same role gate as the server.
-    expect(source).toContain("window.confirm(");
-    expect(source).toContain(
-      "Prescription safety checks will stop warning about it."
-    );
+    expect(source).toContain('triggerLabel="Mark allergy entered in error"');
+    expect(source).toContain("canCorrect={canCorrectClinicalRecords}");
+    expect(source).toContain("Reaction: {allergy.reaction || \"Not documented\"}");
+    expect(source).toContain("Allergy correction history");
+    expect(source).toContain("Legacy removal retained.");
     expect(source).toContain("{canManagePatientDetail && !showAllergyForm ?");
     expect(source).toContain("allergen: allergyName.trim()");
     // Read-only roles still see the alert bar but never the empty-state

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -1750,6 +1750,13 @@ describe("restorePracticeData", () => {
           administeredBy: "user-1",
         },
       ],
+      patientAllergies: [
+        {
+          id: "allergy-1",
+          patientId: "patient-1",
+          notedBy: "user-1",
+        },
+      ],
       clinicalRecordCorrections: [
         {
           id: "correction-1",
@@ -1777,6 +1784,18 @@ describe("restorePracticeData", () => {
           vaccinationRecordId: "vaccination-1",
           patientId: "patient-1",
           appointmentId: "appointment-1",
+          correctedBy: "user-1",
+        },
+        {
+          id: "correction-4",
+          recordType: "patient_allergy",
+          soapNoteId: null,
+          vitalSignId: null,
+          vaccinationRecordId: null,
+          labResultId: null,
+          patientAllergyId: "allergy-1",
+          patientId: "patient-1",
+          appointmentId: null,
           correctedBy: "user-1",
         },
       ],
@@ -1813,7 +1832,7 @@ describe("restorePracticeData", () => {
         ],
       }).errors,
     ).toContain(
-      "clinicalRecordCorrections[correction-1].recordType must be soap_note, vital_sign, vaccination_record, or lab_result.",
+      "clinicalRecordCorrections[correction-1].recordType must be soap_note, vital_sign, vaccination_record, lab_result, or patient_allergy.",
     );
 
     expect(
@@ -1838,12 +1857,26 @@ describe("restorePracticeData", () => {
           backup.clinicalRecordCorrections[2],
           {
             ...backup.clinicalRecordCorrections[2],
-            id: "correction-4",
+            id: "correction-5",
           },
         ],
       }).errors,
     ).toContain(
-      "clinicalRecordCorrections[correction-4] duplicates an existing correction source.",
+      "clinicalRecordCorrections[correction-5] duplicates an existing correction source.",
+    );
+
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        clinicalRecordCorrections: [
+          {
+            ...backup.clinicalRecordCorrections[3],
+            patientId: "patient-2",
+          },
+        ],
+      }).errors,
+    ).toContain(
+      "clinicalRecordCorrections[correction-4] must match its source record patientId and appointmentId exactly.",
     );
   });
 

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -431,6 +431,11 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
     "vaccinationRecords",
   ),
   optionalRef("clinicalRecordCorrections", "labResultId", "labResults"),
+  optionalRef(
+    "clinicalRecordCorrections",
+    "patientAllergyId",
+    "patientAllergies",
+  ),
   requiredRef(
     "labResultReplacements",
     "correctionId",
@@ -1224,6 +1229,7 @@ export function validatePracticeExportRestore(data: unknown): {
   const soapRows = rowsById("soapNotes");
   const vitalRows = rowsById("vitalSigns");
   const vaccinationRows = rowsById("vaccinationRecords");
+  const allergyRows = rowsById("patientAllergies");
   const correctedSources = new Set<string>();
   const correctionOperationIds = new Set<string>();
   rowsFor(data, "clinicalRecordCorrections").forEach((row, index) => {
@@ -1254,6 +1260,12 @@ export function validatePracticeExportRestore(data: unknown): {
         );
         return;
       }
+      if (row.patientAllergyId != null) {
+        pushError(
+          `${label}.patientAllergyId must be null for recordType soap_note.`,
+        );
+        return;
+      }
       source = soapRows.get(row.soapNoteId);
       sourceIdentity = `soap_note:${row.soapNoteId}`;
     } else if (row.recordType === "vital_sign") {
@@ -1281,6 +1293,12 @@ export function validatePracticeExportRestore(data: unknown): {
         );
         return;
       }
+      if (row.patientAllergyId != null) {
+        pushError(
+          `${label}.patientAllergyId must be null for recordType vital_sign.`,
+        );
+        return;
+      }
       source = vitalRows.get(row.vitalSignId);
       sourceIdentity = `vital_sign:${row.vitalSignId}`;
     } else if (row.recordType === "vaccination_record") {
@@ -1296,7 +1314,8 @@ export function validatePracticeExportRestore(data: unknown): {
       if (
         row.soapNoteId != null ||
         row.vitalSignId != null ||
-        row.labResultId != null
+        row.labResultId != null ||
+        row.patientAllergyId != null
       ) {
         pushError(
           `${label} may only set .vaccinationRecordId for recordType vaccination_record.`,
@@ -1315,7 +1334,8 @@ export function validatePracticeExportRestore(data: unknown): {
       if (
         row.soapNoteId != null ||
         row.vitalSignId != null ||
-        row.vaccinationRecordId != null
+        row.vaccinationRecordId != null ||
+        row.patientAllergyId != null
       ) {
         pushError(
           `${label} may only set .labResultId for recordType lab_result.`,
@@ -1342,9 +1362,32 @@ export function validatePracticeExportRestore(data: unknown): {
       correctionOperationIds.add(row.operationId);
       source = labRows.get(row.labResultId);
       sourceIdentity = `lab_result:${row.labResultId}`;
+    } else if (row.recordType === "patient_allergy") {
+      if (
+        typeof row.patientAllergyId !== "string" ||
+        row.patientAllergyId.length === 0
+      ) {
+        pushError(
+          `${label}.patientAllergyId is required for recordType patient_allergy.`,
+        );
+        return;
+      }
+      if (
+        row.soapNoteId != null ||
+        row.vitalSignId != null ||
+        row.vaccinationRecordId != null ||
+        row.labResultId != null
+      ) {
+        pushError(
+          `${label} may only set .patientAllergyId for recordType patient_allergy.`,
+        );
+        return;
+      }
+      source = allergyRows.get(row.patientAllergyId);
+      sourceIdentity = `patient_allergy:${row.patientAllergyId}`;
     } else {
       pushError(
-        `${label}.recordType must be soap_note, vital_sign, vaccination_record, or lab_result.`,
+        `${label}.recordType must be soap_note, vital_sign, vaccination_record, lab_result, or patient_allergy.`,
       );
       return;
     }

--- a/apps/web/lib/pdf.ts
+++ b/apps/web/lib/pdf.ts
@@ -427,7 +427,11 @@ export interface MedicalSummaryData {
   clientName: string;
   clientPhone?: string;
   clientEmail?: string;
-  allergies: Array<{ allergen: string; severity: string }>;
+  allergies: Array<{
+    allergen: string;
+    severity: string;
+    reaction?: string;
+  }>;
   problems: Array<{ description: string; status: string; onsetDate?: string }>;
   vaccinations: Array<{ name: string; date: string; nextDue?: string }>;
   recentNotes: Array<{
@@ -618,7 +622,18 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
       doc.setFont(FONT, "normal");
       setColor(doc, COLOR_GRAY);
       doc.text(`(${allergy.severity})`, PAGE_MARGIN + 2 + doc.getTextWidth(allergy.allergen + " "), y);
-      y += 8;
+      y += 5;
+      if (allergy.reaction) {
+        doc.setFontSize(8);
+        writeWrappedText(
+          `Reaction: ${allergy.reaction}`,
+          PAGE_MARGIN + 2,
+          CONTENT_WIDTH - 4,
+          3.5,
+        );
+        doc.setFontSize(10);
+      }
+      y += 3;
     }
   }
 

--- a/apps/web/server/__tests__/patients-query-scoping.test.ts
+++ b/apps/web/server/__tests__/patients-query-scoping.test.ts
@@ -51,8 +51,15 @@ describe("patients query scoping", () => {
     expect(weightsRead).toContain("activePracticePredicate(ctx.practiceId)");
 
     const allergiesRead = source.match(
-      /\.from\(patientAllergies\)[\s\S]+?eq\(patientAllergies\.patientId, patient\.id\)[\s\S]+?isNull\(patientAllergies\.deletedAt\)/
+      /\.from\(patientAllergies\)[\s\S]+?eq\(patientAllergies\.patientId, patient\.id\)[\s\S]+?\.orderBy\(desc\(patientAllergies\.notedAt\)/
     )?.[0];
+    expect(allergiesRead).toContain(".leftJoin(");
+    expect(allergiesRead).toContain(
+      "clinicalRecordCorrections.patientAllergyId"
+    );
+    expect(allergiesRead).toContain(
+      "eq(clinicalRecordCorrections.practiceId, ctx.practiceId)"
+    );
     expect(allergiesRead).toContain("from ${patients}");
     expect(allergiesRead).toContain(
       "${patients.id} = ${patientAllergies.patientId}"

--- a/apps/web/server/__tests__/patients-safety.test.ts
+++ b/apps/web/server/__tests__/patients-safety.test.ts
@@ -59,7 +59,7 @@ function createDb(opts?: {
     const builder: Record<string, unknown> = {
       then: (
         resolve: (value: unknown[]) => unknown,
-        reject?: (error: unknown) => unknown
+        reject?: (error: unknown) => unknown,
       ) => Promise.resolve(result).then(resolve, reject),
     };
     builder.from = vi.fn(() => builder);
@@ -67,13 +67,19 @@ function createDb(opts?: {
     builder.innerJoin = vi.fn(() => builder);
     builder.where = vi.fn(() => builder);
     builder.orderBy = vi.fn(() => builder);
-    builder.limit = vi.fn(async () => result);
+    builder.limit = vi.fn(() => builder);
     builder.for = vi.fn(async () => result);
     return builder;
   });
 
   const insertReturning = vi.fn(async () => opts?.insertedRows ?? []);
-  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insertOnConflictDoNothing = vi.fn(() => ({
+    returning: insertReturning,
+  }));
+  const insertValues = vi.fn(() => ({
+    returning: insertReturning,
+    onConflictDoNothing: insertOnConflictDoNothing,
+  }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const updatedResults = [...(opts?.updatedResults ?? [])];
@@ -113,26 +119,26 @@ describe("patients mutation safety", () => {
         clientId: CLIENT_ID,
         name: "Biscuit",
         species: "canine",
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     await expect(
       viewer.update({
         id: PATIENT_ID,
         name: "Biscuit",
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     await expect(
       viewer.addWeight({
         patientId: PATIENT_ID,
         weightKg: "12.5",
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     await expect(
       viewer.addAllergy({
         patientId: PATIENT_ID,
         allergen: "Chicken",
         severity: "mild",
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(select).not.toHaveBeenCalled();
@@ -149,7 +155,7 @@ describe("patients mutation safety", () => {
         clientId: CLIENT_ID,
         name: "Biscuit",
         species: "canine",
-      })
+      }),
     ).resolves.toMatchObject({ id: PATIENT_ID });
   });
 
@@ -161,7 +167,7 @@ describe("patients mutation safety", () => {
         clientId: CLIENT_ID,
         name: "   ",
         species: "canine",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -170,7 +176,7 @@ describe("patients mutation safety", () => {
         name: "Biscuit",
         species: "canine",
         dob: "2026-02-30",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -179,35 +185,35 @@ describe("patients mutation safety", () => {
         name: "Biscuit",
         species: "canine",
         breed: "b".repeat(129),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).update({
         id: PATIENT_ID,
         dob: "not-a-date",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).update({
         id: PATIENT_ID,
         name: "   ",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).update({
         id: PATIENT_ID,
         color: "c".repeat(65),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).update({
         id: PATIENT_ID,
         photoUrl: "p".repeat(513),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -215,14 +221,14 @@ describe("patients mutation safety", () => {
         species: "dragon",
         limit: 25,
         offset: 0,
-      } as never)
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).list({
         limit: 1.5,
         offset: 0,
-      } as never)
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -230,27 +236,27 @@ describe("patients mutation safety", () => {
         search: "s".repeat(129),
         limit: 25,
         offset: 0,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).list({
         limit: 25,
         offset: LIST_OFFSET_MAX + 1,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).search({
         query: "   ",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).addWeight({
         patientId: PATIENT_ID,
         weightKg: "12.3456",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(PATIENT_WEIGHT_MIN_KG).toBe(0.001);
@@ -265,21 +271,21 @@ describe("patients mutation safety", () => {
       callerWithDb(db).addWeight({
         patientId: PATIENT_ID,
         weightKg: "0",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).addWeight({
         patientId: PATIENT_ID,
         weightKg: "100000",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).addAllergy({
         patientId: PATIENT_ID,
         allergen: "   ",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -287,7 +293,7 @@ describe("patients mutation safety", () => {
         patientId: PATIENT_ID,
         allergen: "Chicken",
         reaction: "r".repeat(2001),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -305,7 +311,7 @@ describe("patients mutation safety", () => {
         clientId: CLIENT_ID,
         name: "Biscuit",
         species: "canine",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -319,7 +325,7 @@ describe("patients mutation safety", () => {
         clientId: CLIENT_ID,
         name: "Biscuit",
         species: "canine",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -354,7 +360,7 @@ describe("patients mutation safety", () => {
         breed: "  Corgi  ",
         color: "  Tricolor  ",
         microchipNumber: "  985112003001234  ",
-      })
+      }),
     ).resolves.toMatchObject({ id: PATIENT_ID, practiceId: PRACTICE_ID });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -365,7 +371,7 @@ describe("patients mutation safety", () => {
         breed: "Corgi",
         color: "Tricolor",
         microchipNumber: "985112003001234",
-      })
+      }),
     );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
@@ -376,7 +382,7 @@ describe("patients mutation safety", () => {
         name: "Biscuit",
         breed: "Corgi",
         source: "dashboard",
-      })
+      }),
     );
   });
 
@@ -393,7 +399,7 @@ describe("patients mutation safety", () => {
         color: "  Tricolor  ",
         microchipNumber: "  985112003001234  ",
         photoUrl: "  https://cdn.example.test/biscuit.jpg  ",
-      })
+      }),
     ).resolves.toMatchObject({ id: PATIENT_ID });
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -412,7 +418,7 @@ describe("patients mutation safety", () => {
       callerWithDb(db).addWeight({
         patientId: PATIENT_ID,
         weightKg: "12.4",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -428,7 +434,7 @@ describe("patients mutation safety", () => {
       callerWithDb(db).addWeight({
         patientId: PATIENT_ID,
         weightKg: " 12.400 ",
-      })
+      }),
     ).resolves.toMatchObject({ id: PATIENT_ID });
 
     await expect(
@@ -436,7 +442,7 @@ describe("patients mutation safety", () => {
         patientId: PATIENT_ID,
         allergen: "  Chicken  ",
         reaction: "  Facial swelling  ",
-      })
+      }),
     ).resolves.toMatchObject({ id: PATIENT_ID });
 
     expect(insertValues).toHaveBeenNthCalledWith(
@@ -444,7 +450,7 @@ describe("patients mutation safety", () => {
       expect.objectContaining({
         patientId: PATIENT_ID,
         weightKg: "12.400",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenNthCalledWith(
       2,
@@ -453,7 +459,7 @@ describe("patients mutation safety", () => {
         allergen: "Chicken",
         reaction: "Facial swelling",
         severity: "moderate",
-      })
+      }),
     );
   });
 
@@ -464,70 +470,114 @@ describe("patients mutation safety", () => {
       callerWithDb(db).addAllergy({
         patientId: PATIENT_ID,
         allergen: "Chicken",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("keeps allergy removal restricted to non-viewer staff roles", async () => {
-    const { db, select, updateSet } = createDb();
+  it("keeps allergy corrections restricted to administrators and veterinarians", async () => {
+    for (const role of ["viewer", "front_desk", "technician"]) {
+      const { db, select, insertValues } = createDb();
+      await expect(
+        callerWithDb(db, role).markAllergyEnteredInError({
+          patientId: PATIENT_ID,
+          recordId: ALLERGY_ID,
+          reason: "Recorded on the wrong patient.",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(select).not.toHaveBeenCalled();
+      expect(insertValues).not.toHaveBeenCalled();
+    }
+  });
 
+  it("requires a bounded allergy correction reason before DB work", async () => {
+    const { db, select, insertValues } = createDb();
     await expect(
-      callerWithDb(db, "viewer").removeAllergy({
+      callerWithDb(db).markAllergyEnteredInError({
         patientId: PATIENT_ID,
-        id: ALLERGY_ID,
-      })
-    ).rejects.toMatchObject({ code: "FORBIDDEN" });
-
+        recordId: ALLERGY_ID,
+        reason: "no",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     expect(select).not.toHaveBeenCalled();
-    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("soft deletes allergies for tenant-owned patients only", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[{ id: PATIENT_ID }]],
-      updatedRows: [{ id: ALLERGY_ID }],
+  it("appends an attributed allergy correction without mutating the source", async () => {
+    const correction = {
+      id: "00000000-0000-0000-0000-000000000011",
+      patientAllergyId: ALLERGY_ID,
+      reason: "Recorded on the wrong patient.",
+    };
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [[{ id: ALLERGY_ID, patientId: PATIENT_ID }]],
+      insertedRows: [correction],
     });
 
     await expect(
-      callerWithDb(db, "front_desk").removeAllergy({
+      callerWithDb(db, "veterinarian").markAllergyEnteredInError({
         patientId: PATIENT_ID,
-        id: ALLERGY_ID,
-      })
-    ).resolves.toEqual({ ok: true });
+        recordId: ALLERGY_ID,
+        reason: "  Recorded on the wrong patient.  ",
+      }),
+    ).resolves.toEqual(correction);
 
-    // Soft delete: the row is retired via deletedAt, never hard-deleted.
-    expect(updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ deletedAt: expect.any(Date) })
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        recordType: "patient_allergy",
+        patientAllergyId: ALLERGY_ID,
+        patientId: PATIENT_ID,
+        reason: "Recorded on the wrong patient.",
+        correctedBy: USER_ID,
+        correctedByName: "Patient User",
+      }),
     );
-  });
-
-  it("404s allergy removal when the patient is not tenant-owned", async () => {
-    const { db, updateSet } = createDb({ selectResults: [[]] });
-
-    await expect(
-      callerWithDb(db).removeAllergy({
-        patientId: PATIENT_ID,
-        id: ALLERGY_ID,
-      })
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-
     expect(updateSet).not.toHaveBeenCalled();
   });
 
-  it("404s allergy removal when the row is missing or already removed", async () => {
-    const { db } = createDb({
-      selectResults: [[{ id: PATIENT_ID }]],
-      updatedRows: [],
-    });
-
+  it("does not enumerate missing, wrong-patient, or cross-tenant allergy sources", async () => {
+    const { db, insertValues } = createDb({ selectResults: [[]] });
     await expect(
-      callerWithDb(db).removeAllergy({
+      callerWithDb(db).markAllergyEnteredInError({
         patientId: PATIENT_ID,
-        id: ALLERGY_ID,
-      })
+        recordId: ALLERGY_ID,
+        reason: "Recorded on the wrong patient.",
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("replays the same allergy correction and rejects a conflicting reason", async () => {
+    const existing = {
+      id: "00000000-0000-0000-0000-000000000011",
+      patientAllergyId: ALLERGY_ID,
+      reason: "Recorded on the wrong patient.",
+    };
+    const replay = createDb({
+      selectResults: [[{ id: ALLERGY_ID, patientId: PATIENT_ID }], [existing]],
+      insertedRows: [],
+    });
+    await expect(
+      callerWithDb(replay.db).markAllergyEnteredInError({
+        patientId: PATIENT_ID,
+        recordId: ALLERGY_ID,
+        reason: existing.reason,
+      }),
+    ).resolves.toEqual(existing);
+
+    const conflict = createDb({
+      selectResults: [[{ id: ALLERGY_ID, patientId: PATIENT_ID }], [existing]],
+      insertedRows: [],
+    });
+    await expect(
+      callerWithDb(conflict.db).markAllergyEnteredInError({
+        patientId: PATIENT_ID,
+        recordId: ALLERGY_ID,
+        reason: "Duplicate allergy record.",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
   });
 
   it("rejects stale or cross-tenant patient updates", async () => {
@@ -537,7 +587,7 @@ describe("patients mutation safety", () => {
       callerWithDb(db).update({
         id: PATIENT_ID,
         name: "Biscuit",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).toHaveBeenCalledWith({ name: "Biscuit" });
@@ -566,7 +616,7 @@ describe("patients mutation safety", () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).delete({ id: PATIENT_ID })
+      callerWithDb(db).delete({ id: PATIENT_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -578,7 +628,7 @@ describe("patients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db).delete({ id: PATIENT_ID })
+      callerWithDb(db).delete({ id: PATIENT_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -590,7 +640,7 @@ describe("patients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db).delete({ id: PATIENT_ID })
+      callerWithDb(db).delete({ id: PATIENT_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -602,24 +652,21 @@ describe("patients mutation safety", () => {
       updatedRows: [{ id: PATIENT_ID }],
     });
 
-    await expect(
-      callerWithDb(db).delete({ id: PATIENT_ID })
-    ).resolves.toEqual({ success: true });
+    await expect(callerWithDb(db).delete({ id: PATIENT_ID })).resolves.toEqual({
+      success: true,
+    });
 
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: expect.any(Date) });
   });
 
   it("does not delete a patient with retained clinical or prescription history", async () => {
     const { db, updateSet } = createDb({
-      selectResults: [
-        [{ id: PATIENT_ID }],
-        [],
-        [],
-        [{ exists: true }],
-      ],
+      selectResults: [[{ id: PATIENT_ID }], [], [], [{ exists: true }]],
     });
 
-    await expect(callerWithDb(db).delete({ id: PATIENT_ID })).rejects.toMatchObject({
+    await expect(
+      callerWithDb(db).delete({ id: PATIENT_ID }),
+    ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
     });
     expect(updateSet).not.toHaveBeenCalled();
@@ -649,7 +696,7 @@ describe("patients mutation safety", () => {
       callerWithDb(db).previewMerge({
         keepId: PATIENT_ID,
         mergeId: MERGE_PATIENT_ID,
-      })
+      }),
     ).resolves.toMatchObject({
       allowed: false,
       blockerCounts: { differentClient: 1 },

--- a/apps/web/server/__tests__/portal-scoping.test.ts
+++ b/apps/web/server/__tests__/portal-scoping.test.ts
@@ -189,6 +189,10 @@ describe("portal public read scoping", () => {
     );
     expect(allergiesBlock).toContain('eq(patients.status, "active")');
     expect(allergiesBlock).toContain("isNull(patients.deletedAt)");
+    expect(allergiesBlock).toContain("not exists (");
+    expect(allergiesBlock).toContain(
+      "allergy_correction.patient_allergy_id = ${patientAllergies.id}"
+    );
 
     const vaccinationsBlock = src.match(
       /\.from\(vaccinationRecords\)[\s\S]+?\.orderBy\(desc\(vaccinationRecords\.administeredAt\)\)/

--- a/apps/web/server/__tests__/records-prescription-safety.test.ts
+++ b/apps/web/server/__tests__/records-prescription-safety.test.ts
@@ -733,6 +733,10 @@ describe("records list query scoping", () => {
       "${patients.practiceId} = ${ctx.practiceId}",
     );
     expect(allergySafetyBlock).toContain("${patients.deletedAt} is null");
+    expect(allergySafetyBlock).toContain("not exists (");
+    expect(allergySafetyBlock).toContain(
+      "allergy_correction.patient_allergy_id = ${patientAllergies.id}",
+    );
   });
 });
 

--- a/apps/web/server/routers/ai.ts
+++ b/apps/web/server/routers/ai.ts
@@ -345,6 +345,12 @@ export const aiRouter = createRouter({
                     and ${patients.practiceId} = ${ctx.practiceId}
                     and ${patients.deletedAt} is null
                 )`,
+                sql`not exists (
+                  select 1
+                  from ${clinicalRecordCorrections} as allergy_correction
+                  where allergy_correction.practice_id = ${ctx.practiceId}
+                    and allergy_correction.patient_allergy_id = ${patientAllergies.id}
+                )`,
                 isNull(patientAllergies.deletedAt)
               )
             ),

--- a/apps/web/server/routers/patients.ts
+++ b/apps/web/server/routers/patients.ts
@@ -50,6 +50,10 @@ import type { Database } from "@openpims/db/client";
 import { alias } from "drizzle-orm/pg-core";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
 import {
+  CLINICAL_CORRECTION_REASON_MAX_LENGTH,
+  CLINICAL_CORRECTION_REASON_MIN_LENGTH,
+} from "@/lib/records/clinical-correction-policy";
+import {
   clinicalDateInput,
   clinicalTextInput,
 } from "@/lib/records/clinical-inputs";
@@ -914,7 +918,7 @@ export const patientsRouter = createRouter({
       }
       const { patient, mergeMetadata } = resolved;
 
-      const [weights, allergies] = await Promise.all([
+      const [weights, allergyHistory] = await Promise.all([
         ctx.db
           .select()
           .from(patientWeights)
@@ -934,8 +938,34 @@ export const patientsRouter = createRouter({
           )
           .orderBy(desc(patientWeights.recordedAt)),
         ctx.db
-          .select()
+          .select({
+            id: patientAllergies.id,
+            createdAt: patientAllergies.createdAt,
+            updatedAt: patientAllergies.updatedAt,
+            deletedAt: patientAllergies.deletedAt,
+            patientId: patientAllergies.patientId,
+            allergen: patientAllergies.allergen,
+            reaction: patientAllergies.reaction,
+            severity: patientAllergies.severity,
+            notedBy: patientAllergies.notedBy,
+            notedAt: patientAllergies.notedAt,
+            correctionId: clinicalRecordCorrections.id,
+            correctionReason: clinicalRecordCorrections.reason,
+            correctedAt: clinicalRecordCorrections.createdAt,
+            correctedBy: clinicalRecordCorrections.correctedBy,
+            correctedByName: clinicalRecordCorrections.correctedByName,
+          })
           .from(patientAllergies)
+          .leftJoin(
+            clinicalRecordCorrections,
+            and(
+              eq(
+                clinicalRecordCorrections.patientAllergyId,
+                patientAllergies.id,
+              ),
+              eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+            ),
+          )
           .where(
             and(
               eq(patientAllergies.patientId, patient.id),
@@ -946,16 +976,21 @@ export const patientsRouter = createRouter({
                   and ${patients.practiceId} = ${ctx.practiceId}
                   and ${patients.deletedAt} is null
               )`,
-              activePracticePredicate(ctx.practiceId),
-              isNull(patientAllergies.deletedAt)
+              activePracticePredicate(ctx.practiceId)
             )
-          ),
+          )
+          .orderBy(desc(patientAllergies.notedAt), desc(patientAllergies.id)),
       ]);
+
+      const allergies = allergyHistory.filter(
+        (allergy) => !allergy.deletedAt && !allergy.correctionId,
+      );
 
       return {
         ...patient,
         weights,
         allergies,
+        allergyHistory,
         requestedPatientId: input.id,
         canonicalPatientId: patient.id,
         mergeMetadata,
@@ -1168,35 +1203,92 @@ export const patientsRouter = createRouter({
       return allergy!;
     }),
 
-  /**
-   * Soft delete: the row keeps its history (the Rx safety log may reference
-   * it) but stops feeding the alert bar, prescription checks, and portal.
-   */
-  removeAllergy: patientManagerProcedure
+  markAllergyEnteredInError: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
     .input(
       z.object({
         patientId: z.string().uuid(),
-        id: z.string().uuid(),
+        recordId: z.string().uuid(),
+        reason: z
+          .string()
+          .trim()
+          .min(CLINICAL_CORRECTION_REASON_MIN_LENGTH)
+          .max(CLINICAL_CORRECTION_REASON_MAX_LENGTH),
       })
     )
-    .mutation(async ({ ctx, input }) => {
-      await assertPatientBelongsToPractice(ctx.db, ctx.practiceId, input.patientId);
-      const [removed] = await ctx.db
-        .update(patientAllergies)
-        .set({ deletedAt: new Date() })
-        .where(
-          and(
-            eq(patientAllergies.id, input.id),
-            eq(patientAllergies.patientId, input.patientId),
-            isNull(patientAllergies.deletedAt)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const sourcePredicate = and(
+          eq(patientAllergies.id, input.recordId),
+          eq(patientAllergies.patientId, input.patientId),
+          isNull(patientAllergies.deletedAt),
+          sql`exists (
+            select 1
+            from ${patients}
+            where ${patients.id} = ${patientAllergies.patientId}
+              and ${patients.practiceId} = ${ctx.practiceId}
+              and ${patients.deletedAt} is null
+          )`,
+          activePracticePredicate(ctx.practiceId),
+        );
+        const [source] = await tx
+          .select({
+            id: patientAllergies.id,
+            patientId: patientAllergies.patientId,
+          })
+          .from(patientAllergies)
+          .where(sourcePredicate)
+          .limit(1);
+        if (!source) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Clinical record not found",
+          });
+        }
+
+        const [created] = await tx
+          .insert(clinicalRecordCorrections)
+          .values({
+            practiceId: ctx.practiceId,
+            recordType: "patient_allergy",
+            action: "entered_in_error",
+            patientAllergyId: source.id,
+            patientId: source.patientId,
+            reason: input.reason,
+            correctedBy: ctx.user.id,
+            correctedByName: ctx.user.name,
+          })
+          .onConflictDoNothing()
+          .returning();
+        if (created) return created;
+
+        const [existing] = await tx
+          .select()
+          .from(clinicalRecordCorrections)
+          .where(
+            and(
+              eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+              eq(clinicalRecordCorrections.patientAllergyId, source.id),
+            ),
           )
-        )
-        .returning({ id: patientAllergies.id });
-      if (!removed) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Allergy not found" });
-      }
-      return { ok: true };
-    }),
+          .limit(1);
+        if (existing) {
+          if (existing.reason !== input.reason) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "This allergy already has a different permanent correction reason. Refresh the chart.",
+            });
+          }
+          return existing;
+        }
+
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Clinical correction changed; refresh and retry.",
+        });
+      }),
+    ),
 
   previewMerge: protectedProcedure
     .use(requireRole("admin"))

--- a/apps/web/server/routers/portal.ts
+++ b/apps/web/server/routers/portal.ts
@@ -16,6 +16,7 @@ import {
   communications,
   practices,
   locations,
+  clinicalRecordCorrections,
 } from "@openpims/db";
 import { users } from "@openpims/db";
 import { rateLimit } from "@/lib/rate-limit";
@@ -447,6 +448,12 @@ export const portalRouter = createRouter({
           .where(
             and(
               eq(patientAllergies.patientId, input.patientId),
+              sql`not exists (
+                select 1
+                from ${clinicalRecordCorrections} as allergy_correction
+                where allergy_correction.practice_id = ${client.practiceId}
+                  and allergy_correction.patient_allergy_id = ${patientAllergies.id}
+              )`,
               isNull(patientAllergies.deletedAt)
             )
           ),

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -671,6 +671,12 @@ async function assessPrescriptionSafety(
               and ${patients.practiceId} = ${ctx.practiceId}
               and ${patients.deletedAt} is null
           )`,
+          sql`not exists (
+            select 1
+            from ${clinicalRecordCorrections} as allergy_correction
+            where allergy_correction.practice_id = ${ctx.practiceId}
+              and allergy_correction.patient_allergy_id = ${patientAllergies.id}
+          )`,
           isNull(patientAllergies.deletedAt)
         )
       ),


### PR DESCRIPTION
## Summary
- replace allergy soft-deletion with an attributed, permanent “entered in error” correction
- limit allergy correction to administrators and veterinarians
- preserve current allergies separately from full correction/legacy history
- display allergen severity and reaction in patient and encounter workflows
- exclude corrected allergies from prescribing checks, AI context, the client portal, and current PDF summaries
- retain correction reason, clinician, time, and original source in staff history and PDFs
- extend practice backup/restore validation for allergy correction references

## Rollout
This is **phase 2 of 3** for OPENVPM-57.

- Phase 1 / PR #182 installed migration 0074 in production and demo.
- This PR ships the application and backup behavior against that already-live additive schema.
- After the new application is confirmed live, phase 3 will install migration 0075 and RLS hardening so allergy sources cannot be updated or deleted even by generic application code.

This ordering avoids a deployment race between Vercel and database migrations. No migration is included here.

## Clinical safety
- only admin/veterinarian can correct an allergy
- reason is required and permanently attributed
- original allergy row is never changed by this application flow
- exact source uniqueness plus `ON CONFLICT` makes concurrent/replayed corrections safe
- same-reason retries replay; different-reason retries surface a conflict
- legacy soft-deleted allergies remain visible as unattributed historical entries
- active allergy warnings retain severity and make reaction visible

## Validation
- database and web typechecks passed
- 145 targeted tests passed
- full suite: 344 files passed, 2 skipped; 3,516 tests passed, 2 integration tests skipped
- production build passed
- schema generation reports no drift
- staged diff check and Gitleaks passed
- independent application and database reviews: GO
- independent backup/release review: GO for this app-first split

Tracks OPENVPM-57; remains In Progress until phase 3 is migrated and production-smoked.