### PR TITLE
Harden clinic recovery and durable workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,22 @@ S3_SECRET_KEY="openpims123"
 S3_BUCKET="openpims"
 S3_REGION="us-east-1"
 
+# Independent attachment + database-backup replica. Use a different provider
+# account/failure domain and runtime credentials without delete authority.
+# Leave execution disabled until that bucket has versioning, encryption,
+# private access, retention, and spend controls configured. Credentials can be
+# staged safely; enable only an exact UUID cohort before an all-practice rollout.
+FILE_REPLICA_REQUIRED=false
+FILE_REPLICA_ENABLED=false
+FILE_REPLICA_ALL_PRACTICES=false
+FILE_REPLICA_PRACTICE_IDS=
+FILE_REPLICA_S3_ENDPOINT=
+FILE_REPLICA_S3_ACCESS_KEY=
+FILE_REPLICA_S3_SECRET_KEY=
+FILE_REPLICA_S3_BUCKET=
+# Recommended when enabled: us-west-2. Leave blank until the full target is ready.
+FILE_REPLICA_S3_REGION=
+
 # Resend (email)
 RESEND_API_KEY=
 # Resend webhook secret for delivery/bounce/complaint callbacks.
@@ -143,6 +159,7 @@ CRON_SECRET=
 CRON_HEARTBEAT_URL=
 CRON_HEARTBEAT_REMINDERS_URL=
 CRON_HEARTBEAT_BACKUP_URL=
+CRON_HEARTBEAT_FILE_REPLICAS_URL=
 CRON_HEARTBEAT_USAGE_RECONCILE_URL=
 CRON_HEARTBEAT_BILLING_LIFECYCLE_URL=
 CRON_HEARTBEAT_WELLNESS_BILLING_URL=

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -43,6 +43,11 @@ import {
   isImageUploadFileValid,
 } from "@/lib/upload-policy";
 import {
+  selectManagedUploadFile,
+  settleManagedUploadAttempt,
+  type ManagedUploadAttempt,
+} from "@/lib/managed-upload-attempt";
+import {
   buildVitalTrend,
   buildWeightTrend,
 } from "@/lib/records/clinical-trends";
@@ -104,23 +109,23 @@ function PatientChartChunkLoading() {
 const WeightTrendChart = dynamic(
   () =>
     import("@/components/patients/patient-trend-charts").then(
-      (mod) => mod.WeightTrendChart
+      (mod) => mod.WeightTrendChart,
     ),
   {
     ssr: false,
     loading: PatientChartChunkLoading,
-  }
+  },
 );
 
 const VitalsTrendChart = dynamic(
   () =>
     import("@/components/patients/patient-trend-charts").then(
-      (mod) => mod.VitalsTrendChart
+      (mod) => mod.VitalsTrendChart,
     ),
   {
     ssr: false,
     loading: PatientChartChunkLoading,
-  }
+  },
 );
 
 const speciesEmoji: Record<string, string> = {
@@ -193,9 +198,7 @@ function canManagePatientDetailRole(role?: string | null): boolean {
 }
 
 function canRecordVitalsRole(role?: string | null): boolean {
-  return (
-    role === "admin" || role === "veterinarian" || role === "technician"
-  );
+  return role === "admin" || role === "veterinarian" || role === "technician";
 }
 
 function canCorrectClinicalRecordRole(role?: string | null): boolean {
@@ -252,25 +255,32 @@ export default function PatientDetailPage() {
   const [activeTab, setActiveTab] = useState<Tab>("overview");
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const photoUploadAttemptRef = useRef<ManagedUploadAttempt | null>(null);
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const [photoUploadError, setPhotoUploadError] = useState<string | null>(null);
   const utils = trpc.useUtils();
   const canManagePatientDetail = canManagePatientDetailRole(
-    session?.user?.role
+    session?.user?.role,
   );
   const canRecordVitals = canRecordVitalsRole(session?.user?.role);
   const canCorrectClinicalRecords = canCorrectClinicalRecordRole(
-    session?.user?.role
+    session?.user?.role,
   );
 
-  const { data: patient, isLoading, error } = trpc.patients.getById.useQuery(
+  const {
+    data: patient,
+    isLoading,
+    error,
+  } = trpc.patients.getById.useQuery(
     { id: params.id },
-    { enabled: !!params.id }
+    { enabled: !!params.id },
   );
   const canonicalPatientId = patient?.id ?? params.id;
   const refreshPatientDetail = () =>
     Promise.all(
       Array.from(new Set([params.id, canonicalPatientId])).map((id) =>
-        utils.patients.getById.invalidate({ id })
-      )
+        utils.patients.getById.invalidate({ id }),
+      ),
     );
 
   useEffect(() => {
@@ -278,7 +288,7 @@ export default function PatientDetailPage() {
     window.history.replaceState(
       window.history.state,
       "",
-      `/patients/${patient.id}?mergedFrom=${params.id}`
+      `/patients/${patient.id}?mergedFrom=${params.id}`,
     );
   }, [params.id, patient?.id, patient?.mergeMetadata]);
   const {
@@ -287,76 +297,96 @@ export default function PatientDetailPage() {
     error: recordsSettingsError,
   } = trpc.records.settings.useQuery();
 
-  const updatePhotoMutation = trpc.patients.update.useMutation({
-    onSuccess: () => {
-      toast.success("Patient photo updated");
-      void refreshPatientDetail();
-    },
-    onError: (err) => {
-      toast.error(`Failed to update patient photo: ${err.message}`);
-    },
-  });
-
-  async function handlePhotoUpload(e: React.ChangeEvent<HTMLInputElement>) {
+  async function uploadPatientPhoto(selectedFile?: File) {
     if (!canManagePatientDetail) {
-      e.currentTarget.value = "";
       return;
     }
-    const file = e.target.files?.[0];
-    if (!file) return;
 
-    if (!isImageUploadFileValid(file)) {
+    if (selectedFile && !isImageUploadFileValid(selectedFile)) {
+      photoUploadAttemptRef.current = null;
+      setPhotoUploadError(null);
       toast.error(IMAGE_UPLOAD_POLICY_MESSAGE);
-      e.currentTarget.value = "";
       return;
     }
+
+    if (selectedFile) {
+      photoUploadAttemptRef.current = selectManagedUploadFile(
+        photoUploadAttemptRef.current,
+        selectedFile,
+      );
+    }
+    const attempt = photoUploadAttemptRef.current;
+    if (!attempt) return;
 
     const formData = new FormData();
-    formData.append("file", file);
+    formData.append("file", attempt.file);
     formData.append("category", "patient-photos");
+    formData.append("patientId", canonicalPatientId);
 
+    setUploadingPhoto(true);
+    setPhotoUploadError(null);
     try {
       const res = await fetchWithClientTimeout(
         "/api/upload",
         {
           method: "POST",
           body: formData,
+          headers: { "Idempotency-Key": attempt.idempotencyKey },
         },
-        CLIENT_UPLOAD_TIMEOUT_MS
+        CLIENT_UPLOAD_TIMEOUT_MS,
       );
 
+      const json = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) {
-        throw new Error("Upload failed");
+        photoUploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+          kind: "response",
+          status: res.status,
+        });
+        throw new Error(json.error ?? "Upload failed");
       }
 
-      const data = await res.json();
-      updatePhotoMutation.mutate({ id: canonicalPatientId, photoUrl: data.url });
-    } catch {
-      toast.error("Failed to upload photo");
+      photoUploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+        kind: "success",
+      });
+      await refreshPatientDetail();
+      toast.success("Patient photo updated");
+    } catch (err) {
+      if (photoUploadAttemptRef.current === attempt) {
+        photoUploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+          kind: "ambiguous",
+        });
+      }
+      const message =
+        err instanceof Error ? err.message : "Failed to upload photo";
+      setPhotoUploadError(message);
+      toast.error(message);
+    } finally {
+      setUploadingPhoto(false);
     }
+  }
 
-    // Reset file input so the same file can be re-selected
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
+  function handlePhotoUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.currentTarget.value = "";
+    if (file) void uploadPatientPhoto(file);
   }
 
   // Medical summary PDF data queries (lazy -- only fetched on demand)
   const problemsQuery = trpc.records.listProblems.useQuery(
     { patientId: canonicalPatientId },
-    { enabled: false }
+    { enabled: false },
   );
   const vaccinationsQuery = trpc.records.listVaccinations.useQuery(
     { patientId: canonicalPatientId },
-    { enabled: false }
+    { enabled: false },
   );
   const soapNotesQuery = trpc.records.listSoapNotes.useQuery(
     { patientId: canonicalPatientId },
-    { enabled: false }
+    { enabled: false },
   );
   const prescriptionsQuery = trpc.records.listPrescriptions.useQuery(
     { patientId: canonicalPatientId },
-    { enabled: false }
+    { enabled: false },
   );
   const recordsSettingsMissing =
     !recordsSettingsLoading && !recordsSettingsError && !recordsSettings;
@@ -369,7 +399,7 @@ export default function PatientDetailPage() {
     : undefined;
   const weightTrend = useMemo(
     () => buildWeightTrend(patient?.weights ?? [], recordsSettingsTimeZone),
-    [patient?.weights, recordsSettingsTimeZone]
+    [patient?.weights, recordsSettingsTimeZone],
   );
   const [weightKg, setWeightKg] = useState("");
   const addWeight = trpc.patients.addWeight.useMutation({
@@ -382,7 +412,8 @@ export default function PatientDetailPage() {
   });
   const canSubmitWeight =
     canManagePatientDetail &&
-    isPatientWeightInputValid(weightKg) && !addWeight.isPending;
+    isPatientWeightInputValid(weightKg) &&
+    !addWeight.isPending;
 
   function handleRecordWeight(e: React.FormEvent) {
     e.preventDefault();
@@ -475,13 +506,17 @@ export default function PatientDetailPage() {
 
   async function handleDownloadSummary() {
     try {
-      const [problemsResult, vaccinationsResult, soapNotesResult, prescriptionsResult] =
-        await Promise.all([
-          problemsQuery.refetch(),
-          vaccinationsQuery.refetch(),
-          soapNotesQuery.refetch(),
-          prescriptionsQuery.refetch(),
-        ]);
+      const [
+        problemsResult,
+        vaccinationsResult,
+        soapNotesResult,
+        prescriptionsResult,
+      ] = await Promise.all([
+        problemsQuery.refetch(),
+        vaccinationsQuery.refetch(),
+        soapNotesQuery.refetch(),
+        prescriptionsQuery.refetch(),
+      ]);
 
       const summaryError =
         problemsResult.error ??
@@ -498,7 +533,7 @@ export default function PatientDetailPage() {
         !prescriptionsResult.data
       ) {
         throw new Error(
-          "Unable to load complete medical summary data. Please retry."
+          "Unable to load complete medical summary data. Please retry.",
         );
       }
 
@@ -531,15 +566,17 @@ export default function PatientDetailPage() {
           status: p.status ?? "active",
           onsetDate: p.onsetDate ?? undefined,
         })),
-        vaccinations: vaccinations.filter((v) => !v.correctionId).map((v) => ({
-          name: v.vaccineName,
-          date: v.administeredAt
-            ? formatClinicalDate(v.administeredAt, recordsTimeZone, "Unknown")
-            : "Unknown",
-          nextDue: v.nextDueDate
-            ? formatClinicalDate(v.nextDueDate, recordsTimeZone)
-            : undefined,
-        })),
+        vaccinations: vaccinations
+          .filter((v) => !v.correctionId)
+          .map((v) => ({
+            name: v.vaccineName,
+            date: v.administeredAt
+              ? formatClinicalDate(v.administeredAt, recordsTimeZone, "Unknown")
+              : "Unknown",
+            nextDue: v.nextDueDate
+              ? formatClinicalDate(v.nextDueDate, recordsTimeZone)
+              : undefined,
+          })),
         recentNotes: soapNotes
           .filter((note) => note.status === "finalized" && !note.correctionId)
           .slice(0, 5)
@@ -589,13 +626,9 @@ export default function PatientDetailPage() {
                 "Unknown date",
               )}`,
               reason: allergy.correctionReason ?? "Reason unavailable",
-              correctedByName:
-                allergy.correctedByName ?? "Unknown clinician",
+              correctedByName: allergy.correctedByName ?? "Unknown clinician",
               correctedAt: allergy.correctedAt
-                ? formatClinicalDateTime(
-                    allergy.correctedAt,
-                    recordsTimeZone,
-                  )
+                ? formatClinicalDateTime(allergy.correctedAt, recordsTimeZone)
                 : "Unknown time",
             })),
           ...soapNotes
@@ -604,30 +637,31 @@ export default function PatientDetailPage() {
                 note.status === "finalized" && Boolean(note.correctionId),
             )
             .map((note) => ({
-            recordLabel: `SOAP note dated ${formatClinicalDate(
-              note.createdAt,
-              recordsTimeZone,
-              "Unknown date",
-            )}`,
-            reason: note.correctionReason ?? "Reason unavailable",
-            correctedByName: note.correctedByName ?? "Unknown clinician",
-            correctedAt: note.correctedAt
-              ? formatClinicalDateTime(note.correctedAt, recordsTimeZone)
-              : "Unknown time",
-            replacementLabel: note.replacementSoapNoteId
-              ? (() => {
-                  const replacement = soapNotes.find(
-                    (candidate) => candidate.id === note.replacementSoapNoteId,
-                  );
-                  return replacement
-                    ? `SOAP note dated ${formatClinicalDate(
-                        replacement.createdAt,
-                        recordsTimeZone,
-                        "unknown date",
-                      )}, finalized by ${replacement.finalizerName ?? "Unknown clinician"}`
-                    : "Replacement SOAP retained in chart";
-              })()
-              : undefined,
+              recordLabel: `SOAP note dated ${formatClinicalDate(
+                note.createdAt,
+                recordsTimeZone,
+                "Unknown date",
+              )}`,
+              reason: note.correctionReason ?? "Reason unavailable",
+              correctedByName: note.correctedByName ?? "Unknown clinician",
+              correctedAt: note.correctedAt
+                ? formatClinicalDateTime(note.correctedAt, recordsTimeZone)
+                : "Unknown time",
+              replacementLabel: note.replacementSoapNoteId
+                ? (() => {
+                    const replacement = soapNotes.find(
+                      (candidate) =>
+                        candidate.id === note.replacementSoapNoteId,
+                    );
+                    return replacement
+                      ? `SOAP note dated ${formatClinicalDate(
+                          replacement.createdAt,
+                          recordsTimeZone,
+                          "unknown date",
+                        )}, finalized by ${replacement.finalizerName ?? "Unknown clinician"}`
+                      : "Replacement SOAP retained in chart";
+                  })()
+                : undefined,
             })),
         ],
         prescriptions: prescriptions.map((rx) => ({
@@ -642,7 +676,9 @@ export default function PatientDetailPage() {
       toast.success("Medical summary downloaded");
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to generate medical summary"
+        err instanceof Error
+          ? err.message
+          : "Failed to generate medical summary",
       );
     }
   }
@@ -679,7 +715,7 @@ export default function PatientDetailPage() {
                 chart by {patient.mergeMetadata.performedByName} on{" "}
                 {formatClinicalDateTime(
                   patient.mergeMetadata.createdAt,
-                  recordsTimeZone
+                  recordsTimeZone,
                 )}
                 .
               </p>
@@ -695,37 +731,54 @@ export default function PatientDetailPage() {
       <div className="rounded-lg border border-border bg-card p-6">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex items-start gap-4">
-            <div className="group relative h-14 w-14">
-              {patient.photoUrl ? (
-                <img
-                  src={patient.photoUrl}
-                  alt={patient.name}
-                  className="h-14 w-14 rounded-full object-cover"
-                />
-              ) : (
-                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted text-2xl">
-                  {speciesEmoji[patient.species ?? "other"] ?? "\uD83D\uDC3E"}
-                </div>
-              )}
-              {canManagePatientDetail && (
-                <>
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100"
-                    title="Upload photo"
-                  >
-                    <Camera className="h-5 w-5 text-white" />
-                  </button>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept="image/png,image/jpeg,image/webp"
-                    onChange={handlePhotoUpload}
-                    className="hidden"
+            <div className="space-y-1">
+              <div className="group relative h-14 w-14">
+                {patient.photoUrl ? (
+                  <img
+                    src={patient.photoUrl}
+                    alt={patient.name}
+                    className="h-14 w-14 rounded-full object-cover"
                   />
-                </>
-              )}
+                ) : (
+                  <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted text-2xl">
+                    {speciesEmoji[patient.species ?? "other"] ?? "\uD83D\uDC3E"}
+                  </div>
+                )}
+                {canManagePatientDetail && (
+                  <>
+                    <button
+                      type="button"
+                      disabled={uploadingPhoto}
+                      onClick={() => fileInputRef.current?.click()}
+                      className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100 disabled:cursor-wait"
+                      title="Upload photo"
+                    >
+                      {uploadingPhoto ? (
+                        <Loader2 className="h-5 w-5 animate-spin text-white" />
+                      ) : (
+                        <Camera className="h-5 w-5 text-white" />
+                      )}
+                    </button>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/png,image/jpeg,image/webp"
+                      onChange={handlePhotoUpload}
+                      className="hidden"
+                    />
+                  </>
+                )}
+              </div>
+              {photoUploadError && photoUploadAttemptRef.current ? (
+                <button
+                  type="button"
+                  disabled={uploadingPhoto}
+                  onClick={() => void uploadPatientPhoto()}
+                  className="whitespace-nowrap text-xs font-medium text-destructive underline underline-offset-2 disabled:opacity-50"
+                >
+                  Try photo again
+                </button>
+              ) : null}
             </div>
             <div>
               <div className="flex items-center gap-2">
@@ -735,7 +788,7 @@ export default function PatientDetailPage() {
                 <span
                   className={cn(
                     "inline-block h-2.5 w-2.5 rounded-full",
-                    statusColor
+                    statusColor,
                   )}
                   title={patient.status ?? "active"}
                 />
@@ -774,11 +827,7 @@ export default function PatientDetailPage() {
                 <ConsentSign patientId={patient.id} />
               </>
             )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleDownloadSummary}
-            >
+            <Button variant="outline" size="sm" onClick={handleDownloadSummary}>
               <FileDown className="mr-2 h-4 w-4" />
               Download Summary
             </Button>
@@ -813,7 +862,7 @@ export default function PatientDetailPage() {
                       ? "border-red-300 bg-red-100 text-red-900 dark:border-red-800 dark:bg-red-950/60 dark:text-red-100"
                       : allergy.severity === "moderate"
                         ? "border-amber-300 bg-amber-100 text-amber-900 dark:border-amber-800 dark:bg-amber-950/60 dark:text-amber-100"
-                        : "border-yellow-300 bg-yellow-50 text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950/50 dark:text-yellow-100"
+                        : "border-yellow-300 bg-yellow-50 text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950/50 dark:text-yellow-100",
                   )}
                 >
                   <div className="flex flex-wrap items-center justify-between gap-2">
@@ -903,7 +952,8 @@ export default function PatientDetailPage() {
       ) : null}
 
       {patient.allergyHistory.some(
-        (allergy) => Boolean(allergy.correctionId) || Boolean(allergy.deletedAt),
+        (allergy) =>
+          Boolean(allergy.correctionId) || Boolean(allergy.deletedAt),
       ) ? (
         <details className="mt-3 rounded-lg border border-border bg-card px-4 py-3">
           <summary className="cursor-pointer text-sm font-medium">
@@ -968,7 +1018,7 @@ export default function PatientDetailPage() {
                 "relative px-4 py-2.5 text-sm font-medium transition-colors",
                 activeTab === tab.id
                   ? "text-primary"
-                  : "text-muted-foreground hover:text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
               )}
             >
               {tab.label}
@@ -1124,7 +1174,7 @@ export default function PatientDetailPage() {
                             {formatClinicalDate(
                               weight.recordedAt,
                               recordsTimeZone,
-                              "\u2014"
+                              "\u2014",
                             )}
                           </td>
                           <td className="px-4 py-3 font-medium">
@@ -1175,10 +1225,7 @@ export default function PatientDetailPage() {
         )}
 
         {activeTab === "appointments" && (
-          <AppointmentsTab
-            patientId={patient.id}
-            timeZone={recordsTimeZone}
-          />
+          <AppointmentsTab patientId={patient.id} timeZone={recordsTimeZone} />
         )}
 
         {activeTab === "invoices" && <InvoicesTab patientId={patient.id} />}
@@ -1199,16 +1246,19 @@ function VitalsTab({
   canCorrectClinicalRecords: boolean;
 }) {
   const utils = trpc.useUtils();
-  const { data: vitals, isLoading, error } =
-    trpc.vitals.listByPatient.useQuery({ patientId });
+  const {
+    data: vitals,
+    isLoading,
+    error,
+  } = trpc.vitals.listByPatient.useQuery({ patientId });
   const vitalsMissing = !isLoading && !error && !vitals;
   const vitalTrend = useMemo(
     () =>
       buildVitalTrend(
         (vitals ?? []).filter((vital) => !vital.correctionId),
-        timeZone
+        timeZone,
       ),
-    [vitals, timeZone]
+    [vitals, timeZone],
   );
   const record = trpc.vitals.record.useMutation({
     onSuccess: () => {
@@ -1227,15 +1277,16 @@ function VitalsTab({
   });
 
   const [form, setForm] = useState<VitalsFormState>(() => initialVitalsForm());
-  const set = (k: keyof VitalsFormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
-    setForm((f) => ({ ...f, [k]: e.target.value }));
+  const set =
+    (k: keyof VitalsFormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
+      setForm((f) => ({ ...f, [k]: e.target.value }));
   const num = (v?: string) => {
     if (v === undefined || v.trim() === "") return undefined;
     const n = Number(v);
     return Number.isFinite(n) ? n : undefined;
   };
   const hasVitalsFormContent = Object.values(form).some(
-    (value) => value.trim().length > 0
+    (value) => value.trim().length > 0,
   );
   const canSubmitVitals =
     canRecordVitals &&
@@ -1248,7 +1299,7 @@ function VitalsTab({
     isVitalsOptionalPainScoreInputValid(form.painScore) &&
     isVitalsOptionalTextInputValid(
       form.mucousMembrane,
-      VITALS_MUCOUS_MEMBRANE_MAX_LENGTH
+      VITALS_MUCOUS_MEMBRANE_MAX_LENGTH,
     ) &&
     isVitalsOptionalCapillaryRefillInputValid(form.capillaryRefillSec) &&
     isVitalsOptionalTextInputValid(form.notes, VITALS_NOTES_MAX_LENGTH) &&
@@ -1274,7 +1325,10 @@ function VitalsTab({
   return (
     <div className="space-y-6">
       {canRecordVitals && (
-        <form onSubmit={submit} className="rounded-lg border border-border bg-card p-4">
+        <form
+          onSubmit={submit}
+          className="rounded-lg border border-border bg-card p-4"
+        >
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
             <div>
               <label className="mb-1 block text-xs font-medium text-muted-foreground">
@@ -1286,135 +1340,141 @@ function VitalsTab({
                 max={VITALS_TEMPERATURE_MAX_C}
                 step={VITALS_TEMPERATURE_STEP}
                 value={form.temperatureC}
-                aria-invalid={!isVitalsOptionalTemperatureInputValid(form.temperatureC)}
+                aria-invalid={
+                  !isVitalsOptionalTemperatureInputValid(form.temperatureC)
+                }
                 onChange={set("temperatureC")}
                 className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
               />
             </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">
-              HR (bpm)
-            </label>
-            <input
-              type="number"
-              min={VITALS_HEART_RATE_MIN_BPM}
-              max={VITALS_HEART_RATE_MAX_BPM}
-              step={1}
-              value={form.heartRateBpm}
-              aria-invalid={!isVitalsOptionalHeartRateInputValid(form.heartRateBpm)}
-              onChange={set("heartRateBpm")}
-              className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                HR (bpm)
+              </label>
+              <input
+                type="number"
+                min={VITALS_HEART_RATE_MIN_BPM}
+                max={VITALS_HEART_RATE_MAX_BPM}
+                step={1}
+                value={form.heartRateBpm}
+                aria-invalid={
+                  !isVitalsOptionalHeartRateInputValid(form.heartRateBpm)
+                }
+                onChange={set("heartRateBpm")}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                RR (bpm)
+              </label>
+              <input
+                type="number"
+                min={VITALS_RESPIRATORY_RATE_MIN_BPM}
+                max={VITALS_RESPIRATORY_RATE_MAX_BPM}
+                step={1}
+                value={form.respiratoryRateBpm}
+                aria-invalid={
+                  !isVitalsOptionalRespiratoryRateInputValid(
+                    form.respiratoryRateBpm,
+                  )
+                }
+                onChange={set("respiratoryRateBpm")}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Weight (kg)
+              </label>
+              <input
+                type="number"
+                min={VITALS_WEIGHT_MIN_KG}
+                max={VITALS_WEIGHT_MAX_KG}
+                step={VITALS_WEIGHT_STEP}
+                value={form.weightKg}
+                aria-invalid={!isVitalsOptionalWeightInputValid(form.weightKg)}
+                onChange={set("weightKg")}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                BCS (1-9)
+              </label>
+              <input
+                type="number"
+                min={VITALS_BODY_CONDITION_MIN}
+                max={VITALS_BODY_CONDITION_MAX}
+                step={1}
+                value={form.bodyConditionScore}
+                aria-invalid={
+                  !isVitalsOptionalBodyConditionInputValid(
+                    form.bodyConditionScore,
+                  )
+                }
+                onChange={set("bodyConditionScore")}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Pain (0-10)
+              </label>
+              <input
+                type="number"
+                min={VITALS_PAIN_SCORE_MIN}
+                max={VITALS_PAIN_SCORE_MAX}
+                step={1}
+                value={form.painScore}
+                aria-invalid={
+                  !isVitalsOptionalPainScoreInputValid(form.painScore)
+                }
+                onChange={set("painScore")}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                CRT (sec)
+              </label>
+              <input
+                type="number"
+                min={VITALS_CAPILLARY_REFILL_MIN_SEC}
+                max={VITALS_CAPILLARY_REFILL_MAX_SEC}
+                step={VITALS_CAPILLARY_REFILL_STEP}
+                value={form.capillaryRefillSec}
+                aria-invalid={
+                  !isVitalsOptionalCapillaryRefillInputValid(
+                    form.capillaryRefillSec,
+                  )
+                }
+                onChange={set("capillaryRefillSec")}
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div className="col-span-2">
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Mucous Membrane
+              </label>
+              <input
+                type="text"
+                value={form.mucousMembrane}
+                maxLength={VITALS_MUCOUS_MEMBRANE_MAX_LENGTH}
+                onChange={set("mucousMembrane")}
+                placeholder="e.g. Pink and moist"
+                className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
           </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">
-              RR (bpm)
-            </label>
-            <input
-              type="number"
-              min={VITALS_RESPIRATORY_RATE_MIN_BPM}
-              max={VITALS_RESPIRATORY_RATE_MAX_BPM}
-              step={1}
-              value={form.respiratoryRateBpm}
-              aria-invalid={
-                !isVitalsOptionalRespiratoryRateInputValid(
-                  form.respiratoryRateBpm
-                )
-              }
-              onChange={set("respiratoryRateBpm")}
-              className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">
-              Weight (kg)
-            </label>
-            <input
-              type="number"
-              min={VITALS_WEIGHT_MIN_KG}
-              max={VITALS_WEIGHT_MAX_KG}
-              step={VITALS_WEIGHT_STEP}
-              value={form.weightKg}
-              aria-invalid={!isVitalsOptionalWeightInputValid(form.weightKg)}
-              onChange={set("weightKg")}
-              className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">
-              BCS (1-9)
-            </label>
-            <input
-              type="number"
-              min={VITALS_BODY_CONDITION_MIN}
-              max={VITALS_BODY_CONDITION_MAX}
-              step={1}
-              value={form.bodyConditionScore}
-              aria-invalid={
-                !isVitalsOptionalBodyConditionInputValid(
-                  form.bodyConditionScore
-                )
-              }
-              onChange={set("bodyConditionScore")}
-              className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">
-              Pain (0-10)
-            </label>
-            <input
-              type="number"
-              min={VITALS_PAIN_SCORE_MIN}
-              max={VITALS_PAIN_SCORE_MAX}
-              step={1}
-              value={form.painScore}
-              aria-invalid={!isVitalsOptionalPainScoreInputValid(form.painScore)}
-              onChange={set("painScore")}
-              className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">
-              CRT (sec)
-            </label>
-            <input
-              type="number"
-              min={VITALS_CAPILLARY_REFILL_MIN_SEC}
-              max={VITALS_CAPILLARY_REFILL_MAX_SEC}
-              step={VITALS_CAPILLARY_REFILL_STEP}
-              value={form.capillaryRefillSec}
-              aria-invalid={
-                !isVitalsOptionalCapillaryRefillInputValid(
-                  form.capillaryRefillSec
-                )
-              }
-              onChange={set("capillaryRefillSec")}
-              className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
-          </div>
-          <div className="col-span-2">
-            <label className="mb-1 block text-xs font-medium text-muted-foreground">
-              Mucous Membrane
-            </label>
-            <input
-              type="text"
-              value={form.mucousMembrane}
-              maxLength={VITALS_MUCOUS_MEMBRANE_MAX_LENGTH}
-              onChange={set("mucousMembrane")}
-              placeholder="e.g. Pink and moist"
-              className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-            />
-          </div>
-        </div>
-        <input
-          type="text"
-          value={form.notes ?? ""}
-          maxLength={VITALS_NOTES_MAX_LENGTH}
-          onChange={set("notes")}
-          placeholder="Notes (optional)"
-          className="mt-3 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-        />
+          <input
+            type="text"
+            value={form.notes ?? ""}
+            maxLength={VITALS_NOTES_MAX_LENGTH}
+            onChange={set("notes")}
+            placeholder="Notes (optional)"
+            className="mt-3 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+          />
           <div className="mt-3 flex justify-end">
             <Button type="submit" disabled={!canSubmitVitals}>
               {record.isPending ? "Saving..." : "Record vitals"}
@@ -1456,7 +1516,7 @@ function VitalsTab({
                     key={v.id}
                     className={cn(
                       "border-b border-border last:border-0",
-                      v.correctionId && "bg-destructive/5"
+                      v.correctionId && "bg-destructive/5",
                     )}
                   >
                     <td className="px-3 py-2">
@@ -1471,9 +1531,7 @@ function VitalsTab({
                     <td className="min-w-64 px-3 py-2">
                       <ClinicalCorrectionControl
                         correction={
-                          v.correctionId &&
-                          v.correctionReason &&
-                          v.correctedAt
+                          v.correctionId && v.correctionReason && v.correctedAt
                             ? {
                                 id: v.correctionId,
                                 reason: v.correctionReason,
@@ -1517,8 +1575,11 @@ function VaccinationsTab({
   canCorrectClinicalRecords: boolean;
 }) {
   const utils = trpc.useUtils();
-  const { data: vaccinations, isLoading, error } =
-    trpc.records.listVaccinations.useQuery({ patientId });
+  const {
+    data: vaccinations,
+    isLoading,
+    error,
+  } = trpc.records.listVaccinations.useQuery({ patientId });
   const correctVaccination =
     trpc.records.markVaccinationEnteredInError.useMutation({
       onSuccess: async () => {
@@ -1539,9 +1600,7 @@ function VaccinationsTab({
 
   if (vaccinationsMissing) {
     return (
-      <PatientDetailErrorPanel
-        message="Unable to load vaccination records. Please retry."
-      />
+      <PatientDetailErrorPanel message="Unable to load vaccination records. Please retry." />
     );
   }
 
@@ -1550,9 +1609,7 @@ function VaccinationsTab({
   }
 
   if (!vaccinations || vaccinations.length === 0) {
-    return (
-      <EmptyState icon={Shield} title="No vaccination records yet" />
-    );
+    return <EmptyState icon={Shield} title="No vaccination records yet" />;
   }
 
   return (
@@ -1586,7 +1643,7 @@ function VaccinationsTab({
               key={vax.id}
               className={cn(
                 "border-b border-border last:border-0",
-                vax.correctionId && "bg-destructive/5 text-muted-foreground"
+                vax.correctionId && "bg-destructive/5 text-muted-foreground",
               )}
             >
               <td className="px-4 py-3 font-medium">{vax.vaccineName}</td>
@@ -1606,13 +1663,13 @@ function VaccinationsTab({
                     Entered in error
                   </span>
                 ) : (
-                  <span className="text-xs text-muted-foreground">Recorded</span>
+                  <span className="text-xs text-muted-foreground">
+                    Recorded
+                  </span>
                 )}
                 <ClinicalCorrectionControl
                   correction={
-                    vax.correctionId &&
-                    vax.correctionReason &&
-                    vax.correctedAt
+                    vax.correctionId && vax.correctionReason && vax.correctedAt
                       ? {
                           id: vax.correctionId,
                           reason: vax.correctionReason,
@@ -1653,8 +1710,11 @@ function MedicalRecordsTab({
   canCorrectClinicalRecords: boolean;
 }) {
   const utils = trpc.useUtils();
-  const { data: notes, isLoading, error } =
-    trpc.records.listSoapNotes.useQuery({ patientId });
+  const {
+    data: notes,
+    isLoading,
+    error,
+  } = trpc.records.listSoapNotes.useQuery({ patientId });
   const correctSoap = trpc.records.markSoapNoteEnteredInError.useMutation({
     onSuccess: async () => {
       toast.success("SOAP note retained and marked entered in error");
@@ -1704,12 +1764,12 @@ function MedicalRecordsTab({
         );
         const hasAppointmentSoapDraft = Boolean(
           note.appointmentId &&
-            notes.some(
-              (candidate) =>
-                candidate.id !== note.id &&
-                candidate.appointmentId === note.appointmentId &&
-                candidate.status === "draft",
-            ),
+          notes.some(
+            (candidate) =>
+              candidate.id !== note.id &&
+              candidate.appointmentId === note.appointmentId &&
+              candidate.status === "draft",
+          ),
         );
         return (
           <div
@@ -1864,10 +1924,10 @@ function MedicalRecordsTab({
                       View signed replacement
                     </a>
                   </div>
-              ) : canCorrectClinicalRecords &&
-                (!note.correctionId ||
-                  (!hasOtherCurrentAppointmentSoap &&
-                    !hasAppointmentSoapDraft)) ? (
+                ) : canCorrectClinicalRecords &&
+                  (!note.correctionId ||
+                    (!hasOtherCurrentAppointmentSoap &&
+                      !hasAppointmentSoapDraft)) ? (
                   <div className="mt-3 flex justify-end">
                     <Button asChild size="sm">
                       <Link
@@ -1879,17 +1939,17 @@ function MedicalRecordsTab({
                       </Link>
                     </Button>
                   </div>
-              ) : hasAppointmentSoapDraft && note.appointmentId ? (
-                <div className="mt-3 flex justify-end">
-                  <Button asChild size="sm" variant="outline">
-                    <a
-                      href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
-                    >
-                      Review encounter SOAP draft
-                    </a>
-                  </Button>
-                </div>
-              ) : note.correctionId && hasOtherCurrentAppointmentSoap ? (
+                ) : hasAppointmentSoapDraft && note.appointmentId ? (
+                  <div className="mt-3 flex justify-end">
+                    <Button asChild size="sm" variant="outline">
+                      <a
+                        href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+                      >
+                        Review encounter SOAP draft
+                      </a>
+                    </Button>
+                  </div>
+                ) : note.correctionId && hasOtherCurrentAppointmentSoap ? (
                   <p className="mt-3 text-right text-xs text-muted-foreground">
                     This encounter already has a current finalized SOAP.
                   </p>
@@ -2011,8 +2071,11 @@ function AppointmentsTab({
   patientId: string;
   timeZone?: string | null;
 }) {
-  const { data: visits, isLoading, error } =
-    trpc.appointments.listByPatient.useQuery({ patientId });
+  const {
+    data: visits,
+    isLoading,
+    error,
+  } = trpc.appointments.listByPatient.useQuery({ patientId });
   const visitsMissing = !isLoading && !error && !visits;
   const [expandedVisitId, setExpandedVisitId] = useState<string | null>(null);
 
@@ -2098,7 +2161,7 @@ function AppointmentsTab({
                       ? formatClinicalDateTime(
                           visit.startTime,
                           timeZone,
-                          "Unknown"
+                          "Unknown",
                         )
                       : "Unknown"}
                   </td>
@@ -2122,7 +2185,7 @@ function AppointmentsTab({
                       className={cn(
                         "inline-flex whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium capitalize",
                         appointmentStatusStyles[visit.status] ??
-                          "bg-gray-100 text-gray-600"
+                          "bg-gray-100 text-gray-600",
                       )}
                     >
                       {visit.status.replace(/_/g, " ")}
@@ -2279,8 +2342,8 @@ function VisitDocuments({
   if (photos.length === 0 && documents.length === 0) {
     return (
       <p className="text-xs text-muted-foreground">
-        Nothing attached to this visit yet. Photos and consents captured
-        during the visit show up here.
+        Nothing attached to this visit yet. Photos and consents captured during
+        the visit show up here.
       </p>
     );
   }
@@ -2369,12 +2432,10 @@ function DocumentsTab({
   }
 
   const visible = data.filter(
-    (file) => filter === "all" || patientFileKind(file) === filter
+    (file) => filter === "all" || patientFileKind(file) === filter,
   );
   const photos = visible.filter((file) => patientFileKind(file) === "photo");
-  const documents = visible.filter(
-    (file) => patientFileKind(file) !== "photo"
-  );
+  const documents = visible.filter((file) => patientFileKind(file) !== "photo");
 
   return (
     <div className="space-y-4">
@@ -2388,7 +2449,7 @@ function DocumentsTab({
               "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
               filter === option.id
                 ? "border-primary bg-primary/10 text-primary"
-                : "border-border text-muted-foreground hover:text-foreground"
+                : "border-border text-muted-foreground hover:text-foreground",
             )}
           >
             {option.label} ({counts[option.id]})
@@ -2503,7 +2564,7 @@ function InvoicesTab({ patientId }: { patientId: string }) {
                     "inline-flex whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium capitalize",
                     invoiceStatusStyles[
                       invoice.isEstimate ? "draft" : invoice.status
-                    ] ?? "bg-gray-100 text-gray-600"
+                    ] ?? "bg-gray-100 text-gray-600",
                   )}
                 >
                   {invoice.isEstimate ? "estimate" : invoice.status}
@@ -2580,7 +2641,7 @@ function AllergyForm({
           value={allergySeverity}
           onChange={(event) =>
             setAllergySeverity(
-              event.target.value as "mild" | "moderate" | "severe"
+              event.target.value as "mild" | "moderate" | "severe",
             )
           }
           className="rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -87,6 +87,11 @@ import {
   isImageUploadFileValid,
 } from "@/lib/upload-policy";
 import {
+  selectManagedUploadFile,
+  settleManagedUploadAttempt,
+  type ManagedUploadAttempt,
+} from "@/lib/managed-upload-attempt";
+import {
   IMPORT_CSV_MAX_BYTES,
   isImportCsvSizeValid,
 } from "@/lib/import/policy";
@@ -461,31 +466,67 @@ function PracticeInfoTab() {
     });
 
   const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [logoUploadError, setLogoUploadError] = useState<string | null>(null);
   const logoInputRef = useRef<HTMLInputElement>(null);
+  const logoUploadAttemptRef = useRef<ManagedUploadAttempt | null>(null);
 
-  const handleLogoUpload = async (file: File) => {
-    if (!isImageUploadFileValid(file)) {
+  const handleLogoUpload = async (selectedFile?: File) => {
+    if (selectedFile && !isImageUploadFileValid(selectedFile)) {
+      logoUploadAttemptRef.current = null;
+      setLogoUploadError(null);
       toast.error(IMAGE_UPLOAD_POLICY_MESSAGE);
       return;
     }
 
+    if (selectedFile) {
+      logoUploadAttemptRef.current = selectManagedUploadFile(
+        logoUploadAttemptRef.current,
+        selectedFile,
+      );
+    }
+    const attempt = logoUploadAttemptRef.current;
+    if (!attempt) return;
+
     setUploadingLogo(true);
+    setLogoUploadError(null);
     try {
       const body = new FormData();
-      body.append("file", file);
+      body.append("file", attempt.file);
       body.append("category", "branding");
       const res = await fetchWithClientTimeout(
         "/api/upload",
-        { method: "POST", body },
+        {
+          method: "POST",
+          body,
+          headers: { "Idempotency-Key": attempt.idempotencyKey },
+        },
         CLIENT_UPLOAD_TIMEOUT_MS,
       );
-      const json = await res.json();
+      const json = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) {
+        logoUploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+          kind: "response",
+          status: res.status,
+        });
         throw new Error(json.error ?? "Upload failed");
       }
-      brandingMutation.mutate({ logoUrl: json.url });
+      logoUploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+        kind: "success",
+      });
+      await Promise.all([
+        utils.settings.getPractice.invalidate(),
+        utils.settings.getBranding.invalidate(),
+      ]);
+      toast.success("Logo saved");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Upload failed");
+      if (logoUploadAttemptRef.current === attempt) {
+        logoUploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+          kind: "ambiguous",
+        });
+      }
+      const message = err instanceof Error ? err.message : "Upload failed";
+      setLogoUploadError(message);
+      toast.error(message);
     } finally {
       setUploadingLogo(false);
     }
@@ -757,6 +798,21 @@ function PracticeInfoTab() {
                   <p className="mt-1.5 text-xs text-muted-foreground">
                     PNG, JPG, or WebP. Square images work best.
                   </p>
+                  {logoUploadError ? (
+                    <div className="mt-2 flex items-center gap-2 text-xs text-destructive">
+                      <span>{logoUploadError}</span>
+                      {logoUploadAttemptRef.current ? (
+                        <button
+                          type="button"
+                          disabled={uploadingLogo}
+                          onClick={() => void handleLogoUpload()}
+                          className="font-medium underline underline-offset-2 disabled:opacity-50"
+                        >
+                          Try again
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/apps/web/app/api/capture/[token]/route.test.ts
+++ b/apps/web/app/api/capture/[token]/route.test.ts
@@ -4,23 +4,48 @@ import { fileURLToPath } from "node:url";
 
 const ROUTE_SOURCE = readFileSync(
   fileURLToPath(new URL("./route.ts", import.meta.url)),
-  "utf8"
+  "utf8",
 );
 
 const mocks = vi.hoisted(() => {
-  const practiceId = "00000000-0000-0000-0000-000000000001";
-  const patientId = "00000000-0000-0000-0000-000000000002";
-  const createdBy = "00000000-0000-0000-0000-000000000003";
-  const fileId = "00000000-0000-0000-0000-000000000004";
+  const practiceId = "00000000-0000-4000-8000-000000000001";
+  const patientId = "00000000-0000-4000-8000-000000000002";
+  const createdBy = "00000000-0000-4000-8000-000000000003";
+  const fileId = "00000000-0000-4000-8000-000000000004";
+  const captureSessionId = "00000000-0000-4000-8000-000000000005";
+  const appointmentId = "00000000-0000-4000-8000-000000000006";
 
   const captureSession = (overrides: Record<string, unknown> = {}) => ({
-    id: "00000000-0000-0000-0000-000000000005",
+    id: captureSessionId,
     practiceId,
     patientId,
     createdBy,
+    appointmentId,
     tier: "free",
     billingStatus: "trialing",
     trialEndsAt: new Date("2099-01-01T00:00:00Z"),
+    ...overrides,
+  });
+
+  const reservation = (overrides: Record<string, unknown> = {}) => ({
+    id: fileId,
+    practiceId,
+    uploadedBy: createdBy,
+    idempotencyKey: "00000000-0000-4000-8000-000000000099",
+    fileName: "photo.png",
+    fileKey: `${practiceId}/patient-photos/${fileId}`,
+    fileUrl: `/api/files/${practiceId}/patient-photos/${fileId}`,
+    mimeType: "image/png",
+    fileSizeBytes: 8,
+    checksumSha256: "a".repeat(64),
+    storageStatus: "pending_upload",
+    category: "patient-photos",
+    source: `capture:${captureSessionId}`,
+    entityType: "patient",
+    entityId: patientId,
+    patientId,
+    appointmentId,
+    created: true,
     ...overrides,
   });
 
@@ -31,36 +56,62 @@ const mocks = vi.hoisted(() => {
       from: vi.fn(() => builder),
       innerJoin: vi.fn(() => builder),
       where: vi.fn(() => builder),
-      limit: vi.fn(async () => result),
+      limit: vi.fn(() => builder),
+      for: vi.fn(async () => result),
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject: (reason: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject),
     };
     return builder;
   });
-
-  const insertReturning = vi.fn(async () => [{ id: fileId }]);
-  const insertValues = vi.fn(() => ({ returning: insertReturning }));
-  const insert = vi.fn(() => ({ values: insertValues }));
-  const tx = { select, insert };
+  const tx = { select };
+  class ManagedUploadConflictError extends Error {}
 
   return {
     practiceId,
     patientId,
     createdBy,
     fileId,
+    captureSessionId,
+    appointmentId,
+    tx,
     captureSession,
+    reservation,
     selectResults,
-    insertValues,
-    insertReturning,
-    uploadFile: vi.fn(async () => undefined),
-    deleteFile: vi.fn(async () => undefined),
+    ManagedUploadConflictError,
+    reserveManagedUpload: vi.fn(
+      async (_tx: unknown, _input: Record<string, unknown>) => reservation(),
+    ),
+    putAndVerifyManagedUpload: vi.fn(
+      async (
+        _input: unknown,
+      ): Promise<
+        | {
+            status: "verified";
+            evidence: { url: string; etag: string; versionId: string };
+          }
+        | { status: "unavailable" }
+        | { status: "corrupt" }
+      > => ({
+        status: "verified",
+        evidence: {
+          url: "https://storage.example/object",
+          etag: "etag-1",
+          versionId: "version-1",
+        },
+      }),
+    ),
+    finalizeManagedUploadManifest: vi.fn(async () => true),
+    markManagedUploadCorrupt: vi.fn(async (): Promise<boolean> => true),
+    queueManagedUploadReplication: vi.fn(async () => true),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(tx)
+      fn(tx),
     ),
     withTenant: vi.fn(
-      async (
-        _db: unknown,
-        _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(tx)
+      async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+        fn(tx),
     ),
     billingEnforced: vi.fn(() => false),
     hasHostedFullAccess: vi.fn(() => true),
@@ -69,6 +120,7 @@ const mocks = vi.hoisted(() => {
       remaining: 10,
       resetAt: new Date("2026-07-10T13:00:00Z"),
     })),
+    readRequestBytesWithLimit: vi.fn(),
   };
 });
 
@@ -77,10 +129,22 @@ vi.mock("@/lib/tenant-db", () => ({
   withSystem: mocks.withSystem,
   withTenant: mocks.withTenant,
 }));
-vi.mock("@/lib/s3", () => ({
-  uploadFile: mocks.uploadFile,
-  deleteFile: mocks.deleteFile,
+vi.mock("@/lib/recovery-hold", () => ({
+  lockPracticeForExternalSideEffects: mocks.lockPracticeForExternalSideEffects,
 }));
+vi.mock("@/lib/file-replication", () => ({
+  checksumSha256Hex: vi.fn(() => "a".repeat(64)),
+}));
+vi.mock("@/lib/managed-file-upload", () => {
+  return {
+    ManagedUploadConflictError: mocks.ManagedUploadConflictError,
+    reserveManagedUpload: mocks.reserveManagedUpload,
+    putAndVerifyManagedUpload: mocks.putAndVerifyManagedUpload,
+    finalizeManagedUploadManifest: mocks.finalizeManagedUploadManifest,
+    markManagedUploadCorrupt: mocks.markManagedUploadCorrupt,
+    queueManagedUploadReplication: mocks.queueManagedUploadReplication,
+  };
+});
 vi.mock("@/lib/billing/plans", () => ({
   billingEnforced: mocks.billingEnforced,
   hasHostedFullAccess: mocks.hasHostedFullAccess,
@@ -92,27 +156,47 @@ vi.mock("@/lib/rate-limit", async (importOriginal) => {
     rateLimitResponseHeaders: actual.rateLimitResponseHeaders,
   };
 });
+vi.mock("@/lib/request-body", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/request-body")>();
+  mocks.readRequestBytesWithLimit.mockImplementation(
+    actual.readRequestBytesWithLimit,
+  );
+  return {
+    ...actual,
+    readRequestBytesWithLimit: mocks.readRequestBytesWithLimit,
+  };
+});
 
 const { POST } = await import("./route");
 
 const TOKEN = "ab".repeat(32);
-
+const IDEMPOTENCY_KEY = "00000000-0000-4000-8000-000000000099";
 const PNG_BYTES = new Uint8Array([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
 ]);
 
-function captureRequest(tokenParam: string, file?: File) {
+function captureRequest(
+  tokenParam: string,
+  file?: File,
+  idempotencyKey: string | null = IDEMPOTENCY_KEY,
+) {
   const formData = new FormData();
   if (file) formData.append("file", file);
-
+  const headers = new Headers();
+  if (idempotencyKey) headers.set("Idempotency-Key", idempotencyKey);
   return new Request(`https://openvpm.test/api/capture/${tokenParam}`, {
     method: "POST",
+    headers,
     body: formData,
   }) as never;
 }
 
-function call(tokenParam: string, file?: File) {
-  return POST(captureRequest(tokenParam, file), {
+function call(
+  tokenParam: string,
+  file?: File,
+  idempotencyKey: string | null = IDEMPOTENCY_KEY,
+) {
+  return POST(captureRequest(tokenParam, file, idempotencyKey), {
     params: Promise.resolve({ token: tokenParam }),
   });
 }
@@ -121,17 +205,56 @@ function pngFile(name = "photo.png") {
   return new File([PNG_BYTES], name, { type: "image/png" });
 }
 
+function queueValidContext(
+  input: {
+    appointmentId?: string | null;
+    usage?: { count: number; replayCount: number };
+  } = {},
+) {
+  const session = mocks.captureSession({
+    appointmentId:
+      input.appointmentId === undefined
+        ? mocks.appointmentId
+        : input.appointmentId,
+  });
+  mocks.selectResults.push(
+    [session],
+    [{ id: mocks.captureSessionId }],
+    [{ id: mocks.patientId }],
+    [{ id: mocks.createdBy }],
+  );
+  if (session.appointmentId) {
+    mocks.selectResults.push([{ id: session.appointmentId }]);
+  }
+  mocks.selectResults.push([input.usage ?? { count: 0, replayCount: 0 }]);
+}
+
 afterEach(() => {
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
+  mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
+  mocks.withSystem.mockImplementation(
+    async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+  );
   mocks.rateLimit.mockResolvedValue({
     success: true,
     remaining: 10,
     resetAt: new Date("2026-07-10T13:00:00Z"),
   });
-  mocks.insertReturning.mockResolvedValue([{ id: mocks.fileId }]);
+  mocks.reserveManagedUpload.mockImplementation(async () =>
+    mocks.reservation(),
+  );
+  mocks.putAndVerifyManagedUpload.mockResolvedValue({
+    status: "verified",
+    evidence: {
+      url: "https://storage.example/object",
+      etag: "etag-1",
+      versionId: "version-1",
+    },
+  });
+  mocks.finalizeManagedUploadManifest.mockResolvedValue(true);
 });
 
 describe("POST /api/capture/[token]", () => {
@@ -139,42 +262,97 @@ describe("POST /api/capture/[token]", () => {
     for (const bad of ["short", "Z".repeat(64), "../etc", `${TOKEN}x`]) {
       const res = await call(bad, pngFile());
       expect(res.status).toBe(404);
+      expect(res.headers.get("Cache-Control")).toBe(
+        "private, no-store, max-age=0",
+      );
       await expect(res.json()).resolves.toEqual({ error: "Not found" });
     }
     expect(mocks.rateLimit).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("returns identical generic 404s for unknown and expired tokens (no validity oracle)", async () => {
-    // Unknown token: the session lookup misses.
+  it("returns identical generic 404s for unknown and expired tokens", async () => {
     mocks.selectResults.push([]);
     const unknownRes = await call(TOKEN, pngFile());
-
-    // Expired token: the expiresAt > now predicate makes the lookup miss the
-    // same way, so the route cannot tell (or reveal) the difference.
     mocks.selectResults.push([]);
     const expiredRes = await call(TOKEN, pngFile());
 
     expect(unknownRes.status).toBe(404);
     expect(expiredRes.status).toBe(404);
-    const unknownBody = await unknownRes.json();
-    const expiredBody = await expiredRes.json();
-    expect(unknownBody).toEqual({ error: "Not found" });
-    expect(expiredBody).toEqual(unknownBody);
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    await expect(unknownRes.json()).resolves.toEqual({ error: "Not found" });
+    await expect(expiredRes.json()).resolves.toEqual({ error: "Not found" });
+    expect(mocks.readRequestBytesWithLimit).not.toHaveBeenCalled();
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("hides missing, deleted, and recovery-held practices before body or provider work", async () => {
+    for (const _state of ["missing", "deleted", "recovery-held"]) {
+      mocks.selectResults.push([]);
+      const response = await call(TOKEN, pngFile());
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({ error: "Not found" });
+    }
+    expect(mocks.readRequestBytesWithLimit).not.toHaveBeenCalled();
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
     expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("404s generically on orphaned sessions without a creator", async () => {
-    mocks.selectResults.push([mocks.captureSession({ createdBy: null })]);
-    const res = await call(TOKEN, pngFile());
-    expect(res.status).toBe(404);
-    await expect(res.json()).resolves.toEqual({ error: "Not found" });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+  it("fails closed before body or provider work when recovery wins after lookup", async () => {
+    mocks.selectResults.push([mocks.captureSession()]);
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+
+    const response = await call(TOKEN, pngFile());
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+    expect(mocks.lockPracticeForExternalSideEffects).toHaveBeenCalledWith(
+      expect.anything(),
+      mocks.practiceId,
+    );
+    expect(mocks.readRequestBytesWithLimit).not.toHaveBeenCalled();
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("429s with rate-limit headers when a limit trips", async () => {
+  it("requires a client-generated canonical UUID after validating the link", async () => {
+    mocks.selectResults.push([mocks.captureSession()]);
+    const res = await call(TOKEN, pngFile(), null);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "A canonical UUID Idempotency-Key header is required",
+    });
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("rate limits both the token and caller IP without storing the raw token", async () => {
+    mocks.selectResults.push([mocks.captureSession()]);
+    await call(TOKEN, pngFile());
+    const calls = mocks.rateLimit.mock.calls as unknown as [
+      { key: string; limit: number; windowMs: number },
+    ][];
+    const keys = calls.map((call) => call[0].key);
+    expect(keys.some((key) => key.startsWith("capture-upload:ip:"))).toBe(true);
+    expect(keys.some((key) => key.startsWith("capture-upload:token:"))).toBe(
+      true,
+    );
+    expect(keys.every((key) => !key.includes(TOKEN))).toBe(true);
+    expect(calls[0]?.[0]).toMatchObject({
+      limit: 300,
+      windowMs: 10 * 60 * 1000,
+    });
+    expect(calls[1]?.[0]).toMatchObject({
+      limit: 60,
+      windowMs: 10 * 60 * 1000,
+    });
+  });
+
+  it("429s with retry headers after resolving an active capability", async () => {
+    mocks.selectResults.push([mocks.captureSession()]);
     mocks.rateLimit.mockResolvedValueOnce({
       success: false,
       remaining: 0,
@@ -183,139 +361,283 @@ describe("POST /api/capture/[token]", () => {
     const res = await call(TOKEN, pngFile());
     expect(res.status).toBe(429);
     expect(res.headers.get("Retry-After")).toBeTruthy();
-    expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.withSystem).toHaveBeenCalledTimes(1);
+    expect(mocks.readRequestBytesWithLimit).not.toHaveBeenCalled();
   });
 
-  it("rate limits both the token and the caller IP with a hashed token key", async () => {
-    mocks.selectResults.push([]);
-    await call(TOKEN, pngFile());
-    const keys = (
-      mocks.rateLimit.mock.calls as unknown as [{ key: string }][]
-    ).map((c) => c[0].key);
-    expect(keys.some((k) => k.startsWith("capture-upload:ip:"))).toBe(true);
-    expect(keys.some((k) => k.startsWith("capture-upload:token:"))).toBe(true);
-    // The raw token never appears in a rate-limit key (it is hashed).
-    expect(keys.every((k) => !k.includes(TOKEN))).toBe(true);
-  });
-
-  it("hides hosted read-only practices behind the same generic 404", async () => {
+  it("hides inactive billing and orphaned creator states behind a generic 404", async () => {
     mocks.billingEnforced.mockReturnValue(true);
     mocks.hasHostedFullAccess.mockReturnValue(false);
-    mocks.selectResults.push([
-      mocks.captureSession({
-        tier: "basic",
-        billingStatus: "past_due",
-        trialEndsAt: null,
-      }),
-    ]);
-    const res = await call(TOKEN, pngFile());
-    expect(res.status).toBe(404);
-    await expect(res.json()).resolves.toEqual({ error: "Not found" });
-    expect(mocks.hasHostedFullAccess).toHaveBeenCalledWith(
-      "basic",
-      "past_due",
-      null
-    );
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-  });
-
-  it("rejects missing file fields", async () => {
     mocks.selectResults.push([mocks.captureSession()]);
-    const res = await call(TOKEN);
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toEqual({ error: "Missing file field" });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    const billingRes = await call(TOKEN, pngFile());
+    expect(billingRes.status).toBe(404);
+
+    mocks.billingEnforced.mockReturnValue(false);
+    mocks.selectResults.push([mocks.captureSession({ createdBy: null })]);
+    const orphanRes = await call(TOKEN, pngFile());
+    expect(orphanRes.status).toBe(404);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("rejects non-image uploads even when the type is otherwise allowed", async () => {
+  it("rejects missing, non-image, and spoofed image payloads", async () => {
+    mocks.selectResults.push([mocks.captureSession()]);
+    expect((await call(TOKEN)).status).toBe(400);
+
     mocks.selectResults.push([mocks.captureSession()]);
     const pdf = new File([new TextEncoder().encode("%PDF-1.7\n")], "lab.pdf", {
       type: "application/pdf",
     });
-    const res = await call(TOKEN, pdf);
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toEqual({
-      error: "Capture uploads must be JPG, PNG, or WebP images",
-    });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-  });
+    expect((await call(TOKEN, pdf)).status).toBe(400);
 
-  it("rejects uploads whose bytes do not match the declared MIME type", async () => {
     mocks.selectResults.push([mocks.captureSession()]);
-    const fake = new File([new TextEncoder().encode("<html></html>")], "fake.png", {
-      type: "image/png",
-    });
-    const res = await call(TOKEN, fake);
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toEqual({
+    const fake = new File(
+      [new TextEncoder().encode("<html></html>")],
+      "fake.png",
+      {
+        type: "image/png",
+      },
+    );
+    const spoofed = await call(TOKEN, fake);
+    expect(spoofed.status).toBe(400);
+    await expect(spoofed.json()).resolves.toEqual({
       error: "File contents do not match the declared file type",
     });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("stores a valid photo and links it to the session's patient", async () => {
-    mocks.selectResults.push([mocks.captureSession()]);
+  it.each([
+    ["capture session", 1],
+    ["patient", 2],
+    ["creator", 3],
+    ["appointment", 4],
+  ])(
+    "404s when the exact active %s ownership check fails",
+    async (_label, missAt) => {
+      const results: unknown[][] = [
+        [mocks.captureSession()],
+        [{ id: mocks.captureSessionId }],
+        [{ id: mocks.patientId }],
+        [{ id: mocks.createdBy }],
+        [{ id: mocks.appointmentId }],
+        [{ count: 0, replayCount: 0 }],
+      ];
+      results[missAt] = [];
+      mocks.selectResults.push(...results);
+
+      const res = await call(TOKEN, pngFile());
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "Not found" });
+      expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+      expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reserves a semantically bound manifest before provider I/O", async () => {
+    queueValidContext();
     const res = await call(TOKEN, pngFile("side view.png"));
 
     expect(res.status).toBe(201);
+    expect(res.headers.get("Cache-Control")).toBe(
+      "private, no-store, max-age=0",
+    );
     await expect(res.json()).resolves.toEqual({
       ok: true,
       fileId: mocks.fileId,
     });
-    expect(mocks.uploadFile).toHaveBeenCalledWith(
-      expect.stringMatching(
-        new RegExp(`^${mocks.practiceId}/patient-photos/.+-side_view\\.png$`)
-      ),
-      expect.any(Buffer),
-      "image/png"
-    );
-    expect(mocks.withTenant).toHaveBeenCalledWith(
+    expect(mocks.reserveManagedUpload).toHaveBeenCalledWith(
       expect.anything(),
-      mocks.practiceId,
-      expect.any(Function)
-    );
-    expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: mocks.practiceId,
         uploadedBy: mocks.createdBy,
+        idempotencyKey: IDEMPOTENCY_KEY,
         fileName: "side view.png",
-        mimeType: "image/png",
         category: "patient-photos",
+        source: `capture:${mocks.captureSessionId}`,
         entityType: "patient",
         entityId: mocks.patientId,
-      })
+        patientId: mocks.patientId,
+        appointmentId: mocks.appointmentId,
+      }),
+    );
+    expect(mocks.reserveManagedUpload.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.putAndVerifyManagedUpload.mock.invocationCallOrder[0],
+    );
+    expect(
+      mocks.lockPracticeForExternalSideEffects.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.readRequestBytesWithLimit.mock.invocationCallOrder[0]!,
+    );
+    expect(
+      mocks.readRequestBytesWithLimit.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.putAndVerifyManagedUpload.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalled();
+    expect(mocks.queueManagedUploadReplication).toHaveBeenCalledWith(
+      expect.objectContaining({ id: mocks.fileId }),
+      expect.objectContaining({ versionId: "version-1" }),
     );
   });
 
-  it("cleans up the uploaded object when metadata persistence fails", async () => {
+  it("retains the shared-lock transaction until provider work and finalization finish", async () => {
+    queueValidContext();
+    let releaseProvider!: () => void;
+    const providerGate = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    mocks.putAndVerifyManagedUpload.mockImplementationOnce(async () => {
+      await providerGate;
+      return {
+        status: "verified",
+        evidence: {
+          url: "https://storage.example/object",
+          etag: "etag-1",
+          versionId: "version-1",
+        },
+      };
+    });
+
+    let systemTransactionFinished = false;
+    mocks.withSystem.mockImplementationOnce(async (_db, fn) => {
+      const result = await fn(mocks.tx);
+      systemTransactionFinished = true;
+      return result;
+    });
+
+    const responsePromise = call(TOKEN, pngFile());
+    await vi.waitFor(() => {
+      expect(mocks.putAndVerifyManagedUpload).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.lockPracticeForExternalSideEffects).toHaveBeenCalledTimes(1);
+    expect(systemTransactionFinished).toBe(false);
+
+    releaseProvider();
+    expect((await responsePromise).status).toBe(201);
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledTimes(1);
+    expect(systemTransactionFinished).toBe(true);
+  });
+
+  it("supports capture sessions without an appointment while retaining patient binding", async () => {
+    queueValidContext({ appointmentId: null });
+    mocks.reserveManagedUpload.mockImplementationOnce(async (_tx, input) =>
+      mocks.reservation({ appointmentId: null, ...input }),
+    );
+    const res = await call(TOKEN, pngFile());
+    expect(res.status).toBe(201);
+    expect(mocks.reserveManagedUpload).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        patientId: mocks.patientId,
+        appointmentId: null,
+      }),
+    );
+  });
+
+  it("enforces a hard 20-photo session cap but permits an idempotent replay", async () => {
+    queueValidContext({ usage: { count: 20, replayCount: 0 } });
+    const capped = await call(TOKEN, pngFile());
+    expect(capped.status).toBe(409);
+    await expect(capped.json()).resolves.toEqual({
+      error: "This capture link has reached its 20-photo limit",
+    });
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+
+    queueValidContext({ usage: { count: 20, replayCount: 1 } });
+    mocks.reserveManagedUpload.mockResolvedValueOnce(
+      mocks.reservation({ created: false, storageStatus: "available" }),
+    );
+    const replay = await call(TOKEN, pngFile());
+    expect(replay.status).toBe(200);
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when an idempotency replay resolves to a tombstoned manifest", async () => {
+    queueValidContext();
+    mocks.reserveManagedUpload.mockRejectedValueOnce(
+      new mocks.ManagedUploadConflictError(
+        "Upload reservation is not retryable from state: deleted",
+      ),
+    );
+
+    const response = await call(TOKEN, pngFile());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Upload reservation is not retryable from state: deleted",
+    });
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+  });
+
+  it("leaves ambiguous provider outcomes retryable without finalizing", async () => {
+    queueValidContext();
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "unavailable",
+    });
+    const res = await call(TOKEN, pngFile());
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+  });
+
+  it("marks a checksum-mismatched object corrupt and does not finalize it", async () => {
+    queueValidContext();
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "corrupt",
+    });
+    const res = await call(TOKEN, pngFile());
+    expect(res.status).toBe(503);
+    expect(mocks.markManagedUploadCorrupt).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: mocks.fileId }),
+    );
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when quarantine loses the exact reservation generation", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    mocks.selectResults.push([mocks.captureSession()]);
-    mocks.insertReturning.mockRejectedValueOnce(new Error("db unavailable"));
+    queueValidContext();
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "corrupt",
+    });
+    mocks.markManagedUploadCorrupt.mockResolvedValueOnce(false);
 
-    try {
-      const res = await call(TOKEN, pngFile());
-      expect(res.status).toBe(500);
-      await expect(res.json()).resolves.toEqual({ error: "Upload failed" });
-      expect(mocks.uploadFile).toHaveBeenCalledTimes(1);
-      expect(mocks.deleteFile).toHaveBeenCalledWith(
-        expect.stringMatching(
-          new RegExp(`^${mocks.practiceId}/patient-photos/.+-photo\\.png$`)
-        )
-      );
-    } finally {
-      consoleError.mockRestore();
-    }
+    const res = await call(TOKEN, pngFile());
+    expect(res.status).toBe(500);
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[capture] managed upload failed",
+    );
+    consoleError.mockRestore();
   });
 
-  it("checks the token shape and practice liveness in source", () => {
-    expect(ROUTE_SOURCE).toContain("isCaptureTokenShape(token)");
-    expect(ROUTE_SOURCE).toContain("isNull(practices.deletedAt)");
-    expect(ROUTE_SOURCE).toContain("gt(captureSessions.expiresAt, now)");
+  it("locks the capture row and filters exact patient, creator, and visit ownership", () => {
+    expect(ROUTE_SOURCE).toContain('.for("update")');
+    expect(ROUTE_SOURCE).toContain('eq(patients.status, "active")');
+    expect(ROUTE_SOURCE).toContain("eq(users.practiceId, session.practiceId)");
+    expect(ROUTE_SOURCE).toContain(
+      "eq(appointments.patientId, session.patientId)",
+    );
+    expect(ROUTE_SOURCE).toContain("source = `capture:${session.id}`");
+    expect(ROUTE_SOURCE).toContain("CAPTURE_SESSION_FILE_LIMIT = 20");
+    expect(ROUTE_SOURCE).toContain("eq(practices.recoveryHold, false)");
     expect(ROUTE_SOURCE).toContain("readRequestBytesWithLimit(");
+    const postSource = ROUTE_SOURCE.slice(
+      ROUTE_SOURCE.indexOf("async function handlePost("),
+      ROUTE_SOURCE.indexOf("export async function POST("),
+    );
+    expect(postSource).toContain("return withSystem(db, async (systemTx) => {");
+    expect(
+      postSource.indexOf("lockPracticeForExternalSideEffects("),
+    ).toBeLessThan(postSource.indexOf("readRequestBytesWithLimit("));
+    expect(postSource.lastIndexOf("});")).toBeGreaterThan(
+      postSource.indexOf("queueManagedUploadReplication("),
+    );
+    expect(ROUTE_SOURCE).toContain(
+      'response.headers.set("Cache-Control", "private, no-store, max-age=0")',
+    );
     expect(ROUTE_SOURCE).toContain('export const dynamic = "force-dynamic"');
   });
 });

--- a/apps/web/app/api/capture/[token]/route.ts
+++ b/apps/web/app/api/capture/[token]/route.ts
@@ -1,16 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
-import { randomUUID } from "crypto";
-import { and, eq, gt, isNull } from "drizzle-orm";
-import { captureSessions, files, practices } from "@openpims/db";
-import { db } from "@openpims/db/client";
+import { and, eq, gt, isNull, sql } from "drizzle-orm";
+import {
+  appointments,
+  captureSessions,
+  files,
+  patients,
+  practices,
+  users,
+} from "@openpims/db";
+import { db, type Database } from "@openpims/db/client";
 import { withSystem, withTenant } from "@/lib/tenant-db";
+import { lockPracticeForExternalSideEffects } from "@/lib/recovery-hold";
 import { rateLimit, rateLimitResponseHeaders } from "@/lib/rate-limit";
 import { clientIpFromRequest } from "@/lib/request-ip";
-import {
-  captureRateLimitKey,
-  isCaptureTokenShape,
-} from "@/lib/consult/tokens";
-import { deleteFile, uploadFile } from "@/lib/s3";
+import { captureRateLimitKey, isCaptureTokenShape } from "@/lib/consult/tokens";
 import {
   isAllowedUploadMimeType,
   uploadBytesMatchMimeType,
@@ -23,6 +26,15 @@ import {
 import { readRequestBytesWithLimit } from "@/lib/request-body";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import { PATIENT_PHOTO_CATEGORY } from "@/lib/records/file-kinds";
+import { checksumSha256Hex } from "@/lib/file-replication";
+import {
+  finalizeManagedUploadManifest,
+  ManagedUploadConflictError,
+  markManagedUploadCorrupt,
+  putAndVerifyManagedUpload,
+  queueManagedUploadReplication,
+  reserveManagedUpload,
+} from "@/lib/managed-file-upload";
 
 export const dynamic = "force-dynamic";
 
@@ -38,213 +50,380 @@ export const dynamic = "force-dynamic";
 
 const TOKEN_LIMIT = 60;
 const TOKEN_WINDOW_MS = 10 * 60 * 1000;
-const IP_LIMIT = 30;
+// A clinic NAT can legitimately have many staff phones uploading at once.
+// Token and per-session limits remain the tighter capability controls.
+const IP_LIMIT = 300;
 const IP_WINDOW_MS = 10 * 60 * 1000;
 
 const MAX_FILE_NAME_LENGTH = 255;
 const CAPTURE_FILE_CATEGORY = PATIENT_PHOTO_CATEGORY;
+const CAPTURE_SESSION_FILE_LIMIT = 20;
+const IDEMPOTENCY_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+class CaptureSessionLimitError extends Error {}
 
 function notFound(): NextResponse {
   return NextResponse.json({ error: "Not found" }, { status: 404 });
 }
 
-export async function POST(
+function privateNoStore(response: NextResponse): NextResponse {
+  response.headers.set("Cache-Control", "private, no-store, max-age=0");
+  return response;
+}
+
+async function lookupCaptureSession(database: Database, token: string) {
+  const now = new Date();
+  const [row] = await database
+    .select({
+      id: captureSessions.id,
+      practiceId: captureSessions.practiceId,
+      patientId: captureSessions.patientId,
+      createdBy: captureSessions.createdBy,
+      appointmentId: captureSessions.appointmentId,
+      tier: practices.subscriptionTier,
+      billingStatus: practices.billingStatus,
+      trialEndsAt: practices.trialEndsAt,
+    })
+    .from(captureSessions)
+    .innerJoin(
+      practices,
+      and(
+        eq(practices.id, captureSessions.practiceId),
+        eq(practices.recoveryHold, false),
+        isNull(practices.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(captureSessions.token, token),
+        isNull(captureSessions.deletedAt),
+        gt(captureSessions.expiresAt, now),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function handlePost(
   request: NextRequest,
-  { params }: { params: Promise<{ token: string }> }
+  { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
   if (!isCaptureTokenShape(token)) {
     return notFound();
   }
 
-  const ipResult = await rateLimit({
-    key: `capture-upload:ip:${clientIpFromRequest(request)}`,
-    limit: IP_LIMIT,
-    windowMs: IP_WINDOW_MS,
-  });
-  if (!ipResult.success) {
-    return NextResponse.json(
-      { error: "Too many requests" },
-      { status: 429, headers: rateLimitResponseHeaders(IP_LIMIT, ipResult) }
-    );
-  }
+  return withSystem(db, async (systemTx) => {
+    const session = await lookupCaptureSession(systemTx, token);
+    // Unknown, expired, orphaned, deleted-practice, and recovery-held sessions
+    // all get the same generic miss before request-body or provider work.
+    if (!session || !session.createdBy) {
+      return notFound();
+    }
+    if (
+      !(await lockPracticeForExternalSideEffects(systemTx, session.practiceId))
+    ) {
+      return notFound();
+    }
 
-  const tokenResult = await rateLimit({
-    key: captureRateLimitKey("capture-upload", token),
-    limit: TOKEN_LIMIT,
-    windowMs: TOKEN_WINDOW_MS,
-  });
-  if (!tokenResult.success) {
-    return NextResponse.json(
-      { error: "Too many requests" },
-      {
-        status: 429,
-        headers: rateLimitResponseHeaders(TOKEN_LIMIT, tokenResult),
-      }
-    );
-  }
-
-  if (uploadRequestContentLengthTooLarge(request.headers)) {
-    return NextResponse.json(
-      { error: "Upload exceeds maximum request size" },
-      { status: 413 }
-    );
-  }
-
-  const now = new Date();
-  const session = await withSystem(db, async (tx) => {
-    const [row] = await tx
-      .select({
-        id: captureSessions.id,
-        practiceId: captureSessions.practiceId,
-        patientId: captureSessions.patientId,
-        createdBy: captureSessions.createdBy,
-        appointmentId: captureSessions.appointmentId,
-        tier: practices.subscriptionTier,
-        billingStatus: practices.billingStatus,
-        trialEndsAt: practices.trialEndsAt,
-      })
-      .from(captureSessions)
-      .innerJoin(
-        practices,
-        and(
-          eq(practices.id, captureSessions.practiceId),
-          isNull(practices.deletedAt)
-        )
+    // Hosted read-only practices cannot take on new uploads (mirrors
+    // /api/upload); keep the response generic so it is not a billing oracle.
+    if (
+      billingEnforced() &&
+      !hasHostedFullAccess(
+        session.tier,
+        session.billingStatus,
+        session.trialEndsAt,
       )
-      .where(
-        and(
-          eq(captureSessions.token, token),
-          isNull(captureSessions.deletedAt),
-          gt(captureSessions.expiresAt, now)
-        )
-      )
-      .limit(1);
-    return row ?? null;
-  });
+    ) {
+      return notFound();
+    }
 
-  // Unknown, expired, and orphaned sessions all get the same generic miss.
-  if (!session || !session.createdBy) {
-    return notFound();
-  }
+    const ipResult = await rateLimit({
+      key: `capture-upload:ip:${clientIpFromRequest(request)}`,
+      limit: IP_LIMIT,
+      windowMs: IP_WINDOW_MS,
+    });
+    if (!ipResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests" },
+        { status: 429, headers: rateLimitResponseHeaders(IP_LIMIT, ipResult) },
+      );
+    }
 
-  // Hosted read-only practices cannot take on new uploads (mirrors
-  // /api/upload); keep the response generic so it is not a billing oracle.
-  if (
-    billingEnforced() &&
-    !hasHostedFullAccess(session.tier, session.billingStatus, session.trialEndsAt)
-  ) {
-    return notFound();
-  }
+    const tokenResult = await rateLimit({
+      key: captureRateLimitKey("capture-upload", token),
+      limit: TOKEN_LIMIT,
+      windowMs: TOKEN_WINDOW_MS,
+    });
+    if (!tokenResult.success) {
+      return NextResponse.json(
+        { error: "Too many requests" },
+        {
+          status: 429,
+          headers: rateLimitResponseHeaders(TOKEN_LIMIT, tokenResult),
+        },
+      );
+    }
 
-  // ---------- Parse multipart form data ----------
-  let formData: FormData;
-  try {
-    const body = await readRequestBytesWithLimit(
-      request,
-      UPLOAD_REQUEST_MAX_BYTES
-    );
-    if (!body.ok) {
+    if (uploadRequestContentLengthTooLarge(request.headers)) {
       return NextResponse.json(
         { error: "Upload exceeds maximum request size" },
-        { status: 413 }
+        { status: 413 },
       );
     }
 
-    const boundedBody = new ArrayBuffer(body.bytes.byteLength);
-    new Uint8Array(boundedBody).set(body.bytes);
-    const boundedRequest = new Request(request.url, {
-      method: request.method,
-      headers: request.headers,
-      body: boundedBody,
-    });
-    formData = await boundedRequest.formData();
-  } catch {
-    return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
-  }
-
-  const file = formData.get("file");
-  if (!file || !(file instanceof File)) {
-    return NextResponse.json({ error: "Missing file field" }, { status: 400 });
-  }
-  if (!file.name || file.name.length > MAX_FILE_NAME_LENGTH) {
-    return NextResponse.json(
-      { error: "File name must be between 1 and 255 characters" },
-      { status: 400 }
-    );
-  }
-
-  // ---------- Validate MIME type (images only for capture) ----------
-  const mimeType = file.type;
-  if (!mimeType.startsWith("image/") || !isAllowedUploadMimeType(mimeType)) {
-    return NextResponse.json(
-      { error: "Capture uploads must be JPG, PNG, or WebP images" },
-      { status: 400 }
-    );
-  }
-
-  // ---------- Validate size ----------
-  if (file.size > UPLOAD_FILE_MAX_BYTES) {
-    return NextResponse.json(
-      { error: "File exceeds maximum size of 10 MB" },
-      { status: 400 }
-    );
-  }
-
-  // ---------- Build S3 key ----------
-  const uuid = randomUUID();
-  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
-  const key = `${session.practiceId}/${CAPTURE_FILE_CATEGORY}/${uuid}-${safeName}`;
-  let uploadedKey: string | null = null;
-
-  // ---------- Upload ----------
-  try {
-    const buffer = Buffer.from(await file.arrayBuffer());
-    if (!uploadBytesMatchMimeType(mimeType, buffer)) {
+    const idempotencyKey = request.headers.get("idempotency-key")?.trim() ?? "";
+    if (!IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey)) {
       return NextResponse.json(
-        { error: "File contents do not match the declared file type" },
-        { status: 400 }
+        { error: "A canonical UUID Idempotency-Key header is required" },
+        { status: 400 },
       );
     }
 
-    await uploadFile(key, buffer, mimeType);
-    uploadedKey = key;
-
-    // Serve through the same-origin proxy (app/api/files/[...path]).
-    const url = `/api/files/${key}`;
-
-    const [inserted] = await withTenant(db, session.practiceId, (tx) =>
-      tx
-        .insert(files)
-        .values({
-          practiceId: session.practiceId,
-          uploadedBy: session.createdBy!,
-          fileName: file.name,
-          fileKey: key,
-          fileUrl: url,
-          mimeType,
-          fileSizeBytes: file.size,
-          category: CAPTURE_FILE_CATEGORY,
-          entityType: "patient",
-          entityId: session.patientId,
-          appointmentId: session.appointmentId,
-        })
-        .returning({ id: files.id })
-    );
-
-    return NextResponse.json(
-      { ok: true, fileId: inserted?.id ?? null },
-      { status: 201 }
-    );
-  } catch (err) {
-    console.error("Capture upload failed:", err);
-    if (uploadedKey) {
-      try {
-        await deleteFile(uploadedKey);
-      } catch (cleanupErr) {
-        console.error("Failed to clean up uploaded object:", cleanupErr);
+    // ---------- Parse multipart form data ----------
+    let formData: FormData;
+    try {
+      const body = await readRequestBytesWithLimit(
+        request,
+        UPLOAD_REQUEST_MAX_BYTES,
+      );
+      if (!body.ok) {
+        return NextResponse.json(
+          { error: "Upload exceeds maximum request size" },
+          { status: 413 },
+        );
       }
+
+      const boundedBody = new ArrayBuffer(body.bytes.byteLength);
+      new Uint8Array(boundedBody).set(body.bytes);
+      const boundedRequest = new Request(request.url, {
+        method: request.method,
+        headers: request.headers,
+        body: boundedBody,
+      });
+      formData = await boundedRequest.formData();
+    } catch {
+      return NextResponse.json({ error: "Invalid form data" }, { status: 400 });
     }
-    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
-  }
+
+    const file = formData.get("file");
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json(
+        { error: "Missing file field" },
+        { status: 400 },
+      );
+    }
+    if (!file.name || file.name.length > MAX_FILE_NAME_LENGTH) {
+      return NextResponse.json(
+        { error: "File name must be between 1 and 255 characters" },
+        { status: 400 },
+      );
+    }
+
+    // ---------- Validate MIME type (images only for capture) ----------
+    const mimeType = file.type;
+    if (!mimeType.startsWith("image/") || !isAllowedUploadMimeType(mimeType)) {
+      return NextResponse.json(
+        { error: "Capture uploads must be JPG, PNG, or WebP images" },
+        { status: 400 },
+      );
+    }
+
+    // ---------- Validate size ----------
+    if (file.size > UPLOAD_FILE_MAX_BYTES) {
+      return NextResponse.json(
+        { error: "File exceeds maximum size of 10 MB" },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const buffer = Buffer.from(await file.arrayBuffer());
+      if (!uploadBytesMatchMimeType(mimeType, buffer)) {
+        return NextResponse.json(
+          { error: "File contents do not match the declared file type" },
+          { status: 400 },
+        );
+      }
+
+      const checksumSha256 = checksumSha256Hex(buffer);
+      const source = `capture:${session.id}`;
+      const reservation = await withTenant(
+        db,
+        session.practiceId,
+        async (tx) => {
+          // Serialize uploads for one capture link. This makes the hard session
+          // cap safe even when several phones submit at the same time.
+          const [lockedSession] = await tx
+            .select({ id: captureSessions.id })
+            .from(captureSessions)
+            .where(
+              and(
+                eq(captureSessions.id, session.id),
+                eq(captureSessions.practiceId, session.practiceId),
+                eq(captureSessions.patientId, session.patientId),
+                eq(captureSessions.createdBy, session.createdBy!),
+                isNull(captureSessions.deletedAt),
+                gt(captureSessions.expiresAt, new Date()),
+              ),
+            )
+            .limit(1)
+            .for("update");
+          if (!lockedSession) return null;
+
+          const [activePatient] = await tx
+            .select({ id: patients.id })
+            .from(patients)
+            .where(
+              and(
+                eq(patients.id, session.patientId),
+                eq(patients.practiceId, session.practiceId),
+                eq(patients.status, "active"),
+                isNull(patients.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!activePatient) return null;
+
+          const [activeCreator] = await tx
+            .select({ id: users.id })
+            .from(users)
+            .where(
+              and(
+                eq(users.id, session.createdBy!),
+                eq(users.practiceId, session.practiceId),
+                isNull(users.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!activeCreator) return null;
+
+          if (session.appointmentId) {
+            const [linkedAppointment] = await tx
+              .select({ id: appointments.id })
+              .from(appointments)
+              .where(
+                and(
+                  eq(appointments.id, session.appointmentId),
+                  eq(appointments.practiceId, session.practiceId),
+                  eq(appointments.patientId, session.patientId),
+                  isNull(appointments.deletedAt),
+                ),
+              )
+              .limit(1);
+            if (!linkedAppointment) return null;
+          }
+
+          const [usage] = await tx
+            .select({
+              count: sql<number>`count(*)::int`,
+              replayCount: sql<number>`count(*) filter (where ${files.idempotencyKey} = ${idempotencyKey}::uuid)::int`,
+            })
+            .from(files)
+            .where(
+              and(
+                eq(files.practiceId, session.practiceId),
+                eq(files.source, source),
+                isNull(files.deletedAt),
+              ),
+            );
+          if (
+            (usage?.count ?? 0) >= CAPTURE_SESSION_FILE_LIMIT &&
+            (usage?.replayCount ?? 0) === 0
+          ) {
+            throw new CaptureSessionLimitError();
+          }
+
+          return reserveManagedUpload(tx, {
+            practiceId: session.practiceId,
+            uploadedBy: session.createdBy!,
+            idempotencyKey,
+            fileName: file.name,
+            mimeType,
+            fileSizeBytes: buffer.length,
+            checksumSha256,
+            category: CAPTURE_FILE_CATEGORY,
+            source,
+            entityType: "patient",
+            entityId: session.patientId,
+            patientId: session.patientId,
+            appointmentId: session.appointmentId,
+          });
+        },
+      );
+      if (!reservation) return notFound();
+
+      if (reservation.storageStatus === "available") {
+        return NextResponse.json(
+          { ok: true, fileId: reservation.id },
+          { status: 200 },
+        );
+      }
+
+      const writeResult = await putAndVerifyManagedUpload({
+        reservation,
+        body: buffer,
+      });
+      if (writeResult.status === "unavailable") {
+        return NextResponse.json(
+          { error: "Upload outcome is still being verified. Please retry." },
+          { status: 503, headers: { "Retry-After": "5" } },
+        );
+      }
+      if (writeResult.status === "corrupt") {
+        const marked = await withTenant(db, session.practiceId, (tx) =>
+          markManagedUploadCorrupt(tx, reservation),
+        );
+        if (!marked) {
+          throw new Error("Capture reservation changed before quarantine");
+        }
+        return NextResponse.json(
+          { error: "Uploaded object failed integrity verification" },
+          { status: 503, headers: { "Retry-After": "5" } },
+        );
+      }
+
+      await withTenant(db, session.practiceId, async (tx) => {
+        if (
+          !(await finalizeManagedUploadManifest(
+            tx,
+            reservation,
+            writeResult.evidence,
+          ))
+        ) {
+          throw new Error(
+            "Capture reservation disappeared before finalization",
+          );
+        }
+      });
+
+      await queueManagedUploadReplication(reservation, writeResult.evidence);
+
+      return NextResponse.json(
+        { ok: true, fileId: reservation.id },
+        { status: reservation.created ? 201 : 200 },
+      );
+    } catch (err) {
+      if (err instanceof ManagedUploadConflictError) {
+        return NextResponse.json({ error: err.message }, { status: 409 });
+      }
+      if (err instanceof CaptureSessionLimitError) {
+        return NextResponse.json(
+          { error: "This capture link has reached its 20-photo limit" },
+          { status: 409 },
+        );
+      }
+      console.error("[capture] managed upload failed");
+      return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+    }
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ token: string }> },
+) {
+  return privateNoStore(await handlePost(request, context));
 }

--- a/apps/web/app/api/cron/backup/route.test.ts
+++ b/apps/web/app/api/cron/backup/route.test.ts
@@ -1,27 +1,84 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+type PracticeExportFixture = {
+  formatVersion: number;
+  practiceId: string;
+  exportedAt: string;
+  counts: Record<string, number>;
+  clients: unknown[];
+  [key: string]: unknown;
+};
+
 const mocks = vi.hoisted(() => {
   const db = {};
 
   return {
     db,
     alertOps: vi.fn(async () => undefined),
-    backupKey: vi.fn((practiceId: string, dateYmd: string) =>
-      `backups/${practiceId}/${dateYmd}.json`
+    backupKey: vi.fn(
+      (practiceId: string, dateYmd: string) =>
+        `backups/${practiceId}/${dateYmd}.json`,
     ),
     cronAuthError: vi.fn((): Response | null => null),
     exportPracticeData: vi.fn(
-      async (_tx: unknown, practiceId: string, exportedAt: string) => ({
+      async (
+        _tx: unknown,
+        practiceId: string,
+        exportedAt: string,
+      ): Promise<PracticeExportFixture> => ({
+        formatVersion: 6,
         practiceId,
         exportedAt,
         counts: {},
         clients: [],
-      })
+      }),
     ),
     reportCronHeartbeat: vi.fn(async () => undefined),
-    uploadFile: vi.fn(async (key: string, _body: Buffer, _contentType: string) =>
-      `s3://openpims/${key}`
+    uploadManagedFile: vi.fn(
+      async (
+        _key: string,
+        _body: Buffer,
+        _contentType: string,
+        _checksumSha256: string,
+      ) => ({
+        url: "s3://openpims/object",
+        etag: "primary-etag",
+        versionId: "primary-version",
+      }),
     ),
+    uploadReplicaFile: vi.fn(
+      async (
+        _key: string,
+        _body: Buffer,
+        _contentType: string,
+        _checksumSha256: string,
+      ) => ({
+        url: "s3://replica/object",
+        etag: "replica-etag",
+        versionId: "replica-version",
+      }),
+    ),
+    readPrimaryObject: vi.fn(),
+    readReplicaObject: vi.fn(
+      async (
+        _key: string,
+        _options?: { maxBytes?: number },
+      ): Promise<
+        | { status: "failed" }
+        | {
+            status: "available";
+            body: Uint8Array;
+            versionId: string;
+          }
+      > => ({ status: "failed" }),
+    ),
+    replicaStorageReadiness: vi.fn(() => ({
+      intended: false,
+      ready: false,
+      detail: "Independent object replica is not configured",
+    })),
+    replicaStorageRolloutEnabled: vi.fn(() => false),
+    replicaStorageIncludesPractice: vi.fn(() => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
       fn({
         select: vi.fn(() => ({
@@ -32,11 +89,11 @@ const mocks = vi.hoisted(() => {
             ]),
           })),
         })),
-      })
+      }),
     ),
-    withTenant: vi.fn(
+    withTenantReadOnlySnapshot: vi.fn(
       async (_db: unknown, practiceId: string, fn: (tx: unknown) => unknown) =>
-        fn({ tenantPracticeId: practiceId })
+        fn({ tenantPracticeId: practiceId }),
     ),
   };
 });
@@ -63,12 +120,33 @@ vi.mock("@/lib/cron-heartbeat", () => ({
 }));
 
 vi.mock("@/lib/s3", () => ({
-  uploadFile: mocks.uploadFile,
+  normalizeS3VersionId: (value: unknown) => {
+    if (typeof value !== "string") return undefined;
+    const normalized = value.trim();
+    return normalized && normalized.toLowerCase() !== "null"
+      ? normalized
+      : undefined;
+  },
+  uploadManagedFile: mocks.uploadManagedFile,
+  uploadReplicaFile: mocks.uploadReplicaFile,
+  readPrimaryObject: mocks.readPrimaryObject,
+  readReplicaObject: mocks.readReplicaObject,
+  replicaStorageIncludesPractice: mocks.replicaStorageIncludesPractice,
+  replicaStorageReadiness: mocks.replicaStorageReadiness,
+  replicaStorageRolloutEnabled: mocks.replicaStorageRolloutEnabled,
+}));
+
+vi.mock("@/lib/file-replication", () => ({
+  checksumSha256Hex: vi.fn(() => "a".repeat(64)),
+}));
+
+vi.mock("@/lib/backup/policy", () => ({
+  PRACTICE_BACKUP_JSON_MAX_BYTES: 1_024,
 }));
 
 vi.mock("@/lib/tenant-db", () => ({
   withSystem: mocks.withSystem,
-  withTenant: mocks.withTenant,
+  withTenantReadOnlySnapshot: mocks.withTenantReadOnlySnapshot,
 }));
 
 const { GET } = await import("./route");
@@ -76,6 +154,21 @@ const { GET } = await import("./route");
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-06-28T14:05:06.789Z"));
+  mocks.replicaStorageReadiness.mockReturnValue({
+    intended: false,
+    ready: false,
+    detail: "Independent object replica is not configured",
+  });
+  mocks.replicaStorageRolloutEnabled.mockReturnValue(false);
+  mocks.replicaStorageIncludesPractice.mockReturnValue(true);
+  mocks.readPrimaryObject.mockImplementation(async () => ({
+    status: "available" as const,
+    body: new Uint8Array(
+      mocks.uploadManagedFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+    ),
+    versionId: "primary-version",
+  }));
+  mocks.readReplicaObject.mockResolvedValue({ status: "failed" });
 });
 
 afterEach(() => {
@@ -89,23 +182,23 @@ describe("backup cron", () => {
       new Response(JSON.stringify({ error: "Unauthorized" }), {
         status: 401,
         headers: { "content-type": "application/json" },
-      })
+      }),
     );
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/backup")
+      new Request("https://openvpm.test/api/cron/backup"),
     );
 
     expect(response.status).toBe(401);
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.withTenantReadOnlySnapshot).not.toHaveBeenCalled();
+    expect(mocks.uploadManagedFile).not.toHaveBeenCalled();
     expect(mocks.reportCronHeartbeat).not.toHaveBeenCalled();
   });
 
   it("exports each active practice in tenant context and uploads dated JSON", async () => {
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/backup")
+      new Request("https://openvpm.test/api/cron/backup"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -113,47 +206,64 @@ describe("backup cron", () => {
       practices: 2,
       ok: 2,
       failed: 0,
+      otherFailed: 0,
+      oversized: 0,
+      nearLimit: 0,
+      maxExportBytes: expect.any(Number),
+      replicaOk: 0,
+      replicaFailed: 0,
     });
 
     expect(mocks.withSystem).toHaveBeenCalledTimes(1);
-    expect(mocks.withTenant).toHaveBeenCalledTimes(2);
+    expect(mocks.withTenantReadOnlySnapshot).toHaveBeenCalledTimes(2);
     expect(mocks.exportPracticeData).toHaveBeenNthCalledWith(
       1,
       { tenantPracticeId: "practice-1" },
       "practice-1",
-      "2026-06-28T14:05:06.789Z"
+      "2026-06-28T14:05:06.789Z",
     );
     expect(mocks.exportPracticeData).toHaveBeenNthCalledWith(
       2,
       { tenantPracticeId: "practice-2" },
       "practice-2",
-      "2026-06-28T14:05:06.789Z"
+      "2026-06-28T14:05:06.789Z",
     );
     expect(mocks.backupKey).toHaveBeenNthCalledWith(
       1,
       "practice-1",
-      "2026-06-28"
+      "2026-06-28",
     );
-    expect(mocks.uploadFile).toHaveBeenNthCalledWith(
+    expect(mocks.uploadManagedFile).toHaveBeenNthCalledWith(
       1,
       "backups/practice-1/2026-06-28.json",
       expect.any(Buffer),
-      "application/json"
+      "application/json",
+      "a".repeat(64),
     );
-    const uploadedPayload = mocks.uploadFile.mock.calls[0]?.[1];
+    const uploadedPayload = mocks.uploadManagedFile.mock.calls[0]?.[1];
     expect(uploadedPayload).toBeInstanceOf(Buffer);
-    expect(JSON.parse((uploadedPayload as Buffer).toString("utf8"))).toMatchObject({
+    expect(
+      JSON.parse((uploadedPayload as Buffer).toString("utf8")),
+    ).toMatchObject({
       practiceId: "practice-1",
       exportedAt: "2026-06-28T14:05:06.789Z",
     });
     expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
       job: "backup",
       status: "ok",
-      detail: "2 practice backups succeeded, 0 failed",
+      detail:
+        "2 primary backups succeeded, 0 independent copies verified, 0 failed",
       metrics: {
         practices: 2,
         ok: 2,
         failed: 0,
+        otherFailed: 0,
+        oversized: 0,
+        nearLimit: 0,
+        maxExportBytes: expect.any(Number),
+        backupMaxBytes: 1_024,
+        replicaOk: 0,
+        replicaFailed: 0,
       },
     });
   });
@@ -171,11 +281,11 @@ describe("backup cron", () => {
               ]),
             })),
           })),
-        })
+        }),
     );
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/backup")
+      new Request("https://openvpm.test/api/cron/backup"),
     );
 
     await expect(response.json()).resolves.toMatchObject({
@@ -187,39 +297,344 @@ describe("backup cron", () => {
       1,
       { tenantPracticeId: "practice-la" },
       "practice-la",
-      "2026-06-28T02:30:00.000Z"
+      "2026-06-28T02:30:00.000Z",
     );
     expect(mocks.backupKey).toHaveBeenNthCalledWith(
       1,
       "practice-la",
-      "2026-06-27"
+      "2026-06-27",
     );
     expect(mocks.backupKey).toHaveBeenNthCalledWith(
       2,
       "practice-tokyo",
-      "2026-06-28"
+      "2026-06-28",
     );
-    expect(mocks.uploadFile).toHaveBeenNthCalledWith(
+    expect(mocks.uploadManagedFile).toHaveBeenNthCalledWith(
       1,
       "backups/practice-la/2026-06-27.json",
       expect.any(Buffer),
-      "application/json"
+      "application/json",
+      "a".repeat(64),
     );
-    expect(mocks.uploadFile).toHaveBeenNthCalledWith(
+    expect(mocks.uploadManagedFile).toHaveBeenNthCalledWith(
       2,
       "backups/practice-tokyo/2026-06-28.json",
       expect.any(Buffer),
-      "application/json"
+      "application/json",
+      "a".repeat(64),
+    );
+  });
+
+  it("copies each database backup to the independent target and verifies its bytes", async () => {
+    mocks.replicaStorageRolloutEnabled.mockReturnValue(true);
+    mocks.replicaStorageReadiness.mockReturnValue({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.readReplicaObject.mockImplementation(async () => ({
+      status: "available" as const,
+      body: new Uint8Array(
+        mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+      ),
+      versionId: "replica-version",
+    }));
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 2,
+      failed: 0,
+      replicaOk: 2,
+      replicaFailed: 0,
+    });
+    expect(mocks.uploadReplicaFile).toHaveBeenNthCalledWith(
+      1,
+      `database-backups/v2/practice-1/2026-06-28/${"a".repeat(64)}.json`,
+      expect.any(Buffer),
+      "application/json",
+      "a".repeat(64),
+    );
+    expect(mocks.readReplicaObject).toHaveBeenNthCalledWith(
+      1,
+      `database-backups/v2/practice-1/2026-06-28/${"a".repeat(64)}.json`,
+      { maxBytes: expect.any(Number), versionId: "replica-version" },
+    );
+    expect(mocks.uploadReplicaFile).toHaveBeenNthCalledWith(
+      2,
+      `database-backup-catalog/v2/practice-1/2026-06-28/${"a".repeat(64)}.json`,
+      expect.any(Buffer),
+      "application/json",
+      "a".repeat(64),
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        job: "backup",
+        status: "ok",
+        metrics: expect.objectContaining({ replicaOk: 2, replicaFailed: 0 }),
+      }),
+    );
+  });
+
+  it("converges an ambiguous checksum-addressed replica backup PUT by read-back", async () => {
+    mocks.replicaStorageRolloutEnabled.mockReturnValue(true);
+    mocks.replicaStorageReadiness.mockReturnValue({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.uploadReplicaFile.mockRejectedValueOnce(
+      new Error("replica PUT timed out"),
+    );
+    mocks.readReplicaObject.mockImplementation(async () => ({
+      status: "available" as const,
+      body: new Uint8Array(
+        mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+      ),
+      versionId: "replica-version",
+    }));
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 2,
+      replicaOk: 2,
+      replicaFailed: 0,
+    });
+    expect(mocks.readReplicaObject).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/^database-backups\/v2\//),
+      { maxBytes: expect.any(Number) },
+    );
+  });
+
+  it("converges an ambiguous checksum-addressed replica catalog PUT by read-back", async () => {
+    mocks.replicaStorageRolloutEnabled.mockReturnValue(true);
+    mocks.replicaStorageReadiness.mockReturnValue({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.uploadReplicaFile
+      .mockResolvedValueOnce({
+        url: "s3://replica/object",
+        etag: "replica-etag",
+        versionId: "replica-version",
+      })
+      .mockRejectedValueOnce(new Error("catalog PUT timed out"));
+    mocks.readReplicaObject.mockImplementation(async () => ({
+      status: "available" as const,
+      body: new Uint8Array(
+        mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+      ),
+      versionId: "replica-version",
+    }));
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 2,
+      replicaOk: 2,
+      replicaFailed: 0,
+    });
+    expect(mocks.readReplicaObject).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^database-backup-catalog\/v2\//),
+      { maxBytes: expect.any(Number) },
+    );
+  });
+
+  it("rejects provider-null replica version IDs as exact recovery evidence", async () => {
+    mocks.replicaStorageRolloutEnabled.mockReturnValue(true);
+    mocks.replicaStorageReadiness.mockReturnValue({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.uploadReplicaFile.mockResolvedValue({
+      url: "s3://replica/object",
+      etag: "replica-etag",
+      versionId: "null",
+    });
+    mocks.readReplicaObject.mockImplementation(async () => ({
+      status: "available" as const,
+      body: new Uint8Array(
+        mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+      ),
+      versionId: "null",
+    }));
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 2,
+      replicaOk: 0,
+      replicaFailed: 2,
+    });
+  });
+
+  it("fails before upload when an export cannot be restored within the supported size cap", async () => {
+    mocks.exportPracticeData.mockResolvedValueOnce({
+      formatVersion: 6,
+      practiceId: "practice-1",
+      exportedAt: "2026-06-28T14:05:06.789Z",
+      counts: {},
+      clients: [],
+      oversized: "x".repeat(1_100),
+    });
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 1,
+      failed: 1,
+      otherFailed: 0,
+      oversized: 1,
+    });
+    expect(mocks.uploadManagedFile).toHaveBeenCalledTimes(1);
+    expect(mocks.uploadManagedFile).toHaveBeenCalledWith(
+      "backups/practice-2/2026-06-28.json",
+      expect.any(Buffer),
+      "application/json",
+      "a".repeat(64),
+    );
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Practice backup failed",
+      expect.stringContaining("restore safety limit"),
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metrics: expect.objectContaining({
+          failed: 1,
+          otherFailed: 0,
+          oversized: 1,
+          nearLimit: 0,
+          maxExportBytes: expect.any(Number),
+          backupMaxBytes: 1_024,
+        }),
+      }),
+    );
+  });
+
+  it("reports exports approaching the restore cap separately from failures", async () => {
+    mocks.exportPracticeData.mockResolvedValueOnce({
+      formatVersion: 6,
+      practiceId: "practice-1",
+      exportedAt: "2026-06-28T14:05:06.789Z",
+      counts: {},
+      clients: [],
+      capacityProbe: "x".repeat(700),
+    });
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 2,
+      failed: 0,
+      otherFailed: 0,
+      oversized: 0,
+      nearLimit: 1,
+    });
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metrics: expect.objectContaining({
+          failed: 0,
+          otherFailed: 0,
+          oversized: 0,
+          nearLimit: 1,
+          maxExportBytes: expect.any(Number),
+          backupMaxBytes: 1_024,
+        }),
+      }),
+    );
+  });
+
+  it("accepts an ambiguous primary PUT only when read-back proves the exact bytes", async () => {
+    mocks.uploadManagedFile.mockRejectedValueOnce(
+      new Error("request timed out"),
+    );
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 2,
+      failed: 0,
+      otherFailed: 0,
+      oversized: 0,
+    });
+    expect(mocks.readPrimaryObject).toHaveBeenNthCalledWith(
+      1,
+      "backups/practice-1/2026-06-28.json",
+      { maxBytes: expect.any(Number) },
+    );
+    expect(mocks.alertOps).not.toHaveBeenCalledWith(
+      "Practice backup failed",
+      expect.any(String),
+    );
+  });
+
+  it("degrades without failing the primary backup when replica verification fails", async () => {
+    mocks.replicaStorageRolloutEnabled.mockReturnValue(true);
+    mocks.replicaStorageReadiness.mockReturnValue({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.readReplicaObject.mockResolvedValue({ status: "failed" });
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/backup"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      ok: 2,
+      failed: 0,
+      replicaOk: 0,
+      replicaFailed: 2,
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Independent practice backup failed",
+      "practice practice-1: replica write or verification failed",
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({ job: "backup", status: "degraded" }),
     );
   });
 
   it("reports degraded heartbeat and ops alerts when one practice backup fails", async () => {
-    mocks.uploadFile
-      .mockResolvedValueOnce("s3://openpims/backups/practice-1/2026-06-28.json")
+    mocks.uploadManagedFile
+      .mockResolvedValueOnce({
+        url: "s3://openpims/backups/practice-1/2026-06-28.json",
+        etag: "primary-etag",
+        versionId: "primary-version",
+      })
       .mockRejectedValueOnce(new Error("object storage unavailable"));
+    mocks.readPrimaryObject
+      .mockImplementationOnce(async () => ({
+        status: "available" as const,
+        body: new Uint8Array(
+          mocks.uploadManagedFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+        ),
+        versionId: "primary-version",
+      }))
+      .mockResolvedValueOnce({ status: "failed" });
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/backup")
+      new Request("https://openvpm.test/api/cron/backup"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -227,24 +642,38 @@ describe("backup cron", () => {
       practices: 2,
       ok: 1,
       failed: 1,
+      otherFailed: 1,
+      oversized: 0,
+      nearLimit: 0,
+      maxExportBytes: expect.any(Number),
+      replicaOk: 0,
+      replicaFailed: 0,
     });
 
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Practice backup failed",
-      "practice practice-2: object storage unavailable"
+      "practice practice-2: object storage unavailable",
     );
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Scheduled backup had failures",
-      "1 of 2 practice backups failed for UTC run 2026-06-28."
+      "1 primary and 0 independent backup copies failed for UTC run 2026-06-28.",
     );
     expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
       job: "backup",
       status: "degraded",
-      detail: "1 practice backups succeeded, 1 failed",
+      detail:
+        "1 primary backups succeeded, 0 independent copies verified, 1 failed",
       metrics: {
         practices: 2,
         ok: 1,
         failed: 1,
+        otherFailed: 1,
+        oversized: 0,
+        nearLimit: 0,
+        maxExportBytes: expect.any(Number),
+        backupMaxBytes: 1_024,
+        replicaOk: 0,
+        replicaFailed: 0,
       },
     });
   });
@@ -257,7 +686,7 @@ describe("backup cron", () => {
 
     try {
       const response = await GET(
-        new Request("https://openvpm.test/api/cron/backup")
+        new Request("https://openvpm.test/api/cron/backup"),
       );
 
       expect(response.status).toBe(500);
@@ -266,7 +695,7 @@ describe("backup cron", () => {
       });
       expect(mocks.alertOps).toHaveBeenCalledWith(
         "Backup cron job crashed",
-        "database unavailable"
+        "database unavailable",
       );
       expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
         job: "backup",

--- a/apps/web/app/api/cron/backup/route.ts
+++ b/apps/web/app/api/cron/backup/route.ts
@@ -3,15 +3,78 @@ import { isNull } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import { practices } from "@openpims/db";
 import { exportPracticeData, backupKey } from "@/lib/backup/export";
-import { uploadFile } from "@/lib/s3";
+import {
+  readPrimaryObject,
+  readReplicaObject,
+  normalizeS3VersionId,
+  replicaStorageIncludesPractice,
+  replicaStorageReadiness,
+  replicaStorageRolloutEnabled,
+  uploadManagedFile,
+  uploadReplicaFile,
+} from "@/lib/s3";
 import { alertOps } from "@/lib/alerts";
-import { withSystem, withTenant } from "@/lib/tenant-db";
+import { withSystem, withTenantReadOnlySnapshot } from "@/lib/tenant-db";
 import { cronAuthError } from "@/lib/cron-auth";
 import { reportCronHeartbeat } from "@/lib/cron-heartbeat";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
+import { checksumSha256Hex } from "@/lib/file-replication";
+import { PRACTICE_BACKUP_JSON_MAX_BYTES } from "@/lib/backup/policy";
+import {
+  databaseBackupReplicaCatalog,
+  databaseBackupReplicaKey,
+} from "@/lib/backup/replica";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
+
+async function writeAndVerifyReplicaObject(input: {
+  key: string;
+  body: Buffer;
+  checksumSha256: string;
+}): Promise<{ etag?: string; versionId: string }> {
+  let write: Awaited<ReturnType<typeof uploadReplicaFile>> | undefined;
+  let writeError: unknown;
+  try {
+    write = await uploadReplicaFile(
+      input.key,
+      input.body,
+      "application/json",
+      input.checksumSha256,
+    );
+  } catch (error) {
+    // The deterministic checksum-addressed key makes an ambiguous PUT safe to
+    // converge through a bounded read-back of the exact expected bytes.
+    writeError = error;
+  }
+
+  const requestedVersionId = normalizeS3VersionId(write?.versionId);
+  const verification = await readReplicaObject(input.key, {
+    maxBytes: input.body.byteLength,
+    ...(requestedVersionId ? { versionId: requestedVersionId } : {}),
+  });
+  const verifiedVersionId =
+    verification.status === "available"
+      ? normalizeS3VersionId(verification.versionId)
+      : undefined;
+  if (
+    verification.status !== "available" ||
+    !verifiedVersionId ||
+    (requestedVersionId && verifiedVersionId !== requestedVersionId) ||
+    verification.body.byteLength !== input.body.byteLength ||
+    checksumSha256Hex(verification.body) !== input.checksumSha256
+  ) {
+    if (writeError) throw writeError;
+    throw new Error("Replica object verification failed");
+  }
+
+  return {
+    ...((verification.etag ?? write?.etag)
+      ? { etag: verification.etag ?? write?.etag }
+      : {}),
+    versionId: verifiedVersionId,
+  };
+}
 
 // Scheduled per-practice backup → object storage. A clinic gets a daily,
 // restorable JSON snapshot of its data, independent of the live DB.
@@ -24,6 +87,11 @@ export async function GET(request: Request) {
   const runDateUtc = exportedAt.slice(0, 10);
   let ok = 0;
   let failed = 0;
+  let oversized = 0;
+  let nearLimit = 0;
+  let maxExportBytes = 0;
+  let replicaOk = 0;
+  let replicaFailed = 0;
 
   try {
     // Cross-tenant sweep → system context (RLS bypass).
@@ -31,21 +99,109 @@ export async function GET(request: Request) {
       tx
         .select({ id: practices.id, timezone: practices.timezone })
         .from(practices)
-        .where(isNull(practices.deletedAt))
+        .where(isNull(practices.deletedAt)),
     );
 
     for (const p of allPractices) {
       try {
         // Export each practice in its own tenant context (RLS-scoped).
-        const data = await withTenant(db, p.id, (tx) =>
-          exportPracticeData(tx, p.id, exportedAt)
+        const data = await withTenantReadOnlySnapshot(db, p.id, (tx) =>
+          exportPracticeData(tx, p.id, exportedAt),
         );
         const backupDate = formatDateInputForTimeZone(
           startedAt,
-          p.timezone?.trim() || "UTC"
+          p.timezone?.trim() || "UTC",
         );
         const key = backupKey(p.id, backupDate);
-        await uploadFile(key, Buffer.from(JSON.stringify(data)), "application/json");
+        const body = Buffer.from(JSON.stringify(data));
+        maxExportBytes = Math.max(maxExportBytes, body.byteLength);
+        if (body.byteLength > PRACTICE_BACKUP_JSON_MAX_BYTES) {
+          oversized++;
+          throw new Error(
+            `backup exceeds the ${PRACTICE_BACKUP_JSON_MAX_BYTES}-byte restore safety limit`,
+          );
+        }
+        if (body.byteLength >= PRACTICE_BACKUP_JSON_MAX_BYTES * 0.8) {
+          nearLimit++;
+        }
+        const checksumSha256 = checksumSha256Hex(body);
+        let primaryWrite:
+          | Awaited<ReturnType<typeof uploadManagedFile>>
+          | undefined;
+        let primaryWriteError: unknown;
+        try {
+          primaryWrite = await uploadManagedFile(
+            key,
+            body,
+            "application/json",
+            checksumSha256,
+          );
+        } catch (error) {
+          // A timed-out PUT may still have committed. Read the deterministic
+          // daily key before declaring failure so retries converge safely.
+          primaryWriteError = error;
+        }
+        const primaryVersionId = normalizeS3VersionId(primaryWrite?.versionId);
+        const primaryVerification = await readPrimaryObject(key, {
+          maxBytes: body.length,
+          ...(primaryVersionId ? { versionId: primaryVersionId } : {}),
+        });
+        if (
+          primaryVerification.status !== "available" ||
+          primaryVerification.body.byteLength !== body.length ||
+          checksumSha256Hex(primaryVerification.body) !== checksumSha256
+        ) {
+          if (primaryWriteError) throw primaryWriteError;
+          throw new Error("Primary backup verification failed");
+        }
+
+        const replicaReadiness = replicaStorageReadiness();
+        const replicaEnabled = replicaStorageRolloutEnabled();
+        if (
+          replicaEnabled &&
+          replicaReadiness.ready &&
+          replicaStorageIncludesPractice(p.id)
+        ) {
+          const replicaKey = databaseBackupReplicaKey({
+            practiceId: p.id,
+            backupDate,
+            checksumSha256,
+          });
+          try {
+            const replicaEvidence = await writeAndVerifyReplicaObject({
+              key: replicaKey,
+              body,
+              checksumSha256,
+            });
+
+            const catalog = databaseBackupReplicaCatalog({
+              practiceId: p.id,
+              backupDate,
+              exportedAt,
+              objectKey: replicaKey,
+              checksumSha256,
+              fileSizeBytes: body.byteLength,
+              exportFormatVersion: data.formatVersion,
+              counts: data.counts,
+              objectEtag: replicaEvidence.etag,
+              objectVersionId: replicaEvidence.versionId,
+            });
+            await writeAndVerifyReplicaObject({
+              key: catalog.key,
+              body: catalog.body,
+              checksumSha256: catalog.checksumSha256,
+            });
+            replicaOk++;
+          } catch {
+            replicaFailed++;
+            void alertOps(
+              "Independent practice backup failed",
+              `practice ${p.id}: replica write or verification failed`,
+            );
+          }
+        } else if (replicaEnabled && !replicaReadiness.ready) {
+          replicaFailed++;
+        }
         ok++;
       } catch (err) {
         failed++;
@@ -56,37 +212,55 @@ export async function GET(request: Request) {
       }
     }
 
-    if (failed > 0) {
+    if (failed > 0 || replicaFailed > 0) {
       void alertOps(
         "Scheduled backup had failures",
-        `${failed} of ${allPractices.length} practice backups failed for UTC run ${runDateUtc}.`,
+        `${failed} primary and ${replicaFailed} independent backup copies failed for UTC run ${runDateUtc}.`,
       );
     }
 
     await reportCronHeartbeat({
       job: "backup",
-      status: failed > 0 ? "degraded" : "ok",
-      detail: `${ok} practice backups succeeded, ${failed} failed`,
+      status: failed > 0 || replicaFailed > 0 ? "degraded" : "ok",
+      detail: `${ok} primary backups succeeded, ${replicaOk} independent copies verified, ${failed + replicaFailed} failed`,
       metrics: {
         practices: allPractices.length,
         ok,
         failed,
+        otherFailed: failed - oversized,
+        oversized,
+        nearLimit,
+        maxExportBytes,
+        backupMaxBytes: PRACTICE_BACKUP_JSON_MAX_BYTES,
+        replicaOk,
+        replicaFailed,
       },
     });
 
-    return NextResponse.json({ date: runDateUtc, practices: allPractices.length, ok, failed });
+    return NextResponse.json({
+      date: runDateUtc,
+      practices: allPractices.length,
+      ok,
+      failed,
+      otherFailed: failed - oversized,
+      oversized,
+      nearLimit,
+      maxExportBytes,
+      replicaOk,
+      replicaFailed,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    void alertOps(
-      "Backup cron job crashed",
-      message,
-    );
+    void alertOps("Backup cron job crashed", message);
     console.error("Cron backup job failed:", error);
     await reportCronHeartbeat({
       job: "backup",
       status: "failed",
       detail: message,
     });
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }

--- a/apps/web/app/api/cron/billing-lifecycle/route.ts
+++ b/apps/web/app/api/cron/billing-lifecycle/route.ts
@@ -73,6 +73,7 @@ export async function GET(request: Request) {
             isNotNull(practices.trialEndsAt),
             gte(practices.trialEndsAt, now),
             lte(practices.trialEndsAt, latestTrialEnd),
+            eq(practices.recoveryHold, false),
             isNull(practices.deletedAt),
           ),
         ),

--- a/apps/web/app/api/cron/file-replicas/route.test.ts
+++ b/apps/web/app/api/cron/file-replicas/route.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  alertOps: vi.fn(async () => undefined),
+  cronAuthError: vi.fn((): Response | null => null),
+  reportCronHeartbeat: vi.fn(async () => undefined),
+  reconcileFileReplicas: vi.fn(async () => ({
+    intended: true,
+    required: true,
+    configured: true,
+    enabled: true,
+    candidates: 1,
+    claimed: 1,
+    deferred: 0,
+    copied: 1,
+    alreadyPresent: 0,
+    repairedPrimary: 0,
+    sourceMissing: 0,
+    sourceCorrupt: 0,
+    failed: 0,
+    bytesCopied: 3,
+    backlog: 0,
+    available: 1,
+    activeFiles: 1,
+    coveragePct: 100,
+  })),
+}));
+
+vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
+vi.mock("@/lib/cron-auth", () => ({ cronAuthError: mocks.cronAuthError }));
+vi.mock("@/lib/cron-heartbeat", () => ({
+  reportCronHeartbeat: mocks.reportCronHeartbeat,
+}));
+vi.mock("@/lib/file-replication", () => ({
+  reconcileFileReplicas: mocks.reconcileFileReplicas,
+}));
+
+const { GET } = await import("./route");
+
+const request = () =>
+  new Request("https://openvpm.test/api/cron/file-replicas");
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mocks.cronAuthError.mockReturnValue(null);
+  mocks.reconcileFileReplicas.mockResolvedValue({
+    intended: true,
+    required: true,
+    configured: true,
+    enabled: true,
+    candidates: 1,
+    claimed: 1,
+    deferred: 0,
+    copied: 1,
+    alreadyPresent: 0,
+    repairedPrimary: 0,
+    sourceMissing: 0,
+    sourceCorrupt: 0,
+    failed: 0,
+    bytesCopied: 3,
+    backlog: 0,
+    available: 1,
+    activeFiles: 1,
+    coveragePct: 100,
+  });
+});
+
+describe("file replica reconciliation cron", () => {
+  it("requires cron authorization before starting reconciliation", async () => {
+    mocks.cronAuthError.mockReturnValueOnce(
+      Response.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(401);
+    expect(mocks.reconcileFileReplicas).not.toHaveBeenCalled();
+    expect(mocks.reportCronHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("reports verified independent coverage", async () => {
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      status: "ok",
+      detail: "1/1 active files independently available (100%)",
+    });
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
+      job: "file-replicas",
+      status: "ok",
+      detail: "1/1 active files independently available (100%)",
+      metrics: expect.objectContaining({ copied: 1, coveragePct: 100 }),
+    });
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("keeps an intentionally disabled rollout non-degraded", async () => {
+    mocks.reconcileFileReplicas.mockResolvedValueOnce({
+      intended: false,
+      required: false,
+      configured: false,
+      enabled: false,
+      candidates: 0,
+      claimed: 0,
+      deferred: 0,
+      copied: 0,
+      alreadyPresent: 0,
+      repairedPrimary: 0,
+      sourceMissing: 0,
+      sourceCorrupt: 0,
+      failed: 0,
+      bytesCopied: 0,
+      backlog: 0,
+      available: 0,
+      activeFiles: 0,
+      coveragePct: 0,
+    });
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      status: "ok",
+      detail: "Independent file replica rollout is not enabled",
+    });
+  });
+
+  it("keeps a fully configured target staged until execution is explicitly enabled", async () => {
+    mocks.reconcileFileReplicas.mockResolvedValueOnce({
+      intended: true,
+      required: false,
+      configured: true,
+      enabled: false,
+      candidates: 0,
+      claimed: 0,
+      deferred: 0,
+      copied: 0,
+      alreadyPresent: 0,
+      repairedPrimary: 0,
+      sourceMissing: 0,
+      sourceCorrupt: 0,
+      failed: 0,
+      bytesCopied: 0,
+      backlog: 0,
+      available: 0,
+      activeFiles: 0,
+      coveragePct: 0,
+    });
+
+    const response = await GET(request());
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ok",
+      detail:
+        "Independent file replica target is staged but execution is disabled",
+    });
+  });
+
+  it("degrades when replica protection is required but execution is disabled", async () => {
+    mocks.reconcileFileReplicas.mockResolvedValueOnce({
+      intended: true,
+      required: true,
+      configured: true,
+      enabled: false,
+      candidates: 0,
+      claimed: 0,
+      deferred: 0,
+      copied: 0,
+      alreadyPresent: 0,
+      repairedPrimary: 0,
+      sourceMissing: 0,
+      sourceCorrupt: 0,
+      failed: 0,
+      bytesCopied: 0,
+      backlog: 0,
+      available: 0,
+      activeFiles: 0,
+      coveragePct: 0,
+    });
+
+    const response = await GET(request());
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      detail: "Independent file replica is required but execution is disabled",
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "File replica reconciliation degraded",
+      "Independent file replica is required but execution is disabled.",
+    );
+  });
+
+  it("degrades incomplete coverage after replica protection becomes required", async () => {
+    mocks.reconcileFileReplicas.mockResolvedValueOnce({
+      intended: true,
+      required: true,
+      configured: true,
+      enabled: true,
+      candidates: 0,
+      claimed: 0,
+      deferred: 0,
+      copied: 0,
+      alreadyPresent: 0,
+      repairedPrimary: 0,
+      sourceMissing: 0,
+      sourceCorrupt: 0,
+      failed: 0,
+      bytesCopied: 0,
+      backlog: 1,
+      available: 2,
+      activeFiles: 3,
+      coveragePct: 66.67,
+    });
+
+    const response = await GET(request());
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      metrics: { backlog: 1, coveragePct: 66.67 },
+    });
+  });
+
+  it("reports an incomplete intended rollout as degraded", async () => {
+    mocks.reconcileFileReplicas.mockResolvedValueOnce({
+      intended: true,
+      required: true,
+      configured: false,
+      enabled: true,
+      candidates: 0,
+      claimed: 0,
+      deferred: 0,
+      copied: 0,
+      alreadyPresent: 0,
+      repairedPrimary: 0,
+      sourceMissing: 0,
+      sourceCorrupt: 0,
+      failed: 0,
+      bytesCopied: 0,
+      backlog: 0,
+      available: 0,
+      activeFiles: 0,
+      coveragePct: 0,
+    });
+
+    const response = await GET(request());
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      detail: "Independent file replica configuration is incomplete",
+    });
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({ job: "file-replicas", status: "degraded" }),
+    );
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("alerts and reports degraded state for failed or unrecoverable files", async () => {
+    mocks.reconcileFileReplicas.mockResolvedValueOnce({
+      intended: true,
+      required: true,
+      configured: true,
+      enabled: true,
+      candidates: 0,
+      claimed: 3,
+      deferred: 0,
+      copied: 0,
+      alreadyPresent: 0,
+      repairedPrimary: 0,
+      sourceMissing: 1,
+      sourceCorrupt: 1,
+      failed: 1,
+      bytesCopied: 0,
+      backlog: 3,
+      available: 7,
+      activeFiles: 10,
+      coveragePct: 70,
+    });
+
+    const response = await GET(request());
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      metrics: { failed: 1, sourceMissing: 1, sourceCorrupt: 1 },
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "File replica reconciliation degraded",
+      "1 failed, 1 primary missing, 1 integrity mismatch, 3 in backlog, 70% independently available.",
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith(
+      expect.objectContaining({ job: "file-replicas", status: "degraded" }),
+    );
+  });
+
+  it("returns 500 and reports a failed heartbeat when the worker crashes", async () => {
+    mocks.reconcileFileReplicas.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Internal server error",
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "File replica reconciliation crashed",
+      "database unavailable",
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
+      job: "file-replicas",
+      status: "failed",
+      detail: "File replica reconciliation crashed",
+    });
+  });
+});

--- a/apps/web/app/api/cron/file-replicas/route.ts
+++ b/apps/web/app/api/cron/file-replicas/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { alertOps } from "@/lib/alerts";
+import { cronAuthError } from "@/lib/cron-auth";
+import { reportCronHeartbeat } from "@/lib/cron-heartbeat";
+import { reconcileFileReplicas } from "@/lib/file-replication";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function GET(request: Request) {
+  const authError = cronAuthError(request);
+  if (authError) return authError;
+
+  try {
+    const metrics = await reconcileFileReplicas();
+    const status = !metrics.configured
+      ? metrics.intended
+        ? "degraded"
+        : "ok"
+      : !metrics.enabled
+        ? metrics.required
+          ? "degraded"
+          : "ok"
+        : metrics.failed > 0 ||
+            metrics.sourceMissing > 0 ||
+            metrics.sourceCorrupt > 0 ||
+            (metrics.required &&
+              (metrics.backlog > 0 || metrics.coveragePct < 100))
+          ? "degraded"
+          : "ok";
+    const detail = !metrics.configured
+      ? metrics.intended
+        ? "Independent file replica configuration is incomplete"
+        : "Independent file replica rollout is not enabled"
+      : !metrics.enabled
+        ? metrics.required
+          ? "Independent file replica is required but execution is disabled"
+          : "Independent file replica target is staged but execution is disabled"
+        : `${metrics.available}/${metrics.activeFiles} active files independently available (${metrics.coveragePct}%)`;
+
+    await reportCronHeartbeat({
+      job: "file-replicas",
+      status,
+      detail,
+      metrics: { ...metrics },
+    });
+
+    if (status === "degraded" && metrics.configured) {
+      const alertDetail =
+        metrics.required && !metrics.enabled
+          ? "Independent file replica is required but execution is disabled."
+          : `${metrics.failed} failed, ${metrics.sourceMissing} primary missing, ${metrics.sourceCorrupt} integrity mismatch, ${metrics.backlog} in backlog, ${metrics.coveragePct}% independently available.`;
+      void alertOps(
+        "File replica reconciliation degraded",
+        alertDetail,
+      );
+    }
+
+    return NextResponse.json({ ok: true, status, detail, metrics });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await alertOps("File replica reconciliation crashed", message);
+    await reportCronHeartbeat({
+      job: "file-replicas",
+      status: "failed",
+      detail: "File replica reconciliation crashed",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/cron/reminders/route.test.ts
+++ b/apps/web/app/api/cron/reminders/route.test.ts
@@ -86,6 +86,7 @@ const mocks = vi.hoisted(() => {
     deleteReturning,
     sendAppointmentReminder: vi.fn(),
     sendAppointmentReminderSms: vi.fn(),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
     alertOps: vi.fn(async () => undefined),
     cronAuthError: vi.fn(() => null),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -117,6 +118,11 @@ vi.mock("@/lib/sms", () => ({
 
 vi.mock("@/lib/alerts", () => ({
   alertOps: mocks.alertOps,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 vi.mock("@/lib/cron-auth", () => ({
@@ -745,6 +751,35 @@ describe("appointment reminder cron", () => {
       expect.objectContaining({
         channel: "email",
         status: "failed",
+      }),
+    );
+  });
+
+  it("does not call the email provider if recovery begins after the sweep", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+    mocks.selectResults.push([
+      appointment({
+        preferredContactMethod: "email",
+      }),
+    ]);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/reminders"),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      sent: 0,
+      failed: 1,
+      skipped: 0,
+      deduped: 0,
+      suppressed: 0,
+    });
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "email",
+        status: "failed",
+        content: expect.stringContaining("recovery is in progress"),
       }),
     );
   });

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -33,6 +33,7 @@ import {
   currentAppointmentReminderEmailRecipient,
   claimAppointmentReminderCommunication,
 } from "@/lib/messaging/appointment-reminder";
+import { lockPracticeForExternalSideEffects } from "@/lib/recovery-hold";
 
 type ReminderChannel = "sms" | "email";
 
@@ -263,6 +264,7 @@ export async function GET(request: Request) {
             eq(clients.practiceId, appointments.practiceId),
             isNull(clients.deletedAt),
             eq(practices.appointmentRemindersEnabled, true),
+            eq(practices.recoveryHold, false),
             gte(appointments.startTime, now),
             lte(
               appointments.startTime,
@@ -391,21 +393,55 @@ export async function GET(request: Request) {
           });
           return false;
         }
-        let success = false;
-        let providerMessageId: string | undefined;
-        try {
-          const result = await sendAppointmentReminder({
-            to: clientEmail,
-            clientName: `${currentRecipient.clientFirstName} ${currentRecipient.clientLastName}`,
-            patientName: currentRecipient.patientName ?? "Unknown",
-            appointmentDate,
-            appointmentTime,
-            practiceName: currentRecipient.practiceName,
+        const providerResult = await withTenant(
+          db,
+          appt.practiceId,
+          async (tx) => {
+            // Hold this shared practice-row lock through the provider request.
+            // Restore's hold update therefore drains an already-started email,
+            // while a committed hold prevents any later provider request.
+            if (
+              !(await lockPracticeForExternalSideEffects(
+                tx,
+                appt.practiceId,
+              ))
+            ) {
+              return { held: true as const, success: false as const };
+            }
+            try {
+              const result = await sendAppointmentReminder({
+                to: clientEmail,
+                clientName: `${currentRecipient.clientFirstName} ${currentRecipient.clientLastName}`,
+                patientName: currentRecipient.patientName ?? "Unknown",
+                appointmentDate,
+                appointmentTime,
+                practiceName: currentRecipient.practiceName,
+              });
+              return {
+                held: false as const,
+                success: result.success,
+                providerMessageId: result.id,
+              };
+            } catch {
+              return { held: false as const, success: false as const };
+            }
+          },
+        );
+        const success = providerResult.success;
+        const providerMessageId =
+          "providerMessageId" in providerResult
+            ? providerResult.providerMessageId
+            : undefined;
+        if (providerResult.held) {
+          await recordReminderOutcome({
+            practiceId: appt.practiceId,
+            communicationId,
+            channel: "email",
+            content:
+              "Automated appointment reminder paused because practice recovery is in progress",
+            status: "failed",
           });
-          success = result.success;
-          providerMessageId = result.id;
-        } catch {
-          success = false;
+          return false;
         }
         if (success) {
           await recordReminderOutcome({

--- a/apps/web/app/api/cron/wellness-billing/route.ts
+++ b/apps/web/app/api/cron/wellness-billing/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { isNull } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import { practices } from "@openpims/db";
 import { alertOps } from "@/lib/alerts";
@@ -41,7 +41,12 @@ export async function GET(request: Request) {
       tx
         .select({ id: practices.id, timezone: practices.timezone })
         .from(practices)
-        .where(isNull(practices.deletedAt))
+        .where(
+          and(
+            isNull(practices.deletedAt),
+            eq(practices.recoveryHold, false),
+          ),
+        )
     );
 
     for (const practice of allPractices) {

--- a/apps/web/app/api/files/[...path]/route.test.ts
+++ b/apps/web/app/api/files/[...path]/route.test.ts
@@ -4,20 +4,33 @@ import { fileURLToPath } from "node:url";
 
 const ROUTE_SOURCE = readFileSync(
   fileURLToPath(new URL("./route.ts", import.meta.url)),
-  "utf8"
+  "utf8",
 );
 
 const mocks = vi.hoisted(() => {
   const practiceId = "00000000-0000-0000-0000-000000000001";
   const userId = "00000000-0000-0000-0000-000000000002";
+  const fileMetadata = (overrides: Record<string, unknown> = {}) => ({
+    id: "file_123",
+    fileName: "logo.png",
+    mimeType: "image/png",
+    checksumSha256: null,
+    fileSizeBytes: null,
+    storageStatus: "unverified",
+    replicaObjectKey: null,
+    replicaObjectVersionId: null,
+    replicaChecksumSha256: null,
+    replicaFileSizeBytes: null,
+    replicaStatus: null,
+    ...overrides,
+  });
   const selectResults: unknown[][] = [];
   const select = vi.fn(() => {
-    const result = selectResults.shift() ?? [
-      { id: "file_123", mimeType: "image/png" },
-    ];
+    const result = selectResults.shift() ?? [fileMetadata()];
     const builder = {
       from: vi.fn(() => builder),
       innerJoin: vi.fn(() => builder),
+      leftJoin: vi.fn(() => builder),
       where: vi.fn(() => builder),
       limit: vi.fn(async () => result),
     };
@@ -28,13 +41,16 @@ const mocks = vi.hoisted(() => {
   return {
     practiceId,
     userId,
+    fileMetadata,
     selectResults,
     getServerSession: vi.fn(async () => ({
       user: { id: userId, practiceId },
     })),
-    getObject: vi.fn(),
+    readPrimaryObject: vi.fn(),
+    readReplicaObject: vi.fn(),
+    schedulePrimaryRepair: vi.fn(async () => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(tx)
+      fn(tx),
     ),
   };
 });
@@ -52,7 +68,21 @@ vi.mock("@openpims/db/client", () => ({
 }));
 
 vi.mock("@/lib/s3", () => ({
-  getObject: mocks.getObject,
+  FILE_REPLICA_TARGET: "independent-v1",
+  normalizeS3VersionId: (value: unknown) => {
+    if (typeof value !== "string") return undefined;
+    const normalized = value.trim();
+    return normalized && normalized.toLowerCase() !== "null"
+      ? normalized
+      : undefined;
+  },
+  readPrimaryObject: mocks.readPrimaryObject,
+  readReplicaObject: mocks.readReplicaObject,
+}));
+
+vi.mock("@/lib/file-replication", () => ({
+  checksumSha256Hex: vi.fn(() => "a".repeat(64)),
+  schedulePrimaryRepair: mocks.schedulePrimaryRepair,
 }));
 
 vi.mock("@/lib/tenant-db", () => ({
@@ -81,45 +111,47 @@ afterEach(() => {
 
 describe("file proxy response headers", () => {
   it("serves public branding images inline without requiring a session", async () => {
-    mocks.getObject.mockResolvedValue({
+    mocks.readPrimaryObject.mockResolvedValue({
+      status: "available",
       body: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
       contentType: "image/png",
     });
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/branding/logo.png`),
-      routeContext([mocks.practiceId, "branding", "logo.png"])
+      routeContext([mocks.practiceId, "branding", "logo.png"]),
     );
 
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).toHaveBeenCalledTimes(1);
-    expect(mocks.getObject).toHaveBeenCalledWith(
+    expect(mocks.readPrimaryObject).toHaveBeenCalledWith(
       `${mocks.practiceId}/branding/logo.png`,
-      { maxBytes: UPLOAD_FILE_MAX_BYTES }
+      { maxBytes: UPLOAD_FILE_MAX_BYTES },
     );
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("image/png");
     expect(response.headers.get("Content-Disposition")).toBe(
-      'inline; filename="logo.png"'
+      'inline; filename="logo.png"',
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=86400");
   });
 
   it("does not serve non-image objects from the public branding category", async () => {
-    mocks.getObject.mockResolvedValue({
+    mocks.readPrimaryObject.mockResolvedValue({
+      status: "available",
       body: new TextEncoder().encode("%PDF-1.7\n"),
       contentType: "application/pdf",
     });
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/branding/logo.pdf`),
-      routeContext([mocks.practiceId, "branding", "logo.pdf"])
+      routeContext([mocks.practiceId, "branding", "logo.pdf"]),
     );
 
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).toHaveBeenCalledTimes(1);
-    expect(mocks.getObject).toHaveBeenCalledTimes(1);
+    expect(mocks.readPrimaryObject).toHaveBeenCalledTimes(1);
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
   });
@@ -129,27 +161,29 @@ describe("file proxy response headers", () => {
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/branding/logo.png`),
-      routeContext([mocks.practiceId, "branding", "logo.png"])
+      routeContext([mocks.practiceId, "branding", "logo.png"]),
     );
 
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).toHaveBeenCalledTimes(1);
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
   });
 
   it("does not fetch public branding objects with non-image file metadata", async () => {
-    mocks.selectResults.push([{ id: "file_123", mimeType: "application/pdf" }]);
+    mocks.selectResults.push([
+      mocks.fileMetadata({ mimeType: "application/pdf" }),
+    ]);
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/branding/logo.png`),
-      routeContext([mocks.practiceId, "branding", "logo.png"])
+      routeContext([mocks.practiceId, "branding", "logo.png"]),
     );
 
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).toHaveBeenCalledTimes(1);
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
   });
@@ -157,53 +191,53 @@ describe("file proxy response headers", () => {
   it("rejects malformed encoded paths before auth or storage lookup", async () => {
     const response = await GET(
       fileRequest(`${mocks.practiceId}/branding/%`),
-      routeContext([mocks.practiceId, "branding", "%"])
+      routeContext([mocks.practiceId, "branding", "%"]),
     );
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
   });
 
   it("rejects encoded path separators before auth or storage lookup", async () => {
     const response = await GET(
       fileRequest(`${mocks.practiceId}/branding/logo%2Fsecret.png`),
-      routeContext([mocks.practiceId, "branding", "logo%2Fsecret.png"])
+      routeContext([mocks.practiceId, "branding", "logo%2Fsecret.png"]),
     );
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported categories before auth or storage lookup", async () => {
     const response = await GET(
       fileRequest(`${mocks.practiceId}/exports/backup.json`),
-      routeContext([mocks.practiceId, "exports", "backup.json"])
+      routeContext([mocks.practiceId, "exports", "backup.json"]),
     );
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
   });
 
   it("rejects deeper object paths before auth or storage lookup", async () => {
     const response = await GET(
       fileRequest(`${mocks.practiceId}/documents/nested/lab.pdf`),
-      routeContext([mocks.practiceId, "documents", "nested", "lab.pdf"])
+      routeContext([mocks.practiceId, "documents", "nested", "lab.pdf"]),
     );
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
   });
 
   it("rejects private objects without session lookup when NEXTAUTH_SECRET is blank", async () => {
@@ -211,25 +245,35 @@ describe("file proxy response headers", () => {
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/documents/lab.pdf`),
-      routeContext([mocks.practiceId, "documents", "lab.pdf"])
+      routeContext([mocks.practiceId, "documents", "lab.pdf"]),
     );
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
     expect(mocks.getServerSession).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
   });
 
   it("serves private document files as attachments with nosniff", async () => {
-    mocks.getObject.mockResolvedValue({
+    mocks.selectResults.push(
+      [{ id: mocks.userId }],
+      [
+        mocks.fileMetadata({
+          fileName: "lab.pdf",
+          mimeType: "application/pdf",
+        }),
+      ],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({
+      status: "available",
       body: new TextEncoder().encode("%PDF-1.7\n"),
       contentType: "application/pdf",
     });
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/documents/lab.pdf`),
-      routeContext([mocks.practiceId, "documents", "lab.pdf"])
+      routeContext([mocks.practiceId, "documents", "lab.pdf"]),
     );
 
     expect(mocks.getServerSession).toHaveBeenCalledTimes(1);
@@ -237,25 +281,151 @@ describe("file proxy response headers", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
     expect(response.headers.get("Content-Disposition")).toBe(
-      'attachment; filename="lab.pdf"'
+      'attachment; filename="lab.pdf"',
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(response.headers.get("Cache-Control")).toBe("private, max-age=3600");
   });
 
-  it("treats oversized storage objects as missing", async () => {
-    mocks.getObject.mockResolvedValue(null);
+  it("serves a checksum-verified replica when the primary provider fails", async () => {
+    const replicaBody = new Uint8Array([1, 2, 3]);
+    mocks.selectResults.push(
+      [{ id: mocks.userId }],
+      [
+        mocks.fileMetadata({
+          fileName: "lab report.pdf",
+          mimeType: "application/pdf",
+          checksumSha256: "a".repeat(64),
+          fileSizeBytes: replicaBody.byteLength,
+          storageStatus: "missing",
+          replicaObjectKey: "attachments/v1/practice/file/checksum",
+          replicaObjectVersionId: "replica-version-1",
+          replicaChecksumSha256: "a".repeat(64),
+          replicaFileSizeBytes: replicaBody.byteLength,
+          replicaStatus: "available",
+        }),
+      ],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "failed" });
+    mocks.readReplicaObject.mockResolvedValue({
+      status: "available",
+      body: replicaBody,
+      contentType: "application/pdf",
+      versionId: "replica-version-1",
+    });
 
     const response = await GET(
-      fileRequest(`${mocks.practiceId}/documents/lab.pdf`),
-      routeContext([mocks.practiceId, "documents", "lab.pdf"])
+      fileRequest(`${mocks.practiceId}/documents/opaque-key`),
+      routeContext([mocks.practiceId, "documents", "opaque-key"]),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="lab_report.pdf"',
+    );
+    expect(mocks.readReplicaObject).toHaveBeenCalledWith(
+      "attachments/v1/practice/file/checksum",
+      {
+        maxBytes: UPLOAD_FILE_MAX_BYTES,
+        versionId: "replica-version-1",
+      },
+    );
+    expect(mocks.schedulePrimaryRepair).toHaveBeenCalledWith({
+      practiceId: mocks.practiceId,
+      fileId: "file_123",
+      fileKey: `${mocks.practiceId}/documents/opaque-key`,
+      checksumSha256: "a".repeat(64),
+      fileSizeBytes: replicaBody.byteLength,
+      storageStatus: "missing",
+      observedState: "failed",
+    });
+  });
+
+  it("does not serve a replica whose stored version is provider-null", async () => {
+    mocks.selectResults.push(
+      [{ id: mocks.userId }],
+      [
+        mocks.fileMetadata({
+          fileName: "lab.pdf",
+          mimeType: "application/pdf",
+          checksumSha256: "a".repeat(64),
+          fileSizeBytes: 3,
+          storageStatus: "missing",
+          replicaObjectKey: "attachments/v1/practice/file/checksum",
+          replicaObjectVersionId: "null",
+          replicaChecksumSha256: "a".repeat(64),
+          replicaFileSizeBytes: 3,
+          replicaStatus: "available",
+        }),
+      ],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "missing" });
+
+    const response = await GET(
+      fileRequest(`${mocks.practiceId}/documents/opaque-key`),
+      routeContext([mocks.practiceId, "documents", "opaque-key"]),
     );
 
     expect(response.status).toBe(404);
-    await expect(response.json()).resolves.toEqual({ error: "Not found" });
-    expect(mocks.getObject).toHaveBeenCalledWith(
+    expect(mocks.readReplicaObject).not.toHaveBeenCalled();
+  });
+
+  it("does not report a missing primary as definitive when replica verification fails", async () => {
+    mocks.selectResults.push(
+      [{ id: mocks.userId }],
+      [
+        mocks.fileMetadata({
+          fileName: "lab.pdf",
+          mimeType: "application/pdf",
+          checksumSha256: "a".repeat(64),
+          fileSizeBytes: 3,
+          storageStatus: "missing",
+          replicaObjectKey: "attachments/v1/practice/file/checksum",
+          replicaObjectVersionId: "replica-version-1",
+          replicaChecksumSha256: "a".repeat(64),
+          replicaFileSizeBytes: 3,
+          replicaStatus: "available",
+        }),
+      ],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "missing" });
+    mocks.readReplicaObject.mockResolvedValue({ status: "failed" });
+
+    const response = await GET(
+      fileRequest(`${mocks.practiceId}/documents/opaque-key`),
+      routeContext([mocks.practiceId, "documents", "opaque-key"]),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "File temporarily unavailable",
+    });
+  });
+
+  it("treats oversized storage objects as missing", async () => {
+    mocks.selectResults.push(
+      [{ id: mocks.userId }],
+      [
+        mocks.fileMetadata({
+          fileName: "lab.pdf",
+          mimeType: "application/pdf",
+        }),
+      ],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "failed" });
+
+    const response = await GET(
+      fileRequest(`${mocks.practiceId}/documents/lab.pdf`),
+      routeContext([mocks.practiceId, "documents", "lab.pdf"]),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "File temporarily unavailable",
+    });
+    expect(mocks.readPrimaryObject).toHaveBeenCalledWith(
       `${mocks.practiceId}/documents/lab.pdf`,
-      { maxBytes: UPLOAD_FILE_MAX_BYTES }
+      { maxBytes: UPLOAD_FILE_MAX_BYTES },
     );
   });
 
@@ -264,12 +434,12 @@ describe("file proxy response headers", () => {
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/documents/lab.pdf`),
-      routeContext([mocks.practiceId, "documents", "lab.pdf"])
+      routeContext([mocks.practiceId, "documents", "lab.pdf"]),
     );
 
     expect(mocks.getServerSession).toHaveBeenCalledTimes(1);
     expect(mocks.withSystem).toHaveBeenCalledTimes(2);
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Not found" });
   });
@@ -279,13 +449,13 @@ describe("file proxy response headers", () => {
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/documents/lab.pdf`),
-      routeContext([mocks.practiceId, "documents", "lab.pdf"])
+      routeContext([mocks.practiceId, "documents", "lab.pdf"]),
     );
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
     expect(mocks.withSystem).toHaveBeenCalledTimes(1);
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
   });
 
   it("does not fetch private objects for another practice", async () => {
@@ -298,12 +468,12 @@ describe("file proxy response headers", () => {
 
     const response = await GET(
       fileRequest(`${mocks.practiceId}/documents/lab.pdf`),
-      routeContext([mocks.practiceId, "documents", "lab.pdf"])
+      routeContext([mocks.practiceId, "documents", "lab.pdf"]),
     );
 
     expect(response.status).toBe(403);
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.getObject).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
   });
 
   it("revalidates private file sessions against active user and practice rows", () => {

--- a/apps/web/app/api/files/[...path]/route.ts
+++ b/apps/web/app/api/files/[...path]/route.ts
@@ -2,17 +2,25 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { db } from "@openpims/db/client";
-import { files, practices, users } from "@openpims/db";
+import { fileObjectReplicas, files, practices, users } from "@openpims/db";
 import { and, eq, isNull } from "drizzle-orm";
-import { getObject } from "@/lib/s3";
+import {
+  FILE_REPLICA_TARGET,
+  normalizeS3VersionId,
+  readPrimaryObject,
+  readReplicaObject,
+} from "@/lib/s3";
 import { withSystem } from "@/lib/tenant-db";
 import { hasBlankConfiguredNextAuthSecret } from "@/lib/auth-secret";
 import {
   contentDispositionForFile,
-  filenameFromObjectKey,
   isAllowedUploadCategory,
 } from "@/lib/upload-security";
 import { UPLOAD_FILE_MAX_BYTES } from "@/lib/upload-limits";
+import {
+  checksumSha256Hex,
+  schedulePrimaryRepair,
+} from "@/lib/file-replication";
 
 export const dynamic = "force-dynamic";
 
@@ -29,12 +37,30 @@ async function getActiveFileMetadata({
     tx
       .select({
         id: files.id,
+        fileName: files.fileName,
         mimeType: files.mimeType,
+        checksumSha256: files.checksumSha256,
+        fileSizeBytes: files.fileSizeBytes,
+        storageStatus: files.storageStatus,
+        replicaObjectKey: fileObjectReplicas.objectKey,
+        replicaObjectVersionId: fileObjectReplicas.objectVersionId,
+        replicaChecksumSha256: fileObjectReplicas.checksumSha256,
+        replicaFileSizeBytes: fileObjectReplicas.fileSizeBytes,
+        replicaStatus: fileObjectReplicas.status,
       })
       .from(files)
       .innerJoin(
         practices,
         and(eq(practices.id, files.practiceId), isNull(practices.deletedAt)),
+      )
+      .leftJoin(
+        fileObjectReplicas,
+        and(
+          eq(fileObjectReplicas.fileId, files.id),
+          eq(fileObjectReplicas.practiceId, files.practiceId),
+          eq(fileObjectReplicas.replicaTarget, FILE_REPLICA_TARGET),
+          isNull(fileObjectReplicas.deletedAt),
+        ),
       )
       .where(
         and(
@@ -142,21 +168,96 @@ export async function GET(
   if (!metadata) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
+  if (isPublic && !metadata.mimeType?.toLowerCase().startsWith("image/")) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
   if (
-    isPublic &&
-    !metadata.mimeType?.toLowerCase().startsWith("image/")
+    metadata.storageStatus === "pending_upload" ||
+    metadata.storageStatus === "cleanup_pending"
   ) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  const obj = await getObject(key, { maxBytes: UPLOAD_FILE_MAX_BYTES });
-  if (!obj) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  const primary = await readPrimaryObject(key, {
+    maxBytes: UPLOAD_FILE_MAX_BYTES,
+  });
+  const primaryMatchesManifest =
+    primary.status === "available" &&
+    (!metadata.checksumSha256 ||
+      (primary.body.byteLength === metadata.fileSizeBytes &&
+        checksumSha256Hex(primary.body) === metadata.checksumSha256));
+  let obj = primaryMatchesManifest
+    ? { body: primary.body, contentType: primary.contentType }
+    : null;
+  let replicaFallbackState:
+    | "not_attempted"
+    | "available"
+    | "missing"
+    | "failed"
+    | "corrupt" = "not_attempted";
+  const replicaObjectVersionId = normalizeS3VersionId(
+    metadata.replicaObjectVersionId,
+  );
+
   if (
-    isPublic &&
-    !obj.contentType?.toLowerCase().startsWith("image/")
+    !obj &&
+    metadata.replicaStatus === "available" &&
+    metadata.replicaObjectKey &&
+    replicaObjectVersionId
   ) {
+    const expectedChecksum =
+      metadata.checksumSha256 ?? metadata.replicaChecksumSha256;
+    const expectedSize =
+      metadata.fileSizeBytes ?? metadata.replicaFileSizeBytes;
+    if (expectedChecksum && expectedSize != null) {
+      const replica = await readReplicaObject(metadata.replicaObjectKey, {
+        maxBytes: UPLOAD_FILE_MAX_BYTES,
+        versionId: replicaObjectVersionId,
+      });
+      if (
+        replica.status === "available" &&
+        normalizeS3VersionId(replica.versionId) === replicaObjectVersionId &&
+        replica.body.byteLength === expectedSize &&
+        checksumSha256Hex(replica.body) === expectedChecksum
+      ) {
+        replicaFallbackState = "available";
+        obj = { body: replica.body, contentType: replica.contentType };
+        const observedState =
+          primary.status === "missing"
+            ? "missing"
+            : primary.status === "available"
+              ? "corrupt"
+              : "failed";
+        await schedulePrimaryRepair({
+          practiceId,
+          fileId: metadata.id,
+          fileKey: key,
+          checksumSha256: metadata.checksumSha256,
+          fileSizeBytes: metadata.fileSizeBytes,
+          storageStatus: metadata.storageStatus,
+          observedState,
+        });
+      } else {
+        replicaFallbackState =
+          replica.status === "available" ? "corrupt" : replica.status;
+      }
+    }
+  }
+
+  if (!obj) {
+    const definitiveMissing =
+      primary.status === "missing" &&
+      (replicaFallbackState === "not_attempted" ||
+        replicaFallbackState === "missing");
+    return NextResponse.json(
+      {
+        error: definitiveMissing ? "Not found" : "File temporarily unavailable",
+      },
+      { status: definitiveMissing ? 404 : 503 },
+    );
+  }
+  if (isPublic && !obj.contentType?.toLowerCase().startsWith("image/")) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
@@ -164,7 +265,7 @@ export async function GET(
     headers: {
       "Content-Type": obj.contentType ?? "application/octet-stream",
       "Content-Disposition": contentDispositionForFile({
-        filename: filenameFromObjectKey(key),
+        filename: metadata.fileName,
         contentType: obj.contentType,
         isPublic,
       }),

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -30,6 +30,23 @@ const mocks = vi.hoisted(() => ({
     ok: true,
     detail: "Object storage bucket reachable",
   })),
+  checkReplicaStorageHealth: vi.fn(async () => ({
+    ok: true,
+    detail: "Replica object storage reachable",
+  })),
+  replicaStorageReadiness: vi.fn(() => ({
+    intended: false,
+    ready: false,
+    detail: "Independent object replica is not configured",
+  })),
+  replicaStorageRequired: vi.fn(() => false),
+  replicaStorageRolloutEnabled: vi.fn(() => false),
+  getFileReplicaCoverage: vi.fn(async () => ({
+    backlog: 0,
+    available: 1,
+    activeFiles: 1,
+    coveragePct: 100,
+  })),
   findSchemaDrift: vi.fn(async () => ({
     missingTables: [] as string[],
     missingColumns: [] as { table: string; column: string }[],
@@ -86,6 +103,14 @@ vi.mock("@/lib/cron-heartbeat", () => ({
 
 vi.mock("@/lib/s3", () => ({
   checkObjectStorageHealth: mocks.checkObjectStorageHealth,
+  checkReplicaStorageHealth: mocks.checkReplicaStorageHealth,
+  replicaStorageReadiness: mocks.replicaStorageReadiness,
+  replicaStorageRequired: mocks.replicaStorageRequired,
+  replicaStorageRolloutEnabled: mocks.replicaStorageRolloutEnabled,
+}));
+
+vi.mock("@/lib/file-replication", () => ({
+  getFileReplicaCoverage: mocks.getFileReplicaCoverage,
 }));
 
 vi.mock("@/lib/platform-email-preferences", () => ({
@@ -153,6 +178,23 @@ afterEach(() => {
   mocks.dbExecute.mockResolvedValue([{ ok: 1, scopeValid: true }]);
   mocks.withSystem.mockImplementation(async (database, fn) => fn(database));
   mocks.billingEnforced.mockReturnValue(false);
+  mocks.replicaStorageReadiness.mockReturnValue({
+    intended: false,
+    ready: false,
+    detail: "Independent object replica is not configured",
+  });
+  mocks.replicaStorageRequired.mockReturnValue(false);
+  mocks.replicaStorageRolloutEnabled.mockReturnValue(false);
+  mocks.getFileReplicaCoverage.mockResolvedValue({
+    backlog: 0,
+    available: 1,
+    activeFiles: 1,
+    coveragePct: 100,
+  });
+  mocks.checkReplicaStorageHealth.mockResolvedValue({
+    ok: true,
+    detail: "Replica object storage reachable",
+  });
   mocks.requiredMessagingEnvNames.mockReturnValue([
     "TELNYX_API_KEY",
     "TELNYX_PUBLIC_KEY",
@@ -931,6 +973,171 @@ describe("health route", () => {
     const body = JSON.stringify(json);
     expect(body).not.toContain("storage.example");
     expect(body).not.toContain("clinic-private-bucket");
+  });
+
+  it("keeps an intentionally absent file replica advisory", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.checks.hostedFileReplica).toEqual({
+      ok: false,
+      detail: "Independent object replica is not configured",
+      advisory: true,
+    });
+    expect(mocks.checkReplicaStorageHealth).not.toHaveBeenCalled();
+  });
+
+  it("fails hosted readiness once the replica rollout is intended but incomplete", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    mocks.replicaStorageReadiness.mockReturnValueOnce({
+      intended: true,
+      ready: false,
+      detail: "2 required replica storage values are missing",
+    });
+    mocks.replicaStorageRequired.mockReturnValueOnce(true);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedFileReplica).toEqual({
+      ok: false,
+      detail: "2 required replica storage values are missing",
+      advisory: false,
+    });
+    expect(mocks.checkReplicaStorageHealth).not.toHaveBeenCalled();
+    const body = JSON.stringify(json);
+    expect(body).not.toContain("FILE_REPLICA_S3_ACCESS_KEY");
+    expect(body).not.toContain("FILE_REPLICA_S3_SECRET_KEY");
+  });
+
+  it("gates partial replica rollout even before it is marked required", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    mocks.replicaStorageReadiness.mockReturnValueOnce({
+      intended: true,
+      ready: false,
+      detail: "Replica rollout needs an exact practice cohort",
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedFileReplica).toEqual({
+      ok: false,
+      detail: "Replica rollout needs an exact practice cohort",
+      advisory: false,
+    });
+    expect(mocks.checkReplicaStorageHealth).not.toHaveBeenCalled();
+  });
+
+  it("checks replica reachability when its complete rollout is enabled", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    mocks.replicaStorageReadiness.mockReturnValueOnce({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.replicaStorageRequired.mockReturnValueOnce(true);
+    mocks.replicaStorageRolloutEnabled.mockReturnValueOnce(true);
+    mocks.checkReplicaStorageHealth.mockResolvedValueOnce({
+      ok: false,
+      detail: "Replica object storage check failed",
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(mocks.checkReplicaStorageHealth).toHaveBeenCalledTimes(1);
+    expect(json.checks.hostedFileReplica).toEqual({
+      ok: false,
+      detail: "Replica object storage check failed",
+      advisory: false,
+    });
+  });
+
+  it("fails hosted readiness when required replica execution is disabled", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    mocks.replicaStorageReadiness.mockReturnValueOnce({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.replicaStorageRequired.mockReturnValueOnce(true);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedFileReplica).toEqual({
+      ok: false,
+      detail: "Independent file replica is required but execution is disabled",
+      advisory: false,
+    });
+    expect(mocks.checkReplicaStorageHealth).not.toHaveBeenCalled();
+  });
+
+  it("fails hosted readiness when required replica coverage is incomplete", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    mocks.replicaStorageReadiness.mockReturnValueOnce({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.replicaStorageRequired.mockReturnValueOnce(true);
+    mocks.replicaStorageRolloutEnabled.mockReturnValueOnce(true);
+    mocks.getFileReplicaCoverage.mockResolvedValueOnce({
+      backlog: 1,
+      available: 2,
+      activeFiles: 3,
+      coveragePct: 66.67,
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedFileReplica).toEqual({
+      ok: false,
+      detail:
+        "2/3 active files independently available (66.67%); backlog 1",
+      advisory: false,
+    });
+  });
+
+  it("passes hosted readiness only after required replica coverage is complete", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    mocks.replicaStorageReadiness.mockReturnValueOnce({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    });
+    mocks.replicaStorageRequired.mockReturnValueOnce(true);
+    mocks.replicaStorageRolloutEnabled.mockReturnValueOnce(true);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.checks.hostedFileReplica).toEqual({
+      ok: true,
+      detail:
+        "1/1 active files independently available (100%); backlog 0",
+      advisory: false,
+    });
+    expect(mocks.checkReplicaStorageHealth).toHaveBeenCalledTimes(1);
+    expect(mocks.getFileReplicaCoverage).toHaveBeenCalledTimes(1);
   });
 
   it("does not expose the current database role when the hosted RLS check fails", async () => {

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -17,7 +17,14 @@ import {
 } from "@/lib/rls-assertion";
 import { cronHeartbeatConfigured } from "@/lib/cron-heartbeat";
 import { envFlagEnabled } from "@/lib/env-bool";
-import { checkObjectStorageHealth } from "@/lib/s3";
+import {
+  checkObjectStorageHealth,
+  checkReplicaStorageHealth,
+  replicaStorageReadiness,
+  replicaStorageRequired,
+  replicaStorageRolloutEnabled,
+} from "@/lib/s3";
+import { getFileReplicaCoverage } from "@/lib/file-replication";
 import { normalizeAppBaseUrl } from "@/lib/app-url";
 import { platformAdminEmails } from "@/lib/platform-admin";
 import { rowsFromExecute } from "@/lib/db/execute-rows";
@@ -521,6 +528,45 @@ export async function GET() {
     checks.hostedStorage = hostedStorageEnv.ok
       ? await checkObjectStorageHealth()
       : hostedStorageEnv;
+    const replicaReadiness = replicaStorageReadiness();
+    const replicaRequired = replicaStorageRequired();
+    const replicaEnabled = replicaStorageRolloutEnabled();
+    let replicaCheck: { ok: boolean; detail: string };
+    if (!replicaReadiness.ready) {
+      replicaCheck = { ok: false, detail: replicaReadiness.detail };
+    } else if (replicaRequired && !replicaEnabled) {
+      replicaCheck = {
+        ok: false,
+        detail: "Independent file replica is required but execution is disabled",
+      };
+    } else {
+      const storageCheck = await checkReplicaStorageHealth();
+      if (!storageCheck.ok || !replicaEnabled) {
+        replicaCheck = storageCheck;
+      } else {
+        try {
+          const coverage = await getFileReplicaCoverage();
+          const complete = coverage.backlog === 0 && coverage.coveragePct === 100;
+          replicaCheck = {
+            ok: replicaRequired ? complete : storageCheck.ok,
+            detail: `${coverage.available}/${coverage.activeFiles} active files independently available (${coverage.coveragePct}%); backlog ${coverage.backlog}`,
+          };
+        } catch {
+          replicaCheck = {
+            ok: false,
+            detail: "Independent file replica coverage check failed",
+          };
+        }
+      }
+    }
+    checks.hostedFileReplica = {
+      ...replicaCheck,
+      // Any rollout signal makes invalid/incomplete replica configuration a
+      // release gate. Only the intentionally absent, disabled default remains
+      // advisory; otherwise a mistyped cohort or partial credentials could
+      // hide behind FILE_REPLICA_REQUIRED=false and still return HTTP 200.
+      advisory: !(replicaReadiness.intended || replicaRequired),
+    };
     checks.hostedEmail = await hostedEmailCheck();
     checks.hostedAi = hostedAiCheck();
     checks.hostedOps = hostedOpsCheck();

--- a/apps/web/app/api/portal/checkout/route.test.ts
+++ b/apps/web/app/api/portal/checkout/route.test.ts
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => {
     const builder = {
       from: vi.fn(() => builder),
       where: vi.fn(() => builder),
-      limit: vi.fn(() => resultPromise()),
+      limit: vi.fn(() => builder),
       for: vi.fn(() => resultPromise()),
       then: (
         resolve: (value: unknown[]) => unknown,
@@ -488,6 +488,23 @@ describe("portal checkout route", () => {
     );
     // Self-host: the platform Stripe key IS the practice's account.
     expect(mocks.getChargeableStripeConnectAccountId).not.toHaveBeenCalled();
+  });
+
+  it("does not create portal checkout while the clinic is held", async () => {
+    mocks.selectResults.push(
+      [client()],
+      [invoice()],
+      [{ amount: "0.00" }],
+      [{ name: "Biscuit" }],
+      [practice({ recoveryHold: true })],
+    );
+
+    const response = await POST(
+      portalRequest({ token: "portal-token", invoiceId: INVOICE_ID }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
   });
 
   it("returns a controlled conflict when a linked visit is not ready", async () => {

--- a/apps/web/app/api/portal/checkout/route.ts
+++ b/apps/web/app/api/portal/checkout/route.ts
@@ -295,17 +295,29 @@ export async function POST(req: NextRequest) {
           tier: practices.subscriptionTier,
           billingStatus: practices.billingStatus,
           trialEndsAt: practices.trialEndsAt,
+          recoveryHold: practices.recoveryHold,
         })
         .from(practices)
         .where(
           and(eq(practices.id, invoice.practiceId), isNull(practices.deletedAt)),
         )
-        .limit(1);
+        .limit(1)
+        .for("share", { of: practices });
 
       if (!practice) {
         return NextResponse.json(
           { error: "Invalid portal link" },
           { status: 404 },
+        );
+      }
+
+      if (practice.recoveryHold) {
+        return NextResponse.json(
+          {
+            error:
+              "Online payments are temporarily unavailable. Please call the clinic to pay.",
+          },
+          { status: 503 },
         );
       }
 

--- a/apps/web/app/api/sign/[token]/route.test.ts
+++ b/apps/web/app/api/sign/[token]/route.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const ROUTE_SOURCE = readFileSync(
   fileURLToPath(new URL("./route.ts", import.meta.url)),
-  "utf8"
+  "utf8",
 );
 
 const mocks = vi.hoisted(() => {
@@ -13,24 +13,39 @@ const mocks = vi.hoisted(() => {
   const createdBy = "00000000-0000-0000-0000-000000000003";
   const fileId = "00000000-0000-0000-0000-000000000004";
   const consentId = "00000000-0000-0000-0000-000000000005";
+  const signedAt = new Date("2026-07-10T12:00:00.000Z");
+  const signaturePngBytes = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+    "base64",
+  );
+  const signatureSha256 = "a".repeat(64);
 
-  const consentRow = (overrides: Record<string, unknown> = {}) => ({
-    id: consentId,
-    practiceId,
-    patientId,
-    createdBy,
-    title: "Consent to treatment",
-    bodyText: "I agree to treatment for my pet.",
-    status: "pending",
-    signerName: null,
-    expiresAt: new Date("2099-01-01T00:00:00Z"),
-    patientName: "Peanut",
-    practiceName: "Drill Vet",
-    tier: "free",
-    billingStatus: "trialing",
-    trialEndsAt: new Date("2099-01-01T00:00:00Z"),
-    ...overrides,
-  });
+  const consentRow = (overrides: Record<string, unknown> = {}) => {
+    const status =
+      typeof overrides.status === "string" ? overrides.status : "pending";
+    return {
+      id: consentId,
+      practiceId,
+      patientId,
+      createdBy,
+      appointmentId: null,
+      title: "Consent to treatment",
+      bodyText: "I agree to treatment for my pet.",
+      status,
+      signerName: null,
+      signedAt: null,
+      signaturePngBytes: status === "pending" ? null : signaturePngBytes,
+      signatureSha256: status === "pending" ? null : signatureSha256,
+      fileId: null,
+      expiresAt: new Date("2099-01-01T00:00:00Z"),
+      patientName: "Peanut",
+      practiceName: "Drill Vet",
+      tier: "free",
+      billingStatus: "trialing",
+      trialEndsAt: new Date("2099-01-01T00:00:00Z"),
+      ...overrides,
+    };
+  };
 
   const selectResults: unknown[][] = [];
   const select = vi.fn(() => {
@@ -45,15 +60,38 @@ const mocks = vi.hoisted(() => {
   });
 
   const updateReturningResults: unknown[][] = [];
-  const updateReturning = vi.fn(async () => updateReturningResults.shift() ?? []);
+  const updateReturning = vi.fn(
+    async () => updateReturningResults.shift() ?? [],
+  );
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
-
-  const insertReturning = vi.fn(async () => [{ id: fileId }]);
-  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insertValues = vi.fn(async () => undefined);
   const insert = vi.fn(() => ({ values: insertValues }));
   const tx = { select, insert, update };
+
+  const reservation = {
+    id: fileId,
+    practiceId,
+    uploadedBy: createdBy,
+    idempotencyKey: consentId,
+    fileName: "signed-consent-00000000.pdf",
+    fileKey: `${practiceId}/consents/${fileId}`,
+    fileUrl: `/api/files/${practiceId}/consents/${fileId}`,
+    mimeType: "application/pdf",
+    fileSizeBytes: 2_000,
+    checksumSha256: "a".repeat(64),
+    storageStatus: "pending_upload",
+    category: "consents",
+    source: "consent_signature",
+    entityType: "patient",
+    entityId: patientId,
+    patientId,
+    appointmentId: null,
+    created: true,
+  };
+
+  class ManagedUploadConflictError extends Error {}
 
   return {
     practiceId,
@@ -61,23 +99,42 @@ const mocks = vi.hoisted(() => {
     createdBy,
     fileId,
     consentId,
+    signedAt,
+    signaturePngBytes,
+    signatureSha256,
+    tx,
     consentRow,
     selectResults,
     updateReturningResults,
+    updateReturning,
     updateSet,
     insertValues,
-    insertReturning,
-    uploadFile: vi.fn(async () => undefined),
-    deleteFile: vi.fn(async () => undefined),
+    reservation,
+    ManagedUploadConflictError,
+    reserveManagedUpload: vi.fn(async () => reservation),
+    putAndVerifyManagedUpload: vi.fn(
+      async (): Promise<
+        | {
+            status: "verified";
+            evidence: { etag: string; versionId: string };
+          }
+        | { status: "unavailable" }
+        | { status: "corrupt" }
+      > => ({
+        status: "verified",
+        evidence: { etag: "etag-1", versionId: "version-1" },
+      }),
+    ),
+    finalizeManagedUploadManifest: vi.fn(async () => true),
+    markManagedUploadCorrupt: vi.fn(async (): Promise<boolean> => true),
+    queueManagedUploadReplication: vi.fn(async () => true),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(tx)
+      fn(tx),
     ),
     withTenant: vi.fn(
-      async (
-        _db: unknown,
-        _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(tx)
+      async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+        fn(tx),
     ),
     billingEnforced: vi.fn(() => false),
     hasHostedFullAccess: vi.fn(() => true),
@@ -86,6 +143,12 @@ const mocks = vi.hoisted(() => {
       remaining: 10,
       resetAt: new Date("2026-07-10T13:00:00Z"),
     })),
+    checksumSha256Hex: vi.fn((body: Uint8Array) =>
+      Buffer.from(body).equals(signaturePngBytes)
+        ? signatureSha256
+        : "b".repeat(64),
+    ),
+    readRequestBytesWithLimit: vi.fn(),
   };
 });
 
@@ -94,9 +157,19 @@ vi.mock("@/lib/tenant-db", () => ({
   withSystem: mocks.withSystem,
   withTenant: mocks.withTenant,
 }));
-vi.mock("@/lib/s3", () => ({
-  uploadFile: mocks.uploadFile,
-  deleteFile: mocks.deleteFile,
+vi.mock("@/lib/recovery-hold", () => ({
+  lockPracticeForExternalSideEffects: mocks.lockPracticeForExternalSideEffects,
+}));
+vi.mock("@/lib/managed-file-upload", () => ({
+  ManagedUploadConflictError: mocks.ManagedUploadConflictError,
+  reserveManagedUpload: mocks.reserveManagedUpload,
+  putAndVerifyManagedUpload: mocks.putAndVerifyManagedUpload,
+  finalizeManagedUploadManifest: mocks.finalizeManagedUploadManifest,
+  markManagedUploadCorrupt: mocks.markManagedUploadCorrupt,
+  queueManagedUploadReplication: mocks.queueManagedUploadReplication,
+}));
+vi.mock("@/lib/file-replication", () => ({
+  checksumSha256Hex: mocks.checksumSha256Hex,
 }));
 vi.mock("@/lib/billing/plans", () => ({
   billingEnforced: mocks.billingEnforced,
@@ -109,13 +182,40 @@ vi.mock("@/lib/rate-limit", async (importOriginal) => {
     rateLimitResponseHeaders: actual.rateLimitResponseHeaders,
   };
 });
+vi.mock("@/lib/request-body", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/request-body")>();
+  mocks.readRequestBytesWithLimit.mockImplementation(
+    actual.readRequestBytesWithLimit,
+  );
+  return {
+    ...actual,
+    readRequestBytesWithLimit: mocks.readRequestBytesWithLimit,
+  };
+});
 
 const { GET, POST } = await import("./route");
 
 const TOKEN = "ab".repeat(32);
-// 1x1 PNG (valid magic bytes, decodes as a real image).
 const SIGNATURE_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const CHANGED_VALID_SIGNATURE_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+function signatureDataUrlWithDimensions(width: number, height: number) {
+  const bytes = Buffer.from(
+    SIGNATURE_DATA_URL.slice("data:image/png;base64,".length),
+    "base64",
+  );
+  bytes.writeUInt32BE(width, 16);
+  bytes.writeUInt32BE(height, 20);
+  return `data:image/png;base64,${bytes.toString("base64")}`;
+}
+
+function corruptSignatureDataUrl() {
+  const bytes = Buffer.from(mocks.signaturePngBytes);
+  bytes[40] = bytes[40]! ^ 1;
+  return `data:image/png;base64,${bytes.toString("base64")}`;
+}
 
 function signRequest(tokenParam: string, body?: unknown) {
   return new Request(`https://openvpm.test/api/sign/${tokenParam}`, {
@@ -125,10 +225,6 @@ function signRequest(tokenParam: string, body?: unknown) {
   }) as never;
 }
 
-function viewRequest(tokenParam: string) {
-  return new Request(`https://openvpm.test/api/sign/${tokenParam}`) as never;
-}
-
 function callPost(tokenParam: string, body?: unknown) {
   return POST(signRequest(tokenParam, body), {
     params: Promise.resolve({ token: tokenParam }),
@@ -136,9 +232,10 @@ function callPost(tokenParam: string, body?: unknown) {
 }
 
 function callGet(tokenParam: string) {
-  return GET(viewRequest(tokenParam), {
-    params: Promise.resolve({ token: tokenParam }),
-  });
+  return GET(
+    new Request(`https://openvpm.test/api/sign/${tokenParam}`) as never,
+    { params: Promise.resolve({ token: tokenParam }) },
+  );
 }
 
 function validBody(overrides: Record<string, unknown> = {}) {
@@ -149,263 +246,793 @@ function validBody(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function queueHappyPending() {
+  mocks.selectResults.push([mocks.consentRow()]);
+  mocks.updateReturningResults.push(
+    [
+      {
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        signaturePngBytes: mocks.signaturePngBytes,
+        signatureSha256: mocks.signatureSha256,
+      },
+    ],
+    [{ id: mocks.consentId }],
+    [{ id: mocks.consentId }],
+  );
+}
+
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
   mocks.updateReturningResults.length = 0;
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
+  mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
+  mocks.withSystem.mockImplementation(
+    async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+  );
+  mocks.withTenant.mockImplementation(
+    async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+      fn(mocks.tx),
+  );
   mocks.rateLimit.mockResolvedValue({
     success: true,
     remaining: 10,
     resetAt: new Date("2026-07-10T13:00:00Z"),
   });
-  mocks.insertReturning.mockResolvedValue([{ id: mocks.fileId }]);
+  mocks.reserveManagedUpload.mockResolvedValue(mocks.reservation);
+  mocks.putAndVerifyManagedUpload.mockResolvedValue({
+    status: "verified",
+    evidence: { etag: "etag-1", versionId: "version-1" },
+  });
+  mocks.finalizeManagedUploadManifest.mockResolvedValue(true);
+  mocks.queueManagedUploadReplication.mockResolvedValue(true);
 });
 
 describe("GET /api/sign/[token]", () => {
-  it("404s on malformed tokens before doing any work", async () => {
-    for (const bad of ["short", "Z".repeat(64), "../etc", `${TOKEN}x`]) {
-      const res = await callGet(bad);
-      expect(res.status).toBe(404);
-      await expect(res.json()).resolves.toEqual({ error: "Not found" });
-    }
+  it("404s malformed tokens before doing any work", async () => {
+    const res = await callGet("short");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Cache-Control")).toBe(
+      "private, no-store, max-age=0",
+    );
     expect(mocks.rateLimit).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
   });
 
-  it("returns the consent content for a live token", async () => {
-    mocks.selectResults.push([mocks.consentRow()]);
-    const res = await callGet(TOKEN);
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({
+  it("returns full content only while pending and minimizes terminal states", async () => {
+    mocks.selectResults.push([mocks.consentRow({ status: "pending" })]);
+    const pending = await callGet(TOKEN);
+    await expect(pending.json()).resolves.toEqual({
+      status: "pending",
       title: "Consent to treatment",
       bodyText: "I agree to treatment for my pet.",
       patientName: "Peanut",
       practiceName: "Drill Vet",
-      status: "pending",
-      signerName: null,
     });
-  });
 
-  it("returns identical generic 404s for unknown and expired tokens", async () => {
-    mocks.selectResults.push([]);
-    const unknownRes = await callGet(TOKEN);
-    mocks.selectResults.push([]);
-    const expiredRes = await callGet(TOKEN);
-    expect(unknownRes.status).toBe(404);
-    expect(expiredRes.status).toBe(404);
-    expect(await expiredRes.json()).toEqual(await unknownRes.json());
-  });
+    mocks.selectResults.push([mocks.consentRow({ status: "signing" })]);
+    const signing = await callGet(TOKEN);
+    await expect(signing.json()).resolves.toEqual({ status: "signing" });
 
-  it("shows the signer name only once signed", async () => {
     mocks.selectResults.push([
       mocks.consentRow({ status: "signed", signerName: "Jordan Marsh" }),
     ]);
-    const res = await callGet(TOKEN);
-    const body = await res.json();
-    expect(body.status).toBe("signed");
-    expect(body.signerName).toBe("Jordan Marsh");
+    const signed = await callGet(TOKEN);
+    await expect(signed.json()).resolves.toEqual({ status: "signed" });
+    expect(signed.headers.get("Cache-Control")).toBe(
+      "private, no-store, max-age=0",
+    );
   });
 
-  it("429s when a limit trips", async () => {
+  it("returns only minimal persisted states after the original expiry", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        expiresAt: new Date("2000-01-01T00:00:00Z"),
+      }),
+    ]);
+    await expect((await callGet(TOKEN)).json()).resolves.toEqual({
+      status: "signing",
+    });
+
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signed",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+        expiresAt: new Date("2000-01-01T00:00:00Z"),
+      }),
+    ]);
+    await expect((await callGet(TOKEN)).json()).resolves.toEqual({
+      status: "signed",
+    });
+  });
+
+  it("returns generic misses before rate limiting and enforces limits for live capabilities", async () => {
+    for (const _state of ["missing", "deleted", "recovery-held"]) {
+      mocks.selectResults.push([]);
+      const missing = await callGet(TOKEN);
+      expect(missing.status).toBe(404);
+      await expect(missing.json()).resolves.toEqual({ error: "Not found" });
+    }
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+
+    mocks.selectResults.push([mocks.consentRow()]);
     mocks.rateLimit.mockResolvedValueOnce({
       success: false,
       remaining: 0,
       resetAt: new Date(Date.now() + 60_000),
     });
-    const res = await callGet(TOKEN);
-    expect(res.status).toBe(429);
-    expect(mocks.withSystem).not.toHaveBeenCalled();
+    const limited = await callGet(TOKEN);
+    expect(limited.status).toBe(429);
+  });
+
+  it("fails closed before rate limiting when recovery wins after lookup", async () => {
+    mocks.selectResults.push([mocks.consentRow()]);
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+
+    const response = await callGet(TOKEN);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+    expect(mocks.lockPracticeForExternalSideEffects).toHaveBeenCalledWith(
+      expect.anything(),
+      mocks.practiceId,
+    );
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
   });
 });
 
 describe("POST /api/sign/[token]", () => {
-  it("404s on malformed tokens before doing any work", async () => {
-    const res = await callPost("nope", validBody());
-    expect(res.status).toBe(404);
-    expect(mocks.rateLimit).not.toHaveBeenCalled();
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+  it("rejects JSON null and arrays as invalid request bodies", async () => {
+    for (const payload of [null, []]) {
+      mocks.selectResults.push([mocks.consentRow()]);
+      const response = await callPost(TOKEN, payload);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "Invalid JSON body",
+      });
+    }
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("rate limits both the token and the caller IP with a hashed token key", async () => {
-    mocks.selectResults.push([]);
+  it("resolves a live capability before validating JSON, signer, and PNG", async () => {
+    expect((await callPost("nope", validBody())).status).toBe(404);
+    mocks.selectResults.push([mocks.consentRow()]);
+    expect((await callPost(TOKEN)).status).toBe(400);
+    mocks.selectResults.push([mocks.consentRow()]);
+    expect((await callPost(TOKEN, validBody({ signerName: " " }))).status).toBe(
+      400,
+    );
+    mocks.selectResults.push([mocks.consentRow()]);
+    expect(
+      (
+        await callPost(
+          TOKEN,
+          validBody({ signaturePngDataUrl: "data:image/png;base64,YmFk" }),
+        )
+      ).status,
+    ).toBe(400);
+    mocks.selectResults.push([mocks.consentRow()]);
+    expect(
+      (
+        await callPost(
+          TOKEN,
+          validBody({ signaturePngDataUrl: corruptSignatureDataUrl() }),
+        )
+      ).status,
+    ).toBe(400);
+    mocks.selectResults.push([mocks.consentRow()]);
+    expect(
+      (
+        await callPost(
+          TOKEN,
+          validBody({
+            signaturePngDataUrl: signatureDataUrlWithDimensions(20_000, 1),
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    mocks.selectResults.push([mocks.consentRow()]);
+    expect(
+      (
+        await callPost(
+          TOKEN,
+          validBody({
+            signaturePngDataUrl: signatureDataUrlWithDimensions(2_000, 2_000),
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect(mocks.withSystem).toHaveBeenCalledTimes(6);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("uses hashed token and IP rate-limit keys", async () => {
+    mocks.selectResults.push([mocks.consentRow()]);
     await callPost(TOKEN, validBody());
     const keys = (
       mocks.rateLimit.mock.calls as unknown as [{ key: string }][]
-    ).map((c) => c[0].key);
-    expect(keys.some((k) => k.startsWith("consent-sign:ip:"))).toBe(true);
-    expect(keys.some((k) => k.startsWith("consent-sign:token:"))).toBe(true);
-    expect(keys.every((k) => !k.includes(TOKEN))).toBe(true);
+    ).map((call) => call[0].key);
+    expect(keys.some((key) => key.startsWith("consent-sign:ip:"))).toBe(true);
+    expect(keys.some((key) => key.startsWith("consent-sign:token:"))).toBe(
+      true,
+    );
+    expect(keys.every((key) => !key.includes(TOKEN))).toBe(true);
   });
 
-  it("rejects invalid JSON bodies", async () => {
-    const res = await callPost(TOKEN);
-    expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON body" });
-  });
-
-  it("requires a signer name within bounds", async () => {
-    for (const signerName of ["", "   ", "x".repeat(121)]) {
-      const res = await callPost(TOKEN, validBody({ signerName }));
-      expect(res.status).toBe(400);
-      await expect(res.json()).resolves.toEqual({
-        error: "Please type your full name",
-      });
+  it("hides missing, deleted, and recovery-held practices before body or provider work", async () => {
+    for (const _state of ["missing", "deleted", "recovery-held"]) {
+      mocks.selectResults.push([]);
+      const response = await callPost(TOKEN, validBody());
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Cache-Control")).toBe(
+        "private, no-store, max-age=0",
+      );
+      await expect(response.json()).resolves.toEqual({ error: "Not found" });
     }
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.readRequestBytesWithLimit).not.toHaveBeenCalled();
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("rejects signatures that are not PNG data URLs", async () => {
-    for (const signaturePngDataUrl of [
-      "",
-      "data:image/jpeg;base64,abcd",
-      "https://evil.test/sig.png",
-      // Declared PNG but the bytes are HTML.
-      `data:image/png;base64,${Buffer.from("<html></html>").toString("base64")}`,
-    ]) {
-      const res = await callPost(TOKEN, validBody({ signaturePngDataUrl }));
-      expect(res.status).toBe(400);
-      await expect(res.json()).resolves.toEqual({
-        error: "Please draw your signature",
-      });
-    }
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withSystem).not.toHaveBeenCalled();
+  it("fails closed before body or provider work when recovery wins after lookup", async () => {
+    mocks.selectResults.push([mocks.consentRow()]);
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+
+    const response = await callPost(TOKEN, validBody());
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+    expect(mocks.lockPracticeForExternalSideEffects).toHaveBeenCalledWith(
+      expect.anything(),
+      mocks.practiceId,
+    );
+    expect(mocks.readRequestBytesWithLimit).not.toHaveBeenCalled();
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("returns identical generic 404s for unknown and expired tokens", async () => {
-    mocks.selectResults.push([]);
-    const unknownRes = await callPost(TOKEN, validBody());
-    mocks.selectResults.push([]);
-    const expiredRes = await callPost(TOKEN, validBody());
-    expect(unknownRes.status).toBe(404);
-    expect(expiredRes.status).toBe(404);
-    expect(await expiredRes.json()).toEqual(await unknownRes.json());
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-  });
-
-  it("404s generically on orphaned requests without a creator", async () => {
-    mocks.selectResults.push([mocks.consentRow({ createdBy: null })]);
-    const res = await callPost(TOKEN, validBody());
-    expect(res.status).toBe(404);
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-  });
-
-  it("hides hosted read-only practices behind the same generic 404", async () => {
-    mocks.billingEnforced.mockReturnValue(true);
-    mocks.hasHostedFullAccess.mockReturnValue(false);
+  it("rejects an expired pending request before reading or claiming evidence", async () => {
     mocks.selectResults.push([
       mocks.consentRow({
-        tier: "basic",
-        billingStatus: "past_due",
-        trialEndsAt: null,
+        status: "pending",
+        expiresAt: new Date("2000-01-01T00:00:00Z"),
+      }),
+    ]);
+    const response = await callPost(TOKEN, validBody());
+    expect(response.status).toBe(404);
+    expect(mocks.readRequestBytesWithLimit).not.toHaveBeenCalled();
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("does not claim evidence when body reading crosses capability expiry", async () => {
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const expiresAt = new Date(now.getTime() + 1_000);
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mocks.selectResults.push([
+      mocks.consentRow({ status: "pending", expiresAt }),
+    ]);
+
+    let bodyReadStarted!: () => void;
+    const bodyStarted = new Promise<void>((resolve) => {
+      bodyReadStarted = resolve;
+    });
+    let releaseBody!: () => void;
+    const bodyGate = new Promise<void>((resolve) => {
+      releaseBody = resolve;
+    });
+    mocks.readRequestBytesWithLimit.mockImplementationOnce(async () => {
+      bodyReadStarted();
+      await bodyGate;
+      return {
+        ok: true,
+        bytes: Buffer.from(JSON.stringify(validBody())),
+      };
+    });
+
+    const responsePromise = callPost(TOKEN, validBody());
+    await bodyStarted;
+    vi.setSystemTime(new Date(expiresAt.getTime() + 1));
+    releaseBody();
+
+    const response = await responsePromise;
+    expect(response.status).toBe(404);
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when expiry wins at the atomic pending claim", async () => {
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const expiresAt = new Date(now.getTime() + 1_000);
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mocks.selectResults.push([
+      mocks.consentRow({ status: "pending", expiresAt }),
+    ]);
+    // The database update returns no row when its wall-clock expiry CAS loses,
+    // even though application validation ran while the capability was live.
+    mocks.updateReturningResults.push([]);
+
+    let claimTransactionStarted!: () => void;
+    const claimStarted = new Promise<void>((resolve) => {
+      claimTransactionStarted = resolve;
+    });
+    let releaseClaim!: () => void;
+    const claimGate = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    mocks.withTenant.mockImplementationOnce(async (_db, _practiceId, fn) => {
+      claimTransactionStarted();
+      await claimGate;
+      return fn(mocks.tx);
+    });
+
+    const responsePromise = callPost(TOKEN, validBody());
+    await claimStarted;
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    vi.setSystemTime(new Date(expiresAt.getTime() + 1));
+    releaseClaim();
+
+    const response = await responsePromise;
+    expect(response.status).toBe(404);
+    expect(mocks.updateSet).toHaveBeenCalledTimes(1);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("hides unknown, orphaned, billing-blocked, and invalid-state requests", async () => {
+    mocks.selectResults.push([]);
+    expect((await callPost(TOKEN, validBody())).status).toBe(404);
+
+    mocks.selectResults.push([mocks.consentRow({ createdBy: null })]);
+    expect((await callPost(TOKEN, validBody())).status).toBe(404);
+
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.hasHostedFullAccess.mockReturnValue(false);
+    mocks.selectResults.push([mocks.consentRow()]);
+    expect((await callPost(TOKEN, validBody())).status).toBe(404);
+    mocks.billingEnforced.mockReturnValue(false);
+
+    mocks.selectResults.push([mocks.consentRow({ status: "cancelled" })]);
+    expect((await callPost(TOKEN, validBody())).status).toBe(404);
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("claims pending before render/reservation/PUT, binds the manifest, and commits once", async () => {
+    queueHappyPending();
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(201);
+    expect(res.headers.get("Cache-Control")).toBe(
+      "private, no-store, max-age=0",
+    );
+    await expect(res.json()).resolves.toEqual({ ok: true });
+
+    expect(mocks.updateSet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: expect.anything(),
+        signaturePngBytes: mocks.signaturePngBytes,
+        signatureSha256: mocks.signatureSha256,
+      }),
+    );
+    expect(mocks.reserveManagedUpload).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        idempotencyKey: mocks.consentId,
+        category: "consents",
+        source: "consent_signature",
+        patientId: mocks.patientId,
+      }),
+    );
+    expect(mocks.updateSet).toHaveBeenNthCalledWith(2, {
+      fileId: mocks.fileId,
+    });
+    expect(mocks.updateReturning.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.reserveManagedUpload.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.updateReturning.mock.invocationCallOrder[1]).toBeLessThan(
+      mocks.putAndVerifyManagedUpload.mock.invocationCallOrder[0]!,
+    );
+    expect(
+      mocks.lockPracticeForExternalSideEffects.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.readRequestBytesWithLimit.mock.invocationCallOrder[0]!,
+    );
+    expect(
+      mocks.readRequestBytesWithLimit.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.putAndVerifyManagedUpload.mock.invocationCallOrder[0]!,
+    );
+
+    const pdf = (
+      mocks.putAndVerifyManagedUpload.mock.calls as unknown as [
+        { body: Buffer },
+      ][]
+    )[0][0].body;
+    expect(pdf.subarray(0, 4).toString()).toBe("%PDF");
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledTimes(1);
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: mocks.practiceId,
+        userId: null,
+        action: "sign",
+        entityType: "consent",
+        entityId: mocks.consentId,
+        ipAddress: "unknown",
+        changes: expect.objectContaining({
+          actorType: "client",
+          provenance: "public_consent_capability",
+          dispatchedByUserId: mocks.createdBy,
+          signatureSha256: mocks.signatureSha256,
+        }),
+      }),
+    );
+    expect(mocks.queueManagedUploadReplication).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the shared-lock transaction until signing storage and commit finish", async () => {
+    queueHappyPending();
+    let releaseProvider!: () => void;
+    const providerGate = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    mocks.putAndVerifyManagedUpload.mockImplementationOnce(async () => {
+      await providerGate;
+      return {
+        status: "verified",
+        evidence: { etag: "etag-1", versionId: "version-1" },
+      };
+    });
+
+    let systemTransactionFinished = false;
+    mocks.withSystem.mockImplementationOnce(async (_db, fn) => {
+      const result = await fn(mocks.tx);
+      systemTransactionFinished = true;
+      return result;
+    });
+
+    const responsePromise = callPost(TOKEN, validBody());
+    await vi.waitFor(() => {
+      expect(mocks.putAndVerifyManagedUpload).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.lockPracticeForExternalSideEffects).toHaveBeenCalledTimes(1);
+    expect(systemTransactionFinished).toBe(false);
+
+    releaseProvider();
+    expect((await responsePromise).status).toBe(201);
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledTimes(1);
+    expect(systemTransactionFinished).toBe(true);
+  });
+
+  it("makes the compare-and-swap loser exit before reservation or provider I/O", async () => {
+    mocks.selectResults.push([mocks.consentRow()]);
+    mocks.updateReturningResults.push([]);
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(404);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("resumes stale signing state with persisted signer and timestamp", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+        updatedAt: new Date("2026-07-01T00:00:00Z"),
+      }),
+    ]);
+    mocks.updateReturningResults.push(
+      [{ id: mocks.consentId }],
+      [{ id: mocks.consentId }],
+    );
+
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(201);
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ signerName: "Jordan Marsh" }),
+    );
+    expect(mocks.reserveManagedUpload).toHaveBeenCalledTimes(1);
+    expect(mocks.putAndVerifyManagedUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes persisted signing evidence after expiry without accepting new bytes", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+        expiresAt: new Date("2000-01-01T00:00:00Z"),
+      }),
+    ]);
+    mocks.updateReturningResults.push(
+      [{ id: mocks.consentId }],
+      [{ id: mocks.consentId }],
+    );
+
+    const res = await callPost(TOKEN, { resume: true });
+    expect(res.status).toBe(201);
+    expect(mocks.reserveManagedUpload).toHaveBeenCalledTimes(1);
+    expect(mocks.putAndVerifyManagedUpload).toHaveBeenCalledTimes(1);
+    expect(mocks.checksumSha256Hex).not.toHaveBeenCalledWith(
+      mocks.signaturePngBytes,
+    );
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        signerName: expect.anything(),
+        signaturePngBytes: expect.anything(),
+        signatureSha256: expect.anything(),
+      }),
+    );
+  });
+
+  it("rejects replacement signature bytes after expiry; only resume may replay", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+        expiresAt: new Date("2000-01-01T00:00:00Z"),
+      }),
+    ]);
+
+    const response = await callPost(
+      TOKEN,
+      validBody({ signaturePngDataUrl: CHANGED_VALID_SIGNATURE_DATA_URL }),
+    );
+    expect(response.status).toBe(404);
+    expect(mocks.readRequestBytesWithLimit).toHaveBeenCalledTimes(1);
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("does not let a resume-only request create signing evidence", async () => {
+    mocks.selectResults.push([mocks.consentRow({ status: "pending" })]);
+    const res = await callPost(TOKEN, { resume: true });
+    expect(res.status).toBe(404);
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects changed retry bytes without replacing persisted signature evidence", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+      }),
+    ]);
+    const res = await callPost(
+      TOKEN,
+      validBody({ signaturePngDataUrl: CHANGED_VALID_SIGNATURE_DATA_URL }),
+    );
+    expect(res.status).toBe(409);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        signaturePngBytes: expect.anything(),
+        signatureSha256: expect.anything(),
+      }),
+    );
+  });
+
+  it("fails closed for legacy signed rows without persisted signature bytes", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signed",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        signaturePngBytes: null,
+        signatureSha256: null,
+        fileId: mocks.fileId,
+      }),
+    ]);
+
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(404);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite persisted signing identity on a mismatched retry", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "First Signer",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
       }),
     ]);
     const res = await callPost(TOKEN, validBody());
     expect(res.status).toBe(404);
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("treats already-signed requests as a generic miss (single-use links)", async () => {
-    mocks.selectResults.push([mocks.consentRow({ status: "signed" })]);
-    const res = await callPost(TOKEN, validBody());
-    expect(res.status).toBe(404);
-    await expect(res.json()).resolves.toEqual({ error: "Not found" });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-  });
-
-  it("stores the signed PDF, claims the request, and audits the signing", async () => {
-    mocks.selectResults.push([mocks.consentRow()]);
-    mocks.updateReturningResults.push([{ id: mocks.consentId }]);
-
-    const res = await callPost(TOKEN, validBody());
-    expect(res.status).toBe(201);
-    await expect(res.json()).resolves.toEqual({ ok: true });
-
-    expect(mocks.uploadFile).toHaveBeenCalledWith(
-      expect.stringMatching(
-        new RegExp(`^${mocks.practiceId}/consents/.+\\.pdf$`)
-      ),
-      expect.any(Buffer),
-      "application/pdf"
-    );
-    // The uploaded artifact really is a PDF.
-    const pdfBuffer = (
-      mocks.uploadFile.mock.calls as unknown as [string, Buffer, string][]
-    )[0][1];
-    expect(pdfBuffer.subarray(0, 4).toString()).toBe("%PDF");
-
-    expect(mocks.withTenant).toHaveBeenCalledWith(
-      expect.anything(),
-      mocks.practiceId,
-      expect.any(Function)
-    );
-    // Claim marks the row signed.
-    expect(mocks.updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: "signed",
+  it("leaves signing and its reservation retryable when PUT outcome is ambiguous", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
         signerName: "Jordan Marsh",
-      })
-    );
-    // The file row links to the patient under the consents category.
-    expect(mocks.insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        practiceId: mocks.practiceId,
-        uploadedBy: mocks.createdBy,
-        mimeType: "application/pdf",
-        category: "consents",
-        entityType: "patient",
-        entityId: mocks.patientId,
-      })
-    );
-    // The audit row records the signing against the dispatching staff user.
-    expect(mocks.insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        practiceId: mocks.practiceId,
-        userId: mocks.createdBy,
-        action: "sign",
-        entityType: "consent",
-        entityId: mocks.consentId,
-      })
-    );
-  });
-
-  it("cleans up the uploaded PDF when a concurrent submission wins the claim", async () => {
-    mocks.selectResults.push([mocks.consentRow()]);
-    mocks.updateReturningResults.push([]); // claim misses: someone else won
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+      }),
+    ]);
+    mocks.updateReturningResults.push([{ id: mocks.consentId }]);
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "unavailable",
+    });
 
     const res = await callPost(TOKEN, validBody());
-    expect(res.status).toBe(404);
-    expect(mocks.uploadFile).toHaveBeenCalledTimes(1);
-    expect(mocks.deleteFile).toHaveBeenCalledWith(
-      expect.stringMatching(new RegExp(`^${mocks.practiceId}/consents/.+\\.pdf$`))
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("5");
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+    expect(mocks.queueManagedUploadReplication).not.toHaveBeenCalled();
+  });
+
+  it("marks integrity failures without deleting possibly committed objects", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+      }),
+    ]);
+    mocks.updateReturningResults.push([{ id: mocks.consentId }]);
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "corrupt",
+    });
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(503);
+    expect(mocks.markManagedUploadCorrupt).toHaveBeenCalledWith(
+      expect.anything(),
+      mocks.reservation,
     );
   });
 
-  it("cleans up the uploaded PDF when persistence fails", async () => {
+  it("fails closed when a stale request loses the corrupt-state claim", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    mocks.selectResults.push([mocks.consentRow()]);
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+      }),
+    ]);
     mocks.updateReturningResults.push([{ id: mocks.consentId }]);
-    mocks.insertReturning.mockRejectedValueOnce(new Error("db unavailable"));
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "corrupt",
+    });
+    mocks.markManagedUploadCorrupt.mockResolvedValueOnce(false);
 
-    try {
-      const res = await callPost(TOKEN, validBody());
-      expect(res.status).toBe(500);
-      await expect(res.json()).resolves.toEqual({ error: "Signing failed" });
-      expect(mocks.deleteFile).toHaveBeenCalledTimes(1);
-    } finally {
-      consoleError.mockRestore();
-    }
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(500);
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Consent signing failed:",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
   });
 
-  it("checks the token shape, practice liveness, and expiry in source", () => {
+  it("returns an idempotent 200 for an already-committed exact retry without another audit", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signed",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+      }),
+    ]);
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(200);
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledTimes(1);
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(mocks.queueManagedUploadReplication).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 when the durable reservation does not match retry bytes", async () => {
+    mocks.selectResults.push([
+      mocks.consentRow({
+        status: "signing",
+        signerName: "Jordan Marsh",
+        signedAt: mocks.signedAt,
+        fileId: mocks.fileId,
+      }),
+    ]);
+    mocks.reserveManagedUpload.mockRejectedValueOnce(
+      new mocks.ManagedUploadConflictError(),
+    );
+    const res = await callPost(TOKEN, validBody());
+    expect(res.status).toBe(409);
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before provider I/O when the consent manifest was tombstoned", async () => {
+    queueHappyPending();
+    mocks.reserveManagedUpload.mockRejectedValueOnce(
+      new mocks.ManagedUploadConflictError(
+        "Upload reservation is not retryable from state: deleted",
+      ),
+    );
+
+    const response = await callPost(TOKEN, validBody());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "This signing attempt does not match the in-progress request",
+    });
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+  });
+
+  it("checks capability shape, tenant liveness, expiry, and claim-before-render in source", () => {
     expect(ROUTE_SOURCE).toContain("isCaptureTokenShape(token)");
     expect(ROUTE_SOURCE).toContain("isNull(practices.deletedAt)");
+    expect(ROUTE_SOURCE).toContain("eq(practices.recoveryHold, false)");
+    expect(ROUTE_SOURCE).toContain("isNull(patients.deletedAt)");
     expect(ROUTE_SOURCE).toContain("gt(consentRequests.expiresAt, now)");
-    expect(ROUTE_SOURCE).toContain("readRequestBytesWithLimit(");
-    expect(ROUTE_SOURCE).toContain('export const dynamic = "force-dynamic"');
+    expect(ROUTE_SOURCE).toContain(
+      "gt(consentRequests.expiresAt, sql`clock_timestamp()`)",
+    );
+    expect(ROUTE_SOURCE).toContain("signedAt: sql`clock_timestamp()`");
+    expect(ROUTE_SOURCE).toContain('eq(consentRequests.status, "pending")');
+    const claimIndex = ROUTE_SOURCE.lastIndexOf("await claimSigning(");
+    expect(claimIndex).toBeGreaterThan(0);
+    expect(claimIndex).toBeLessThan(ROUTE_SOURCE.indexOf("buildConsentPdf({"));
+    expect(ROUTE_SOURCE.indexOf("consentSignaturePngDecodes(")).toBeLessThan(
+      claimIndex,
+    );
+    const renderSource = ROUTE_SOURCE.slice(
+      ROUTE_SOURCE.indexOf("const pdf = buildConsentPdf({"),
+      ROUTE_SOURCE.indexOf("const reservation = await reserveConsentFile"),
+    );
+    expect(renderSource).toContain("practiceId: signing.practiceId");
+    expect(renderSource).toContain("patientId: signing.patientId");
+    expect(renderSource).not.toContain("signing.practiceName");
+    expect(renderSource).not.toContain("signing.patientName");
+    const postSource = ROUTE_SOURCE.slice(
+      ROUTE_SOURCE.indexOf("async function handlePost("),
+      ROUTE_SOURCE.indexOf("export async function GET("),
+    );
+    expect(postSource).toContain("return withSystem(db, async (systemTx) => {");
+    expect(
+      postSource.indexOf("lockPracticeForExternalSideEffects("),
+    ).toBeLessThan(postSource.indexOf("readRequestBytesWithLimit("));
+    expect(postSource.lastIndexOf("});")).toBeGreaterThan(
+      postSource.indexOf("queueManagedUploadReplication("),
+    );
+    expect(ROUTE_SOURCE).toContain(
+      'response.headers.set("Cache-Control", "private, no-store, max-age=0")',
+    );
   });
 });

--- a/apps/web/app/api/sign/[token]/route.ts
+++ b/apps/web/app/api/sign/[token]/route.ts
@@ -1,22 +1,32 @@
 import { NextRequest, NextResponse } from "next/server";
-import { randomUUID } from "crypto";
-import { and, eq, gt, isNull } from "drizzle-orm";
-import { auditLog, consentRequests, files, patients, practices } from "@openpims/db";
-import { db } from "@openpims/db/client";
+import { timingSafeEqual } from "node:crypto";
+import { and, eq, gt, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { auditLog, consentRequests, patients, practices } from "@openpims/db";
+import { db, type Database } from "@openpims/db/client";
 import { withSystem, withTenant } from "@/lib/tenant-db";
+import { lockPracticeForExternalSideEffects } from "@/lib/recovery-hold";
 import { rateLimit, rateLimitResponseHeaders } from "@/lib/rate-limit";
 import { clientIpFromRequest } from "@/lib/request-ip";
-import {
-  captureRateLimitKey,
-  isCaptureTokenShape,
-} from "@/lib/consult/tokens";
+import { captureRateLimitKey, isCaptureTokenShape } from "@/lib/consult/tokens";
 import { CONSENT_SIGNER_NAME_MAX_LENGTH } from "@/lib/consult/consent-template";
-import { buildConsentPdf } from "@/lib/consult/consent-pdf";
-import { deleteFile, uploadFile } from "@/lib/s3";
+import {
+  buildConsentPdf,
+  consentSignaturePngDecodes,
+} from "@/lib/consult/consent-pdf";
 import { uploadBytesMatchMimeType } from "@/lib/upload-security";
 import { readRequestBytesWithLimit } from "@/lib/request-body";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import { CONSENT_FILE_CATEGORY as CONSENT_CATEGORY } from "@/lib/records/file-kinds";
+import { checksumSha256Hex } from "@/lib/file-replication";
+import {
+  finalizeManagedUploadManifest,
+  ManagedUploadConflictError,
+  markManagedUploadCorrupt,
+  putAndVerifyManagedUpload,
+  queueManagedUploadReplication,
+  reserveManagedUpload,
+  type ManagedUploadReservation,
+} from "@/lib/managed-file-upload";
 
 export const dynamic = "force-dynamic";
 
@@ -40,17 +50,46 @@ const IP_WINDOW_MS = 10 * 60 * 1000;
 const SIGN_REQUEST_MAX_BYTES = 1_000_000;
 /** Decoded signature image cap. */
 const SIGNATURE_PNG_MAX_BYTES = 500_000;
+const SIGNATURE_PNG_MAX_DIMENSION = 2_048;
+const SIGNATURE_PNG_MAX_PIXELS = 2_000_000;
 const SIGNATURE_DATA_URL_PREFIX = "data:image/png;base64,";
 const CONSENT_FILE_CATEGORY = CONSENT_CATEGORY;
+
+function signaturePngDimensionsAllowed(bytes: Buffer): boolean {
+  // A PNG must begin with a 13-byte IHDR chunk. Bounding both dimensions and
+  // total pixels prevents a tiny compressed payload from making jsPDF decode
+  // an attacker-controlled, memory-heavy canvas.
+  if (
+    bytes.length < 24 ||
+    bytes.readUInt32BE(8) !== 13 ||
+    bytes.toString("ascii", 12, 16) !== "IHDR"
+  ) {
+    return false;
+  }
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  return (
+    width > 0 &&
+    height > 0 &&
+    width <= SIGNATURE_PNG_MAX_DIMENSION &&
+    height <= SIGNATURE_PNG_MAX_DIMENSION &&
+    width * height <= SIGNATURE_PNG_MAX_PIXELS
+  );
+}
 
 function notFound(): NextResponse {
   return NextResponse.json({ error: "Not found" }, { status: 404 });
 }
 
+function privateNoStore(response: NextResponse): NextResponse {
+  response.headers.set("Cache-Control", "private, no-store, max-age=0");
+  return response;
+}
+
 async function enforceRateLimits(
   request: NextRequest,
   token: string,
-  scope: string
+  scope: string,
 ): Promise<NextResponse | null> {
   const ipResult = await rateLimit({
     key: `${scope}:ip:${clientIpFromRequest(request)}`,
@@ -60,7 +99,7 @@ async function enforceRateLimits(
   if (!ipResult.success) {
     return NextResponse.json(
       { error: "Too many requests" },
-      { status: 429, headers: rateLimitResponseHeaders(IP_LIMIT, ipResult) }
+      { status: 429, headers: rateLimitResponseHeaders(IP_LIMIT, ipResult) },
     );
   }
 
@@ -75,7 +114,7 @@ async function enforceRateLimits(
       {
         status: 429,
         headers: rateLimitResponseHeaders(TOKEN_LIMIT, tokenResult),
-      }
+      },
     );
   }
   return null;
@@ -91,6 +130,10 @@ type ConsentLookup = {
   bodyText: string;
   status: string;
   signerName: string | null;
+  signedAt: Date | null;
+  signaturePngBytes: Uint8Array | null;
+  signatureSha256: string | null;
+  fileId: string | null;
   expiresAt: Date;
   patientName: string;
   practiceName: string;
@@ -99,260 +142,588 @@ type ConsentLookup = {
   trialEndsAt: Date | null;
 };
 
-async function lookupConsent(token: string): Promise<ConsentLookup | null> {
+async function lookupConsent(
+  database: Database,
+  token: string,
+): Promise<ConsentLookup | null> {
   const now = new Date();
-  return withSystem(db, async (tx) => {
-    const [row] = await tx
-      .select({
-        id: consentRequests.id,
-        practiceId: consentRequests.practiceId,
-        patientId: consentRequests.patientId,
-        createdBy: consentRequests.createdBy,
-        appointmentId: consentRequests.appointmentId,
-        title: consentRequests.title,
-        bodyText: consentRequests.bodyText,
-        status: consentRequests.status,
-        signerName: consentRequests.signerName,
-        expiresAt: consentRequests.expiresAt,
-        patientName: patients.name,
-        practiceName: practices.name,
-        tier: practices.subscriptionTier,
-        billingStatus: practices.billingStatus,
-        trialEndsAt: practices.trialEndsAt,
-      })
-      .from(consentRequests)
-      .innerJoin(
-        practices,
-        and(
-          eq(practices.id, consentRequests.practiceId),
-          isNull(practices.deletedAt)
-        )
-      )
-      .innerJoin(patients, eq(patients.id, consentRequests.patientId))
-      .where(
-        and(
-          eq(consentRequests.token, token),
-          isNull(consentRequests.deletedAt),
-          gt(consentRequests.expiresAt, now)
-        )
-      )
-      .limit(1);
-    return row ?? null;
-  });
+  const [row] = await database
+    .select({
+      id: consentRequests.id,
+      practiceId: consentRequests.practiceId,
+      patientId: consentRequests.patientId,
+      createdBy: consentRequests.createdBy,
+      appointmentId: consentRequests.appointmentId,
+      title: consentRequests.title,
+      bodyText: consentRequests.bodyText,
+      status: consentRequests.status,
+      signerName: consentRequests.signerName,
+      signedAt: consentRequests.signedAt,
+      signaturePngBytes: consentRequests.signaturePngBytes,
+      signatureSha256: consentRequests.signatureSha256,
+      fileId: consentRequests.fileId,
+      expiresAt: consentRequests.expiresAt,
+      patientName: patients.name,
+      practiceName: practices.name,
+      tier: practices.subscriptionTier,
+      billingStatus: practices.billingStatus,
+      trialEndsAt: practices.trialEndsAt,
+    })
+    .from(consentRequests)
+    .innerJoin(
+      practices,
+      and(
+        eq(practices.id, consentRequests.practiceId),
+        eq(practices.recoveryHold, false),
+        isNull(practices.deletedAt),
+      ),
+    )
+    .innerJoin(
+      patients,
+      and(
+        eq(patients.id, consentRequests.patientId),
+        eq(patients.practiceId, consentRequests.practiceId),
+        isNull(patients.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(consentRequests.token, token),
+        isNull(consentRequests.deletedAt),
+        or(
+          gt(consentRequests.expiresAt, now),
+          and(
+            inArray(consentRequests.status, ["signing", "signed"]),
+            isNotNull(consentRequests.signerName),
+            isNotNull(consentRequests.signedAt),
+            isNotNull(consentRequests.signaturePngBytes),
+            isNotNull(consentRequests.signatureSha256),
+          ),
+        ),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
 }
 
 function billingBlocked(session: ConsentLookup): boolean {
   return (
     billingEnforced() &&
-    !hasHostedFullAccess(session.tier, session.billingStatus, session.trialEndsAt)
+    !hasHostedFullAccess(
+      session.tier,
+      session.billingStatus,
+      session.trialEndsAt,
+    )
   );
+}
+
+class ConsentFileBindingConflictError extends Error {}
+class ConsentSignatureConflictError extends Error {}
+
+type SigningSession = ConsentLookup & {
+  status: "signing" | "signed";
+  signerName: string;
+  signedAt: Date;
+  signaturePngBytes: Buffer;
+  signatureSha256: string;
+};
+
+function signingFromPersistedEvidence(
+  session: ConsentLookup,
+): SigningSession | null {
+  if (
+    (session.status !== "signing" && session.status !== "signed") ||
+    !session.signerName ||
+    !session.signedAt ||
+    !session.signaturePngBytes ||
+    !session.signatureSha256
+  ) {
+    return null;
+  }
+  return {
+    ...session,
+    status: session.status,
+    signerName: session.signerName,
+    signedAt: session.signedAt,
+    signaturePngBytes: Buffer.from(session.signaturePngBytes),
+    signatureSha256: session.signatureSha256,
+  };
+}
+
+function signatureEvidenceMatches(
+  persistedBytes: Uint8Array,
+  persistedSha256: string,
+  submittedBytes: Buffer,
+  submittedSha256: string,
+): boolean {
+  if (
+    persistedSha256 !== submittedSha256 ||
+    persistedBytes.byteLength !== submittedBytes.byteLength
+  ) {
+    return false;
+  }
+  return timingSafeEqual(Buffer.from(persistedBytes), submittedBytes);
+}
+
+/**
+ * Claim is deliberately its own transaction and happens before PDF render or
+ * provider I/O. A failed render/upload leaves durable signing metadata that a
+ * later POST with the same capability can resume.
+ */
+async function claimSigning(
+  session: ConsentLookup,
+  signerName: string,
+  signaturePngBytes: Buffer,
+  signatureSha256: string,
+): Promise<SigningSession | null> {
+  if (session.status === "pending") {
+    const claimed = await withTenant(db, session.practiceId, async (tx) => {
+      const [row] = await tx
+        .update(consentRequests)
+        .set({
+          status: "signing",
+          signerName,
+          signedAt: sql`clock_timestamp()`,
+          signaturePngBytes,
+          signatureSha256,
+        })
+        .where(
+          and(
+            eq(consentRequests.id, session.id),
+            eq(consentRequests.practiceId, session.practiceId),
+            eq(consentRequests.status, "pending"),
+            // Database time makes expiry part of the same atomic claim as the
+            // pending->signing transition; request/body timing cannot extend
+            // the capability lifetime.
+            gt(consentRequests.expiresAt, sql`clock_timestamp()`),
+            isNull(consentRequests.deletedAt),
+          ),
+        )
+        .returning({
+          signerName: consentRequests.signerName,
+          signedAt: consentRequests.signedAt,
+          signaturePngBytes: consentRequests.signaturePngBytes,
+          signatureSha256: consentRequests.signatureSha256,
+        });
+      return row ?? null;
+    });
+    if (
+      !claimed?.signerName ||
+      !claimed.signedAt ||
+      !claimed.signaturePngBytes ||
+      !claimed.signatureSha256
+    ) {
+      return null;
+    }
+    return {
+      ...session,
+      status: "signing",
+      signerName: claimed.signerName,
+      signedAt: claimed.signedAt,
+      signaturePngBytes: Buffer.from(claimed.signaturePngBytes),
+      signatureSha256: claimed.signatureSha256,
+    };
+  }
+
+  if (session.signerName === signerName) {
+    const signing = signingFromPersistedEvidence(session);
+    if (!signing) return null;
+    if (
+      !signatureEvidenceMatches(
+        signing.signaturePngBytes,
+        signing.signatureSha256,
+        signaturePngBytes,
+        signatureSha256,
+      )
+    ) {
+      throw new ConsentSignatureConflictError();
+    }
+    return signing;
+  }
+  return null;
+}
+
+/** Reserve and bind the file manifest atomically, before any provider PUT. */
+async function reserveConsentFile(
+  session: SigningSession,
+  pdf: Buffer,
+): Promise<ManagedUploadReservation> {
+  return withTenant(db, session.practiceId, async (tx) => {
+    const reservation = await reserveManagedUpload(tx, {
+      practiceId: session.practiceId,
+      uploadedBy: session.createdBy!,
+      idempotencyKey: session.id,
+      fileName: `signed-consent-${session.id.slice(0, 8)}.pdf`,
+      mimeType: "application/pdf",
+      fileSizeBytes: pdf.length,
+      checksumSha256: checksumSha256Hex(pdf),
+      category: CONSENT_FILE_CATEGORY,
+      source: "consent_signature",
+      entityType: "patient",
+      entityId: session.patientId,
+      patientId: session.patientId,
+      appointmentId: session.appointmentId,
+    });
+
+    if (session.status === "signed") {
+      if (session.fileId !== reservation.id) {
+        throw new ConsentFileBindingConflictError();
+      }
+      return reservation;
+    }
+
+    const [bound] = await tx
+      .update(consentRequests)
+      .set({ fileId: reservation.id })
+      .where(
+        and(
+          eq(consentRequests.id, session.id),
+          eq(consentRequests.practiceId, session.practiceId),
+          eq(consentRequests.status, "signing"),
+          isNull(consentRequests.deletedAt),
+          or(
+            isNull(consentRequests.fileId),
+            eq(consentRequests.fileId, reservation.id),
+          ),
+        ),
+      )
+      .returning({ id: consentRequests.id });
+    if (!bound) throw new ConsentFileBindingConflictError();
+    return reservation;
+  });
+}
+
+async function handleGet(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  if (!isCaptureTokenShape(token)) {
+    return notFound();
+  }
+
+  return withSystem(db, async (systemTx) => {
+    const session = await lookupConsent(systemTx, token);
+    if (!session || !session.createdBy || billingBlocked(session)) {
+      return notFound();
+    }
+    // Keep the shared practice-row lease until the response is constructed,
+    // so recovery cannot commit a hold between capability resolution and
+    // returning pending consent content.
+    if (
+      !(await lockPracticeForExternalSideEffects(systemTx, session.practiceId))
+    ) {
+      return notFound();
+    }
+    if (
+      session.expiresAt <= new Date() &&
+      !signingFromPersistedEvidence(session)
+    ) {
+      return notFound();
+    }
+
+    const limited = await enforceRateLimits(request, token, "consent-view");
+    if (limited) return limited;
+
+    if (session.status === "signed") {
+      return NextResponse.json({ status: "signed" });
+    }
+    if (session.status === "signing") {
+      return NextResponse.json({ status: "signing" });
+    }
+    if (session.status !== "pending") return notFound();
+
+    return NextResponse.json({
+      title: session.title,
+      bodyText: session.bodyText,
+      patientName: session.patientName,
+      practiceName: session.practiceName,
+      status: "pending",
+    });
+  });
+}
+
+async function handlePost(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  if (!isCaptureTokenShape(token)) {
+    return notFound();
+  }
+
+  return withSystem(db, async (systemTx) => {
+    const session = await lookupConsent(systemTx, token);
+    // Unknown, expired, orphaned, deleted-practice, and recovery-held requests
+    // all get the same generic miss before request-body or provider work.
+    if (!session || !session.createdBy || billingBlocked(session)) {
+      return notFound();
+    }
+    // Hold this shared row lock across body parsing, durable state changes,
+    // object-store work, and the final response. A recovery hold that commits
+    // first fails closed here; one that loses waits for this request to end.
+    if (
+      !(await lockPracticeForExternalSideEffects(systemTx, session.practiceId))
+    ) {
+      return notFound();
+    }
+    if (
+      session.expiresAt <= new Date() &&
+      !signingFromPersistedEvidence(session)
+    ) {
+      return notFound();
+    }
+
+    const limited = await enforceRateLimits(request, token, "consent-sign");
+    if (limited) return limited;
+
+    const body = await readRequestBytesWithLimit(
+      request,
+      SIGN_REQUEST_MAX_BYTES,
+    );
+    if (!body.ok) {
+      return NextResponse.json(
+        { error: "Request exceeds maximum size" },
+        { status: 413 },
+      );
+    }
+
+    let parsedPayload: unknown;
+    try {
+      parsedPayload = JSON.parse(Buffer.from(body.bytes).toString("utf8"));
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    if (
+      parsedPayload === null ||
+      typeof parsedPayload !== "object" ||
+      Array.isArray(parsedPayload)
+    ) {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    const payload = parsedPayload as {
+      signerName?: unknown;
+      signaturePngDataUrl?: unknown;
+      resume?: unknown;
+    };
+
+    const resume = payload.resume === true;
+    // Expiry terminates every new or replacement signing attempt. Only an
+    // explicit server-side replay of exact evidence durably claimed while the
+    // capability was live may finish afterward.
+    if (!resume && session.expiresAt <= new Date()) return notFound();
+    let signerName = "";
+    let signatureBytes: Buffer | null = null;
+    if (!resume) {
+      signerName =
+        typeof payload.signerName === "string" ? payload.signerName.trim() : "";
+      if (
+        signerName.length === 0 ||
+        signerName.length > CONSENT_SIGNER_NAME_MAX_LENGTH
+      ) {
+        return NextResponse.json(
+          { error: "Please type your full name" },
+          { status: 400 },
+        );
+      }
+
+      const dataUrl =
+        typeof payload.signaturePngDataUrl === "string"
+          ? payload.signaturePngDataUrl
+          : "";
+      if (!dataUrl.startsWith(SIGNATURE_DATA_URL_PREFIX)) {
+        return NextResponse.json(
+          { error: "Please draw your signature" },
+          { status: 400 },
+        );
+      }
+
+      try {
+        signatureBytes = Buffer.from(
+          dataUrl.slice(SIGNATURE_DATA_URL_PREFIX.length),
+          "base64",
+        );
+      } catch {
+        return NextResponse.json(
+          { error: "Please draw your signature" },
+          { status: 400 },
+        );
+      }
+      if (
+        signatureBytes.length === 0 ||
+        signatureBytes.length > SIGNATURE_PNG_MAX_BYTES ||
+        !uploadBytesMatchMimeType("image/png", signatureBytes) ||
+        !signaturePngDimensionsAllowed(signatureBytes) ||
+        !consentSignaturePngDecodes(
+          `${SIGNATURE_DATA_URL_PREFIX}${signatureBytes.toString("base64")}`,
+        )
+      ) {
+        return NextResponse.json(
+          { error: "Please draw your signature" },
+          { status: 400 },
+        );
+      }
+    }
+
+    try {
+      const signing = resume
+        ? signingFromPersistedEvidence(session)
+        : await claimSigning(
+            session,
+            signerName,
+            signatureBytes!,
+            checksumSha256Hex(signatureBytes!),
+          );
+      // A failed pending->signing compare-and-swap is the concurrent loser. It
+      // exits before rendering, reserving, or touching object storage.
+      if (!signing) return notFound();
+
+      const persistedSignatureDataUrl = `${SIGNATURE_DATA_URL_PREFIX}${signing.signaturePngBytes.toString("base64")}`;
+      const pdf = buildConsentPdf({
+        documentId: signing.id,
+        practiceId: signing.practiceId,
+        patientId: signing.patientId,
+        title: signing.title,
+        bodyText: signing.bodyText,
+        signerName: signing.signerName,
+        signedAtIso: signing.signedAt.toISOString(),
+        signaturePngDataUrl: persistedSignatureDataUrl,
+      });
+      const reservation = await reserveConsentFile(signing, pdf);
+      const writeResult = await putAndVerifyManagedUpload({
+        reservation,
+        body: pdf,
+      });
+      if (writeResult.status === "unavailable") {
+        return NextResponse.json(
+          { error: "Signing outcome is still being verified. Please retry." },
+          { status: 503, headers: { "Retry-After": "5" } },
+        );
+      }
+      if (writeResult.status === "corrupt") {
+        const marked = await withTenant(db, signing.practiceId, (tx) =>
+          markManagedUploadCorrupt(tx, reservation),
+        );
+        if (!marked) {
+          throw new Error("Consent reservation changed before quarantine");
+        }
+        return NextResponse.json(
+          { error: "Signed document failed integrity verification" },
+          { status: 503, headers: { "Retry-After": "5" } },
+        );
+      }
+
+      let created = false;
+      if (signing.status === "signed") {
+        // A response may have been lost after commit. Verify the exact bytes and
+        // heal manifest evidence, but never duplicate the audit event.
+        await withTenant(db, signing.practiceId, async (tx) => {
+          if (
+            !(await finalizeManagedUploadManifest(
+              tx,
+              reservation,
+              writeResult.evidence,
+            ))
+          ) {
+            throw new Error("Consent file disappeared before finalization");
+          }
+        });
+      } else {
+        created = await withTenant(db, signing.practiceId, async (tx) => {
+          const [completed] = await tx
+            .update(consentRequests)
+            .set({ status: "signed" })
+            .where(
+              and(
+                eq(consentRequests.id, signing.id),
+                eq(consentRequests.practiceId, signing.practiceId),
+                eq(consentRequests.status, "signing"),
+                eq(consentRequests.fileId, reservation.id),
+                isNull(consentRequests.deletedAt),
+              ),
+            )
+            .returning({ id: consentRequests.id });
+          if (!completed) return false;
+
+          if (
+            !(await finalizeManagedUploadManifest(
+              tx,
+              reservation,
+              writeResult.evidence,
+            ))
+          ) {
+            throw new Error("Consent file disappeared before finalization");
+          }
+
+          await tx.insert(auditLog).values({
+            practiceId: signing.practiceId,
+            // The client performed this public capability action. The staff
+            // dispatcher remains explicit provenance, but must not be recorded
+            // as the signer merely because they minted the link.
+            userId: null,
+            action: "sign",
+            entityType: "consent",
+            entityId: signing.id,
+            ipAddress: clientIpFromRequest(request),
+            changes: {
+              actorType: "client",
+              provenance: "public_consent_capability",
+              dispatchedByUserId: signing.createdBy,
+              signerName: signing.signerName,
+              signedAt: signing.signedAt.toISOString(),
+              signatureSha256: signing.signatureSha256,
+              patientId: signing.patientId,
+              fileId: reservation.id,
+            },
+          });
+          return true;
+        });
+
+        if (!created) {
+          // A concurrent retry may have completed the same durable reservation.
+          const completed = await lookupConsent(systemTx, token);
+          if (
+            !completed ||
+            completed.status !== "signed" ||
+            completed.fileId !== reservation.id
+          ) {
+            return notFound();
+          }
+        }
+      }
+
+      await queueManagedUploadReplication(reservation, writeResult.evidence);
+      return NextResponse.json({ ok: true }, { status: created ? 201 : 200 });
+    } catch (err) {
+      if (
+        err instanceof ManagedUploadConflictError ||
+        err instanceof ConsentFileBindingConflictError ||
+        err instanceof ConsentSignatureConflictError
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "This signing attempt does not match the in-progress request",
+          },
+          { status: 409 },
+        );
+      }
+      console.error("Consent signing failed:", err);
+      return NextResponse.json({ error: "Signing failed" }, { status: 500 });
+    }
+  });
 }
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ token: string }> }
+  context: { params: Promise<{ token: string }> },
 ) {
-  const { token } = await params;
-  if (!isCaptureTokenShape(token)) {
-    return notFound();
-  }
-
-  const limited = await enforceRateLimits(request, token, "consent-view");
-  if (limited) return limited;
-
-  const session = await lookupConsent(token);
-  if (!session || !session.createdBy || billingBlocked(session)) {
-    return notFound();
-  }
-
-  return NextResponse.json({
-    title: session.title,
-    bodyText: session.bodyText,
-    patientName: session.patientName,
-    practiceName: session.practiceName,
-    status: session.status,
-    signerName: session.status === "signed" ? session.signerName : null,
-  });
+  return privateNoStore(await handleGet(request, context));
 }
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ token: string }> }
+  context: { params: Promise<{ token: string }> },
 ) {
-  const { token } = await params;
-  if (!isCaptureTokenShape(token)) {
-    return notFound();
-  }
-
-  const limited = await enforceRateLimits(request, token, "consent-sign");
-  if (limited) return limited;
-
-  const body = await readRequestBytesWithLimit(request, SIGN_REQUEST_MAX_BYTES);
-  if (!body.ok) {
-    return NextResponse.json(
-      { error: "Request exceeds maximum size" },
-      { status: 413 }
-    );
-  }
-
-  let payload: { signerName?: unknown; signaturePngDataUrl?: unknown };
-  try {
-    payload = JSON.parse(Buffer.from(body.bytes).toString("utf8"));
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const signerName =
-    typeof payload.signerName === "string" ? payload.signerName.trim() : "";
-  if (
-    signerName.length === 0 ||
-    signerName.length > CONSENT_SIGNER_NAME_MAX_LENGTH
-  ) {
-    return NextResponse.json(
-      { error: "Please type your full name" },
-      { status: 400 }
-    );
-  }
-
-  const dataUrl =
-    typeof payload.signaturePngDataUrl === "string"
-      ? payload.signaturePngDataUrl
-      : "";
-  if (!dataUrl.startsWith(SIGNATURE_DATA_URL_PREFIX)) {
-    return NextResponse.json(
-      { error: "Please draw your signature" },
-      { status: 400 }
-    );
-  }
-
-  let signatureBytes: Buffer;
-  try {
-    signatureBytes = Buffer.from(
-      dataUrl.slice(SIGNATURE_DATA_URL_PREFIX.length),
-      "base64"
-    );
-  } catch {
-    return NextResponse.json(
-      { error: "Please draw your signature" },
-      { status: 400 }
-    );
-  }
-  if (
-    signatureBytes.length === 0 ||
-    signatureBytes.length > SIGNATURE_PNG_MAX_BYTES ||
-    !uploadBytesMatchMimeType("image/png", signatureBytes)
-  ) {
-    return NextResponse.json(
-      { error: "Please draw your signature" },
-      { status: 400 }
-    );
-  }
-
-  const session = await lookupConsent(token);
-  // Unknown, expired, and orphaned requests all get the same generic miss.
-  if (!session || !session.createdBy || billingBlocked(session)) {
-    return notFound();
-  }
-  // A consent link is single-use.
-  if (session.status !== "pending") {
-    return notFound();
-  }
-
-  const signedAt = new Date();
-  const pdf = buildConsentPdf({
-    practiceName: session.practiceName,
-    patientName: session.patientName,
-    title: session.title,
-    bodyText: session.bodyText,
-    signerName,
-    signedAtIso: signedAt.toISOString(),
-    signaturePngDataUrl: dataUrl,
-  });
-
-  const uuid = randomUUID();
-  const fileName = `signed-consent-${uuid.slice(0, 8)}.pdf`;
-  const key = `${session.practiceId}/${CONSENT_FILE_CATEGORY}/${uuid}-${fileName}`;
-  let uploadedKey: string | null = null;
-
-  try {
-    await uploadFile(key, pdf, "application/pdf");
-    uploadedKey = key;
-    const url = `/api/files/${key}`;
-
-    const result = await withTenant(db, session.practiceId, async (tx) => {
-      // Claim the pending row first: the guard makes concurrent submissions
-      // for the same token single-winner.
-      const [claimed] = await tx
-        .update(consentRequests)
-        .set({ status: "signed", signerName, signedAt })
-        .where(
-          and(
-            eq(consentRequests.id, session.id),
-            eq(consentRequests.status, "pending"),
-            isNull(consentRequests.deletedAt)
-          )
-        )
-        .returning({ id: consentRequests.id });
-      if (!claimed) return null;
-
-      const [inserted] = await tx
-        .insert(files)
-        .values({
-          practiceId: session.practiceId,
-          uploadedBy: session.createdBy!,
-          fileName,
-          fileKey: key,
-          fileUrl: url,
-          mimeType: "application/pdf",
-          fileSizeBytes: pdf.length,
-          category: CONSENT_FILE_CATEGORY,
-          entityType: "patient",
-          entityId: session.patientId,
-          appointmentId: session.appointmentId,
-        })
-        .returning({ id: files.id });
-
-      await tx
-        .update(consentRequests)
-        .set({ fileId: inserted!.id })
-        .where(eq(consentRequests.id, session.id));
-
-      await tx.insert(auditLog).values({
-        practiceId: session.practiceId,
-        userId: session.createdBy!,
-        action: "sign",
-        entityType: "consent",
-        entityId: session.id,
-        changes: {
-          signerName,
-          patientId: session.patientId,
-          fileId: inserted!.id,
-        },
-      });
-
-      return { fileId: inserted!.id };
-    });
-
-    if (!result) {
-      // Another submission won the race after our lookup; drop our upload.
-      try {
-        await deleteFile(uploadedKey);
-      } catch (cleanupErr) {
-        console.error("Failed to clean up uploaded object:", cleanupErr);
-      }
-      return notFound();
-    }
-
-    return NextResponse.json({ ok: true }, { status: 201 });
-  } catch (err) {
-    console.error("Consent signing failed:", err);
-    if (uploadedKey) {
-      try {
-        await deleteFile(uploadedKey);
-      } catch (cleanupErr) {
-        console.error("Failed to clean up uploaded object:", cleanupErr);
-      }
-    }
-    return NextResponse.json({ error: "Signing failed" }, { status: 500 });
-  }
+  return privateNoStore(await handlePost(request, context));
 }

--- a/apps/web/app/api/upload/route.test.ts
+++ b/apps/web/app/api/upload/route.test.ts
@@ -4,19 +4,43 @@ import { fileURLToPath } from "node:url";
 
 const ROUTE_SOURCE = readFileSync(
   fileURLToPath(new URL("./route.ts", import.meta.url)),
-  "utf8"
+  "utf8",
 );
 
 const mocks = vi.hoisted(() => {
-  const practiceId = "00000000-0000-0000-0000-000000000001";
-  const userId = "00000000-0000-0000-0000-000000000002";
-  const insertValues = vi.fn(async () => undefined);
-  const insert = vi.fn(() => ({ values: insertValues }));
+  const practiceId = "00000000-0000-4000-8000-000000000001";
+  const userId = "00000000-0000-4000-8000-000000000002";
+  const patientId = "00000000-0000-4000-8000-000000000003";
+  const fileId = "00000000-0000-4000-8000-000000000004";
+  class ManagedUploadConflictError extends Error {}
+  class ManagedUploadStateError extends ManagedUploadConflictError {}
   const activeAccount = (overrides: Record<string, unknown> = {}) => ({
     userId,
+    role: "admin",
     tier: "free",
     billingStatus: "trialing",
-    trialEndsAt: new Date("2026-07-15T00:00:00Z"),
+    trialEndsAt: new Date("2026-08-20T00:00:00Z"),
+    ...overrides,
+  });
+  const reservation = (overrides: Record<string, unknown> = {}) => ({
+    id: fileId,
+    practiceId,
+    uploadedBy: userId,
+    idempotencyKey: "00000000-0000-4000-8000-000000000099",
+    fileName: "logo.png",
+    fileKey: `${practiceId}/branding/${fileId}`,
+    fileUrl: `/api/files/${practiceId}/branding/${fileId}`,
+    mimeType: "image/png",
+    fileSizeBytes: 8,
+    checksumSha256: "a".repeat(64),
+    storageStatus: "pending_upload",
+    category: "branding",
+    source: "practice_logo",
+    entityType: "practice",
+    entityId: practiceId,
+    patientId: null,
+    appointmentId: null,
+    created: true,
     ...overrides,
   });
   const selectResults: unknown[][] = [];
@@ -30,101 +54,139 @@ const mocks = vi.hoisted(() => {
     };
     return builder;
   });
-  const tx = { insert, select };
+  const updateSets: Record<string, unknown>[] = [];
+  const updateReturningResults: unknown[][] = [];
+  const update = vi.fn(() => {
+    const builder = {
+      set: vi.fn((value: Record<string, unknown>) => {
+        updateSets.push(value);
+        return builder;
+      }),
+      where: vi.fn(() => builder),
+      returning: vi.fn(
+        async () => updateReturningResults.shift() ?? [{ id: "linked" }],
+      ),
+    };
+    return builder;
+  });
+  const tx = { select, update };
 
   return {
+    tx,
+    practiceId,
+    userId,
+    patientId,
+    ManagedUploadConflictError,
+    ManagedUploadStateError,
+    activeAccount,
+    reservation,
+    selectResults,
+    updateSets,
+    updateReturningResults,
     getServerSession: vi.fn(async () => ({
       user: { id: userId, practiceId },
     })),
-    uploadFile: vi.fn(async () => undefined),
-    deleteFile: vi.fn(async () => undefined),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(tx)
+      fn(tx),
     ),
     withTenant: vi.fn(
-      async (
-        _db: unknown,
-        _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(tx)
+      async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+        fn(tx),
     ),
     billingEnforced: vi.fn(() => false),
     hasHostedFullAccess: vi.fn(() => true),
-    insertValues,
-    activeAccount,
-    selectResults,
-    practiceId,
-    userId,
+    rateLimit: vi.fn(async () => ({
+      success: true,
+      remaining: 29,
+      resetAt: new Date("2026-08-10T12:10:00Z"),
+    })),
+    reserveManagedUpload: vi.fn(async () => reservation()),
+    putAndVerifyManagedUpload: vi.fn(async () => ({
+      status: "verified" as const,
+      evidence: {
+        url: "https://storage.example/object",
+        etag: "etag-1",
+        versionId: "version-1",
+      },
+    })),
+    finalizeManagedUploadManifest: vi.fn(async () => true),
+    markManagedUploadCorrupt: vi.fn(async (): Promise<boolean> => true),
+    queueManagedUploadReplication: vi.fn(async () => true),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
   };
 });
 
 vi.mock("next-auth", () => ({
   getServerSession: mocks.getServerSession,
 }));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
-}));
-
-vi.mock("@/lib/s3", () => ({
-  deleteFile: mocks.deleteFile,
-  uploadFile: mocks.uploadFile,
-}));
-
-vi.mock("@openpims/db/client", () => ({
-  db: {},
-}));
-
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@openpims/db/client", () => ({ db: {} }));
 vi.mock("@/lib/tenant-db", () => ({
   withSystem: mocks.withSystem,
   withTenant: mocks.withTenant,
 }));
-
 vi.mock("@/lib/billing/plans", () => ({
   billingEnforced: mocks.billingEnforced,
   hasHostedFullAccess: mocks.hasHostedFullAccess,
+}));
+vi.mock("@/lib/file-replication", () => ({
+  checksumSha256Hex: vi.fn(() => "a".repeat(64)),
+}));
+vi.mock("@/lib/rate-limit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/rate-limit")>();
+  return { ...actual, rateLimit: mocks.rateLimit };
+});
+vi.mock("@/lib/managed-file-upload", () => ({
+  ManagedUploadConflictError: mocks.ManagedUploadConflictError,
+  reserveManagedUpload: mocks.reserveManagedUpload,
+  putAndVerifyManagedUpload: mocks.putAndVerifyManagedUpload,
+  finalizeManagedUploadManifest: mocks.finalizeManagedUploadManifest,
+  markManagedUploadCorrupt: mocks.markManagedUploadCorrupt,
+  queueManagedUploadReplication: mocks.queueManagedUploadReplication,
+}));
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "Practice recovery is in progress.",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { POST } = await import("./route");
 const { UPLOAD_REQUEST_MAX_BYTES } = await import("@/lib/upload-limits");
 
-function uploadRequest(file: File, category = "branding") {
-  const formData = new FormData();
-  formData.append("file", file);
-  formData.append("category", category);
+const PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
 
-  return new Request("https://openvpm.test/api/upload", {
-    method: "POST",
-    body: formData,
-  }) as never;
-}
-
-function oversizedUploadRequest() {
+function uploadRequest(
+  options: {
+    file?: File;
+    category?: string;
+    patientId?: string;
+    idempotencyKey?: string | null;
+    contentLength?: number;
+  } = {},
+) {
   const formData = new FormData();
   formData.append(
     "file",
-    new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], "lab.pdf", {
-      type: "application/pdf",
-    })
+    options.file ?? new File([PNG_BYTES], "logo.png", { type: "image/png" }),
   );
-  formData.append("category", "documents");
-
+  formData.append("category", options.category ?? "branding");
+  if (options.patientId) formData.append("patientId", options.patientId);
+  const headers = new Headers();
+  if (options.idempotencyKey !== null) {
+    headers.set(
+      "Idempotency-Key",
+      options.idempotencyKey ?? "00000000-0000-4000-8000-000000000099",
+    );
+  }
+  if (options.contentLength != null) {
+    headers.set("content-length", String(options.contentLength));
+  }
   return new Request("https://openvpm.test/api/upload", {
     method: "POST",
-    headers: {
-      "content-length": String(UPLOAD_REQUEST_MAX_BYTES + 1),
-    },
+    headers,
     body: formData,
-  }) as never;
-}
-
-function streamedOversizedUploadRequest() {
-  return new Request("https://openvpm.test/api/upload", {
-    method: "POST",
-    headers: {
-      "content-type": "multipart/form-data; boundary=openvpm",
-    },
-    body: "x".repeat(UPLOAD_REQUEST_MAX_BYTES + 1),
   }) as never;
 }
 
@@ -132,257 +194,398 @@ afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
   mocks.selectResults.length = 0;
+  mocks.updateSets.length = 0;
+  mocks.updateReturningResults.length = 0;
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
   mocks.getServerSession.mockResolvedValue({
     user: { id: mocks.userId, practiceId: mocks.practiceId },
   });
+  mocks.rateLimit.mockResolvedValue({
+    success: true,
+    remaining: 29,
+    resetAt: new Date("2026-08-10T12:10:00Z"),
+  });
+  mocks.reserveManagedUpload.mockResolvedValue(mocks.reservation());
+  mocks.putAndVerifyManagedUpload.mockResolvedValue({
+    status: "verified",
+    evidence: {
+      url: "https://storage.example/object",
+      etag: "etag-1",
+      versionId: "version-1",
+    },
+  });
+  mocks.finalizeManagedUploadManifest.mockResolvedValue(true);
+  mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
 });
 
-describe("upload route file validation", () => {
-  it("rejects oversized requests before billing, multipart parsing, or upload", async () => {
-    mocks.billingEnforced.mockReturnValue(true);
-
-    const response = await POST(oversizedUploadRequest());
-
+describe("managed dashboard upload route", () => {
+  it("rejects oversized requests before auth or database work", async () => {
+    const response = await POST(
+      uploadRequest({ contentLength: UPLOAD_REQUEST_MAX_BYTES + 1 }),
+    );
     expect(response.status).toBe(413);
-    await expect(response.json()).resolves.toEqual({
-      error: "Upload exceeds maximum request size",
-    });
+    expect(mocks.getServerSession).toHaveBeenCalledTimes(1);
     expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
-    expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 
-  it("rejects streamed oversized requests without a content-length header before multipart parsing", async () => {
-    const response = await POST(streamedOversizedUploadRequest());
-
-    expect(response.status).toBe(413);
-    await expect(response.json()).resolves.toEqual({
-      error: "Upload exceeds maximum request size",
-    });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
-    expect(mocks.insertValues).not.toHaveBeenCalled();
-  });
-
-  it("rejects uploads without session lookup when NEXTAUTH_SECRET is blank", async () => {
+  it("fails closed when the configured auth secret is blank", async () => {
     vi.stubEnv("NEXTAUTH_SECRET", "   ");
-    const file = new File([new TextEncoder().encode("%PDF-1.7\n")], "lab.pdf", {
-      type: "application/pdf",
-    });
-
-    const response = await POST(uploadRequest(file, "documents"));
-
+    const response = await POST(uploadRequest());
     expect(response.status).toBe(401);
-    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
     expect(mocks.getServerSession).not.toHaveBeenCalled();
-    expect(mocks.withSystem).not.toHaveBeenCalled();
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
   });
 
-  it("rejects stale sessions before billing or upload work", async () => {
+  it("rejects stale sessions and viewer mutations", async () => {
     mocks.selectResults.push([]);
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ]);
-    const file = new File([pngBytes], "logo.png", { type: "image/png" });
+    expect((await POST(uploadRequest())).status).toBe(401);
 
-    const response = await POST(uploadRequest(file));
-
-    expect(response.status).toBe(401);
-    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
-    expect(mocks.billingEnforced).not.toHaveBeenCalled();
-    expect(mocks.hasHostedFullAccess).not.toHaveBeenCalled();
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
-    expect(mocks.insertValues).not.toHaveBeenCalled();
+    mocks.selectResults.push([mocks.activeAccount({ role: "viewer" })]);
+    expect((await POST(uploadRequest())).status).toBe(403);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("blocks hosted read-only uploads using the active practice row", async () => {
+  it("preserves the hosted billing write gate", async () => {
     mocks.billingEnforced.mockReturnValue(true);
     mocks.hasHostedFullAccess.mockReturnValue(false);
     mocks.selectResults.push([
       mocks.activeAccount({
-        tier: "basic",
+        tier: "cloud",
         billingStatus: "past_due",
         trialEndsAt: null,
       }),
     ]);
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ]);
-    const file = new File([pngBytes], "logo.png", { type: "image/png" });
-
-    const response = await POST(uploadRequest(file));
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toEqual({
-      error:
-        "OpenVPM Cloud is read-only until your trial or subscription is active.",
-    });
-    expect(mocks.hasHostedFullAccess).toHaveBeenCalledWith(
-      "basic",
-      "past_due",
-      null
-    );
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect((await POST(uploadRequest())).status).toBe(403);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("rejects overlong filenames before upload", async () => {
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ]);
-    const file = new File([pngBytes], `${"a".repeat(252)}.png`, {
-      type: "image/png",
+  it("rate-limits by active user and practice before multipart parsing", async () => {
+    mocks.rateLimit.mockResolvedValueOnce({
+      success: false,
+      remaining: 0,
+      resetAt: new Date("2026-08-10T12:10:00Z"),
     });
-
-    const response = await POST(uploadRequest(file));
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "File name must be between 1 and 255 characters",
-    });
-
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
-  });
-
-  it("rejects non-image uploads in the public branding category", async () => {
-    const file = new File([new TextEncoder().encode("%PDF-1.7\n")], "logo.pdf", {
-      type: "application/pdf",
-    });
-
-    const response = await POST(uploadRequest(file, "branding"));
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "Branding uploads must be image files",
-    });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
-  });
-
-  it("rejects uploads whose bytes do not match the declared MIME type", async () => {
-    const file = new File([new TextEncoder().encode("<html></html>")], "fake.png", {
-      type: "image/png",
-    });
-
-    const response = await POST(uploadRequest(file));
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "File contents do not match the declared file type",
-    });
-    expect(mocks.uploadFile).not.toHaveBeenCalled();
-    expect(mocks.withTenant).not.toHaveBeenCalled();
-  });
-
-  it("still allows PDFs in private document categories", async () => {
-    const file = new File([new TextEncoder().encode("%PDF-1.7\n")], "lab.pdf", {
-      type: "application/pdf",
-    });
-
-    const response = await POST(uploadRequest(file, "documents"));
-
-    expect(response.status).toBe(201);
-    const json = await response.json();
-    expect(json.url).toMatch(
-      new RegExp(`^/api/files/${mocks.practiceId}/documents/.+-lab\\.pdf$`)
-    );
-    expect(mocks.uploadFile).toHaveBeenCalledWith(
-      expect.stringMatching(
-        new RegExp(`^${mocks.practiceId}/documents/.+-lab\\.pdf$`)
-      ),
-      expect.any(Buffer),
-      "application/pdf"
-    );
-    expect(mocks.insertValues).toHaveBeenCalledWith(
+    const response = await POST(uploadRequest());
+    expect(response.status).toBe(429);
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("30");
+    expect(mocks.rateLimit).toHaveBeenCalledWith(
       expect.objectContaining({
-        practiceId: mocks.practiceId,
-        uploadedBy: mocks.userId,
-        fileName: "lab.pdf",
-        mimeType: "application/pdf",
-        category: "documents",
-      })
+        key: `dashboard-upload:user:${mocks.userId}`,
+      }),
     );
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("stores files only after the declared type matches the file signature", async () => {
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ]);
-    const file = new File([pngBytes], "logo.png", { type: "image/png" });
-
-    const response = await POST(uploadRequest(file));
-
-    expect(response.status).toBe(201);
-    const json = await response.json();
-    expect(json.url).toMatch(
-      new RegExp(`^/api/files/${mocks.practiceId}/branding/.+-logo\\.png$`)
+  it("requires a UUID idempotency key and rejects generic clinical categories", async () => {
+    expect((await POST(uploadRequest({ idempotencyKey: null }))).status).toBe(
+      400,
     );
-    expect(mocks.uploadFile).toHaveBeenCalledWith(
-      expect.stringMatching(
-        new RegExp(`^${mocks.practiceId}/branding/.+-logo\\.png$`)
-      ),
-      expect.any(Buffer),
-      "image/png"
+    expect((await POST(uploadRequest({ category: "documents" }))).status).toBe(
+      400,
     );
-    expect(mocks.insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        practiceId: mocks.practiceId,
-        uploadedBy: mocks.userId,
-        fileName: "logo.png",
-        mimeType: "image/png",
-        category: "branding",
-      })
-    );
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("cleans up the uploaded object when metadata persistence fails", async () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    mocks.insertValues.mockRejectedValueOnce(new Error("db unavailable"));
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ]);
-    const file = new File([pngBytes], "logo.png", { type: "image/png" });
+  it("allows only admins to change public branding", async () => {
+    mocks.selectResults.push([mocks.activeAccount({ role: "veterinarian" })]);
+    expect((await POST(uploadRequest())).status).toBe(403);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+  });
 
-    try {
-      const response = await POST(uploadRequest(file));
+  it("requires and verifies an exact active patient for profile photos", async () => {
+    expect(
+      (await POST(uploadRequest({ category: "patient-photos" }))).status,
+    ).toBe(400);
 
-      expect(response.status).toBe(500);
-      await expect(response.json()).resolves.toEqual({ error: "Upload failed" });
-      expect(mocks.uploadFile).toHaveBeenCalledTimes(1);
-      expect(mocks.deleteFile).toHaveBeenCalledWith(
-        expect.stringMatching(
-          new RegExp(`^${mocks.practiceId}/branding/.+-logo\\.png$`)
+    mocks.selectResults.push([mocks.activeAccount()], []);
+    expect(
+      (
+        await POST(
+          uploadRequest({
+            category: "patient-photos",
+            patientId: mocks.patientId,
+          }),
         )
-      );
-      expect(consoleError).toHaveBeenCalledWith(
-        "Upload failed:",
-        expect.any(Error)
-      );
-    } finally {
-      consoleError.mockRestore();
-    }
+      ).status,
+    ).toBe(404);
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
   });
 
-  it("revalidates uploads against active user and practice rows", () => {
-    expect(ROUTE_SOURCE).toContain("innerJoin(");
-    expect(ROUTE_SOURCE).toContain("isNull(practices.deletedAt)");
-    expect(ROUTE_SOURCE).toContain("eq(users.id, session.user.id)");
-    expect(ROUTE_SOURCE).toContain(
-      "eq(users.practiceId, session.user.practiceId)"
+  it("rejects non-images and signature mismatches", async () => {
+    const pdf = new File([new TextEncoder().encode("%PDF-1.7\n")], "logo.pdf", {
+      type: "application/pdf",
+    });
+    expect((await POST(uploadRequest({ file: pdf }))).status).toBe(400);
+
+    const fake = new File(["<html></html>"], "fake.png", {
+      type: "image/png",
+    });
+    expect((await POST(uploadRequest({ file: fake }))).status).toBe(400);
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("reserves before PUT and atomically links a practice logo", async () => {
+    const response = await POST(uploadRequest());
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      url: `/api/files/${mocks.practiceId}/branding/00000000-0000-4000-8000-000000000004`,
+      key: `${mocks.practiceId}/branding/00000000-0000-4000-8000-000000000004`,
+    });
+    expect(mocks.reserveManagedUpload).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        category: "branding",
+        source: "practice_logo",
+        entityType: "practice",
+        entityId: mocks.practiceId,
+      }),
     );
-    expect(ROUTE_SOURCE).toContain("isNull(users.deletedAt)");
+    expect(mocks.reserveManagedUpload.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.putAndVerifyManagedUpload.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledTimes(1);
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        logoUrl: expect.stringContaining("/api/files/"),
+      }),
+    );
+    expect(mocks.queueManagedUploadReplication).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the capped request byte reader before multipart parsing", () => {
+  it("rejects a held practice before reading or calling storage", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+
+    const response = await POST(uploadRequest());
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("5");
+    await expect(response.json()).resolves.toEqual({
+      error: "Practice recovery is in progress.",
+    });
+    expect(mocks.reserveManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+  });
+
+  it("keeps the practice lease active through provider PUT and finalization", async () => {
+    let leaseActive = false;
+    let replicationQueuedAfterCommit = false;
+    let resolvePut:
+      | ((value: {
+          status: "verified";
+          evidence: { url: string; etag: string; versionId: string };
+        }) => void)
+      | undefined;
+    mocks.withTenant.mockImplementationOnce(
+      async (
+        _db: unknown,
+        _practiceId: string,
+        fn: (tx: unknown) => unknown,
+      ) => {
+        leaseActive = true;
+        try {
+          return await fn(mocks.tx);
+        } finally {
+          leaseActive = false;
+        }
+      },
+    );
+    mocks.putAndVerifyManagedUpload.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          expect(leaseActive).toBe(true);
+          resolvePut = resolve;
+        }),
+    );
+    mocks.finalizeManagedUploadManifest.mockImplementationOnce(async () => {
+      expect(leaseActive).toBe(true);
+      return true;
+    });
+    mocks.queueManagedUploadReplication.mockImplementationOnce(async () => {
+      expect(leaseActive).toBe(false);
+      replicationQueuedAfterCommit = true;
+      return true;
+    });
+
+    const responsePromise = POST(uploadRequest());
+    await vi.waitFor(() =>
+      expect(mocks.putAndVerifyManagedUpload).toHaveBeenCalledOnce(),
+    );
+    expect(leaseActive).toBe(true);
+    resolvePut?.({
+      status: "verified",
+      evidence: {
+        url: "https://storage.example/object",
+        etag: "etag-1",
+        versionId: "version-1",
+      },
+    });
+
+    expect((await responsePromise).status).toBe(201);
+    expect(leaseActive).toBe(false);
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledOnce();
+    expect(replicationQueuedAfterCommit).toBe(true);
+  });
+
+  it("rolls back finalization when entity linking fails and allows a retry", async () => {
+    let transactionCallbackRejected = false;
+    mocks.withTenant.mockImplementationOnce(
+      async (
+        _db: unknown,
+        _practiceId: string,
+        fn: (tx: unknown) => unknown,
+      ) => {
+        try {
+          return await fn(mocks.tx);
+        } catch (error) {
+          transactionCallbackRejected = true;
+          throw error;
+        }
+      },
+    );
+    mocks.updateReturningResults.push([]);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const failed = await POST(uploadRequest());
+
+    expect(failed.status).toBe(500);
+    expect(transactionCallbackRejected).toBe(true);
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledOnce();
+    expect(mocks.queueManagedUploadReplication).not.toHaveBeenCalled();
+
+    const retry = await POST(uploadRequest());
+
+    expect(retry.status).toBe(201);
+    expect(mocks.finalizeManagedUploadManifest).toHaveBeenCalledTimes(2);
+    expect(mocks.queueManagedUploadReplication).toHaveBeenCalledOnce();
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        logoUrl: expect.stringContaining("/api/files/"),
+      }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("binds patient-photo ownership and link in the same finalization", async () => {
+    mocks.selectResults.push(
+      [mocks.activeAccount()],
+      [{ id: mocks.patientId }],
+    );
+    mocks.reserveManagedUpload.mockResolvedValueOnce(
+      mocks.reservation({
+        category: "patient-photos",
+        patientId: mocks.patientId,
+        entityType: "patient",
+        entityId: mocks.patientId,
+        source: "profile_photo",
+        fileKey: `${mocks.practiceId}/patient-photos/00000000-0000-4000-8000-000000000004`,
+        fileUrl: `/api/files/${mocks.practiceId}/patient-photos/00000000-0000-4000-8000-000000000004`,
+      }),
+    );
+
+    const response = await POST(
+      uploadRequest({
+        category: "patient-photos",
+        patientId: mocks.patientId,
+      }),
+    );
+    expect(response.status).toBe(201);
+    expect(mocks.reserveManagedUpload).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        patientId: mocks.patientId,
+        entityType: "patient",
+        entityId: mocks.patientId,
+      }),
+    );
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        photoUrl: expect.stringContaining("/api/files/"),
+      }),
+    );
+  });
+
+  it("returns a completed reservation idempotently without another PUT", async () => {
+    mocks.reserveManagedUpload.mockResolvedValueOnce(
+      mocks.reservation({ created: false, storageStatus: "available" }),
+    );
+    const response = await POST(uploadRequest());
+    expect(response.status).toBe(200);
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when an idempotency key is reused for another payload", async () => {
+    mocks.reserveManagedUpload.mockRejectedValueOnce(
+      new mocks.ManagedUploadConflictError("conflict"),
+    );
+    expect((await POST(uploadRequest())).status).toBe(409);
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+  });
+
+  it("returns definitive 409 for a deleted managed-upload reservation", async () => {
+    mocks.reserveManagedUpload.mockRejectedValueOnce(
+      new mocks.ManagedUploadStateError(
+        "Upload reservation is deleted and cannot be retried",
+      ),
+    );
+
+    const response = await POST(uploadRequest());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Upload reservation is deleted and cannot be retried",
+    });
+    expect(mocks.putAndVerifyManagedUpload).not.toHaveBeenCalled();
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+    expect(mocks.queueManagedUploadReplication).not.toHaveBeenCalled();
+    expect(mocks.updateSets).toEqual([]);
+  });
+
+  it("leaves ambiguous provider outcomes reserved and retryable", async () => {
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "unavailable",
+    } as never);
+    const response = await POST(uploadRequest());
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("5");
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+  });
+
+  it("marks checksum mismatches corrupt without deleting ambiguous bytes", async () => {
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "corrupt",
+    } as never);
+    const response = await POST(uploadRequest());
+    expect(response.status).toBe(503);
+    expect(mocks.markManagedUploadCorrupt).toHaveBeenCalledTimes(1);
+    expect(ROUTE_SOURCE).not.toContain("deleteFile(");
+  });
+
+  it("fails closed when quarantine loses the exact reservation generation", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.putAndVerifyManagedUpload.mockResolvedValueOnce({
+      status: "corrupt",
+    } as never);
+    mocks.markManagedUploadCorrupt.mockResolvedValueOnce(false);
+
+    const response = await POST(uploadRequest());
+    expect(response.status).toBe(500);
+    expect(mocks.finalizeManagedUploadManifest).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith("[upload] managed upload failed");
+    consoleError.mockRestore();
+  });
+
+  it("uses bounded parsing and revalidates the active database role", () => {
     expect(ROUTE_SOURCE).toContain("readRequestBytesWithLimit(");
-    expect(ROUTE_SOURCE).toContain("UPLOAD_REQUEST_MAX_BYTES");
     expect(ROUTE_SOURCE).not.toContain("req.formData()");
+    expect(ROUTE_SOURCE).toContain("role: users.role");
+    expect(ROUTE_SOURCE).toContain('activeAccount.role === "viewer"');
+    expect(ROUTE_SOURCE).toContain("eq(patients.practiceId, practiceId)");
+    expect(ROUTE_SOURCE).toContain("isNull(patients.deletedAt)");
   });
 });

--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -1,18 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
-import { randomUUID } from "crypto";
 import { authOptions } from "@/lib/auth";
-import { deleteFile, uploadFile } from "@/lib/s3";
 import { db } from "@openpims/db/client";
-import { files, practices, users } from "@openpims/db";
+import { patients, practices, users } from "@openpims/db";
 import { and, eq, isNull } from "drizzle-orm";
 import { withSystem, withTenant } from "@/lib/tenant-db";
 import { hasBlankConfiguredNextAuthSecret } from "@/lib/auth-secret";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import {
-  ALLOWED_UPLOAD_CATEGORIES,
   ALLOWED_UPLOAD_MIME_TYPES,
-  isAllowedUploadCategory,
   isAllowedUploadMimeType,
   uploadBytesMatchMimeType,
 } from "@/lib/upload-security";
@@ -22,8 +18,67 @@ import {
   uploadRequestContentLengthTooLarge,
 } from "@/lib/upload-limits";
 import { readRequestBytesWithLimit } from "@/lib/request-body";
+import { checksumSha256Hex } from "@/lib/file-replication";
+import { rateLimit, rateLimitResponseHeaders } from "@/lib/rate-limit";
+import {
+  finalizeManagedUploadManifest,
+  ManagedUploadConflictError,
+  markManagedUploadCorrupt,
+  putAndVerifyManagedUpload,
+  queueManagedUploadReplication,
+  reserveManagedUpload,
+  type DashboardUploadCategory,
+} from "@/lib/managed-file-upload";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 const MAX_FILE_NAME_LENGTH = 255;
+const DASHBOARD_UPLOAD_CATEGORIES = ["branding", "patient-photos"] as const;
+const IDEMPOTENCY_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const USER_UPLOAD_LIMIT = 30;
+const USER_UPLOAD_WINDOW_MS = 10 * 60 * 1000;
+const PRACTICE_UPLOAD_LIMIT = 300;
+const PRACTICE_UPLOAD_WINDOW_MS = 60 * 60 * 1000;
+
+function rateLimitedResponse(
+  limit: number,
+  result: { remaining: number; resetAt: Date },
+) {
+  return NextResponse.json(
+    { error: "Too many uploads. Please wait and try again." },
+    { status: 429, headers: rateLimitResponseHeaders(limit, result) },
+  );
+}
+
+async function enforceUploadRateLimits(userId: string, practiceId: string) {
+  try {
+    const userLimit = await rateLimit({
+      key: `dashboard-upload:user:${userId}`,
+      limit: USER_UPLOAD_LIMIT,
+      windowMs: USER_UPLOAD_WINDOW_MS,
+    });
+    if (!userLimit.success) {
+      return rateLimitedResponse(USER_UPLOAD_LIMIT, userLimit);
+    }
+    const practiceLimit = await rateLimit({
+      key: `dashboard-upload:practice:${practiceId}`,
+      limit: PRACTICE_UPLOAD_LIMIT,
+      windowMs: PRACTICE_UPLOAD_WINDOW_MS,
+    });
+    if (!practiceLimit.success) {
+      return rateLimitedResponse(PRACTICE_UPLOAD_LIMIT, practiceLimit);
+    }
+    return null;
+  } catch {
+    return rateLimitedResponse(USER_UPLOAD_LIMIT, {
+      remaining: 0,
+      resetAt: new Date(Date.now() + USER_UPLOAD_WINDOW_MS),
+    });
+  }
+}
 
 export async function POST(req: NextRequest) {
   // ---------- Auth ----------
@@ -46,6 +101,7 @@ export async function POST(req: NextRequest) {
     tx
       .select({
         userId: users.id,
+        role: users.role,
         tier: practices.subscriptionTier,
         billingStatus: practices.billingStatus,
         trialEndsAt: practices.trialEndsAt,
@@ -67,13 +123,22 @@ export async function POST(req: NextRequest) {
   if (!activeAccount) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (activeAccount.role === "viewer") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const uploadRateLimit = await enforceUploadRateLimits(
+    activeAccount.userId,
+    session.user.practiceId,
+  );
+  if (uploadRateLimit) return uploadRateLimit;
 
   if (billingEnforced()) {
     if (
       !hasHostedFullAccess(
         activeAccount.tier,
         activeAccount.billingStatus,
-        activeAccount.trialEndsAt
+        activeAccount.trialEndsAt,
       )
     ) {
       return NextResponse.json(
@@ -81,142 +146,266 @@ export async function POST(req: NextRequest) {
           error:
             "OpenVPM Cloud is read-only until your trial or subscription is active.",
         },
-        { status: 403 }
+        { status: 403 },
       );
     }
   }
 
-  // ---------- Parse multipart form data ----------
-  let formData: FormData;
-  try {
-    const body = await readRequestBytesWithLimit(req, UPLOAD_REQUEST_MAX_BYTES);
-    if (!body.ok) {
-      return NextResponse.json(
-        { error: "Upload exceeds maximum request size" },
-        { status: 413 },
-      );
-    }
-
-    const boundedBody = new ArrayBuffer(body.bytes.byteLength);
-    new Uint8Array(boundedBody).set(body.bytes);
-    const boundedRequest = new Request(req.url, {
-      method: req.method,
-      headers: req.headers,
-      body: boundedBody,
-    });
-    formData = await boundedRequest.formData();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid form data" },
-      { status: 400 },
-    );
-  }
-
-  const file = formData.get("file");
-  const category = formData.get("category");
-
-  if (!file || !(file instanceof File)) {
-    return NextResponse.json(
-      { error: "Missing file field" },
-      { status: 400 },
-    );
-  }
-  if (!file.name || file.name.length > MAX_FILE_NAME_LENGTH) {
-    return NextResponse.json(
-      { error: "File name must be between 1 and 255 characters" },
-      { status: 400 },
-    );
-  }
-
-  // ---------- Validate category ----------
-  if (
-    typeof category !== "string" ||
-    !isAllowedUploadCategory(category)
-  ) {
-    return NextResponse.json(
-      {
-        error: `Invalid category. Allowed: ${ALLOWED_UPLOAD_CATEGORIES.join(", ")}`,
-      },
-      { status: 400 },
-    );
-  }
-
-  // ---------- Validate MIME type ----------
-  const mimeType = file.type;
-  if (!isAllowedUploadMimeType(mimeType)) {
-    return NextResponse.json(
-      {
-        error: `File type not allowed. Accepted: ${Object.keys(ALLOWED_UPLOAD_MIME_TYPES).join(", ")}`,
-      },
-      { status: 400 },
-    );
-  }
-  if (category === "branding" && !mimeType.startsWith("image/")) {
-    return NextResponse.json(
-      { error: "Branding uploads must be image files" },
-      { status: 400 },
-    );
-  }
-
-  // ---------- Validate size ----------
-  if (file.size > UPLOAD_FILE_MAX_BYTES) {
-    return NextResponse.json(
-      { error: "File exceeds maximum size of 10 MB" },
-      { status: 400 },
-    );
-  }
-
-  // ---------- Build S3 key ----------
   const practiceId = session.user.practiceId;
-  const uuid = randomUUID();
-  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
-  const key = `${practiceId}/${category}/${uuid}-${safeName}`;
-  let uploadedKey: string | null = null;
-
-  // ---------- Upload ----------
+  const postCommit = {
+    replicationToQueue: null as null | (() => Promise<boolean>),
+  };
   try {
-    const buffer = Buffer.from(await file.arrayBuffer());
-    if (!uploadBytesMatchMimeType(mimeType, buffer)) {
-      return NextResponse.json(
-        { error: "File contents do not match the declared file type" },
-        { status: 400 },
-      );
-    }
-
-    await uploadFile(key, buffer, mimeType);
-    uploadedKey = key;
-
-    // Serve through the same-origin proxy (app/api/files/[...path]). The raw
-    // R2/S3 URL is private and can't be loaded by an <img> tag.
-    const url = `/api/files/${key}`;
-
-    // Persist metadata in the database (tenant-scoped for RLS).
-    await withTenant(db, practiceId, (tx) =>
-      tx.insert(files).values({
-        practiceId,
-        uploadedBy: session.user.id,
-        fileName: file.name,
-        fileKey: key,
-        fileUrl: url,
-        mimeType,
-        fileSizeBytes: file.size,
-        category,
-      })
-    );
-
-    return NextResponse.json({ url, key }, { status: 201 });
-  } catch (err) {
-    console.error("Upload failed:", err);
-    if (uploadedKey) {
-      try {
-        await deleteFile(uploadedKey);
-      } catch (cleanupErr) {
-        console.error("Failed to clean up uploaded object:", cleanupErr);
+    const response = await withTenant(db, practiceId, async (leaseTx) => {
+      // Acquire the recovery lease before reading the multipart body and keep
+      // the transaction open through primary storage PUT and manifest/link
+      // finalization. The short reservation transaction commits independently
+      // before PUT; finalization and entity linking use this lease-owning
+      // transaction. The shared lock drains in-flight work before restore.
+      if (!(await lockPracticeForExternalSideEffects(leaseTx, practiceId))) {
+        return NextResponse.json(
+          { error: RECOVERY_HOLD_BLOCK_MESSAGE },
+          { status: 503, headers: { "Retry-After": "5" } },
+        );
       }
+
+      // ---------- Parse multipart form data ----------
+      let formData: FormData;
+      try {
+        const body = await readRequestBytesWithLimit(
+          req,
+          UPLOAD_REQUEST_MAX_BYTES,
+        );
+        if (!body.ok) {
+          return NextResponse.json(
+            { error: "Upload exceeds maximum request size" },
+            { status: 413 },
+          );
+        }
+
+        const boundedBody = new ArrayBuffer(body.bytes.byteLength);
+        new Uint8Array(boundedBody).set(body.bytes);
+        const boundedRequest = new Request(req.url, {
+          method: req.method,
+          headers: req.headers,
+          body: boundedBody,
+        });
+        formData = await boundedRequest.formData();
+      } catch {
+        return NextResponse.json(
+          { error: "Invalid form data" },
+          { status: 400 },
+        );
+      }
+
+      const file = formData.get("file");
+      const category = formData.get("category");
+      const patientIdValue = formData.get("patientId");
+      const idempotencyKey = req.headers.get("idempotency-key")?.trim() ?? "";
+
+      if (!IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey)) {
+        return NextResponse.json(
+          { error: "A canonical UUID Idempotency-Key header is required" },
+          { status: 400 },
+        );
+      }
+
+      if (!file || !(file instanceof File)) {
+        return NextResponse.json(
+          { error: "Missing file field" },
+          { status: 400 },
+        );
+      }
+      if (!file.name || file.name.length > MAX_FILE_NAME_LENGTH) {
+        return NextResponse.json(
+          { error: "File name must be between 1 and 255 characters" },
+          { status: 400 },
+        );
+      }
+
+      // ---------- Validate category ----------
+      if (
+        typeof category !== "string" ||
+        !DASHBOARD_UPLOAD_CATEGORIES.includes(
+          category as (typeof DASHBOARD_UPLOAD_CATEGORIES)[number],
+        )
+      ) {
+        return NextResponse.json(
+          {
+            error: `Invalid category. Allowed: ${DASHBOARD_UPLOAD_CATEGORIES.join(", ")}`,
+          },
+          { status: 400 },
+        );
+      }
+      const dashboardCategory = category as DashboardUploadCategory;
+      if (dashboardCategory === "branding" && activeAccount.role !== "admin") {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+      const patientId =
+        dashboardCategory === "patient-photos" &&
+        typeof patientIdValue === "string" &&
+        IDEMPOTENCY_KEY_PATTERN.test(patientIdValue)
+          ? patientIdValue
+          : null;
+      if (dashboardCategory === "patient-photos" && !patientId) {
+        return NextResponse.json(
+          { error: "A canonical patientId is required for patient photos" },
+          { status: 400 },
+        );
+      }
+
+      // ---------- Validate MIME type ----------
+      const mimeType = file.type;
+      if (!isAllowedUploadMimeType(mimeType)) {
+        return NextResponse.json(
+          {
+            error: `File type not allowed. Accepted: ${Object.keys(ALLOWED_UPLOAD_MIME_TYPES).join(", ")}`,
+          },
+          { status: 400 },
+        );
+      }
+      if (!mimeType.startsWith("image/")) {
+        return NextResponse.json(
+          { error: "Dashboard uploads must be image files" },
+          { status: 400 },
+        );
+      }
+
+      // ---------- Validate size ----------
+      if (file.size > UPLOAD_FILE_MAX_BYTES) {
+        return NextResponse.json(
+          { error: "File exceeds maximum size of 10 MB" },
+          { status: 400 },
+        );
+      }
+
+      const buffer = Buffer.from(await file.arrayBuffer());
+      if (!uploadBytesMatchMimeType(mimeType, buffer)) {
+        return NextResponse.json(
+          { error: "File contents do not match the declared file type" },
+          { status: 400 },
+        );
+      }
+
+      const checksumSha256 = checksumSha256Hex(buffer);
+      const reservation = await withTenant(db, practiceId, async (tx) => {
+        if (dashboardCategory === "patient-photos") {
+          const [activePatient] = await tx
+            .select({ id: patients.id })
+            .from(patients)
+            .where(
+              and(
+                eq(patients.id, patientId!),
+                eq(patients.practiceId, practiceId),
+                isNull(patients.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!activePatient) return null;
+        }
+
+        return reserveManagedUpload(tx, {
+          practiceId,
+          uploadedBy: session.user.id,
+          idempotencyKey,
+          fileName: file.name,
+          mimeType,
+          fileSizeBytes: buffer.length,
+          checksumSha256,
+          category: dashboardCategory,
+          source:
+            dashboardCategory === "branding"
+              ? "practice_logo"
+              : "profile_photo",
+          entityType: dashboardCategory === "branding" ? "practice" : "patient",
+          entityId: dashboardCategory === "branding" ? practiceId : patientId!,
+          patientId: dashboardCategory === "patient-photos" ? patientId : null,
+        });
+      });
+      if (!reservation) {
+        return NextResponse.json(
+          { error: "Patient not found" },
+          { status: 404 },
+        );
+      }
+
+      if (reservation.storageStatus === "available") {
+        return NextResponse.json(
+          { url: reservation.fileUrl, key: reservation.fileKey },
+          { status: 200 },
+        );
+      }
+
+      const writeResult = await putAndVerifyManagedUpload({
+        reservation,
+        body: buffer,
+      });
+      if (writeResult.status === "unavailable") {
+        return NextResponse.json(
+          { error: "Upload outcome is still being verified. Please retry." },
+          { status: 503, headers: { "Retry-After": "5" } },
+        );
+      }
+      if (writeResult.status === "corrupt") {
+        const marked = await withTenant(db, practiceId, (tx) =>
+          markManagedUploadCorrupt(tx, reservation),
+        );
+        if (!marked) {
+          throw new Error("Upload reservation changed before quarantine");
+        }
+        return NextResponse.json(
+          { error: "Uploaded object failed integrity verification" },
+          { status: 503, headers: { "Retry-After": "5" } },
+        );
+      }
+
+      if (
+        !(await finalizeManagedUploadManifest(
+          leaseTx,
+          reservation,
+          writeResult.evidence,
+        ))
+      ) {
+        throw new Error("Upload reservation disappeared before finalization");
+      }
+
+      if (dashboardCategory === "branding") {
+        const [linked] = await leaseTx
+          .update(practices)
+          .set({ logoUrl: reservation.fileUrl, updatedAt: new Date() })
+          .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+          .returning({ id: practices.id });
+        if (!linked) throw new Error("Practice disappeared during upload");
+      } else {
+        const [linked] = await leaseTx
+          .update(patients)
+          .set({ photoUrl: reservation.fileUrl, updatedAt: new Date() })
+          .where(
+            and(
+              eq(patients.id, patientId!),
+              eq(patients.practiceId, practiceId),
+              isNull(patients.deletedAt),
+            ),
+          )
+          .returning({ id: patients.id });
+        if (!linked) throw new Error("Patient disappeared during upload");
+      }
+
+      postCommit.replicationToQueue = () =>
+        queueManagedUploadReplication(reservation, writeResult.evidence);
+
+      return NextResponse.json(
+        { url: reservation.fileUrl, key: reservation.fileKey },
+        { status: reservation.created ? 201 : 200 },
+      );
+    });
+    await postCommit.replicationToQueue?.();
+    return response;
+  } catch (error) {
+    if (error instanceof ManagedUploadConflictError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
     }
-    return NextResponse.json(
-      { error: "Upload failed" },
-      { status: 500 },
-    );
+    console.error("[upload] managed upload failed");
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
   }
 }

--- a/apps/web/app/api/v1/agent/route.test.ts
+++ b/apps/web/app/api/v1/agent/route.test.ts
@@ -40,9 +40,17 @@ const mocks = vi.hoisted(() => {
     }
   }
 
+  class AgentRecoveryHoldError extends Error {
+    constructor() {
+      super("Practice recovery is in progress.");
+      this.name = "AgentRecoveryHoldError";
+    }
+  }
+
   return {
     AgentNotConfiguredError,
     AgentPracticeNotFoundError,
+    AgentRecoveryHoldError,
     AgentRateLimitedError,
     activePracticeRows,
     activePracticeSelectBuilders,
@@ -83,6 +91,7 @@ vi.mock("@/lib/agent", () => ({
   runAgent: mocks.runAgent,
   AgentNotConfiguredError: mocks.AgentNotConfiguredError,
   AgentPracticeNotFoundError: mocks.AgentPracticeNotFoundError,
+  AgentRecoveryHoldError: mocks.AgentRecoveryHoldError,
   AgentRateLimitedError: mocks.AgentRateLimitedError,
 }));
 

--- a/apps/web/app/api/v1/agent/route.ts
+++ b/apps/web/app/api/v1/agent/route.ts
@@ -12,6 +12,7 @@ import {
   AgentNotConfiguredError,
   AgentPracticeNotFoundError,
   AgentRateLimitedError,
+  AgentRecoveryHoldError,
   runAgent,
 } from "@/lib/agent";
 import { AGENT_INSTRUCTION_MAX_LENGTH } from "@/lib/agent/policy";
@@ -102,6 +103,9 @@ export async function POST(req: Request) {
             headers: agentRateLimitHeaders(e),
           }
         );
+      }
+      if (e instanceof AgentRecoveryHoldError) {
+        return apiError(e.message, 503);
       }
       if (e instanceof AgentPracticeNotFoundError) {
         return apiError(e.message, 404);

--- a/apps/web/app/api/webhooks/stripe-connect/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe-connect/route.test.ts
@@ -341,6 +341,40 @@ describe("Stripe Connect webhook", () => {
     expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
   });
 
+  it("leaves a held-practice Connect event retryable without capturing money", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_connect_held",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_connect_held",
+          payment_intent: "pi_connect_held",
+          amount_total: 12500,
+          metadata: {
+            invoiceId: "invoice_held",
+            captureMode: "manual_v1",
+            source: "client_invoice_connect",
+            stripeConnectAccountId: "acct_123",
+          },
+        },
+      },
+    });
+    mocks.selectResults.push([
+      {
+        practiceId: "practice_held",
+        stripeAccountId: "acct_123",
+        recoveryHold: true,
+      },
+    ]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.captureStripeCheckoutAuthorization).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+
   it("settles a completed accounts-receivable closeout with a Connect payment", async () => {
     mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
       id: "evt_connect_closeout",

--- a/apps/web/app/api/webhooks/stripe-connect/route.ts
+++ b/apps/web/app/api/webhooks/stripe-connect/route.ts
@@ -228,6 +228,7 @@ export async function POST(req: NextRequest) {
         .select({
           practiceId: practicePaymentAccounts.practiceId,
           stripeAccountId: practicePaymentAccounts.stripeAccountId,
+          recoveryHold: practices.recoveryHold,
         })
         .from(practicePaymentAccounts)
         .innerJoin(
@@ -244,13 +245,21 @@ export async function POST(req: NextRequest) {
             isNull(practicePaymentAccounts.deletedAt)
           )
         )
-        .limit(1);
+        .limit(1)
+        // Serialize provider capture against the committed recovery-hold
+        // update for this practice.
+        .for("share", { of: practices });
 
       if (!paymentAccount) {
         await resolveInvalidCheckout("payment_account_not_found");
         return;
       }
       resolutionPracticeId = paymentAccount.practiceId;
+      if (paymentAccount.recoveryHold) {
+        throw new Error(
+          `Stripe Connect Checkout processing paused for held practice ${paymentAccount.practiceId}`,
+        );
+      }
 
       const [invoiceIdentity] = await tx
         .select({

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -542,6 +542,30 @@ describe("Stripe client invoice webhook", () => {
     expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
   });
 
+  it("leaves a held-practice event retryable without capturing money", async () => {
+    mocks.constructWebhookEvent.mockResolvedValue(
+      checkoutEvent({
+        payment_intent: "pi_held_123",
+        metadata: {
+          invoiceId: INVOICE_ID,
+          captureMode: "manual_v1",
+          source: "client_invoice",
+        },
+      }),
+    );
+    mocks.selectResults.push([
+      { ...activeInvoice, recoveryHold: true },
+    ]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.captureStripeCheckoutAuthorization).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalledWith(
+      expect.objectContaining({ externalId: "stripe:checkout:cs_test_123" }),
+    );
+  });
+
   it("does not capture a manual Checkout after the invoice is voided", async () => {
     mocks.constructWebhookEvent.mockResolvedValue(
       checkoutEvent({

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -167,6 +167,7 @@ export async function POST(req: NextRequest) {
             id: invoices.id,
             practiceId: invoices.practiceId,
             appointmentId: invoices.appointmentId,
+            recoveryHold: practices.recoveryHold,
           })
           .from(invoices)
           .innerJoin(
@@ -177,11 +178,20 @@ export async function POST(req: NextRequest) {
             ),
           )
           .where(and(eq(invoices.id, invoiceId), isNull(invoices.deletedAt)))
-          .limit(1);
+          .limit(1)
+          // Serialize provider capture against the committed recovery-hold
+          // update. If restore wins, this reads held and Stripe retries later;
+          // if capture wins, restore cannot begin until this transaction ends.
+          .for("share", { of: practices });
 
         if (!invoiceIdentity) {
           await resolveInvalidCheckout("invoice_not_found");
           return;
+        }
+        if (invoiceIdentity.recoveryHold) {
+          throw new Error(
+            `Stripe Checkout processing paused for held practice ${invoiceIdentity.practiceId}`,
+          );
         }
         resolutionPracticeId = invoiceIdentity.practiceId;
 

--- a/apps/web/app/capture/[token]/capture-client.tsx
+++ b/apps/web/app/capture/[token]/capture-client.tsx
@@ -6,6 +6,7 @@ import {
   IMAGE_UPLOAD_POLICY_MESSAGE,
   isImageUploadFileValid,
 } from "@/lib/upload-policy";
+import { isRetryableUploadStatus } from "@/lib/managed-upload-attempt";
 
 const EXPIRED_MESSAGE =
   "This link has expired. Ask the front desk for a new code.";
@@ -14,15 +15,21 @@ type UploadStatus = "uploading" | "done" | "error";
 
 interface UploadItem {
   id: string;
+  idempotencyKey: string;
+  file: File;
   name: string;
   progress: number;
   status: UploadStatus;
+  retryable: boolean;
   message?: string;
 }
 
 function errorMessageForStatus(status: number): string {
   if (status === 404) return EXPIRED_MESSAGE;
-  if (status === 429) return "Too many uploads right now. Wait a minute and try again.";
+  if (status === 429)
+    return "Too many uploads right now. Wait a minute and try again.";
+  if (status === 409)
+    return "This capture link cannot accept another photo. Ask the clinic for a new link.";
   if (status === 400 || status === 413) return IMAGE_UPLOAD_POLICY_MESSAGE;
   return "The upload failed. Please try again.";
 }
@@ -31,18 +38,23 @@ function errorMessageForStatus(status: number): string {
 function uploadWithProgress(
   url: string,
   file: File,
-  onProgress: (percent: number) => void
+  idempotencyKey: string,
+  onProgress: (percent: number) => void,
 ): Promise<{ ok: boolean; status: number }> {
   return new Promise((resolve) => {
     const xhr = new XMLHttpRequest();
     xhr.open("POST", url);
+    xhr.setRequestHeader("Idempotency-Key", idempotencyKey);
     xhr.upload.onprogress = (event) => {
       if (event.lengthComputable && event.total > 0) {
         onProgress(Math.round((event.loaded / event.total) * 100));
       }
     };
     xhr.onload = () =>
-      resolve({ ok: xhr.status >= 200 && xhr.status < 300, status: xhr.status });
+      resolve({
+        ok: xhr.status >= 200 && xhr.status < 300,
+        status: xhr.status,
+      });
     xhr.onerror = () => resolve({ ok: false, status: 0 });
     const formData = new FormData();
     formData.append("file", file);
@@ -62,49 +74,69 @@ export function CaptureClient({ token }: { token: string }) {
 
   function updateItem(id: string, patch: Partial<UploadItem>) {
     setItems((prev) =>
-      prev.map((item) => (item.id === id ? { ...item, ...patch } : item))
+      prev.map((item) => (item.id === id ? { ...item, ...patch } : item)),
     );
   }
 
-  async function uploadOne(file: File) {
-    const id = `upload-${nextIdRef.current++}`;
-    if (!isImageUploadFileValid(file)) {
-      setItems((prev) => [
-        ...prev,
-        {
-          id,
-          name: file.name,
-          progress: 0,
-          status: "error",
-          message: IMAGE_UPLOAD_POLICY_MESSAGE,
-        },
-      ]);
-      return;
-    }
-
-    setItems((prev) => [
-      ...prev,
-      { id, name: file.name, progress: 0, status: "uploading" },
-    ]);
-
+  async function performUpload(item: UploadItem) {
+    updateItem(item.id, {
+      progress: 0,
+      status: "uploading",
+      message: undefined,
+    });
     const result = await uploadWithProgress(
       `/api/capture/${encodeURIComponent(token)}`,
-      file,
-      (percent) => updateItem(id, { progress: percent })
+      item.file,
+      item.idempotencyKey,
+      (percent) => updateItem(item.id, { progress: percent }),
     );
 
     if (result.ok) {
-      updateItem(id, { status: "done", progress: 100 });
+      updateItem(item.id, { status: "done", progress: 100 });
       return;
     }
 
     if (result.status === 404) {
       setLinkExpired(true);
     }
-    updateItem(id, {
+    updateItem(item.id, {
       status: "error",
+      retryable: isRetryableUploadStatus(result.status),
       message: errorMessageForStatus(result.status),
     });
+  }
+
+  async function uploadOne(file: File) {
+    const id = `upload-${nextIdRef.current++}`;
+    const idempotencyKey = crypto.randomUUID();
+    if (!isImageUploadFileValid(file)) {
+      setItems((prev) => [
+        ...prev,
+        {
+          id,
+          idempotencyKey,
+          file,
+          name: file.name,
+          progress: 0,
+          status: "error",
+          retryable: false,
+          message: IMAGE_UPLOAD_POLICY_MESSAGE,
+        },
+      ]);
+      return;
+    }
+
+    const item: UploadItem = {
+      id,
+      idempotencyKey,
+      file,
+      name: file.name,
+      progress: 0,
+      status: "uploading",
+      retryable: true,
+    };
+    setItems((prev) => [...prev, item]);
+    await performUpload(item);
   }
 
   function handleFilesSelected(event: React.ChangeEvent<HTMLInputElement>) {
@@ -191,7 +223,18 @@ export function CaptureClient({ token }: { token: string }) {
                 </div>
               )}
               {item.status === "error" && item.message && (
-                <p className="mt-1 text-xs text-red-600">{item.message}</p>
+                <div className="mt-1 flex items-center justify-between gap-3">
+                  <p className="text-xs text-red-600">{item.message}</p>
+                  {item.retryable && !linkExpired && (
+                    <button
+                      type="button"
+                      onClick={() => void performUpload(item)}
+                      className="shrink-0 text-xs font-medium text-teal-700 hover:text-teal-800"
+                    >
+                      Try again
+                    </button>
+                  )}
+                </div>
               )}
             </li>
           ))}

--- a/apps/web/app/capture/layout.tsx
+++ b/apps/web/app/capture/layout.tsx
@@ -4,6 +4,8 @@ import { PawMark } from "@/components/brand/paw-mark";
 export const metadata: Metadata = {
   title: "Add Photos - OpenVPM",
   description: "Add photos to the visit record",
+  referrer: "no-referrer",
+  robots: { index: false, follow: false, nocache: true },
 };
 
 /**

--- a/apps/web/app/sign/[token]/sign-client.tsx
+++ b/apps/web/app/sign/[token]/sign-client.tsx
@@ -6,14 +6,16 @@ import { AlertCircle, CheckCircle2, Eraser, Loader2 } from "lucide-react";
 const EXPIRED_MESSAGE =
   "This link has expired. Ask the front desk for a new code.";
 
-type ConsentView = {
-  title: string;
-  bodyText: string;
-  patientName: string;
-  practiceName: string;
-  status: string;
-  signerName: string | null;
-};
+type ConsentView =
+  | {
+      status: "pending";
+      title: string;
+      bodyText: string;
+      patientName: string;
+      practiceName: string;
+    }
+  | { status: "signing" }
+  | { status: "signed" };
 
 type PageState =
   | { kind: "loading" }
@@ -168,25 +170,24 @@ export function SignClient({ token }: { token: string }) {
     };
   }, [token]);
 
-  async function handleSubmit() {
-    if (state.kind !== "ready" || !signature || !signerName.trim()) return;
+  async function submitSigningPayload(payload: Record<string, unknown>) {
+    if (state.kind !== "ready") return;
     setSubmitting(true);
     setSubmitError(null);
     try {
       const res = await fetch(`/api/sign/${token}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          signerName: signerName.trim(),
-          signaturePngDataUrl: signature,
-        }),
+        body: JSON.stringify(payload),
       });
       if (res.status === 404) {
         setState({ kind: "expired" });
         return;
       }
       if (res.status === 429) {
-        setSubmitError("Too many tries right now. Wait a minute and try again.");
+        setSubmitError(
+          "Too many tries right now. Wait a minute and try again.",
+        );
         return;
       }
       if (!res.ok) {
@@ -198,10 +199,24 @@ export function SignClient({ token }: { token: string }) {
       }
       setState({ kind: "submitted", consent: state.consent });
     } catch {
-      setSubmitError("Signing failed. Please check your connection and try again.");
+      setSubmitError(
+        "Signing failed. Please check your connection and try again.",
+      );
     } finally {
       setSubmitting(false);
     }
+  }
+
+  async function handleSubmit() {
+    if (!signature || !signerName.trim()) return;
+    await submitSigningPayload({
+      signerName: signerName.trim(),
+      signaturePngDataUrl: signature,
+    });
+  }
+
+  async function handleResume() {
+    await submitSigningPayload({ resume: true });
   }
 
   if (state.kind === "loading") {
@@ -239,6 +254,35 @@ export function SignClient({ token }: { token: string }) {
         <p className="text-sm text-gray-600">
           Thank you. The clinic has your signed form. You can close this page.
         </p>
+      </div>
+    );
+  }
+
+  if (state.consent.status === "signing") {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <CheckCircle2 className="h-10 w-10 text-teal-600" />
+        <h1 className="text-lg font-semibold text-gray-900">
+          Your signature is safe
+        </h1>
+        <p className="max-w-sm text-sm text-gray-600">
+          The clinic has your exact signature. Finish saving the signed document
+          without drawing it again.
+        </p>
+        {submitError && (
+          <p className="flex items-center gap-2 text-sm text-red-600">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            {submitError}
+          </p>
+        )}
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={() => void handleResume()}
+          className="w-full max-w-sm rounded-lg bg-teal-600 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? "Finishing…" : "Finish saving"}
+        </button>
       </div>
     );
   }

--- a/apps/web/app/sign/layout.tsx
+++ b/apps/web/app/sign/layout.tsx
@@ -4,6 +4,8 @@ import { PawMark } from "@/components/brand/paw-mark";
 export const metadata: Metadata = {
   title: "Sign Consent - OpenVPM",
   description: "Review and sign a consent form",
+  referrer: "no-referrer",
+  robots: { index: false, follow: false, nocache: true },
 };
 
 /**

--- a/apps/web/components/onboarding/steps/branding.tsx
+++ b/apps/web/components/onboarding/steps/branding.tsx
@@ -13,6 +13,11 @@ import {
   IMAGE_UPLOAD_POLICY_MESSAGE,
   isImageUploadFileValid,
 } from "@/lib/upload-policy";
+import {
+  selectManagedUploadFile,
+  settleManagedUploadAttempt,
+  type ManagedUploadAttempt,
+} from "@/lib/managed-upload-attempt";
 import { toast } from "sonner";
 import type { StepHandle } from "../journey-types";
 
@@ -23,7 +28,11 @@ const SUGGESTED_ACCENT = "#0d9488";
  * Step 2: optional logo upload and accent color. Both save right away through
  * updatePractice, so Continue has nothing extra to do.
  */
-export function BrandingStep({ register }: { register: (h: StepHandle) => void }) {
+export function BrandingStep({
+  register,
+}: {
+  register: (h: StepHandle) => void;
+}) {
   const {
     data: practice,
     error: practiceError,
@@ -41,7 +50,9 @@ export function BrandingStep({ register }: { register: (h: StepHandle) => void }
     (practice?.settings as { brandColor?: string } | null)?.brandColor ?? null;
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const uploadAttemptRef = useRef<ManagedUploadAttempt | null>(null);
 
   const currentLogo = logoUrl ?? practice?.logoUrl ?? null;
 
@@ -50,29 +61,67 @@ export function BrandingStep({ register }: { register: (h: StepHandle) => void }
     register({ onContinue: async () => true });
   }, [register]);
 
-  async function handleFile(file: File) {
-    if (!isImageUploadFileValid(file)) {
+  async function handleFile(selectedFile?: File) {
+    if (selectedFile && !isImageUploadFileValid(selectedFile)) {
+      uploadAttemptRef.current = null;
+      setUploadError(null);
       toast.error(IMAGE_UPLOAD_POLICY_MESSAGE);
       return;
     }
 
+    if (selectedFile) {
+      uploadAttemptRef.current = selectManagedUploadFile(
+        uploadAttemptRef.current,
+        selectedFile,
+      );
+    }
+    const attempt = uploadAttemptRef.current;
+    if (!attempt) return;
+
     setUploading(true);
+    setUploadError(null);
     try {
       const body = new FormData();
-      body.append("file", file);
+      body.append("file", attempt.file);
       body.append("category", "branding");
       const res = await fetchWithClientTimeout(
         "/api/upload",
-        { method: "POST", body },
-        CLIENT_UPLOAD_TIMEOUT_MS
+        {
+          method: "POST",
+          body,
+          headers: { "Idempotency-Key": attempt.idempotencyKey },
+        },
+        CLIENT_UPLOAD_TIMEOUT_MS,
       );
-      const json = await res.json();
-      if (!res.ok) throw new Error(json.error ?? "Upload failed");
-      setLogoUrl(json.url);
-      await updatePractice.mutateAsync({ logoUrl: json.url });
+      const json = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        url?: string;
+      };
+      if (!res.ok) {
+        uploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+          kind: "response",
+          status: res.status,
+        });
+        throw new Error(json.error ?? "Upload failed");
+      }
+      uploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+        kind: "success",
+      });
+      if (json.url) setLogoUrl(json.url);
+      await Promise.all([
+        utils.settings.getPractice.invalidate(),
+        utils.settings.getBranding.invalidate(),
+      ]);
       toast.success("Logo saved");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Upload failed");
+      if (uploadAttemptRef.current === attempt) {
+        uploadAttemptRef.current = settleManagedUploadAttempt(attempt, {
+          kind: "ambiguous",
+        });
+      }
+      const message = err instanceof Error ? err.message : "Upload failed";
+      setUploadError(message);
+      toast.error(message);
     } finally {
       setUploading(false);
     }
@@ -81,7 +130,7 @@ export function BrandingStep({ register }: { register: (h: StepHandle) => void }
   function pickColor(color: string) {
     updatePractice.mutate(
       { brandColor: color },
-      { onSuccess: () => toast.success("Color saved") }
+      { onSuccess: () => toast.success("Color saved") },
     );
   }
 
@@ -160,6 +209,21 @@ export function BrandingStep({ register }: { register: (h: StepHandle) => void }
             <p className="mt-1.5 text-xs text-slate-500">
               PNG, JPG, or WebP. Square images look best.
             </p>
+            {uploadError ? (
+              <div className="mt-2 flex items-center gap-2 text-xs text-red-600">
+                <span>{uploadError}</span>
+                {uploadAttemptRef.current ? (
+                  <button
+                    type="button"
+                    disabled={uploading}
+                    onClick={() => void handleFile()}
+                    className="font-medium underline underline-offset-2 disabled:opacity-50"
+                  >
+                    Try again
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/web/lib/__tests__/analytics-privacy.test.ts
+++ b/apps/web/lib/__tests__/analytics-privacy.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { filterVercelAnalyticsEvent } from "../analytics-privacy";
+
+describe("Vercel Analytics capability privacy", () => {
+  it.each([
+    "https://app.openvpm.com/capture/raw-secret-token",
+    "https://app.openvpm.com/capture/raw-secret-token?source=qr",
+    "https://app.openvpm.com/sign/raw-secret-token",
+    "/capture/raw-secret-token",
+    "/sign/raw-secret-token",
+  ])("drops capability-page events before they are sent: %s", (url) => {
+    expect(filterVercelAnalyticsEvent({ type: "pageview", url })).toBeNull();
+    expect(filterVercelAnalyticsEvent({ type: "event", url })).toBeNull();
+  });
+
+  it("leaves ordinary analytics events unchanged", () => {
+    const event = {
+      type: "pageview" as const,
+      url: "https://app.openvpm.com/patients",
+    };
+    expect(filterVercelAnalyticsEvent(event)).toBe(event);
+  });
+
+  it("wires the privacy filter into the only Vercel Analytics component", () => {
+    const source = readFileSync("lib/providers.tsx", "utf8");
+    expect(source).toContain(
+      "<Analytics beforeSend={filterVercelAnalyticsEvent} />",
+    );
+  });
+});

--- a/apps/web/lib/__tests__/capability-page-privacy.test.ts
+++ b/apps/web/lib/__tests__/capability-page-privacy.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("public capability page privacy", () => {
+  for (const capability of ["capture", "sign"] as const) {
+    it(`${capability} pages suppress indexing, caching, and referrers`, () => {
+      const source = readFileSync(`app/${capability}/layout.tsx`, "utf8");
+
+      expect(source).toContain('referrer: "no-referrer"');
+      expect(source).toContain("index: false");
+      expect(source).toContain("follow: false");
+      expect(source).toContain("nocache: true");
+    });
+  }
+
+  it("sets capability privacy at the HTTP boundary before subresources load", () => {
+    const config = readFileSync("next.config.js", "utf8");
+
+    for (const path of [
+      "/capture/:path*",
+      "/sign/:path*",
+      "/api/capture/:path*",
+      "/api/sign/:path*",
+    ]) {
+      expect(config).toContain(`source: "${path}"`);
+    }
+    expect(config).toContain('{ key: "Referrer-Policy", value: "no-referrer" }');
+    expect(config).toContain(
+      '{ key: "X-Robots-Tag", value: "noindex, nofollow, noarchive" }',
+    );
+    expect(config).toContain(
+      '{ key: "Cache-Control", value: "private, no-store, max-age=0" }',
+    );
+  });
+});

--- a/apps/web/lib/__tests__/client-patient-form-ui.test.ts
+++ b/apps/web/lib/__tests__/client-patient-form-ui.test.ts
@@ -18,7 +18,6 @@ import {
   PATIENT_COLOR_MAX_LENGTH,
   PATIENT_MICROCHIP_NUMBER_MAX_LENGTH,
   PATIENT_NAME_MAX_LENGTH,
-  PATIENT_PHOTO_URL_MAX_LENGTH,
   PATIENT_SEARCH_MAX_LENGTH,
   isOptionalPatientTextValid,
   isPatientSearchInputValid,
@@ -295,12 +294,12 @@ describe("client and patient form UI states", () => {
 
   it("keeps patient form policy aligned with server-side patient bounds", () => {
     const routerSource = readFileSync("server/routers/patients.ts", "utf8");
+    const uploadRouteSource = readFileSync("app/api/upload/route.ts", "utf8");
 
     expect(PATIENT_NAME_MAX_LENGTH).toBe(128);
     expect(PATIENT_BREED_MAX_LENGTH).toBe(128);
     expect(PATIENT_COLOR_MAX_LENGTH).toBe(64);
     expect(PATIENT_MICROCHIP_NUMBER_MAX_LENGTH).toBe(64);
-    expect(PATIENT_PHOTO_URL_MAX_LENGTH).toBe(512);
     expect(PATIENT_SEARCH_MAX_LENGTH).toBe(128);
 
     expect(isRequiredPatientTextValid(" Maple ", PATIENT_NAME_MAX_LENGTH)).toBe(
@@ -332,7 +331,6 @@ describe("client and patient form UI states", () => {
     expect(routerSource).toContain("PATIENT_BREED_MAX_LENGTH");
     expect(routerSource).toContain("PATIENT_COLOR_MAX_LENGTH");
     expect(routerSource).toContain("PATIENT_MICROCHIP_NUMBER_MAX_LENGTH");
-    expect(routerSource).toContain("PATIENT_PHOTO_URL_MAX_LENGTH");
     expect(routerSource).toContain("PATIENT_SEARCH_MAX_LENGTH");
     expect(routerSource).toContain(
       "optionalPatientString(\"Breed\", PATIENT_BREED_MAX_LENGTH)"
@@ -341,6 +339,25 @@ describe("client and patient form UI states", () => {
       "optionalPatientString(\"Color\", PATIENT_COLOR_MAX_LENGTH)"
     );
     expect(routerSource).toContain("PATIENT_MICROCHIP_NUMBER_MAX_LENGTH");
+
+    // Photo URLs are server-owned attachment bindings now. Patient form
+    // mutations cannot write arbitrary URLs; only a verified managed upload
+    // can atomically bind the manifest URL to the patient.
+    const mutableInputSource = routerSource.slice(
+      routerSource.indexOf("const patientMutableInput"),
+      routerSource.indexOf("const patientWeightInput")
+    );
+    const updateInputSource = routerSource.slice(
+      routerSource.indexOf("update: patientManagerProcedure"),
+      routerSource.indexOf("addWeight: patientManagerProcedure")
+    );
+    expect(mutableInputSource).not.toContain("photoUrl");
+    expect(updateInputSource).not.toContain("photoUrl");
+    expect(updateInputSource).toContain(".strict()");
+    expect(uploadRouteSource).toContain("finalizeManagedUploadManifest(");
+    expect(uploadRouteSource).toContain(
+      ".set({ photoUrl: reservation.fileUrl, updatedAt: new Date() })"
+    );
   });
 
   it("matches patient create/edit form controls to server input limits", () => {

--- a/apps/web/lib/__tests__/consult-companion-ui.test.ts
+++ b/apps/web/lib/__tests__/consult-companion-ui.test.ts
@@ -9,31 +9,31 @@ import { describe, expect, it } from "vitest";
 describe("consult companion UI states", () => {
   const patientPage = readFileSync(
     "app/(dashboard)/patients/[id]/page.tsx",
-    "utf8"
+    "utf8",
   );
   const soapPage = readFileSync(
     "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
-    "utf8"
+    "utf8",
   );
   const capturePage = readFileSync("app/capture/[token]/page.tsx", "utf8");
   const captureClient = readFileSync(
     "app/capture/[token]/capture-client.tsx",
-    "utf8"
+    "utf8",
   );
   const captureLayout = readFileSync("app/capture/layout.tsx", "utf8");
   const captureModal = readFileSync(
     "components/records/capture-photos.tsx",
-    "utf8"
+    "utf8",
   );
   const middleware = readFileSync("middleware.ts", "utf8");
   const recordsRouter = readFileSync("server/routers/records.ts", "utf8");
 
   it("gates the capture button on the patient page behind patient management", () => {
     expect(patientPage).toContain(
-      'import { CapturePhotos } from "@/components/records/capture-photos"'
+      'import { CapturePhotos } from "@/components/records/capture-photos"',
     );
     expect(patientPage).toMatch(
-      /\{canManagePatientDetail && \(\s*<>\s*<CapturePhotos patientId=\{patient\.id\} \/>\s*<ConsentSign patientId=\{patient\.id\} \/>\s*<\/>\s*\)\}/
+      /\{canManagePatientDetail && \(\s*<>\s*<CapturePhotos patientId=\{patient\.id\} \/>\s*<ConsentSign patientId=\{patient\.id\} \/>\s*<\/>\s*\)\}/,
     );
   });
 
@@ -42,7 +42,7 @@ describe("consult companion UI states", () => {
     // Regression guard: the allowlist must stay inside PUBLIC_PATH_PREFIXES.
     const allowlist = middleware.slice(
       middleware.indexOf("PUBLIC_PATH_PREFIXES"),
-      middleware.indexOf("];")
+      middleware.indexOf("];"),
     );
     expect(allowlist).toContain('"/capture"');
   });
@@ -54,10 +54,19 @@ describe("consult companion UI states", () => {
     expect(capturePage).toContain("CaptureClient");
   });
 
+  it("keeps one client-generated idempotency key across upload retries", () => {
+    expect(captureClient).toContain("crypto.randomUUID()");
+    expect(captureClient).toContain(
+      'xhr.setRequestHeader("Idempotency-Key", idempotencyKey)',
+    );
+    expect(captureClient).toContain("performUpload(item)");
+    expect(captureClient).toContain("Try again");
+  });
+
   it("keeps the capture page PHI-minimal and failure-friendly", () => {
     expect(captureClient).toContain("Add photos to the visit record");
     expect(captureClient).toContain(
-      "This link has expired. Ask the front desk for a new code."
+      "This link has expired. Ask the front desk for a new code.",
     );
     // No patient identity ever reaches the no-login page.
     expect(captureClient).not.toContain("patientName");
@@ -70,7 +79,7 @@ describe("consult companion UI states", () => {
     expect(recordsRouter).toContain("generateCaptureToken()");
     expect(recordsRouter).toContain("CAPTURE_TOKEN_TTL_MS");
     expect(recordsRouter).toMatch(
-      /createCaptureSession: protectedProcedure\s*\.use\(\s*requireRole\("admin", "veterinarian", "technician", "front_desk"\)\s*\)/
+      /createCaptureSession: protectedProcedure\s*\.use\(\s*requireRole\("admin", "veterinarian", "technician", "front_desk"\)\s*\)/,
     );
   });
 
@@ -78,7 +87,7 @@ describe("consult companion UI states", () => {
     expect(captureModal).toContain("listCaptureFiles.useQuery");
     expect(captureModal).toContain("refetchInterval");
     expect(captureModal).toContain(
-      "Scan with any phone. The code works for 30 minutes."
+      "Scan with any phone. The code works for 30 minutes.",
     );
     expect(captureModal).toContain("photos added");
   });
@@ -88,23 +97,27 @@ describe("consult companion UI states", () => {
     expect(soapPage).toContain("trpc.ai.draftSoapNote.useMutation");
     expect(soapPage).toContain("trpc.agent.status.useQuery");
     // The draft only fills the editors; saving stays behind the Save button.
-    expect(soapPage).toContain("setSubjective(draftTextToHtml(draft.subjective))");
+    expect(soapPage).toContain(
+      "setSubjective(draftTextToHtml(draft.subjective))",
+    );
     expect(soapPage).toContain("setPlan(draftTextToHtml(draft.plan))");
     const draftSuccessHandler = soapPage.slice(
       soapPage.indexOf("trpc.ai.draftSoapNote.useMutation"),
-      soapPage.indexOf("function handleDraftWithAi")
+      soapPage.indexOf("function handleDraftWithAi"),
     );
     expect(draftSuccessHandler).not.toContain("createNote.mutate");
     expect(soapPage).toContain(
-      "Draft ready. Please review and edit before you save."
+      "Draft ready. Please review and edit before you save.",
     );
   });
 
   it("hides the AI draft affordance behind configuration with a gentle note", () => {
     expect(soapPage).toContain("agentStatus.data?.configured ?? false");
-    expect(soapPage).toContain("disabled={!isOnline || !aiConfigured || draftWithAi.isPending}");
     expect(soapPage).toContain(
-      "AI is not set up yet. Ask your admin to add an AI key."
+      "disabled={!isOnline || !aiConfigured || draftWithAi.isPending}",
+    );
+    expect(soapPage).toContain(
+      "AI is not set up yet. Ask your admin to add an AI key.",
     );
   });
 
@@ -118,28 +131,28 @@ describe("consult companion UI states", () => {
 describe("e-sign consent UI states", () => {
   const patientPage = readFileSync(
     "app/(dashboard)/patients/[id]/page.tsx",
-    "utf8"
+    "utf8",
   );
   const signPage = readFileSync("app/sign/[token]/page.tsx", "utf8");
   const signClient = readFileSync("app/sign/[token]/sign-client.tsx", "utf8");
   const signLayout = readFileSync("app/sign/layout.tsx", "utf8");
   const consentModal = readFileSync(
     "components/records/consent-sign.tsx",
-    "utf8"
+    "utf8",
   );
   const middleware = readFileSync("middleware.ts", "utf8");
   const recordsRouter = readFileSync("server/routers/records.ts", "utf8");
 
   it("gates the signature button behind patient management", () => {
     expect(patientPage).toContain(
-      'import { ConsentSign } from "@/components/records/consent-sign"'
+      'import { ConsentSign } from "@/components/records/consent-sign"',
     );
   });
 
   it("allows the no-login sign page through the middleware allowlist", () => {
     const allowlist = middleware.slice(
       middleware.indexOf("PUBLIC_PATH_PREFIXES"),
-      middleware.indexOf("];")
+      middleware.indexOf("];"),
     );
     expect(allowlist).toContain('"/sign"');
   });
@@ -165,15 +178,22 @@ describe("e-sign consent UI states", () => {
 
   it("requires both a name and drawn ink before submitting", () => {
     expect(signClient).toContain(
-      "Boolean(signature) && signerName.trim().length > 0"
+      "Boolean(signature) && signerName.trim().length > 0",
     );
     expect(signClient).toContain("Agree and sign");
     expect(signClient).toContain('toDataURL("image/png")');
   });
 
+  it("lets a refreshed in-progress signing page finish from persisted evidence", () => {
+    expect(signClient).toContain('state.consent.status === "signing"');
+    expect(signClient).toContain("Your signature is safe");
+    expect(signClient).toContain("submitSigningPayload({ resume: true })");
+    expect(signClient).toContain("Finish saving");
+  });
+
   it("shows the friendly expired copy on dead links", () => {
     expect(signClient).toContain(
-      "This link has expired. Ask the front desk for a new code."
+      "This link has expired. Ask the front desk for a new code.",
     );
   });
 
@@ -186,8 +206,22 @@ describe("e-sign consent UI states", () => {
 
   it("snapshots consent copy server-side so edits never rewrite signed forms", () => {
     expect(recordsRouter).toContain("createConsentRequest");
-    expect(recordsRouter).toContain("title: input.title ?? form.title");
-    expect(recordsRouter).toContain("bodyText: input.bodyText ?? form.body");
+    const createConsentSource = recordsRouter.slice(
+      recordsRouter.indexOf("createConsentRequest"),
+      recordsRouter.indexOf(
+        "listConsents",
+        recordsRouter.indexOf("createConsentRequest"),
+      ),
+    );
+    expect(createConsentSource).toContain(
+      "const title = input.title ?? form.title",
+    );
+    expect(createConsentSource).toContain(
+      "const bodyText = input.bodyText ?? form.body",
+    );
+    expect(createConsentSource).toMatch(
+      /\.values\(\{[\s\S]*?title,\s*bodyText,/,
+    );
   });
 
   it("keeps e-sign copy free of em dashes", () => {

--- a/apps/web/lib/__tests__/cron-schedule.test.ts
+++ b/apps/web/lib/__tests__/cron-schedule.test.ts
@@ -12,6 +12,7 @@ describe("Vercel cron schedule", () => {
       new Set([
         "/api/cron/reminders",
         "/api/cron/backup",
+        "/api/cron/file-replicas",
         "/api/cron/usage-reconcile",
         "/api/cron/billing-lifecycle",
         "/api/cron/wellness-billing",

--- a/apps/web/lib/__tests__/email-lifecycle.test.ts
+++ b/apps/web/lib/__tests__/email-lifecycle.test.ts
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => {
     updateSet,
     alertOps: vi.fn(async () => undefined),
     marketingEmailEnabledForRecipient: vi.fn(async () => true),
+    practiceAllowsExternalSideEffects: vi.fn(async () => true),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
       fn(db),
     ),
@@ -59,6 +61,13 @@ vi.mock("@/lib/platform-email-preferences", () => ({
   marketingEmailEnabledForRecipient: mocks.marketingEmailEnabledForRecipient,
 }));
 
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  practiceAllowsExternalSideEffects: mocks.practiceAllowsExternalSideEffects,
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
+}));
+
 const { LIFECYCLE_EMAIL_PENDING_RECLAIM_MS, sendLifecycleEmail } =
   await import("../email-lifecycle");
 
@@ -75,6 +84,8 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-06-28T12:00:00Z"));
   mocks.marketingEmailEnabledForRecipient.mockResolvedValue(true);
+  mocks.practiceAllowsExternalSideEffects.mockResolvedValue(true);
+  mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -87,6 +98,35 @@ afterEach(() => {
 });
 
 describe("sendLifecycleEmail", () => {
+  it("does not claim or send while the practice is on recovery hold", async () => {
+    mocks.practiceAllowsExternalSideEffects.mockResolvedValueOnce(false);
+    const send = vi.fn(async () => ({ success: true, id: "email-1" }));
+
+    await expect(sendLifecycleEmail({ ...BASE_OPTS, send })).resolves.toEqual({
+      sent: false,
+      deduped: false,
+      suppressed: true,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("drops a safe claim if recovery wins immediately before provider send", async () => {
+    mocks.insertResults.push([{ id: "comm-race" }]);
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+    const send = vi.fn(async () => ({ success: true, id: "email-race" }));
+
+    await expect(sendLifecycleEmail({ ...BASE_OPTS, send })).resolves.toEqual({
+      sent: false,
+      deduped: false,
+      suppressed: true,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mocks.deleteWhere).toHaveBeenCalled();
+  });
+
   it("claims, sends, and marks a lifecycle email sent", async () => {
     mocks.insertResults.push([{ id: "comm-1" }]);
     const send = vi.fn(async () => ({ success: true, id: "email-1" }));

--- a/apps/web/lib/__tests__/file-replication.test.ts
+++ b/apps/web/lib/__tests__/file-replication.test.ts
@@ -1,0 +1,881 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const FILE_REPLICATION_SOURCE = readFileSync(
+  fileURLToPath(new URL("../file-replication.ts", import.meta.url)),
+  "utf8",
+);
+
+const mocks = vi.hoisted(() => {
+  const executeResults: unknown[] = [];
+  const returningResults: unknown[][] = [];
+  const insertedValues: unknown[] = [];
+  const onConflictUpdateSets: Record<string, unknown>[] = [];
+  const updateSets: Record<string, unknown>[] = [];
+  const execute = vi.fn(async () => executeResults.shift() ?? []);
+  const insert = vi.fn(() => {
+    const builder = {
+      values: vi.fn((value: unknown) => {
+        insertedValues.push(value);
+        return builder;
+      }),
+      onConflictDoNothing: vi.fn(async () => undefined),
+      onConflictDoUpdate: vi.fn(
+        async (config: { set: Record<string, unknown> }) => {
+          onConflictUpdateSets.push(config.set);
+        },
+      ),
+    };
+    return builder;
+  });
+  const update = vi.fn(() => {
+    const builder = {
+      set: vi.fn((value: Record<string, unknown>) => {
+        updateSets.push(value);
+        return builder;
+      }),
+      where: vi.fn(() => builder),
+      returning: vi.fn(async () =>
+        returningResults.length > 0
+          ? returningResults.shift()!
+          : [{ id: "replica-1" }],
+      ),
+    };
+    return builder;
+  });
+  const tx = { execute, insert, update };
+
+  return {
+    executeResults,
+    returningResults,
+    insertedValues,
+    onConflictUpdateSets,
+    updateSets,
+    execute,
+    insert,
+    update,
+    tx,
+    alertOps: vi.fn(async () => undefined),
+    readPrimaryObject: vi.fn(),
+    readReplicaObject: vi.fn(),
+    replicaStorageReadiness: vi.fn(() => ({
+      intended: true,
+      ready: true,
+      detail: "Replica storage envs present",
+    })),
+    replicaStorageRequired: vi.fn(() => false),
+    replicaStorageRolloutEnabled: vi.fn(() => true),
+    replicaStoragePracticeScope: vi.fn(() => null as string[] | null),
+    uploadManagedFile: vi.fn(
+      async (
+        _key: string,
+        _body: Buffer,
+        _contentType: string,
+        _checksumSha256: string,
+      ) => ({
+        url: "s3://primary/object",
+        etag: "primary-etag",
+        versionId: "primary-version",
+      }),
+    ),
+    uploadReplicaFile: vi.fn(
+      async (
+        _key: string,
+        _body: Buffer,
+        _contentType: string,
+        _checksumSha256: string,
+      ) => ({
+        url: "s3://replica/object",
+        etag: "replica-etag",
+        versionId: "replica-version",
+      }),
+    ),
+    withSystem: vi.fn(
+      async (_db: unknown, fn: (tx: unknown) => Promise<unknown>) => fn(tx),
+    ),
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({ db: {} }));
+vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
+vi.mock("@/lib/s3", () => ({
+  FILE_REPLICA_TARGET: "independent-v1",
+  normalizeS3VersionId: (value: unknown) => {
+    if (typeof value !== "string") return undefined;
+    const normalized = value.trim();
+    return normalized && normalized.toLowerCase() !== "null"
+      ? normalized
+      : undefined;
+  },
+  readPrimaryObject: mocks.readPrimaryObject,
+  readReplicaObject: mocks.readReplicaObject,
+  replicaStoragePracticeScope: mocks.replicaStoragePracticeScope,
+  replicaStorageReadiness: mocks.replicaStorageReadiness,
+  replicaStorageRequired: mocks.replicaStorageRequired,
+  replicaStorageRolloutEnabled: mocks.replicaStorageRolloutEnabled,
+  uploadManagedFile: mocks.uploadManagedFile,
+  uploadReplicaFile: mocks.uploadReplicaFile,
+}));
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
+
+const {
+  checksumSha256Hex,
+  recoveryCatalogKey,
+  registerFileForReplication,
+  reconcileFileReplicas,
+  replicaObjectKey,
+  schedulePrimaryRepair,
+} = await import("../file-replication");
+
+const checksum = checksumSha256Hex(new TextEncoder().encode("abc"));
+
+function claimedReplica(overrides: Record<string, unknown> = {}) {
+  const practiceId = "00000000-0000-0000-0000-000000000001";
+  const fileId = "00000000-0000-0000-0000-000000000002";
+  return {
+    replicaId: "00000000-0000-0000-0000-000000000010",
+    practiceId,
+    fileId,
+    fileKey: `${practiceId}/documents/opaque`,
+    mimeType: "application/pdf",
+    fileChecksum: checksum,
+    fileSize: 3,
+    fileStorageStatus: "available",
+    replicaObjectKey:
+      "attachments/v1/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002/pending",
+    replicaChecksum: checksum,
+    replicaSize: 3,
+    replicaStatus: "pending",
+    replicaObjectEtag: null,
+    replicaObjectVersionId: null,
+    replicaReplicatedAt: null,
+    replicaVerifiedAt: null,
+    attemptCount: 1,
+    leaseToken: "00000000-0000-0000-0000-000000000011",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mocks.executeResults.length = 0;
+  mocks.returningResults.length = 0;
+  mocks.insertedValues.length = 0;
+  mocks.onConflictUpdateSets.length = 0;
+  mocks.updateSets.length = 0;
+  mocks.replicaStorageReadiness.mockReturnValue({
+    intended: true,
+    ready: true,
+    detail: "Replica storage envs present",
+  });
+  mocks.replicaStorageRolloutEnabled.mockReturnValue(true);
+  mocks.replicaStorageRequired.mockReturnValue(false);
+  mocks.replicaStoragePracticeScope.mockReturnValue(null);
+});
+
+describe("file replica identity", () => {
+  it("uses content-addressed object keys and deterministic recovery catalogs", () => {
+    expect(checksum).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    expect(
+      replicaObjectKey({
+        practiceId: "practice-1",
+        fileId: "file-1",
+        checksumSha256: checksum,
+      }),
+    ).toBe(`attachments/v1/practice-1/file-1/${checksum}`);
+    expect(recoveryCatalogKey("practice-1", "file-1", checksum)).toBe(
+      `recovery-catalog/v2/practice-1/file-1/${checksum}.json`,
+    );
+  });
+
+  it("CAS-binds finalization and lease renewal to both claimed generations", () => {
+    const primaryGuard = FILE_REPLICATION_SOURCE.match(
+      /function claimedPrimaryGeneration\([\s\S]*?\n}/,
+    )?.[0];
+    const replicaGuard = FILE_REPLICATION_SOURCE.match(
+      /function claimedReplicaGeneration\([\s\S]*?\n}/,
+    )?.[0];
+    const finalizer = FILE_REPLICATION_SOURCE.match(
+      /async function finalizeReplica\([\s\S]*?\n}\n\nasync function writeRecoveryCatalog/,
+    )?.[0];
+    const renewer = FILE_REPLICATION_SOURCE.match(
+      /async function renewReplicaLease\([\s\S]*?\n}\n\nasync function processClaimedReplica/,
+    )?.[0];
+
+    expect(primaryGuard).toContain("eq(files.fileKey, item.fileKey)");
+    expect(primaryGuard).toContain("item.fileChecksum");
+    expect(primaryGuard).toContain("item.fileSize");
+    expect(primaryGuard).toContain(
+      "eq(files.storageStatus, item.fileStorageStatus)",
+    );
+    expect(primaryGuard).toContain("isNull(files.deletedAt)");
+    expect(replicaGuard).toContain(
+      "eq(fileObjectReplicas.objectKey, item.replicaObjectKey)",
+    );
+    expect(replicaGuard).toContain("item.replicaChecksum");
+    expect(replicaGuard).toContain("item.replicaSize");
+    expect(replicaGuard).toContain("isNull(fileObjectReplicas.deletedAt)");
+    expect(finalizer).toContain("claimedReplicaGeneration(item)");
+    expect(finalizer).toContain("claimedPrimaryGenerationExists(item)");
+    expect(finalizer).toContain(".where(claimedPrimaryGeneration(item))");
+    expect(renewer).toContain("claimedReplicaGeneration(item)");
+    expect(renewer).toContain("claimedPrimaryGenerationExists(item)");
+  });
+});
+
+describe("file replica queue", () => {
+  it("records primary evidence and durably queues an idempotent replica", async () => {
+    await expect(
+      registerFileForReplication({
+        practiceId: "practice-1",
+        fileId: "file-1",
+        fileKey: "practice-1/documents/opaque",
+        checksumSha256: checksum,
+        fileSizeBytes: 3,
+        objectEtag: "etag-1",
+        objectVersionId: "version-1",
+      }),
+    ).resolves.toBe(true);
+
+    expect(mocks.insertedValues).toHaveLength(3);
+    expect(mocks.insertedValues).toContainEqual(
+      expect.objectContaining({
+        fileId: "file-1",
+        storageTarget: "primary",
+        eventKind: "primary_verified",
+        observedChecksumSha256: checksum,
+      }),
+    );
+    expect(mocks.insertedValues).toContainEqual(
+      expect.objectContaining({
+        fileId: "file-1",
+        replicaTarget: "independent-v1",
+        checksumSha256: checksum,
+        status: "pending",
+      }),
+    );
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+    expect(mocks.onConflictUpdateSets).toContainEqual(
+      expect.objectContaining({
+        leaseToken: null,
+        leaseExpiresAt: null,
+      }),
+    );
+  });
+
+  it("invalidates an active worker lease when registration refreshes generation", async () => {
+    await registerFileForReplication({
+      practiceId: "practice-1",
+      fileId: "file-1",
+      fileKey: "practice-1/documents/rotated",
+      checksumSha256: checksum,
+      fileSizeBytes: 3,
+    });
+
+    expect(mocks.onConflictUpdateSets).toHaveLength(1);
+    expect(mocks.onConflictUpdateSets[0]).toMatchObject({
+      leaseToken: null,
+      leaseExpiresAt: null,
+    });
+  });
+
+  it("does not make a completed clinic upload fail when queue persistence fails", async () => {
+    mocks.withSystem.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      registerFileForReplication({
+        practiceId: "practice-1",
+        fileId: "file-1",
+        fileKey: "practice-1/documents/opaque",
+        checksumSha256: checksum,
+        fileSizeBytes: 3,
+      }),
+    ).resolves.toBe(false);
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "File replica queue write failed",
+      expect.stringContaining("reconciliation must recover"),
+    );
+  });
+
+  it("durably wakes reconciliation after a verified replica fallback", async () => {
+    await expect(
+      schedulePrimaryRepair({
+        practiceId: "practice-1",
+        fileId: "file-1",
+        fileKey: "practice-1/documents/opaque",
+        checksumSha256: checksum,
+        fileSizeBytes: 3,
+        storageStatus: "available",
+        observedState: "failed",
+      }),
+    ).resolves.toBe(true);
+
+    expect(mocks.updateSets).toEqual([
+      expect.objectContaining({
+        storageStatus: "unverified",
+        storageVerifiedAt: null,
+      }),
+      expect.objectContaining({ nextAttemptAt: expect.any(Date) }),
+    ]);
+  });
+
+  it("returns false without waking repair after an old proxy read loses generation CAS", async () => {
+    mocks.returningResults.push([]);
+
+    await expect(
+      schedulePrimaryRepair({
+        practiceId: "practice-1",
+        fileId: "file-1",
+        fileKey: "practice-1/documents/old-generation",
+        checksumSha256: checksum,
+        fileSizeBytes: 3,
+        storageStatus: "available",
+        observedState: "missing",
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.updateSets).toHaveLength(1);
+    expect(mocks.updateSets[0]).toMatchObject({ storageStatus: "missing" });
+  });
+
+  it("does not make a fallback file read fail when repair scheduling is unavailable", async () => {
+    mocks.withSystem.mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      schedulePrimaryRepair({
+        practiceId: "practice-1",
+        fileId: "file-1",
+        fileKey: "practice-1/documents/opaque",
+        checksumSha256: checksum,
+        fileSizeBytes: 3,
+        storageStatus: "available",
+        observedState: "missing",
+      }),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("file replica reconciliation", () => {
+  it("skips all database and provider work until the independent target is complete", async () => {
+    mocks.replicaStorageReadiness.mockReturnValueOnce({
+      intended: false,
+      ready: false,
+      detail: "Independent object replica is not configured",
+    });
+
+    await expect(reconcileFileReplicas()).resolves.toMatchObject({
+      intended: false,
+      configured: false,
+      claimed: 0,
+      copied: 0,
+    });
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
+  });
+
+  it("copies, verifies, catalogs, and records a pending primary object", async () => {
+    const body = new TextEncoder().encode("abc");
+    mocks.executeResults.push(
+      [{ id: "materialized-1" }],
+      [claimedReplica()],
+      [{ backlog: "0", available: "1", activeFiles: "1" }],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({
+      status: "available",
+      body,
+      contentType: "application/pdf",
+      etag: "primary-etag",
+    });
+    mocks.readReplicaObject.mockImplementation(async (key: string) => {
+      if (key.startsWith("recovery-catalog/")) {
+        return {
+          status: "available" as const,
+          body: new Uint8Array(
+            mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+          ),
+          contentType: "application/json",
+          versionId: "replica-version",
+        };
+      }
+      if (mocks.uploadReplicaFile.mock.calls.length === 0) {
+        return { status: "missing" as const };
+      }
+      return {
+        status: "available" as const,
+        body,
+        contentType: "application/pdf",
+        etag: "replica-etag",
+        versionId: "replica-version",
+      };
+    });
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      configured: true,
+      candidates: 1,
+      claimed: 1,
+      copied: 1,
+      failed: 0,
+      bytesCopied: 3,
+      backlog: 0,
+      available: 1,
+      activeFiles: 1,
+      coveragePct: 100,
+    });
+    const desiredKey = replicaObjectKey({
+      practiceId: "00000000-0000-0000-0000-000000000001",
+      fileId: "00000000-0000-0000-0000-000000000002",
+      checksumSha256: checksum,
+    });
+    expect(mocks.uploadReplicaFile).toHaveBeenNthCalledWith(
+      1,
+      desiredKey,
+      expect.any(Buffer),
+      "application/pdf",
+      checksum,
+    );
+    expect(mocks.uploadReplicaFile).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(
+        /^recovery-catalog\/v2\/00000000-0000-0000-0000-000000000001\/00000000-0000-0000-0000-000000000002\/[0-9a-f]{64}\.json$/,
+      ),
+      expect.any(Buffer),
+      "application/json",
+      expect.stringMatching(/^[0-9a-f]{64}$/),
+    );
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        status: "available",
+        objectKey: desiredKey,
+        checksumSha256: checksum,
+        verifiedAt: expect.any(Date),
+        leaseToken: null,
+      }),
+    );
+    expect(mocks.insertedValues).toContainEqual(
+      expect.objectContaining({
+        storageTarget: "primary",
+        eventKind: "primary_verified",
+        observedChecksumSha256: checksum,
+        observedFileSizeBytes: 3,
+      }),
+    );
+  });
+
+  it("preserves prior verified evidence across transient provider failures", async () => {
+    const verifiedAt = new Date("2026-08-01T00:00:00.000Z");
+    mocks.executeResults.push(
+      [],
+      [
+        claimedReplica({
+          replicaObjectKey: `attachments/v1/practice/file/${checksum}`,
+          replicaStatus: "available",
+          replicaObjectEtag: "old-etag",
+          replicaObjectVersionId: "old-version",
+          replicaReplicatedAt: verifiedAt,
+          replicaVerifiedAt: verifiedAt,
+        }),
+      ],
+      [{ backlog: 1, available: 0, activeFiles: 1 }],
+    );
+    mocks.readReplicaObject.mockResolvedValue({ status: "failed" });
+    mocks.readPrimaryObject.mockResolvedValue({ status: "failed" });
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      claimed: 1,
+      failed: 1,
+    });
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        status: "available",
+        objectEtag: "old-etag",
+        objectVersionId: "old-version",
+        replicatedAt: verifiedAt,
+        verifiedAt,
+        failureCode: "primary_unavailable",
+      }),
+    );
+  });
+
+  it("downgrades stale evidence when replica and primary bytes are definitively corrupt", async () => {
+    const verifiedAt = new Date("2026-08-01T00:00:00.000Z");
+    mocks.executeResults.push(
+      [],
+      [
+        claimedReplica({
+          replicaObjectKey: `attachments/v1/practice/file/${checksum}`,
+          replicaStatus: "available",
+          replicaObjectEtag: "old-etag",
+          replicaObjectVersionId: "old-version",
+          replicaReplicatedAt: verifiedAt,
+          replicaVerifiedAt: verifiedAt,
+        }),
+      ],
+      [{ backlog: 1, available: 0, activeFiles: 1 }],
+    );
+    mocks.readReplicaObject.mockResolvedValue({
+      status: "available",
+      body: new TextEncoder().encode("bad"),
+    });
+    mocks.readPrimaryObject.mockResolvedValue({
+      status: "available",
+      body: new TextEncoder().encode("bad"),
+    });
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      sourceCorrupt: 1,
+    });
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        status: "corrupt",
+        objectEtag: null,
+        objectVersionId: null,
+        replicatedAt: null,
+        verifiedAt: null,
+        failureCode: "checksum_or_size_mismatch",
+      }),
+    );
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Primary file integrity mismatch",
+      expect.stringContaining("expected manifest does not match stored bytes"),
+    );
+    expect(mocks.insertedValues).toContainEqual(
+      expect.objectContaining({
+        storageTarget: "primary",
+        eventKind: "primary_integrity_mismatch",
+        expectedChecksumSha256: checksum,
+        observedChecksumSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      }),
+    );
+  });
+
+  it("derives the content-addressed key and repairs a missing primary after database loss", async () => {
+    const body = new TextEncoder().encode("abc");
+    const item = claimedReplica({ fileStorageStatus: "unverified" });
+    const desiredKey = replicaObjectKey({
+      practiceId: item.practiceId,
+      fileId: item.fileId,
+      checksumSha256: checksum,
+    });
+    mocks.executeResults.push(
+      [{ id: "materialized-1" }],
+      [item],
+      [{ backlog: 0, available: 1, activeFiles: 1 }],
+    );
+    mocks.readReplicaObject.mockImplementation(async (key: string) => {
+      if (key.startsWith("recovery-catalog/")) {
+        return {
+          status: "available" as const,
+          body: new Uint8Array(
+            mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+          ),
+          versionId: "replica-version",
+        };
+      }
+      return {
+        status: "available" as const,
+        body,
+        contentType: "application/pdf",
+        etag: "replica-etag",
+        versionId: "replica-version",
+      };
+    });
+    mocks.readPrimaryObject
+      .mockResolvedValueOnce({ status: "missing" })
+      .mockResolvedValueOnce({
+        status: "available",
+        body,
+        contentType: "application/pdf",
+        etag: "restored-etag",
+        versionId: "restored-version",
+      });
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      repairedPrimary: 1,
+      failed: 0,
+      bytesCopied: 3,
+    });
+    expect(mocks.readReplicaObject).toHaveBeenNthCalledWith(1, desiredKey, {
+      maxBytes: expect.any(Number),
+    });
+    expect(mocks.readReplicaObject).not.toHaveBeenCalledWith(
+      expect.stringMatching(/\/pending$/),
+      expect.anything(),
+    );
+    expect(mocks.uploadManagedFile).toHaveBeenCalledWith(
+      item.fileKey,
+      Buffer.from(body),
+      "application/pdf",
+      checksum,
+    );
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        storageStatus: "available",
+        checksumSha256: checksum,
+        objectEtag: "restored-etag",
+      }),
+    );
+  });
+
+  it("repairs a corrupt primary from a verified replica", async () => {
+    const body = new TextEncoder().encode("abc");
+    const corrupt = new TextEncoder().encode("bad");
+    const item = claimedReplica({
+      replicaStatus: "available",
+      replicaVerifiedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+    mocks.executeResults.push(
+      [],
+      [item],
+      [{ backlog: 0, available: 1, activeFiles: 1 }],
+    );
+    mocks.readReplicaObject.mockImplementation(async (key: string) => {
+      if (key.startsWith("recovery-catalog/")) {
+        return {
+          status: "available" as const,
+          body: new Uint8Array(
+            mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+          ),
+          versionId: "replica-version",
+        };
+      }
+      return {
+        status: "available" as const,
+        body,
+        versionId: "replica-version",
+      };
+    });
+    mocks.readPrimaryObject
+      .mockResolvedValueOnce({ status: "available", body: corrupt })
+      .mockResolvedValueOnce({ status: "available", body });
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      repairedPrimary: 1,
+      sourceCorrupt: 0,
+      failed: 0,
+    });
+    expect(mocks.uploadManagedFile).toHaveBeenCalledTimes(1);
+    expect(mocks.insertedValues).toContainEqual(
+      expect.objectContaining({
+        storageTarget: "primary",
+        eventKind: "primary_restored_from_replica",
+        nextStatus: "available",
+      }),
+    );
+  });
+
+  it("converges an ambiguous recovery-catalog PUT before marking an existing replica available", async () => {
+    const body = new TextEncoder().encode("abc");
+    const objectKey = replicaObjectKey({
+      practiceId: claimedReplica().practiceId,
+      fileId: claimedReplica().fileId,
+      checksumSha256: checksum,
+    });
+    const first = claimedReplica({ replicaObjectKey: objectKey });
+    mocks.executeResults.push(
+      [],
+      [first],
+      [{ backlog: 0, available: 1, activeFiles: 1 }],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "available", body });
+    mocks.readReplicaObject.mockImplementation(async (key: string) => {
+      if (key.startsWith("recovery-catalog/")) {
+        return {
+          status: "available" as const,
+          body: new Uint8Array(
+            mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+          ),
+          versionId: "replica-version",
+        };
+      }
+      return {
+        status: "available" as const,
+        body,
+        versionId: "replica-version",
+      };
+    });
+    mocks.uploadReplicaFile.mockRejectedValueOnce(
+      new Error("catalog provider timeout"),
+    );
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      failed: 0,
+      alreadyPresent: 1,
+    });
+    expect(mocks.uploadReplicaFile).toHaveBeenCalledTimes(1);
+    expect(mocks.uploadReplicaFile).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(
+        new RegExp(
+          `^recovery-catalog/v2/${first.practiceId}/${first.fileId}/[0-9a-f]{64}\\.json$`,
+        ),
+      ),
+      expect.any(Buffer),
+      "application/json",
+      expect.stringMatching(/^[0-9a-f]{64}$/),
+    );
+    expect(mocks.readReplicaObject).toHaveBeenLastCalledWith(
+      expect.stringMatching(/^recovery-catalog\/v2\//),
+      { maxBytes: expect.any(Number) },
+    );
+  });
+
+  it("rejects provider-null replica versions as immutable recovery evidence", async () => {
+    const body = new TextEncoder().encode("abc");
+    mocks.executeResults.push(
+      [],
+      [claimedReplica()],
+      [{ backlog: 1, available: 0, activeFiles: 1 }],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "available", body });
+    mocks.readReplicaObject.mockResolvedValue({
+      status: "available",
+      body,
+      versionId: "null",
+    });
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      failed: 1,
+      copied: 0,
+      available: 0,
+    });
+    expect(mocks.uploadReplicaFile).toHaveBeenCalledTimes(1);
+    expect(mocks.uploadReplicaFile).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^recovery-catalog\/v2\//),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        status: "pending",
+        objectVersionId: null,
+      }),
+    );
+  });
+
+  it("does not commit primary state or events when replica lease CAS is lost", async () => {
+    const body = new TextEncoder().encode("abc");
+    const item = claimedReplica({ replicaStatus: "available" });
+    mocks.executeResults.push(
+      [],
+      [item],
+      [{ backlog: 1, available: 0, activeFiles: 1 }],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "available", body });
+    mocks.readReplicaObject.mockImplementation(async (key: string) => {
+      if (key.startsWith("recovery-catalog/")) {
+        return {
+          status: "available" as const,
+          body: new Uint8Array(
+            mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+          ),
+        };
+      }
+      return {
+        status: "available" as const,
+        body,
+        versionId: "replica-version",
+      };
+    });
+    mocks.returningResults.push([]);
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      failed: 1,
+      alreadyPresent: 0,
+    });
+    expect(mocks.updateSets).toHaveLength(1);
+    expect(mocks.updateSets[0]).toMatchObject({ leaseToken: null });
+    expect(mocks.insertedValues).toHaveLength(0);
+  });
+
+  it("rolls back stale finalization when a claimed primary rotates before its CAS", async () => {
+    const body = new TextEncoder().encode("abc");
+    mocks.executeResults.push(
+      [],
+      [claimedReplica()],
+      [{ backlog: 1, available: 0, activeFiles: 1 }],
+    );
+    mocks.readPrimaryObject.mockResolvedValue({ status: "available", body });
+    mocks.readReplicaObject.mockImplementation(async (key: string) => {
+      if (key.startsWith("recovery-catalog/")) {
+        return {
+          status: "available" as const,
+          body: new Uint8Array(
+            mocks.uploadReplicaFile.mock.calls.at(-1)?.[1] ?? Buffer.alloc(0),
+          ),
+          versionId: "replica-version",
+        };
+      }
+      return mocks.uploadReplicaFile.mock.calls.length === 0
+        ? { status: "missing" as const }
+        : {
+            status: "available" as const,
+            body,
+            versionId: "replica-version",
+          };
+    });
+    mocks.returningResults.push([{ id: "replica-1" }], []);
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      copied: 0,
+      failed: 1,
+    });
+    expect(mocks.updateSets).toHaveLength(2);
+    expect(mocks.insertedValues).toHaveLength(0);
+  });
+
+  it("stops stale primary repair when generation CAS prevents lease renewal", async () => {
+    const body = new TextEncoder().encode("abc");
+    const item = claimedReplica({
+      replicaStatus: "available",
+      replicaObjectKey: replicaObjectKey({
+        practiceId: claimedReplica().practiceId,
+        fileId: claimedReplica().fileId,
+        checksumSha256: checksum,
+      }),
+      replicaVerifiedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+    mocks.executeResults.push(
+      [],
+      [item],
+      [{ backlog: 1, available: 0, activeFiles: 1 }],
+    );
+    mocks.readReplicaObject.mockResolvedValue({
+      status: "available",
+      body,
+      versionId: "replica-version",
+    });
+    mocks.readPrimaryObject.mockResolvedValue({ status: "missing" });
+    mocks.returningResults.push([]);
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      repairedPrimary: 0,
+      failed: 1,
+    });
+    expect(mocks.uploadManagedFile).not.toHaveBeenCalled();
+    expect(mocks.insertedValues).toHaveLength(0);
+  });
+
+  it("quarantines malformed tenant object namespaces before provider I/O", async () => {
+    mocks.executeResults.push(
+      [],
+      [claimedReplica({ fileKey: "other-practice/documents/opaque" })],
+      [{ backlog: 1, available: 0, activeFiles: 1 }],
+    );
+
+    await expect(reconcileFileReplicas({ limit: 1 })).resolves.toMatchObject({
+      failed: 1,
+    });
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
+    expect(mocks.readReplicaObject).not.toHaveBeenCalled();
+    expect(mocks.updateSets).toContainEqual(
+      expect.objectContaining({
+        status: "failed",
+        failureCode: "invalid_primary_object_namespace",
+      }),
+    );
+  });
+});

--- a/apps/web/lib/__tests__/managed-file-upload.test.ts
+++ b/apps/web/lib/__tests__/managed-file-upload.test.ts
@@ -1,0 +1,524 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const MANAGED_UPLOAD_SOURCE = readFileSync(
+  fileURLToPath(new URL("../managed-file-upload.ts", import.meta.url)),
+  "utf8",
+);
+
+const mocks = vi.hoisted(() => ({
+  readPrimaryObject: vi.fn(),
+  uploadManagedFile: vi.fn(),
+  registerFileForReplication: vi.fn(async () => true),
+}));
+
+vi.mock("@/lib/s3", () => ({
+  readPrimaryObject: mocks.readPrimaryObject,
+  uploadManagedFile: mocks.uploadManagedFile,
+}));
+vi.mock("@/lib/file-replication", () => ({
+  checksumSha256Hex: vi.fn(() => "a".repeat(64)),
+  registerFileForReplication: mocks.registerFileForReplication,
+}));
+
+const {
+  ManagedUploadConflictError,
+  ManagedUploadStateError,
+  finalizeManagedUploadManifest,
+  markManagedUploadCorrupt,
+  putAndVerifyManagedUpload,
+  queueManagedUploadReplication,
+  reserveManagedUpload,
+} = await import("../managed-file-upload");
+
+const practiceId = "00000000-0000-4000-8000-000000000001";
+const uploadedBy = "00000000-0000-4000-8000-000000000002";
+const idempotencyKey = "00000000-0000-4000-8000-000000000099";
+
+function reservation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "00000000-0000-4000-8000-000000000004",
+    practiceId,
+    uploadedBy,
+    idempotencyKey,
+    fileName: "logo.png",
+    fileKey: `${practiceId}/branding/00000000-0000-4000-8000-000000000004`,
+    fileUrl: `/api/files/${practiceId}/branding/00000000-0000-4000-8000-000000000004`,
+    mimeType: "image/png",
+    fileSizeBytes: 8,
+    checksumSha256: "a".repeat(64),
+    storageStatus: "pending_upload",
+    category: "branding" as const,
+    source: "practice_logo",
+    entityType: "practice",
+    entityId: practiceId,
+    patientId: null,
+    appointmentId: null,
+    created: true,
+    ...overrides,
+  };
+}
+
+function reservationInput() {
+  return {
+    practiceId,
+    uploadedBy,
+    idempotencyKey,
+    fileName: "logo.png",
+    mimeType: "image/png",
+    fileSizeBytes: 8,
+    checksumSha256: "a".repeat(64),
+    category: "branding" as const,
+    source: "practice_logo",
+    entityType: "practice" as const,
+    entityId: practiceId,
+  };
+}
+
+function fakeReservationTx(input: {
+  inserted?: Record<string, unknown>;
+  existing?: Record<string, unknown>;
+}) {
+  const insertedValues: Record<string, unknown>[] = [];
+  const updatedValues: Record<string, unknown>[] = [];
+  const insert = vi.fn(() => {
+    const builder = {
+      values: vi.fn((value: Record<string, unknown>) => {
+        insertedValues.push(value);
+        return builder;
+      }),
+      onConflictDoNothing: vi.fn(() => builder),
+      returning: vi.fn(async () => (input.inserted ? [input.inserted] : [])),
+    };
+    return builder;
+  });
+  const select = vi.fn(() => {
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      for: vi.fn(async () => (input.existing ? [input.existing] : [])),
+    };
+    return builder;
+  });
+  const update = vi.fn(() => {
+    const builder = {
+      set: vi.fn((value: Record<string, unknown>) => {
+        updatedValues.push(value);
+        return builder;
+      }),
+      where: vi.fn(() => builder),
+      returning: vi.fn(async () =>
+        input.existing
+          ? [{ ...input.existing, ...(updatedValues.at(-1) ?? {}) }]
+          : [],
+      ),
+    };
+    return builder;
+  });
+  return {
+    tx: { insert, select, update } as never,
+    insertedValues,
+    updatedValues,
+    select,
+  };
+}
+
+function fakeTransitionTx(input: {
+  updated?: Record<string, unknown>[];
+  selected?: Record<string, unknown>[];
+}) {
+  const update = vi.fn(() => {
+    const builder = {
+      set: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      returning: vi.fn(async () => input.updated ?? []),
+    };
+    return builder;
+  });
+  const select = vi.fn(() => {
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      limit: vi.fn(async () => input.selected ?? []),
+    };
+    return builder;
+  });
+  return { tx: { update, select } as never, update, select };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("managed upload reservation", () => {
+  it("persists a pending manifest with semantic ownership before provider I/O", async () => {
+    const row = reservation({ created: undefined });
+    delete (row as { created?: unknown }).created;
+    const { tx, insertedValues } = fakeReservationTx({ inserted: row });
+
+    const result = await reserveManagedUpload(tx, reservationInput());
+
+    expect(result.created).toBe(true);
+    expect(insertedValues).toContainEqual(
+      expect.objectContaining({
+        storageStatus: "pending_upload",
+        idempotencyKey,
+        category: "branding",
+        source: "practice_logo",
+        entityType: "practice",
+        entityId: practiceId,
+      }),
+    );
+    expect(mocks.uploadManagedFile).not.toHaveBeenCalled();
+  });
+
+  it("resumes a matching reservation and rejects key reuse with another payload", async () => {
+    const existing = reservation({ created: undefined });
+    delete (existing as { created?: unknown }).created;
+    const matching = fakeReservationTx({ existing });
+    await expect(
+      reserveManagedUpload(matching.tx, reservationInput()),
+    ).resolves.toMatchObject({ created: false, idempotencyKey });
+
+    const mismatched = fakeReservationTx({
+      existing: { ...existing, checksumSha256: "b".repeat(64) },
+    });
+    await expect(
+      reserveManagedUpload(mismatched.tx, reservationInput()),
+    ).rejects.toBeInstanceOf(ManagedUploadConflictError);
+    expect(mismatched.updatedValues).toHaveLength(0);
+  });
+
+  it("fails closed on a tombstoned idempotency reservation without resurrecting it", async () => {
+    expect(new ManagedUploadStateError("deleted")).toBeInstanceOf(
+      ManagedUploadConflictError,
+    );
+    const tombstoned = reservation({
+      created: undefined,
+      deletedAt: new Date("2026-08-01T00:00:00.000Z"),
+      storageStatus: "available",
+    });
+    delete (tombstoned as { created?: unknown }).created;
+    const replay = fakeReservationTx({ existing: tombstoned });
+
+    await expect(
+      reserveManagedUpload(replay.tx, reservationInput()),
+    ).rejects.toBeInstanceOf(ManagedUploadStateError);
+    expect(replay.updatedValues).toHaveLength(0);
+    expect(mocks.readPrimaryObject).not.toHaveBeenCalled();
+    expect(mocks.uploadManagedFile).not.toHaveBeenCalled();
+  });
+
+  it.each(["missing", "unverified"])(
+    "atomically reopens an exact live %s reservation for safe read-before-write retry",
+    async (storageStatus) => {
+      const existing = reservation({
+        created: undefined,
+        deletedAt: null,
+        storageStatus,
+        storageVerifiedAt: new Date("2026-08-01T00:00:00.000Z"),
+        objectEtag: "stale-etag",
+        objectVersionId: "stale-version",
+      });
+      delete (existing as { created?: unknown }).created;
+      const replay = fakeReservationTx({ existing });
+
+      await expect(
+        reserveManagedUpload(replay.tx, reservationInput()),
+      ).resolves.toMatchObject({
+        id: existing.id,
+        storageStatus: "pending_upload",
+        storageVerifiedAt: null,
+        objectEtag: null,
+        objectVersionId: null,
+        created: false,
+      });
+      expect(replay.updatedValues).toContainEqual(
+        expect.objectContaining({
+          storageStatus: "pending_upload",
+          storageVerifiedAt: null,
+          objectEtag: null,
+          objectVersionId: null,
+        }),
+      );
+    },
+  );
+
+  it("never reopens a cleanup-pending reservation", async () => {
+    const existing = reservation({
+      created: undefined,
+      deletedAt: null,
+      storageStatus: "cleanup_pending",
+    });
+    delete (existing as { created?: unknown }).created;
+    const replay = fakeReservationTx({ existing });
+
+    await expect(
+      reserveManagedUpload(replay.tx, reservationInput()),
+    ).rejects.toBeInstanceOf(ManagedUploadStateError);
+    expect(replay.updatedValues).toHaveLength(0);
+    expect(mocks.uploadManagedFile).not.toHaveBeenCalled();
+  });
+
+  it("rotates a matching corrupt reservation onto a fresh quarantined key", async () => {
+    const existing = reservation({
+      created: undefined,
+      storageStatus: "corrupt",
+      storageVerifiedAt: new Date("2026-08-01T00:00:00.000Z"),
+      objectEtag: "corrupt-etag",
+      objectVersionId: "corrupt-version",
+    });
+    delete (existing as { created?: unknown }).created;
+    const originalKey = existing.fileKey;
+    const recovery = fakeReservationTx({ existing });
+
+    const result = await reserveManagedUpload(recovery.tx, reservationInput());
+
+    expect(result).toMatchObject({
+      id: existing.id,
+      idempotencyKey,
+      storageStatus: "pending_upload",
+      storageVerifiedAt: null,
+      objectEtag: null,
+      objectVersionId: null,
+      created: false,
+    });
+    expect(result.fileKey).not.toBe(originalKey);
+    expect(result.fileKey).toMatch(
+      new RegExp(`^${practiceId}/branding/${existing.id}-[0-9a-f-]{36}$`),
+    );
+    expect(result.fileUrl).toBe(`/api/files/${result.fileKey}`);
+    expect(recovery.updatedValues).toContainEqual(
+      expect.objectContaining({
+        fileKey: result.fileKey,
+        fileUrl: result.fileUrl,
+        storageStatus: "pending_upload",
+        storageVerifiedAt: null,
+        objectEtag: null,
+        objectVersionId: null,
+      }),
+    );
+    const selectBuilder = recovery.select.mock.results[0]?.value;
+    expect(selectBuilder.for).toHaveBeenCalledWith("update");
+  });
+});
+
+describe("managed upload provider convergence", () => {
+  it("recovers a committed PUT even when the provider write returned an error", async () => {
+    const body = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+    mocks.uploadManagedFile.mockRejectedValueOnce(new Error("timeout"));
+    mocks.readPrimaryObject.mockResolvedValueOnce({
+      status: "available",
+      body,
+      etag: "etag-readback",
+      versionId: "version-readback",
+    });
+
+    await expect(
+      putAndVerifyManagedUpload({ reservation: reservation(), body }),
+    ).resolves.toEqual({
+      status: "verified",
+      evidence: {
+        url: `/api/files/${practiceId}/branding/00000000-0000-4000-8000-000000000004`,
+        etag: "etag-readback",
+        versionId: "version-readback",
+      },
+    });
+  });
+
+  it("does not overwrite a pending reservation while provider state is unknown", async () => {
+    const body = Buffer.alloc(8);
+    mocks.readPrimaryObject.mockResolvedValueOnce({ status: "failed" });
+
+    await expect(
+      putAndVerifyManagedUpload({
+        reservation: reservation({ created: false }),
+        body,
+      }),
+    ).resolves.toEqual({ status: "unavailable" });
+    expect(mocks.uploadManagedFile).not.toHaveBeenCalled();
+  });
+
+  it("classifies deterministic-key checksum mismatch as corrupt", async () => {
+    mocks.readPrimaryObject.mockResolvedValueOnce({
+      status: "available",
+      body: new Uint8Array(7),
+    });
+
+    await expect(
+      putAndVerifyManagedUpload({
+        reservation: reservation({ created: false }),
+        body: Buffer.alloc(8),
+      }),
+    ).resolves.toEqual({ status: "corrupt" });
+  });
+
+  it("reads a recovered replacement key before safely writing expected bytes", async () => {
+    const body = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+    const recovered = reservation({
+      created: false,
+      storageStatus: "pending_upload",
+      fileKey: `${practiceId}/branding/00000000-0000-4000-8000-000000000055`,
+      fileUrl: `/api/files/${practiceId}/branding/00000000-0000-4000-8000-000000000055`,
+    });
+    mocks.readPrimaryObject
+      .mockResolvedValueOnce({ status: "missing" })
+      .mockResolvedValueOnce({
+        status: "available",
+        body,
+        etag: "replacement-etag",
+        versionId: "replacement-version",
+      });
+    mocks.uploadManagedFile.mockResolvedValueOnce({
+      url: recovered.fileUrl,
+      etag: "replacement-etag",
+      versionId: "replacement-version",
+    });
+
+    await expect(
+      putAndVerifyManagedUpload({ reservation: recovered, body }),
+    ).resolves.toEqual({
+      status: "verified",
+      evidence: {
+        url: recovered.fileUrl,
+        etag: "replacement-etag",
+        versionId: "replacement-version",
+      },
+    });
+    expect(mocks.readPrimaryObject).toHaveBeenNthCalledWith(
+      1,
+      recovered.fileKey,
+      { maxBytes: 10 * 1024 * 1024 },
+    );
+    expect(mocks.uploadManagedFile).toHaveBeenCalledWith(
+      recovered.fileKey,
+      body,
+      recovered.mimeType,
+      recovered.checksumSha256,
+    );
+  });
+
+  it("queues exact verified evidence for independent replication", async () => {
+    await expect(
+      queueManagedUploadReplication(reservation(), {
+        url: "s3://primary/object",
+        etag: "etag-1",
+        versionId: "version-1",
+      }),
+    ).resolves.toBe(true);
+    expect(mocks.registerFileForReplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: "00000000-0000-4000-8000-000000000004",
+        checksumSha256: "a".repeat(64),
+        objectVersionId: "version-1",
+      }),
+    );
+  });
+});
+
+describe("managed upload manifest transitions", () => {
+  it("fails closed when finalization loses its exact reservation generation", async () => {
+    const stale = fakeTransitionTx({ updated: [], selected: [] });
+
+    await expect(
+      finalizeManagedUploadManifest(stale.tx, reservation(), {
+        url: reservation().fileUrl,
+        etag: "etag-old",
+        versionId: "version-old",
+      }),
+    ).resolves.toBe(false);
+    expect(stale.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows an exact concurrent generation that is already available", async () => {
+    const converged = fakeTransitionTx({
+      updated: [],
+      selected: [{ id: reservation().id }],
+    });
+
+    await expect(
+      finalizeManagedUploadManifest(converged.tx, reservation(), {
+        url: reservation().fileUrl,
+        etag: "etag-retry",
+        versionId: "version-retry",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("reports a lost corrupt-state compare-and-swap without downgrading newer state", async () => {
+    const stale = fakeTransitionTx({ updated: [] });
+    await expect(
+      markManagedUploadCorrupt(stale.tx, reservation()),
+    ).resolves.toBe(false);
+  });
+
+  it("converges when the exact object generation is already quarantined", async () => {
+    const converged = fakeTransitionTx({
+      updated: [],
+      selected: [{ id: reservation().id }],
+    });
+    await expect(
+      markManagedUploadCorrupt(converged.tx, reservation()),
+    ).resolves.toBe(true);
+  });
+
+  it("binds every mutation to the exact object generation and prior state", () => {
+    const finalizeSource = MANAGED_UPLOAD_SOURCE.slice(
+      MANAGED_UPLOAD_SOURCE.indexOf(
+        "export async function finalizeManagedUploadManifest",
+      ),
+      MANAGED_UPLOAD_SOURCE.indexOf(
+        "export async function markManagedUploadCorrupt",
+      ),
+    );
+    const corruptSource = MANAGED_UPLOAD_SOURCE.slice(
+      MANAGED_UPLOAD_SOURCE.indexOf(
+        "export async function markManagedUploadCorrupt",
+      ),
+      MANAGED_UPLOAD_SOURCE.indexOf(
+        "export async function queueManagedUploadReplication",
+      ),
+    );
+    for (const source of [finalizeSource, corruptSource]) {
+      expect(source).toContain(
+        "eq(files.idempotencyKey, reservation.idempotencyKey)",
+      );
+      expect(source).toContain("eq(files.fileKey, reservation.fileKey)");
+      expect(source).toContain("eq(files.fileUrl, reservation.fileUrl)");
+      expect(source).toContain(
+        "eq(files.checksumSha256, reservation.checksumSha256)",
+      );
+      expect(source).toContain(
+        "eq(files.fileSizeBytes, reservation.fileSizeBytes)",
+      );
+      expect(source).toContain("isNull(files.deletedAt)");
+    }
+    expect(finalizeSource).toContain(
+      'eq(files.storageStatus, "pending_upload")',
+    );
+    expect(corruptSource).toContain(
+      'eq(files.storageStatus, "pending_upload")',
+    );
+    const rotateSource = MANAGED_UPLOAD_SOURCE.slice(
+      MANAGED_UPLOAD_SOURCE.indexOf("async function rotateCorruptReservation"),
+      MANAGED_UPLOAD_SOURCE.indexOf(
+        "async function reopenRetryableReservation",
+      ),
+    );
+    const reopenSource = MANAGED_UPLOAD_SOURCE.slice(
+      MANAGED_UPLOAD_SOURCE.indexOf(
+        "async function reopenRetryableReservation",
+      ),
+      MANAGED_UPLOAD_SOURCE.indexOf(
+        "export async function reserveManagedUpload",
+      ),
+    );
+    expect(rotateSource).toContain("isNull(files.deletedAt)");
+    expect(reopenSource).toContain("isNull(files.deletedAt)");
+    expect(reopenSource).toContain(
+      'inArray(files.storageStatus, ["missing", "unverified"])',
+    );
+  });
+});

--- a/apps/web/lib/__tests__/managed-upload-attempt.test.ts
+++ b/apps/web/lib/__tests__/managed-upload-attempt.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  isRetryableUploadStatus,
+  selectManagedUploadFile,
+  settleManagedUploadAttempt,
+} from "../managed-upload-attempt";
+
+describe("managed browser upload attempts", () => {
+  const file = (name: string) => new File(["image"], name, { type: "image/png" });
+
+  it("keeps one idempotency key for ambiguous and retryable attempts", () => {
+    const selected = file("logo.png");
+    const first = selectManagedUploadFile(null, selected, () => "operation-1");
+
+    expect(selectManagedUploadFile(first, selected, () => "operation-2")).toBe(
+      first,
+    );
+    expect(
+      settleManagedUploadAttempt(first, { kind: "ambiguous" }),
+    ).toBe(first);
+    expect(
+      settleManagedUploadAttempt(first, { kind: "response", status: 503 }),
+    ).toBe(first);
+    expect(
+      settleManagedUploadAttempt(first, { kind: "response", status: 429 }),
+    ).toBe(first);
+  });
+
+  it("resets on a file change, definitive success, or client failure", () => {
+    const first = selectManagedUploadFile(null, file("first.png"), () => "one");
+    const second = selectManagedUploadFile(first, file("second.png"), () => "two");
+
+    expect(second.idempotencyKey).toBe("two");
+    expect(settleManagedUploadAttempt(second, { kind: "success" })).toBeNull();
+    expect(
+      settleManagedUploadAttempt(second, { kind: "response", status: 400 }),
+    ).toBeNull();
+    expect(
+      settleManagedUploadAttempt(second, { kind: "response", status: 409 }),
+    ).toBeNull();
+  });
+
+  it("classifies only ambiguous or explicitly retryable statuses as retryable", () => {
+    for (const status of [0, 408, 425, 429, 500, 503]) {
+      expect(isRetryableUploadStatus(status)).toBe(true);
+    }
+    for (const status of [200, 400, 404, 409, 413, 422]) {
+      expect(isRetryableUploadStatus(status)).toBe(false);
+    }
+  });
+});

--- a/apps/web/lib/__tests__/patient-detail-ui.test.ts
+++ b/apps/web/lib/__tests__/patient-detail-ui.test.ts
@@ -29,45 +29,59 @@ import {
 
 describe("patient detail UI states", () => {
   it("resolves merged source charts to the canonical identity with attribution", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
-    expect(source).toContain("const canonicalPatientId = patient?.id ?? params.id");
+    expect(source).toContain(
+      "const canonicalPatientId = patient?.id ?? params.id",
+    );
     expect(source).toContain("patient?.mergeMetadata");
     expect(source).toContain("window.history.replaceState(");
     expect(source).toContain("?mergedFrom=${params.id}");
     expect(source).toContain(
-      "Opened the canonical chart for a merged patient identity"
+      "Opened the canonical chart for a merged patient identity",
     );
     expect(source).toContain("patient.mergeMetadata.sourceSnapshot.name");
     expect(source).toContain("patient.mergeMetadata.performedByName");
     expect(source).toContain("patient.mergeMetadata.reason");
     expect(source).toContain("{ patientId: canonicalPatientId }");
-    expect(source).toMatch(
-      /\{\s*id: canonicalPatientId,\s*photoUrl: data\.url,?\s*\}/,
+    expect(source).toContain(
+      'formData.append("patientId", canonicalPatientId)',
     );
     expect(source).toContain(
-      "Array.from(new Set([params.id, canonicalPatientId]))"
+      'headers: { "Idempotency-Key": attempt.idempotencyKey }',
+    );
+    expect(source).not.toContain("updatePhotoMutation");
+    expect(source).toContain(
+      "Array.from(new Set([params.id, canonicalPatientId]))",
     );
   });
 
   it("keeps viewer access read-only for patient detail writes", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
     expect(source).toContain('import { useSession } from "next-auth/react"');
     expect(source).toContain(
-      "function canManagePatientDetailRole(role?: string | null): boolean"
+      "function canManagePatientDetailRole(role?: string | null): boolean",
     );
     expect(source).toContain(
-      "function canRecordVitalsRole(role?: string | null): boolean"
+      "function canRecordVitalsRole(role?: string | null): boolean",
     );
     expect(source).toContain("const { data: session } = useSession()");
     expect(source).toContain(
-      "const canManagePatientDetail = canManagePatientDetailRole("
+      "const canManagePatientDetail = canManagePatientDetailRole(",
     );
     expect(source).toContain("const canRecordVitals = canRecordVitalsRole(");
     expect(source).toContain("if (!canManagePatientDetail)");
     expect(source).toContain("{canManagePatientDetail && (");
-    expect(source).toContain("canManagePatientDetail &&\n    isPatientWeightInputValid");
+    expect(source).toContain(
+      "canManagePatientDetail &&\n    isPatientWeightInputValid",
+    );
     expect(source).toContain("canRecordVitals={canRecordVitals}");
     expect(source).toContain("canRecordVitals &&");
     expect(source).toContain("canRecordVitals: boolean");
@@ -78,7 +92,10 @@ describe("patient detail UI states", () => {
     expect(source).toContain('role === "front_desk"');
 
     const vitalsRoleStart = source.indexOf("function canRecordVitalsRole");
-    const vitalsRoleEnd = source.indexOf("type VitalsFormState", vitalsRoleStart);
+    const vitalsRoleEnd = source.indexOf(
+      "type VitalsFormState",
+      vitalsRoleStart,
+    );
     const vitalsRoleSource = source.slice(vitalsRoleStart, vitalsRoleEnd);
     expect(vitalsRoleSource).toContain('role === "admin"');
     expect(vitalsRoleSource).toContain('role === "veterinarian"');
@@ -87,9 +104,14 @@ describe("patient detail UI states", () => {
   });
 
   it("uses shared empty states for patient clinical-history tabs", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
-    expect(source).toContain('import { EmptyState } from "@/components/common/empty-state"');
+    expect(source).toContain(
+      'import { EmptyState } from "@/components/common/empty-state"',
+    );
     expect(source).toContain('title="No weight records yet"');
     expect(source).toContain('title="No vitals recorded yet"');
     expect(source).toContain('title="No vaccination records yet"');
@@ -99,10 +121,13 @@ describe("patient detail UI states", () => {
   });
 
   it("gives the chart medical-history tabs backed by tenant-scoped queries", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
     const appointmentsRouter = readFileSync(
       "server/routers/appointments.ts",
-      "utf8"
+      "utf8",
     );
 
     // The chart is the medical record: SOAP timeline, visit history, and
@@ -110,23 +135,28 @@ describe("patient detail UI states", () => {
     for (const label of ["Medical Records", "Appointments", "Invoices"]) {
       expect(source).toContain(`label: "${label}"`);
     }
-    expect(source).toContain("trpc.records.listSoapNotes.useQuery({ patientId })");
     expect(source).toContain(
-      "trpc.appointments.listByPatient.useQuery({ patientId })"
+      "trpc.records.listSoapNotes.useQuery({ patientId })",
+    );
+    expect(source).toContain(
+      "trpc.appointments.listByPatient.useQuery({ patientId })",
     );
     expect(source).toContain("trpc.billing.listInvoices.useQuery({");
     // listByPatient stays tenant-scoped like every appointments query.
     const listByPatient = appointmentsRouter.slice(
-      appointmentsRouter.indexOf("listByPatient:")
+      appointmentsRouter.indexOf("listByPatient:"),
     );
     expect(listByPatient).toContain(
-      "eq(appointments.practiceId, ctx.practiceId)"
+      "eq(appointments.practiceId, ctx.practiceId)",
     );
     expect(listByPatient).toContain("activePracticePredicate(ctx.practiceId)");
   });
 
   it("surfaces Vitals and Vaccinations load errors before empty states", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
     expect(source).toContain("function PatientDetailErrorPanel");
     expect(source).toContain("function PatientDetailLoadingPanel");
@@ -134,18 +164,20 @@ describe("patient detail UI states", () => {
     expect(source).toContain("const loadError = error ?? recordsSettingsError");
     expect(source).toContain("const recordsSettingsMissing =");
     expect(source).toContain(
-      "const isPageLoading = !loadError && (isLoading || recordsSettingsLoading)"
+      "const isPageLoading = !loadError && (isLoading || recordsSettingsLoading)",
     );
     expect(source).toContain(
-      '<PatientDetailLoadingPanel label="Loading patient..." />'
+      '<PatientDetailLoadingPanel label="Loading patient..." />',
     );
     expect(source).toContain("if (\n    loadError ||");
     expect(source).toContain("!verifiedRecordsSettings ||\n    !patient");
     expect(source).toContain('title="Unable to load patient"');
-    expect(source).toContain("recordsSettingsMissing || !verifiedRecordsSettings");
+    expect(source).toContain(
+      "recordsSettingsMissing || !verifiedRecordsSettings",
+    );
     expect(source).toContain("Unable to load clinical settings. Please retry.");
     expect(source).toContain('label: "Back to Patients"');
-    expect(source).toContain("router.push(\"/patients\")");
+    expect(source).toContain('router.push("/patients")');
     expect(source).toMatch(
       /const \{\s*data: vitals,\s*isLoading,\s*error,?\s*\}/,
     );
@@ -154,29 +186,34 @@ describe("patient detail UI states", () => {
     expect(source).toContain("Unable to load vitals. ${error.message}");
     expect(source).toContain("Unable to load vitals. Please retry.");
     expect(source).toContain("const vaccinationsMissing =");
-    expect(source).toContain("Unable to load vaccination records. ${error.message}");
     expect(source).toContain(
-      "Unable to load vaccination records. Please retry."
+      "Unable to load vaccination records. ${error.message}",
+    );
+    expect(source).toContain(
+      "Unable to load vaccination records. Please retry.",
     );
     expect(source.indexOf("vitalsMissing ? (")).toBeLessThan(
-      source.indexOf('title="No vitals recorded yet"')
+      source.indexOf('title="No vitals recorded yet"'),
     );
     expect(source.indexOf("if (vaccinationsMissing)")).toBeLessThan(
-      source.indexOf('title="No vaccination records yet"')
+      source.indexOf('title="No vaccination records yet"'),
     );
     expect(source).not.toContain(
-      'className="text-center text-muted-foreground py-12"'
+      'className="text-center text-muted-foreground py-12"',
     );
     expect(source).not.toContain("if (!patient) return null");
   });
 
   it("fails closed when medical summary clinical payloads are incomplete", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
     expect(source).toContain("const summaryError =");
     expect(source).toContain("throw summaryError");
     expect(source).toContain(
-      "Unable to load complete medical summary data. Please retry."
+      "Unable to load complete medical summary data. Please retry.",
     );
     expect(source).toMatch(/err instanceof Error\s*\?\s*err\.message/);
     expect(source).toContain("const problems = problemsResult.data;");
@@ -185,80 +222,94 @@ describe("patient detail UI states", () => {
     expect(source).toContain("const prescriptions = prescriptionsResult.data;");
     expect(source).not.toContain("if (!patient) return;");
     expect(source).not.toContain("const problems = problemsResult.data ?? []");
-    expect(source).not.toContain("const vaccinations = vaccinationsResult.data ?? []");
-    expect(source).not.toContain("const soapNotes = soapNotesResult.data ?? []");
-    expect(source).not.toContain("const prescriptions = prescriptionsResult.data ?? []");
+    expect(source).not.toContain(
+      "const vaccinations = vaccinationsResult.data ?? []",
+    );
+    expect(source).not.toContain(
+      "const soapNotes = soapNotesResult.data ?? []",
+    );
+    expect(source).not.toContain(
+      "const prescriptions = prescriptionsResult.data ?? []",
+    );
   });
 
   it("renders patient clinical dates through the practice timezone contract", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
     expect(source).toContain(
-      'import {\n  formatClinicalDate,\n  formatClinicalDateTime,\n} from "@/lib/records/clinical-dates"'
+      'import {\n  formatClinicalDate,\n  formatClinicalDateTime,\n} from "@/lib/records/clinical-dates"',
     );
     expect(source).toContain("const verifiedRecordsSettings =");
     expect(source).toContain(
-      "const recordsSettingsTimeZone = verifiedRecordsSettings\n    ? verifiedRecordsSettings.timezone\n    : undefined"
+      "const recordsSettingsTimeZone = verifiedRecordsSettings\n    ? verifiedRecordsSettings.timezone\n    : undefined",
     );
     expect(source).toContain(
-      "buildWeightTrend(patient?.weights ?? [], recordsSettingsTimeZone)"
+      "buildWeightTrend(patient?.weights ?? [], recordsSettingsTimeZone)",
     );
     expect(source).toContain("const patientData = patient");
     expect(source).toContain(
-      "const recordsTimeZone = verifiedRecordsSettings.timezone"
+      "const recordsTimeZone = verifiedRecordsSettings.timezone",
     );
     expect(source).toContain(
-      'const recordsPracticeName =\n    verifiedRecordsSettings.name ?? "Veterinary Practice"'
+      'const recordsPracticeName =\n    verifiedRecordsSettings.name ?? "Veterinary Practice"',
     );
     expect(source).toContain(
-      "const recordsPracticePhone = verifiedRecordsSettings.phone"
+      "const recordsPracticePhone = verifiedRecordsSettings.phone",
     );
     expect(source).toContain("formatClinicalDate(patient.dob, recordsTimeZone");
     expect(source).toContain(
-      "formatClinicalDate(\n                              weight.recordedAt,\n                              recordsTimeZone"
+      "formatClinicalDate(\n                              weight.recordedAt,\n                              recordsTimeZone",
     );
     expect(source).toContain("<VitalsTab");
     expect(source).toContain("canRecordVitals={canRecordVitals}");
     expect(source).toContain("<VaccinationsTab");
     expect(source).toContain("timeZone={recordsTimeZone}");
     expect(source).toContain(
-      "canCorrectClinicalRecords={canCorrectClinicalRecords}"
+      "canCorrectClinicalRecords={canCorrectClinicalRecords}",
     );
     expect(source).toContain(
-      "(vitals ?? []).filter((vital) => !vital.correctionId)"
+      "(vitals ?? []).filter((vital) => !vital.correctionId)",
     );
-    expect(source).toContain(
-      "formatClinicalDateTime(v.recordedAt, timeZone"
-    );
-    expect(source).toContain(
-      "formatClinicalDate(vax.administeredAt, timeZone"
-    );
+    expect(source).toContain("formatClinicalDateTime(v.recordedAt, timeZone");
+    expect(source).toContain("formatClinicalDate(vax.administeredAt, timeZone");
     expect(source).toContain("formatClinicalDate(vax.nextDueDate, timeZone");
     expect(source).toContain(
-      "formatClinicalDate(v.administeredAt, recordsTimeZone"
+      "formatClinicalDate(v.administeredAt, recordsTimeZone",
     );
     expect(source).toContain("formatClinicalDate(n.createdAt, recordsTimeZone");
     expect(source).toContain("practiceName: recordsPracticeName");
-    expect(source).toContain("practicePhone: recordsPracticePhone ?? undefined");
     expect(source).toContain(
-      "generatedDate: formatClinicalDate(new Date(), recordsTimeZone)"
+      "practicePhone: recordsPracticePhone ?? undefined",
     );
-    expect(source).not.toContain("const recordsTimeZone = recordsSettings?.timezone");
-    expect(source).not.toContain("const recordsSettingsTimeZone = recordsSettings?.timezone");
+    expect(source).toContain(
+      "generatedDate: formatClinicalDate(new Date(), recordsTimeZone)",
+    );
+    expect(source).not.toContain(
+      "const recordsTimeZone = recordsSettings?.timezone",
+    );
+    expect(source).not.toContain(
+      "const recordsSettingsTimeZone = recordsSettings?.timezone",
+    );
     expect(source).not.toContain("recordsSettings?.name");
     expect(source).not.toContain("recordsSettings?.phone");
     expect(source).not.toContain('practiceName: ""');
     expect(source).not.toContain(
-      "new Date(weight.recordedAt).toLocaleDateString"
+      "new Date(weight.recordedAt).toLocaleDateString",
     );
     expect(source).not.toContain("new Date(v.recordedAt).toLocaleString");
     expect(source).not.toContain(
-      "new Date(vax.administeredAt).toLocaleDateString"
+      "new Date(vax.administeredAt).toLocaleDateString",
     );
   });
 
   it("bounds the vitals form before record mutation", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
     expect(VITALS_TEMPERATURE_MIN_C).toBe(20);
     expect(VITALS_TEMPERATURE_MAX_C).toBe(45);
@@ -294,14 +345,21 @@ describe("patient detail UI states", () => {
     expect(source).toContain("step={VITALS_WEIGHT_STEP}");
     expect(source).toContain("maxLength={VITALS_MUCOUS_MEMBRANE_MAX_LENGTH}");
     expect(source).toContain("maxLength={VITALS_NOTES_MAX_LENGTH}");
-    expect(source).toContain("mucousMembrane: form.mucousMembrane.trim() || undefined");
-    expect(source).toContain("capillaryRefillSec: num(form.capillaryRefillSec)");
+    expect(source).toContain(
+      "mucousMembrane: form.mucousMembrane.trim() || undefined",
+    );
+    expect(source).toContain(
+      "capillaryRefillSec: num(form.capillaryRefillSec)",
+    );
     expect(source).toContain("disabled={!canSubmitVitals}");
     expect(source).not.toContain("disabled={record.isPending}");
   });
 
   it("bounds and wires the patient weight history form", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
 
     expect(PATIENT_WEIGHT_MIN_KG).toBe(0.001);
     expect(PATIENT_WEIGHT_MAX_KG).toBe(99999.999);
@@ -310,7 +368,9 @@ describe("patient detail UI states", () => {
     expect(isPatientWeightInputValid("12.3456")).toBe(false);
     expect(isPatientWeightInputValid("0")).toBe(false);
     expect(isPatientWeightInputValid("100000")).toBe(false);
-    expect(source).toContain("const addWeight = trpc.patients.addWeight.useMutation");
+    expect(source).toContain(
+      "const addWeight = trpc.patients.addWeight.useMutation",
+    );
     expect(source).toContain("const canSubmitWeight =");
     expect(source).toContain("handleRecordWeight");
     expect(source).toContain("min={PATIENT_WEIGHT_MIN_KG}");
@@ -322,17 +382,22 @@ describe("patient detail UI states", () => {
   });
 
   it("keeps allergy reactions visible and uses permanent clinician corrections", () => {
-    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    const source = readFileSync(
+      "app/(dashboard)/patients/[id]/page.tsx",
+      "utf8",
+    );
     // Add + correction both refresh the same getById payload the bar renders from.
     expect(source).toContain("trpc.patients.addAllergy.useMutation");
     expect(source).toContain(
-      "trpc.patients.markAllergyEnteredInError.useMutation"
+      "trpc.patients.markAllergyEnteredInError.useMutation",
     );
-    const refreshes = source.match(/void refreshPatientDetail\(\)/g);
+    const refreshes = source.match(/refreshPatientDetail\(\)/g);
     expect(refreshes && refreshes.length).toBeGreaterThanOrEqual(4);
     expect(source).toContain('triggerLabel="Mark allergy entered in error"');
     expect(source).toContain("canCorrect={canCorrectClinicalRecords}");
-    expect(source).toContain("Reaction: {allergy.reaction || \"Not documented\"}");
+    expect(source).toContain(
+      'Reaction: {allergy.reaction || "Not documented"}',
+    );
     expect(source).toContain("Allergy correction history");
     expect(source).toContain("Legacy removal retained.");
     expect(source).toContain("{canManagePatientDetail && !showAllergyForm ?");

--- a/apps/web/lib/__tests__/recovery-hold.test.ts
+++ b/apps/web/lib/__tests__/recovery-hold.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertPracticeAllowsExternalSideEffects,
+  lockPracticeForExternalSideEffects,
+  practiceAllowsExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "../recovery-hold";
+
+function databaseWithPractice(recoveryHold: boolean | null) {
+  const limit = vi.fn(async () =>
+    recoveryHold === null ? [] : [{ recoveryHold }],
+  );
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return { database: { select }, select, limit };
+}
+
+function lockDatabaseWithPractice(recoveryHold: boolean) {
+  const locked = vi.fn(async () => [{ recoveryHold }]);
+  const limit = vi.fn(() => ({ for: locked }));
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return { database: { select }, locked };
+}
+
+describe("practice recovery hold", () => {
+  it("allows side effects only for an existing, active, released practice", async () => {
+    const released = databaseWithPractice(false);
+    const held = databaseWithPractice(true);
+    const missing = databaseWithPractice(null);
+
+    await expect(
+      practiceAllowsExternalSideEffects(released.database as never, "p-1"),
+    ).resolves.toBe(true);
+    await expect(
+      practiceAllowsExternalSideEffects(held.database as never, "p-1"),
+    ).resolves.toBe(false);
+    await expect(
+      practiceAllowsExternalSideEffects(missing.database as never, "p-1"),
+    ).resolves.toBe(false);
+  });
+
+  it("fails closed with an operator-facing recovery message", async () => {
+    const held = databaseWithPractice(true);
+
+    await expect(
+      assertPracticeAllowsExternalSideEffects(held.database as never, "p-1"),
+    ).rejects.toThrow(RECOVERY_HOLD_BLOCK_MESSAGE);
+  });
+
+  it("takes a shared practice-row lock for transactional provider work", async () => {
+    const released = lockDatabaseWithPractice(false);
+    const held = lockDatabaseWithPractice(true);
+
+    await expect(
+      lockPracticeForExternalSideEffects(released.database as never, "p-1"),
+    ).resolves.toBe(true);
+    await expect(
+      lockPracticeForExternalSideEffects(held.database as never, "p-1"),
+    ).resolves.toBe(false);
+    expect(released.locked).toHaveBeenCalledWith("share", expect.any(Object));
+  });
+});

--- a/apps/web/lib/__tests__/s3.test.ts
+++ b/apps/web/lib/__tests__/s3.test.ts
@@ -29,8 +29,18 @@ vi.mock("@aws-sdk/s3-request-presigner", () => ({
 const {
   OBJECT_STORAGE_HEALTH_TIMEOUT_MS,
   checkObjectStorageHealth,
+  checkReplicaStorageHealth,
+  deleteFile,
   getObject,
+  normalizeS3VersionId,
+  readPrimaryObject,
+  replicaStorageIncludesPractice,
+  replicaStoragePracticeScope,
+  replicaStorageReadiness,
+  replicaStorageRequired,
+  replicaStorageRolloutEnabled,
   uploadFile,
+  uploadManagedFile,
 } = await import("../s3");
 
 afterEach(() => {
@@ -39,6 +49,81 @@ afterEach(() => {
 });
 
 describe("S3 uploads", () => {
+  it("stores a SHA-256 marker and returns provider write evidence", async () => {
+    mocks.send.mockResolvedValueOnce({
+      ETag: "etag-1",
+      VersionId: "version-1",
+    });
+
+    await expect(
+      uploadManagedFile(
+        "practice-1/documents/file-1",
+        Buffer.from("pdf"),
+        "application/pdf",
+        "a".repeat(64),
+      ),
+    ).resolves.toEqual({
+      url: "https://s3.amazonaws.com/openpims/practice-1/documents/file-1",
+      etag: "etag-1",
+      versionId: "version-1",
+    });
+    expect(mocks.PutObjectCommand).toHaveBeenCalledWith({
+      Bucket: "openpims",
+      Key: "practice-1/documents/file-1",
+      Body: Buffer.from("pdf"),
+      ContentType: "application/pdf",
+      Metadata: { "openvpm-sha256": "a".repeat(64) },
+    });
+    expect(mocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          Key: "practice-1/documents/file-1",
+        }),
+      }),
+      expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("does not expose blank or provider-null version IDs as recovery evidence", async () => {
+    mocks.send
+      .mockResolvedValueOnce({ VersionId: " null " })
+      .mockResolvedValueOnce({ VersionId: "   " });
+
+    await expect(
+      uploadManagedFile(
+        "practice-1/documents/file-1",
+        Buffer.from("pdf"),
+        "application/pdf",
+        "a".repeat(64),
+      ),
+    ).resolves.not.toHaveProperty("versionId");
+    await expect(
+      uploadManagedFile(
+        "practice-1/documents/file-2",
+        Buffer.from("pdf"),
+        "application/pdf",
+        "a".repeat(64),
+      ),
+    ).resolves.not.toHaveProperty("versionId");
+    expect(normalizeS3VersionId(" version-1 ")).toBe("version-1");
+  });
+
+  it("bounds object deletion with the provider I/O timeout signal", async () => {
+    mocks.send.mockResolvedValueOnce({});
+
+    await expect(
+      deleteFile("practice-1/documents/opaque-key"),
+    ).resolves.toBeUndefined();
+    expect(mocks.DeleteObjectCommand).toHaveBeenCalledWith({
+      Bucket: "openpims",
+      Key: "practice-1/documents/opaque-key",
+    });
+    expect(mocks.send).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+    );
+  });
+
   it("trims configured storage env values before creating objects and URLs", async () => {
     vi.stubEnv("S3_ENDPOINT", " https://storage.example ");
     vi.stubEnv("S3_REGION", " us-east-1 ");
@@ -51,10 +136,10 @@ describe("S3 uploads", () => {
       uploadFile(
         "practice-1/branding/logo.png",
         Buffer.from("logo"),
-        "image/png"
-      )
+        "image/png",
+      ),
     ).resolves.toBe(
-      "https://storage.example/clinic-private-bucket/practice-1/branding/logo.png"
+      "https://storage.example/clinic-private-bucket/practice-1/branding/logo.png",
     );
 
     expect(mocks.S3Client).toHaveBeenCalledWith({
@@ -83,8 +168,14 @@ describe("S3 uploads", () => {
     mocks.send.mockResolvedValueOnce({});
 
     await expect(
-      uploadFile("practice-1/files/lab.pdf", Buffer.from("pdf"), "application/pdf")
-    ).resolves.toBe("https://s3.amazonaws.com/openpims/practice-1/files/lab.pdf");
+      uploadFile(
+        "practice-1/files/lab.pdf",
+        Buffer.from("pdf"),
+        "application/pdf",
+      ),
+    ).resolves.toBe(
+      "https://s3.amazonaws.com/openpims/practice-1/files/lab.pdf",
+    );
 
     expect(mocks.S3Client).toHaveBeenCalledWith({
       endpoint: undefined,
@@ -105,6 +196,46 @@ describe("S3 uploads", () => {
 });
 
 describe("S3 object reads", () => {
+  it("rejects unusable exact-version requests before provider I/O", async () => {
+    await expect(
+      readPrimaryObject("practice/documents/file", { versionId: "null" }),
+    ).resolves.toEqual({ status: "failed" });
+    await expect(
+      readPrimaryObject("practice/documents/file", { versionId: "  " }),
+    ).resolves.toEqual({ status: "failed" });
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+
+  it("requires the provider to return the requested usable version ID", async () => {
+    mocks.send.mockResolvedValueOnce({
+      Body: {
+        transformToByteArray: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      },
+      VersionId: "null",
+    });
+
+    await expect(
+      readPrimaryObject("practice/documents/file", {
+        versionId: "version-1",
+      }),
+    ).resolves.toEqual({ status: "failed" });
+  });
+
+  it("distinguishes a definitive missing object from a provider outage", async () => {
+    mocks.send.mockRejectedValueOnce({
+      name: "NoSuchKey",
+      $metadata: { httpStatusCode: 404 },
+    });
+    await expect(
+      readPrimaryObject("practice/documents/missing"),
+    ).resolves.toEqual({ status: "missing" });
+
+    mocks.send.mockRejectedValueOnce(new Error("provider timeout secret=abc"));
+    await expect(
+      readPrimaryObject("practice/documents/unavailable"),
+    ).resolves.toEqual({ status: "failed" });
+  });
+
   it("rejects oversized objects from provider metadata before buffering", async () => {
     const transformToByteArray = vi.fn(async () => new Uint8Array([1, 2, 3]));
     mocks.send.mockResolvedValueOnce({
@@ -113,8 +244,9 @@ describe("S3 object reads", () => {
       ContentType: "image/png",
     });
 
-    await expect(getObject("practice/documents/lab.pdf", { maxBytes: 10 }))
-      .resolves.toBeNull();
+    await expect(
+      getObject("practice/documents/lab.pdf", { maxBytes: 10 }),
+    ).resolves.toBeNull();
     expect(transformToByteArray).not.toHaveBeenCalled();
   });
 
@@ -126,8 +258,9 @@ describe("S3 object reads", () => {
       ContentType: "application/pdf",
     });
 
-    await expect(getObject("practice/documents/lab.pdf", { maxBytes: 10 }))
-      .resolves.toBeNull();
+    await expect(
+      getObject("practice/documents/lab.pdf", { maxBytes: 10 }),
+    ).resolves.toBeNull();
   });
 
   it("returns object bytes within the caller byte cap", async () => {
@@ -140,21 +273,121 @@ describe("S3 object reads", () => {
       ContentType: "image/png",
     });
 
-    await expect(getObject("practice/branding/logo.png", { maxBytes: 10 }))
-      .resolves.toEqual({ body, contentType: "image/png" });
+    await expect(
+      getObject("practice/branding/logo.png", { maxBytes: 10 }),
+    ).resolves.toEqual({ body, contentType: "image/png" });
   });
 });
 
 describe("S3 health checks", () => {
+  it("requires an explicit all-practice flag or valid UUID cohort before rollout", () => {
+    vi.stubEnv("S3_ENDPOINT", "https://primary.example");
+    vi.stubEnv("S3_BUCKET", "primary");
+    vi.stubEnv("FILE_REPLICA_S3_ENDPOINT", "https://replica.example");
+    vi.stubEnv("FILE_REPLICA_S3_BUCKET", "replica");
+    vi.stubEnv("FILE_REPLICA_S3_ACCESS_KEY", "replica-access");
+    vi.stubEnv("FILE_REPLICA_S3_SECRET_KEY", "replica-secret");
+
+    expect(replicaStorageRolloutEnabled()).toBe(false);
+    expect(replicaStorageReadiness()).toMatchObject({ ready: true });
+    expect(replicaStorageIncludesPractice("practice-1")).toBe(false);
+
+    vi.stubEnv("FILE_REPLICA_ENABLED", "true");
+    expect(replicaStorageReadiness()).toMatchObject({
+      ready: false,
+      detail: "Replica rollout needs an exact practice cohort",
+    });
+
+    vi.stubEnv("FILE_REPLICA_PRACTICE_IDS", "not-a-uuid");
+    expect(replicaStorageReadiness()).toMatchObject({
+      ready: false,
+      detail: "Replica rollout practice cohort is invalid",
+    });
+
+    const practiceId = "00000000-0000-4000-8000-000000000001";
+    vi.stubEnv("FILE_REPLICA_PRACTICE_IDS", ` ${practiceId},${practiceId} `);
+    expect(replicaStorageReadiness()).toMatchObject({ ready: true });
+    expect(replicaStoragePracticeScope()).toEqual([practiceId]);
+    expect(replicaStorageIncludesPractice(practiceId)).toBe(true);
+    expect(
+      replicaStorageIncludesPractice("00000000-0000-4000-8000-000000000099"),
+    ).toBe(false);
+
+    vi.stubEnv("FILE_REPLICA_ALL_PRACTICES", "true");
+    expect(replicaStorageReadiness()).toMatchObject({
+      ready: false,
+      detail:
+        "Replica rollout must choose either all practices or an exact cohort",
+    });
+  });
+
+  it("keeps an absent replica advisory but fails closed on partial or identical config", () => {
+    expect(replicaStorageReadiness()).toEqual({
+      intended: false,
+      ready: false,
+      detail: "Independent object replica is not configured",
+    });
+
+    vi.stubEnv("FILE_REPLICA_REQUIRED", "true");
+    expect(replicaStorageRequired()).toBe(true);
+    expect(replicaStorageReadiness()).toMatchObject({
+      intended: true,
+      ready: false,
+      detail: "3 required replica storage values are missing",
+    });
+
+    vi.stubEnv("S3_ENDPOINT", "https://storage.example");
+    vi.stubEnv("S3_BUCKET", "primary");
+    vi.stubEnv("FILE_REPLICA_S3_ENDPOINT", "https://storage.example/");
+    vi.stubEnv("FILE_REPLICA_S3_BUCKET", "primary");
+    vi.stubEnv("FILE_REPLICA_S3_ACCESS_KEY", "replica-access");
+    vi.stubEnv("FILE_REPLICA_S3_SECRET_KEY", "replica-secret");
+    expect(replicaStorageReadiness()).toEqual({
+      intended: true,
+      ready: false,
+      detail: "Replica storage must use a different endpoint or bucket",
+    });
+  });
+
+  it("health-checks a complete independent replica without exposing its identity", async () => {
+    vi.stubEnv("S3_ENDPOINT", "https://primary.example");
+    vi.stubEnv("S3_BUCKET", "primary");
+    vi.stubEnv("FILE_REPLICA_S3_ENDPOINT", " https://replica.example ");
+    vi.stubEnv("FILE_REPLICA_S3_REGION", " us-west-2 ");
+    vi.stubEnv("FILE_REPLICA_S3_ACCESS_KEY", " replica-access ");
+    vi.stubEnv("FILE_REPLICA_S3_SECRET_KEY", " replica-secret ");
+    vi.stubEnv("FILE_REPLICA_S3_BUCKET", " replica-private ");
+    mocks.send.mockResolvedValueOnce({});
+
+    await expect(
+      checkReplicaStorageHealth({ timeoutMs: 1234 }),
+    ).resolves.toEqual({
+      ok: true,
+      detail: "Replica object storage reachable",
+    });
+    expect(mocks.S3Client).toHaveBeenCalledWith({
+      endpoint: "https://replica.example",
+      region: "us-west-2",
+      credentials: {
+        accessKeyId: "replica-access",
+        secretAccessKey: "replica-secret",
+      },
+      forcePathStyle: true,
+    });
+    expect(mocks.HeadBucketCommand).toHaveBeenCalledWith({
+      Bucket: "replica-private",
+    });
+  });
+
   it("checks bucket reachability with a bounded HeadBucket request", async () => {
     mocks.send.mockResolvedValueOnce({});
 
-    await expect(checkObjectStorageHealth({ timeoutMs: 1234 })).resolves.toEqual(
-      {
-        ok: true,
-        detail: "Object storage bucket reachable",
-      }
-    );
+    await expect(
+      checkObjectStorageHealth({ timeoutMs: 1234 }),
+    ).resolves.toEqual({
+      ok: true,
+      detail: "Object storage bucket reachable",
+    });
 
     expect(mocks.HeadBucketCommand).toHaveBeenCalledWith({
       Bucket: "openpims",
@@ -165,14 +398,14 @@ describe("S3 health checks", () => {
       }),
       expect.objectContaining({
         abortSignal: expect.any(AbortSignal),
-      })
+      }),
     );
     expect(OBJECT_STORAGE_HEALTH_TIMEOUT_MS).toBe(5_000);
   });
 
   it("returns a sanitized storage health failure", async () => {
     mocks.send.mockRejectedValueOnce(
-      new Error("AccessDenied bucket=openpims secret=abc123")
+      new Error("AccessDenied bucket=openpims secret=abc123"),
     );
 
     await expect(checkObjectStorageHealth()).resolves.toEqual({

--- a/apps/web/lib/__tests__/sms.test.ts
+++ b/apps/web/lib/__tests__/sms.test.ts
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   withSystem: vi.fn(),
   acquireSmsRecipientLockInTransaction: vi.fn(async () => undefined),
   alertOps: vi.fn(async () => undefined),
+  practiceAllowsExternalSideEffects: vi.fn(async () => true),
+  lockPracticeForExternalSideEffects: vi.fn(async () => true),
 }));
 
 vi.mock("@openpims/db/client", () => ({ db: {} }));
@@ -24,6 +26,12 @@ vi.mock("@/lib/billing/plans", () => ({
 }));
 vi.mock("@/lib/billing/usage", () => ({ recordUsage: mocks.recordUsage }));
 vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  practiceAllowsExternalSideEffects: mocks.practiceAllowsExternalSideEffects,
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
+}));
 vi.mock("@/lib/messaging", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/messaging")>();
   return {
@@ -420,6 +428,7 @@ beforeEach(() => {
   });
   mocks.recordUsage.mockResolvedValue(undefined);
   mocks.acquireSmsRecipientLockInTransaction.mockResolvedValue(undefined);
+  mocks.practiceAllowsExternalSideEffects.mockResolvedValue(true);
   vi.stubEnv("MESSAGING_REGISTERED_DISPLAY_NAME", "Neighborhood Veterinary");
   (globalThis as Record<string, unknown>).__smsLedgerState = state;
 });
@@ -523,6 +532,18 @@ describe("independent ledger reservation", () => {
 });
 
 describe("durable SMS dispatch", () => {
+  it("blocks a held practice before resolving a sender or reserving delivery", async () => {
+    mocks.practiceAllowsExternalSideEffects.mockResolvedValueOnce(false);
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: "recovery hold",
+    });
+    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
   it("keeps hosted sending default-off before DB or provider work", async () => {
     mocks.billingEnforced.mockReturnValue(true);
 

--- a/apps/web/lib/__tests__/stripe.test.ts
+++ b/apps/web/lib/__tests__/stripe.test.ts
@@ -3,7 +3,10 @@ import {
   buildInvoiceCheckoutSessionParams,
   buildSubscriptionCheckoutSessionParams,
   INVOICE_CHECKOUT_CAPTURE_MODE,
+  INVOICE_CHECKOUT_INTEGRATION_IDENTIFIER,
+  STRIPE_API_VERSION,
   STRIPE_TAX_ENABLED_ENV,
+  SUBSCRIPTION_CHECKOUT_INTEGRATION_IDENTIFIER,
 } from "../stripe";
 import { TRIAL_DAYS } from "../billing/plans";
 
@@ -27,10 +30,15 @@ async function importStripeWithMock() {
   const accountLinkCreate = vi.fn();
   const accountLoginLinkCreate = vi.fn();
   const constructEvent = vi.fn();
+  const stripeConstruct = vi.fn();
 
   vi.resetModules();
   vi.doMock("stripe", () => ({
     default: class StripeMock {
+      constructor(...args: unknown[]) {
+        stripeConstruct(...args);
+      }
+
       checkout = {
         sessions: { create: checkoutCreate, retrieve: checkoutRetrieve },
       };
@@ -67,6 +75,7 @@ async function importStripeWithMock() {
     accountLinkCreate,
     accountLoginLinkCreate,
     constructEvent,
+    stripeConstruct,
   };
 }
 
@@ -85,6 +94,9 @@ describe("buildSubscriptionCheckoutSessionParams", () => {
     });
 
     expect(params.mode).toBe("subscription");
+    expect(params.integration_identifier).toBe(
+      SUBSCRIPTION_CHECKOUT_INTEGRATION_IDENTIFIER
+    );
     expect(params.payment_method_collection).toBe("always");
     expect(params.customer_email).toBe("admin@example.com");
     expect(params.line_items).toEqual([
@@ -226,6 +238,7 @@ describe("buildInvoiceCheckoutSessionParams", () => {
 
     expect(params).toMatchObject({
       mode: "payment",
+      integration_identifier: INVOICE_CHECKOUT_INTEGRATION_IDENTIFIER,
       customer_email: "client@example.com",
       client_reference_id: "invoice_123",
       metadata: {
@@ -254,6 +267,9 @@ describe("buildInvoiceCheckoutSessionParams", () => {
         quantity: 1,
       },
     ]);
+    // Let Stripe dynamically show every eligible method for this currency and
+    // manual-capture flow (including wallets) instead of forcing card-only.
+    expect(params.payment_method_types).toBeUndefined();
   });
 
   it("omits customer email when a client has no email on file", () => {
@@ -346,6 +362,26 @@ describe("buildInvoiceCheckoutSessionParams", () => {
 });
 
 describe("create Stripe hosted sessions", () => {
+  it("pins the Stripe API contract used by every server-side request", async () => {
+    const { stripeConstruct } = await importStripeWithMock();
+
+    expect(stripeConstruct).toHaveBeenCalledExactlyOnceWith("sk_test_123", {
+      apiVersion: STRIPE_API_VERSION,
+    });
+  });
+
+  it("uses stable, distinct Checkout integration identifiers", () => {
+    expect(INVOICE_CHECKOUT_INTEGRATION_IDENTIFIER).toMatch(
+      /^openvpm_invoice_[a-z]{8}$/
+    );
+    expect(SUBSCRIPTION_CHECKOUT_INTEGRATION_IDENTIFIER).toMatch(
+      /^openvpm_subscription_[a-z]{8}$/
+    );
+    expect(INVOICE_CHECKOUT_INTEGRATION_IDENTIFIER).not.toBe(
+      SUBSCRIPTION_CHECKOUT_INTEGRATION_IDENTIFIER
+    );
+  });
+
   it("returns safe HTTPS redirect URLs from Stripe sessions", async () => {
     const { stripeModule, checkoutCreate, billingPortalCreate } =
       await importStripeWithMock();
@@ -485,9 +521,11 @@ describe("create Stripe hosted sessions", () => {
       })
     ).resolves.toEqual({ refundId: "re_123" });
 
-    expect(checkoutRetrieve).toHaveBeenCalledWith("cs_456", {
-      stripeAccount: "acct_9",
-    });
+    expect(checkoutRetrieve).toHaveBeenCalledWith(
+      "cs_456",
+      {},
+      { stripeAccount: "acct_9" }
+    );
     expect(refundCreate).toHaveBeenCalledWith(
       {
         payment_intent: "pi_123",
@@ -526,9 +564,11 @@ describe("create Stripe hosted sessions", () => {
       })
     ).resolves.toEqual({ amountCapturedCents: 5000 });
 
-    expect(paymentIntentRetrieve).toHaveBeenCalledWith("pi_123", {
-      stripeAccount: "acct_123",
-    });
+    expect(paymentIntentRetrieve).toHaveBeenCalledWith(
+      "pi_123",
+      {},
+      { stripeAccount: "acct_123" }
+    );
     expect(paymentIntentCapture).toHaveBeenCalledWith(
       "pi_123",
       { amount_to_capture: 5000, application_fee_amount: 49 },

--- a/apps/web/lib/__tests__/tenant-db.test.ts
+++ b/apps/web/lib/__tests__/tenant-db.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { withTenantReadOnlySnapshot } from "../tenant-db";
+
+describe("tenant database snapshots", () => {
+  it("sets repeatable-read/read-only characteristics before tenant scope and export reads", async () => {
+    const execute = vi.fn(async () => undefined);
+    const tx = { execute };
+    const exportRead = vi.fn(async () => "exported");
+    const transaction = vi.fn(
+      async (fn: (transactionDb: typeof tx) => Promise<unknown>) => fn(tx),
+    );
+
+    await expect(
+      withTenantReadOnlySnapshot(
+        { transaction } as never,
+        "practice-1",
+        exportRead as never,
+      ),
+    ).resolves.toBe("exported");
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(exportRead).toHaveBeenCalledWith(tx);
+    expect(execute.mock.invocationCallOrder[0]).toBeLessThan(
+      execute.mock.invocationCallOrder[1]!,
+    );
+    expect(execute.mock.invocationCallOrder[1]).toBeLessThan(
+      exportRead.mock.invocationCallOrder[0]!,
+    );
+  });
+});

--- a/apps/web/lib/__tests__/upload-ui-states.test.ts
+++ b/apps/web/lib/__tests__/upload-ui-states.test.ts
@@ -45,7 +45,7 @@ describe("upload UI states", () => {
 
     for (const source of imageUploadSources) {
       expect(source).toContain('from "@/lib/upload-policy"');
-      expect(source).toContain("isImageUploadFileValid(file)");
+      expect(source).toContain("isImageUploadFileValid(selectedFile)");
       expect(source).toContain("IMAGE_UPLOAD_POLICY_MESSAGE");
       expect(source).toContain('"/api/upload"');
       expect(source).toContain('accept="image/png,image/jpeg,image/webp"');
@@ -57,5 +57,27 @@ describe("upload UI states", () => {
       'formData.append("category", "patient-photos")'
     );
     expect(patientDetail).not.toContain('accept="image/*"');
+  });
+
+  it("keeps one upload operation across retryable dashboard and onboarding failures", () => {
+    for (const source of imageUploadSources) {
+      expect(source).toContain("selectManagedUploadFile(");
+      expect(source).toContain("settleManagedUploadAttempt(");
+      expect(source).toContain("attempt.idempotencyKey");
+      expect(source).toContain("kind: \"response\"");
+      expect(source).toContain("kind: \"success\"");
+      expect(source).toContain("kind: \"ambiguous\"");
+    }
+
+    expect(onboardingBranding).toContain("onClick={() => void handleFile()}");
+    expect(settingsPage).toContain(
+      "onClick={() => void handleLogoUpload()}",
+    );
+    expect(patientDetail).toContain(
+      "onClick={() => void uploadPatientPhoto()}",
+    );
+    expect(onboardingBranding).toContain("Try again");
+    expect(settingsPage).toContain("Try again");
+    expect(patientDetail).toContain("Try photo again");
   });
 });

--- a/apps/web/lib/__tests__/webhook-dispatcher.test.ts
+++ b/apps/web/lib/__tests__/webhook-dispatcher.test.ts
@@ -8,12 +8,23 @@ type WebhookRow = {
 
 const mocks = vi.hoisted(() => {
   const activeWebhooks: WebhookRow[] = [];
+  const selectWhere = vi.fn(async () => activeWebhooks);
+  const tx = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({ where: selectWhere })),
+    })),
+  };
 
   return {
     activeWebhooks,
     db: {},
+    tx,
+    selectWhere,
     alertOps: vi.fn(async () => undefined),
-    withTenant: vi.fn(async () => activeWebhooks),
+    withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
+      fn(tx),
+    ),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
   };
 });
 
@@ -26,7 +37,12 @@ vi.mock("@/lib/alerts", () => ({
 }));
 
 vi.mock("@/lib/tenant-db", () => ({
-  withTenant: mocks.withTenant,
+  withSystem: mocks.withSystem,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { WEBHOOK_DELIVERY_TIMEOUT_MS, dispatchWebhookEvent } = await import(
@@ -47,6 +63,8 @@ function webhook(overrides: Partial<WebhookRow> = {}): WebhookRow {
 
 beforeEach(() => {
   mocks.activeWebhooks.length = 0;
+  mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
+  mocks.selectWhere.mockImplementation(async () => mocks.activeWebhooks);
 });
 
 afterEach(() => {
@@ -56,6 +74,17 @@ afterEach(() => {
 });
 
 describe("webhook dispatcher delivery", () => {
+  it("does not query or deliver while the practice is on recovery hold", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await dispatchWebhookEvent(PRACTICE_ID, EVENT, { id: "appt-1" });
+
+    expect(mocks.tx.select).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("delivers subscribed events with a timeout signal", async () => {
     mocks.activeWebhooks.push(webhook());
     const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
@@ -149,7 +178,7 @@ describe("webhook dispatcher delivery", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    mocks.withTenant.mockRejectedValueOnce(new Error("db down"));
+    mocks.selectWhere.mockRejectedValueOnce(new Error("db down"));
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 

--- a/apps/web/lib/agent/__tests__/runner-rate-limit.test.ts
+++ b/apps/web/lib/agent/__tests__/runner-rate-limit.test.ts
@@ -5,6 +5,7 @@ import {
   AGENT_RUN_RATE_WINDOW_MS,
   AgentNotConfiguredError,
   AgentRateLimitedError,
+  AgentRecoveryHoldError,
   runAgent,
 } from "../runner";
 
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => {
     tool: vi.fn((definition: unknown) => definition),
     rateLimit: vi.fn(),
     recordUsage: vi.fn(),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
   };
 });
 
@@ -51,6 +53,12 @@ vi.mock("@/lib/rate-limit", () => ({
 
 vi.mock("@/lib/billing/usage", () => ({
   recordUsage: mocks.recordUsage,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const resetAt = new Date("2099-01-01T00:00:00.000Z");
@@ -79,6 +87,7 @@ beforeEach(() => {
     remaining: 19,
     resetAt,
   });
+  mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
   mocks.generateText.mockResolvedValue({
     text: " Done ",
     steps: [{}],
@@ -92,6 +101,18 @@ afterEach(() => {
 });
 
 describe("runAgent rate limiting", () => {
+  it("does not call the model provider while the practice is held", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+
+    await expect(
+      runAgent({ instruction: "Summarize today", context }),
+    ).rejects.toBeInstanceOf(AgentRecoveryHoldError);
+
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.generateText).not.toHaveBeenCalled();
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
+  });
+
   it("checks actor and practice buckets before calling the provider", async () => {
     const result = await runAgent({
       instruction: "Summarize today's schedule",

--- a/apps/web/lib/agent/runner.ts
+++ b/apps/web/lib/agent/runner.ts
@@ -15,6 +15,10 @@ import {
 } from "./tools";
 import { recordUsage } from "@/lib/billing/usage";
 import { rateLimit } from "@/lib/rate-limit";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 /**
  * Provider-agnostic agent runner (Vercel AI SDK). The active model is chosen by
@@ -70,6 +74,13 @@ export class AgentRateLimitedError extends Error {
   ) {
     super("Too many agent runs. Try again later.");
     this.name = "AgentRateLimitedError";
+  }
+}
+
+export class AgentRecoveryHoldError extends Error {
+  constructor() {
+    super(RECOVERY_HOLD_BLOCK_MESSAGE);
+    this.name = "AgentRecoveryHoldError";
   }
 }
 
@@ -258,6 +269,14 @@ export async function runAgent(opts: {
 }): Promise<AgentRunResult> {
   const modelId = activeModelId(opts.model);
   if (!hasProviderKey(modelId)) throw new AgentNotConfiguredError();
+  if (
+    !(await lockPracticeForExternalSideEffects(
+      opts.context.db,
+      opts.context.practiceId,
+    ))
+  ) {
+    throw new AgentRecoveryHoldError();
+  }
 
   const allowWrites = opts.allowWrites ?? false;
   await enforceAgentRunRateLimit(opts.context);

--- a/apps/web/lib/analytics-privacy.ts
+++ b/apps/web/lib/analytics-privacy.ts
@@ -1,0 +1,17 @@
+import type { BeforeSend } from "@vercel/analytics";
+
+const CAPABILITY_PATH_PATTERN = /^\/(?:capture|sign)(?:\/|$)/;
+
+/**
+ * Capability URLs are credentials. Drop every analytics event emitted while a
+ * visitor is on one of those pages so the raw token never leaves the browser.
+ */
+export const filterVercelAnalyticsEvent: BeforeSend = (event) => {
+  try {
+    const pathname = new URL(event.url, "https://analytics.invalid").pathname;
+    return CAPABILITY_PATH_PATTERN.test(pathname) ? null : event;
+  } catch {
+    // An unparseable URL is not useful analytics and may contain a credential.
+    return null;
+  }
+};

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import {
   backupKey,
   coerceRowDates,
+  PRACTICE_RECOVERY_HOLD_REASON,
   PRACTICE_EXPORT_SECRET_REPLACEMENTS,
   PRACTICE_EXPORT_AUDIT_ONLY_SECTIONS,
   PRACTICE_EXPORT_FORMAT_VERSION,
@@ -198,6 +199,8 @@ describe("attachment manifest restore safety", () => {
     expect(source).toContain("activeFileRows(db, practiceId)");
     expect(source).not.toContain("activeRows(db, files, practiceId)");
     expect(source).toContain("fileUrl: canonicalFileUrl(row.fileKey)");
+    expect(source).not.toContain("objectEtag: files.objectEtag");
+    expect(source).not.toContain("objectVersionId: files.objectVersionId");
   });
 
   it("validates file namespace and integrity metadata", () => {
@@ -273,8 +276,21 @@ function emptyBackup(): Record<string, unknown[]> {
   );
 }
 
+function withCanonicalCounts<T extends Record<string, unknown>>(backup: T) {
+  return {
+    ...backup,
+    counts: Object.fromEntries(
+      PRACTICE_EXPORT_SECTIONS.map((section) => [
+        section,
+        Array.isArray(backup[section]) ? backup[section].length : 0,
+      ]),
+    ),
+  };
+}
+
 function restoreDb(executeResults: unknown[][] = []) {
   const inserted: { rows: Record<string, unknown>[] }[] = [];
+  const updates: Record<string, unknown>[] = [];
   const executed: unknown[] = [];
   const timeline: string[] = [];
   const pendingExecuteResults = [...executeResults];
@@ -305,8 +321,22 @@ function restoreDb(executeResults: unknown[][] = []) {
         })),
       })),
     })),
+    update: vi.fn(() => {
+      const builder = {
+        set: vi.fn((values: Record<string, unknown>) => {
+          updates.push(values);
+          return builder;
+        }),
+        where: vi.fn(() => builder),
+        returning: vi.fn(async () => {
+          timeline.push("recovery-hold");
+          return [{ id: "target-practice" }];
+        }),
+      };
+      return builder;
+    }),
   };
-  return { db, inserted, executed, timeline };
+  return { db, inserted, updates, executed, timeline };
 }
 
 const MERGE_OPERATION_ID = "00000000-0000-4000-8000-000000000011";
@@ -487,7 +517,7 @@ describe("summarizePracticeExport", () => {
 
   it("requires replacement lineage in current backups but accepts its legacy absence", () => {
     const currentMissing: Record<string, unknown> = {
-      formatVersion: 5,
+      formatVersion: PRACTICE_EXPORT_FORMAT_VERSION,
       ...emptyBackup(),
     };
     delete currentMissing["labResultReplacements"];
@@ -495,7 +525,7 @@ describe("summarizePracticeExport", () => {
       "labResultReplacements",
     );
     const currentSoapMissing: Record<string, unknown> = {
-      formatVersion: 5,
+      formatVersion: PRACTICE_EXPORT_FORMAT_VERSION,
       ...emptyBackup(),
     };
     delete currentSoapMissing["soapNoteReplacements"];
@@ -756,9 +786,10 @@ describe("location-aware scheduling backup compatibility", () => {
   const appointmentId = "appointment-1";
 
   function schedulingBackup() {
-    return {
+    return withCanonicalCounts({
       formatVersion: PRACTICE_EXPORT_FORMAT_VERSION,
       practiceId,
+      practice: { id: practiceId, name: "Recovery Clinic" },
       ...emptyBackup(),
       locations: [
         {
@@ -786,7 +817,7 @@ describe("location-aware scheduling backup compatibility", () => {
           roomId,
         },
       ],
-    };
+    });
   }
 
   it("requires explicit room and appointment locations in v5 backups", () => {
@@ -968,6 +999,69 @@ describe("exportPracticeData query scoping", () => {
   });
 });
 
+describe("independent recovery metadata", () => {
+  it("requires exact clinic identity metadata in current backup format", () => {
+    const backup = withCanonicalCounts({
+      formatVersion: PRACTICE_EXPORT_FORMAT_VERSION,
+      practiceId: "practice-1",
+      practice: { id: "practice-1", name: "Recovery Clinic" },
+      ...emptyBackup(),
+    });
+
+    expect(validatePracticeExportRestore(backup)).toEqual({
+      valid: true,
+      errors: [],
+    });
+
+    expect(
+      validatePracticeExportRestore({ ...backup, practice: undefined }).errors,
+    ).toContain("practice recovery metadata is required in backup format v6.");
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        practice: { id: "other-practice" },
+      }).errors,
+    ).toContain("practice recovery metadata must match practiceId exactly.");
+
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        practice: {
+          id: "practice-1",
+          name: "Recovery Clinic",
+          billingStatus: "active",
+        },
+      }).errors,
+    ).toContain(
+      "practice recovery metadata contains unsupported keys: billingStatus.",
+    );
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        formatVersion: PRACTICE_EXPORT_FORMAT_VERSION + 1,
+      }).errors,
+    ).toContain("backup format v7 is newer than this release supports.");
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        counts: { locations: 1 },
+      }).errors,
+    ).toContain("backup count for locations does not match its rows.");
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        counts: undefined,
+      }).errors,
+    ).toContain("canonical section counts are required in backup format v6.");
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        counts: { ...backup.counts, unexpected: 0 },
+      }).errors,
+    ).toContain("backup counts contain unsupported sections: unexpected.");
+  });
+});
+
 describe("practice backup secret handling", () => {
   it("replaces credential material with restore-safe placeholders", () => {
     expect(
@@ -1023,6 +1117,38 @@ describe("practice backup secret handling", () => {
         id: "webhook-1",
         secret: PRACTICE_EXPORT_SECRET_REPLACEMENTS.webhookSecret,
         active: false,
+      },
+    ]);
+
+    expect(
+      sanitizePracticeExportRows("locationMessaging", [
+        {
+          id: "messaging-1",
+          messagingProfileId: "profile-live",
+          senderE164: "+15555550100",
+          numberSource: "openvpm_provisioned",
+          a2pBrandId: "brand-live",
+          a2pCampaignId: "campaign-live",
+          registrationStatus: "active",
+          registrationDetail: "provider-approved",
+          providerProfileReady: true,
+          providerProfileSyncedAt: new Date("2026-08-01T12:00:00Z"),
+          enabled: true,
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "messaging-1",
+        messagingProfileId: null,
+        senderE164: null,
+        numberSource: null,
+        a2pBrandId: null,
+        a2pCampaignId: null,
+        registrationStatus: "not_started",
+        registrationDetail: null,
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
+        enabled: false,
       },
     ]);
 
@@ -1124,6 +1250,39 @@ describe("practice backup secret handling", () => {
 });
 
 describe("restorePracticeData", () => {
+  it("rejects an oversized restore before opening a transaction", async () => {
+    const rootDb = {
+      transaction: vi.fn(),
+    };
+
+    await expect(
+      restorePracticeData(
+        rootDb as never,
+        "target-practice",
+        { ...emptyBackup(), oversized: "x".repeat(200) },
+        { maxBytes: 100 },
+      ),
+    ).rejects.toThrow("Backup JSON restores must be 50 MB or less.");
+    expect(rootDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it("never lets an internal maxBytes override exceed the global restore cap", async () => {
+    const rootDb = {
+      transaction: vi.fn(),
+    };
+    const oversized = {
+      ...emptyBackup(),
+      oversized: "x".repeat(PRACTICE_BACKUP_JSON_MAX_BYTES),
+    };
+
+    await expect(
+      restorePracticeData(rootDb as never, "target-practice", oversized, {
+        maxBytes: PRACTICE_BACKUP_JSON_MAX_BYTES * 2,
+      }),
+    ).rejects.toThrow("Backup JSON restores must be 50 MB or less.");
+    expect(rootDb.transaction).not.toHaveBeenCalled();
+  });
+
   it("restores immutable SOAP replacement history after later soft deletion", async () => {
     const activeBackup = validSoapReplacementBackup();
     const backup = {
@@ -2735,8 +2894,9 @@ describe("restorePracticeData", () => {
       ...emptyBackup(),
       clients: [{ id: "client-1", practiceId: "source-practice" }],
     };
-    const { db: tx, inserted } = restoreDb();
+    const { db: tx, inserted, updates, timeline } = restoreDb();
     const rootDb = {
+      update: tx.update,
       transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(tx)),
     };
 
@@ -2748,6 +2908,16 @@ describe("restorePracticeData", () => {
     const restoredRows = inserted.flatMap(({ rows }) => rows);
 
     expect(rootDb.transaction).toHaveBeenCalledTimes(1);
+    expect(updates[0]).toMatchObject({
+      recoveryHold: true,
+      recoveryHoldReason: PRACTICE_RECOVERY_HOLD_REASON,
+      recoveryHoldSetAt: expect.any(Date),
+      recoveryHoldReleasedAt: null,
+    });
+    expect(timeline[0]).toBe("recovery-hold");
+    expect(timeline.indexOf("recovery-hold")).toBeLessThan(
+      timeline.indexOf("insert:client-1"),
+    );
     expect(result.totalRows).toBe(1);
     expect(restoredRows).toContainEqual(
       expect.objectContaining({
@@ -2755,6 +2925,99 @@ describe("restorePracticeData", () => {
         practiceId: "target-practice",
       }),
     );
+  });
+
+  it("commits the recovery hold on an independent connection before the outer restore transaction", async () => {
+    const backup = {
+      ...emptyBackup(),
+      clients: [{ id: "client-1", practiceId: "source-practice" }],
+    };
+    const timeline: string[] = [];
+    const { db: holdTx, updates } = restoreDb();
+    const { db: bulkTx, inserted } = restoreDb();
+    const recoveryHoldDb = {
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        timeline.push("hold-begin");
+        const result = await fn({
+          ...holdTx,
+          execute: vi.fn(async () => {
+            timeline.push("hold-system-context");
+            return [];
+          }),
+        });
+        timeline.push("hold-commit");
+        return result;
+      }),
+    };
+    const outerDb = {
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        timeline.push("bulk-begin");
+        const result = await fn(bulkTx);
+        timeline.push("bulk-commit");
+        return result;
+      }),
+    };
+
+    await expect(
+      restorePracticeData(outerDb as never, "target-practice", backup, {
+        recoveryHoldDb: recoveryHoldDb as never,
+      }),
+    ).resolves.toMatchObject({ totalRows: 1 });
+
+    expect(recoveryHoldDb.transaction).toHaveBeenCalledOnce();
+    expect(outerDb.transaction).toHaveBeenCalledOnce();
+    expect(updates).toEqual([
+      expect.objectContaining({
+        recoveryHold: true,
+        recoveryHoldReason: PRACTICE_RECOVERY_HOLD_REASON,
+      }),
+    ]);
+    expect(timeline).toEqual([
+      "hold-begin",
+      "hold-system-context",
+      "hold-commit",
+      "bulk-begin",
+      "bulk-commit",
+    ]);
+    expect(inserted.flatMap(({ rows }) => rows)).toContainEqual(
+      expect.objectContaining({
+        id: "client-1",
+        practiceId: "target-practice",
+      }),
+    );
+  });
+
+  it("commits the recovery hold before bulk restore and leaves it set on failure", async () => {
+    const backup = emptyBackup();
+    const holdValues: Record<string, unknown>[] = [];
+    const returning = vi.fn(async () => [{ id: "target-practice" }]);
+    const where = vi.fn(() => ({ returning }));
+    const set = vi.fn((values: Record<string, unknown>) => {
+      holdValues.push(values);
+      return { where };
+    });
+    const transaction = vi.fn(async () => {
+      throw new Error("bulk restore failed");
+    });
+    const rootDb = {
+      update: vi.fn(() => ({ set })),
+      transaction,
+    };
+
+    await expect(
+      restorePracticeData(rootDb as never, "target-practice", backup),
+    ).rejects.toThrow("bulk restore failed");
+
+    expect(holdValues).toEqual([
+      expect.objectContaining({
+        recoveryHold: true,
+        recoveryHoldReason: PRACTICE_RECOVERY_HOLD_REASON,
+        recoveryHoldReleasedAt: null,
+      }),
+    ]);
+    expect(returning).toHaveBeenCalledOnce();
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(rootDb.update).toHaveBeenCalledOnce();
   });
 
   it("rewrites practice-scoped rows and leaves parent-scoped child rows intact", async () => {
@@ -2766,6 +3029,16 @@ describe("restorePracticeData", () => {
           id: "location-messaging-1",
           practiceId: "source-practice",
           locationId: "location-1",
+          messagingProfileId: "profile-live",
+          senderE164: "+15555550100",
+          numberSource: "openvpm_provisioned",
+          a2pBrandId: "brand-live",
+          a2pCampaignId: "campaign-live",
+          registrationStatus: "active",
+          registrationDetail: "provider-approved",
+          providerProfileReady: true,
+          providerProfileSyncedAt: "2026-08-01T12:00:00.000Z",
+          enabled: true,
         },
       ],
       smsSuppressions: [
@@ -2887,6 +3160,16 @@ describe("restorePracticeData", () => {
     ).toMatchObject({
       id: "location-messaging-1",
       practiceId: "target-practice",
+      messagingProfileId: null,
+      senderE164: null,
+      numberSource: null,
+      a2pBrandId: null,
+      a2pCampaignId: null,
+      registrationStatus: "not_started",
+      registrationDetail: null,
+      providerProfileReady: false,
+      providerProfileSyncedAt: null,
+      enabled: false,
     });
     expect(
       restoredRows.find((row) => row.id === "suppression-1"),

--- a/apps/web/lib/backup/__tests__/recover-practice-cli.test.ts
+++ b/apps/web/lib/backup/__tests__/recover-practice-cli.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseRecoveryArgs } from "../../../scripts/recover-practice";
+
+const PRACTICE_ID = "00000000-0000-4000-8000-000000000001";
+
+describe("owner practice recovery CLI", () => {
+  it("keeps restore dry-run by default", () => {
+    expect(
+      parseRecoveryArgs([
+        "restore",
+        "--practice-id",
+        PRACTICE_ID,
+        "--backup",
+        "/tmp/backup.json",
+        "--practice-name",
+        "Recovery shell",
+      ]),
+    ).toMatchObject({
+      command: "restore",
+      practiceId: PRACTICE_ID,
+      execute: false,
+    });
+  });
+
+  it("requires an exact destructive confirmation", () => {
+    expect(() =>
+      parseRecoveryArgs([
+        "restore",
+        "--practice-id",
+        PRACTICE_ID,
+        "--backup",
+        "/tmp/backup.json",
+        "--practice-name",
+        "Recovery shell",
+        "--execute",
+      ]),
+    ).toThrow(`--confirmation must exactly equal RESTORE:${PRACTICE_ID}`);
+  });
+
+  it("requires every reconciliation gate before releasing a hold", () => {
+    expect(() =>
+      parseRecoveryArgs([
+        "release",
+        "--practice-id",
+        PRACTICE_ID,
+        "--execute",
+        "--confirmation",
+        `RELEASE:${PRACTICE_ID}`,
+      ]),
+    ).toThrow("release requires");
+
+    expect(
+      parseRecoveryArgs([
+        "release",
+        "--practice-id",
+        PRACTICE_ID,
+        "--execute",
+        "--confirmation",
+        `RELEASE:${PRACTICE_ID}`,
+        "--verified-objects",
+        "--verified-user-access",
+        "--reconciled-messaging",
+        "--reconciled-payments",
+        "--reviewed-autonomous-jobs",
+      ]),
+    ).toMatchObject({ command: "release", execute: true });
+  });
+});

--- a/apps/web/lib/backup/__tests__/verify-evidence-cli.test.ts
+++ b/apps/web/lib/backup/__tests__/verify-evidence-cli.test.ts
@@ -1,0 +1,199 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { PRACTICE_EXPORT_SECTIONS } from "../export";
+
+const script = resolve("scripts/verify-backup-evidence.mjs");
+const tempDirectories: string[] = [];
+const practiceId = "11111111-1111-4111-8111-111111111111";
+const backupDate = "2026-08-10";
+const exportedAt = "2026-08-10T09:30:00.000Z";
+
+function sha256(body: Buffer): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function evidenceFixture(
+  options: {
+    omitVersion?: boolean;
+    providerNullVersion?: boolean;
+    formatVersion?: number;
+  } = {},
+) {
+  const directory = mkdtempSync(join(tmpdir(), "openvpm-backup-evidence-"));
+  tempDirectories.push(directory);
+  const objectPath = join(directory, "backup.json");
+  const catalogPath = join(directory, "catalog.json");
+  const sections = Object.fromEntries(
+    PRACTICE_EXPORT_SECTIONS.map((section) => [section, []]),
+  ) as Record<string, unknown[]>;
+  sections.clients = [{ id: "client-1" }, { id: "client-2" }];
+  sections.patients = [
+    { id: "patient-1" },
+    { id: "patient-2" },
+    { id: "patient-3" },
+  ];
+  const counts = Object.fromEntries(
+    PRACTICE_EXPORT_SECTIONS.map((section) => [
+      section,
+      sections[section]!.length,
+    ]),
+  );
+  const formatVersion = options.formatVersion ?? 6;
+  const objectBody = Buffer.from(
+    JSON.stringify({
+      formatVersion,
+      practiceId,
+      exportedAt,
+      counts,
+      ...sections,
+    }),
+  );
+  const checksumSha256 = sha256(objectBody);
+  const objectKey =
+    `database-backups/v2/${practiceId}/${backupDate}/` +
+    `${checksumSha256}.json`;
+  const catalogBody = Buffer.from(
+    JSON.stringify({
+      catalogFormatVersion: 2,
+      practiceId,
+      backupDate,
+      exportedAt,
+      objectKey,
+      checksumSha256,
+      fileSizeBytes: objectBody.byteLength,
+      exportFormatVersion: formatVersion,
+      counts,
+      contentType: "application/json",
+      objectEtag: '"replica-etag"',
+      objectVersionId: options.omitVersion
+        ? null
+        : options.providerNullVersion
+          ? "null"
+          : "replica-version-17",
+    }),
+  );
+  const catalogKey =
+    `database-backup-catalog/v2/${practiceId}/${backupDate}/` +
+    `${sha256(catalogBody)}.json`;
+  writeFileSync(objectPath, objectBody);
+  writeFileSync(catalogPath, catalogBody);
+  return { catalogKey, catalogPath, objectPath };
+}
+
+function run(fixture: ReturnType<typeof evidenceFixture>) {
+  return spawnSync(
+    process.execPath,
+    [
+      script,
+      "--catalog",
+      fixture.catalogPath,
+      "--catalog-key",
+      fixture.catalogKey,
+      "--object",
+      fixture.objectPath,
+      "--expected-practice",
+      practiceId,
+      "--expected-date",
+      backupDate,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("backup recovery evidence CLI", () => {
+  it("verifies checksum-addressed catalog and exact-version recovery evidence without restoring", () => {
+    const result = run(evidenceFixture());
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      status: "artifact_integrity_verified",
+      verificationScope: "artifact_integrity_and_canonical_counts",
+      applicationRestoreValidationPerformed: false,
+      restorePerformed: false,
+      practiceId,
+      backupDate,
+      objectVersionId: "replica-version-17",
+      fileSizeBytes: expect.any(Number),
+      counts: { clients: 2, patients: 3 },
+    });
+  });
+
+  it("rejects the provider-null sentinel as exact-version evidence", () => {
+    const result = run(evidenceFixture({ providerNullVersion: true }));
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "objectVersionId must identify a versioned object",
+    );
+  });
+
+  it("rejects artifacts outside the one canonical supported export format", () => {
+    const result = run(evidenceFixture({ formatVersion: 5 }));
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("exportFormatVersion must be 6");
+  });
+
+  it("checks catalog counts against the actual canonical section arrays", () => {
+    const fixture = evidenceFixture();
+    const backup = JSON.parse(
+      readFileSync(fixture.objectPath, "utf8"),
+    ) as Record<string, unknown>;
+    backup.clients = [];
+    const objectBody = Buffer.from(JSON.stringify(backup));
+    writeFileSync(fixture.objectPath, objectBody);
+    const objectChecksum = sha256(objectBody);
+    const catalog = JSON.parse(
+      readFileSync(fixture.catalogPath, "utf8"),
+    ) as Record<string, unknown>;
+    catalog.checksumSha256 = objectChecksum;
+    catalog.fileSizeBytes = objectBody.byteLength;
+    catalog.objectKey =
+      `database-backups/v2/${practiceId}/${backupDate}/` +
+      `${objectChecksum}.json`;
+    const catalogBody = Buffer.from(JSON.stringify(catalog));
+    writeFileSync(fixture.catalogPath, catalogBody);
+    fixture.catalogKey =
+      `database-backup-catalog/v2/${practiceId}/${backupDate}/` +
+      `${sha256(catalogBody)}.json`;
+
+    const result = run(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "backup object count for clients does not match its actual rows",
+    );
+  });
+
+  it("rejects a catalog that cannot identify an exact provider version", () => {
+    const result = run(evidenceFixture({ omitVersion: true }));
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "objectVersionId must be a non-empty string",
+    );
+  });
+
+  it("rejects object bytes that no longer match the immutable catalog", () => {
+    const fixture = evidenceFixture();
+    writeFileSync(fixture.objectPath, '{"tampered":true}');
+
+    const result = run(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toMatch(/byte length|checksum/);
+  });
+});

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -1,9 +1,15 @@
 import { eq, and, isNull, inArray, sql, getTableColumns } from "drizzle-orm";
 import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "@openpims/db/client";
+import { withSystem } from "@/lib/tenant-db";
 import { redactSecrets } from "@/lib/audit";
 import { normalizeE164 } from "@/lib/messaging/phone";
 import { rowsFromExecute } from "@/lib/db/execute-rows";
+import {
+  isPracticeBackupJsonSizeValid,
+  PRACTICE_BACKUP_JSON_MAX_BYTES,
+  PRACTICE_BACKUP_JSON_SIZE_MESSAGE,
+} from "@/lib/backup/policy";
 import {
   appointmentTypes,
   appointmentWaitlist,
@@ -38,6 +44,7 @@ import {
   prescriptionEvents,
   prescriptions,
   problemList,
+  practices,
   procedures,
   products,
   purchaseOrders,
@@ -103,6 +110,8 @@ export const PRACTICE_EXPORT_SYSTEM_EXCLUSIONS = {
     "Expiring QR photo-capture link tokens; restoring them would resurrect old capture URLs. The photos themselves are in the files section.",
   fileObjectReplicas:
     "Environment-bound object-replica verification state; rebuild it from the configured backup target instead of replaying provider keys or versions.",
+  fileStorageEvents:
+    "Append-only platform recovery evidence; rebuild operational projections from independently retained objects and catalogs.",
   consentRequests:
     "Expiring e-sign link tokens; the signed consent PDF is in the files section and the signing event is in the audit log.",
   messagingRegistrations:
@@ -223,10 +232,35 @@ export type PracticeExport = {
   formatVersion: number;
   practiceId: string;
   exportedAt: string;
+  /** Recovery-only clinic identity/configuration. Restore does not blindly
+   * apply billing authority, provider IDs, or capability tokens from it. */
+  practice: Record<string, unknown>;
   counts: Record<PracticeExportSection, number>;
 } & Record<PracticeExportSection, unknown[]>;
 
-export const PRACTICE_EXPORT_FORMAT_VERSION = 5;
+export const PRACTICE_EXPORT_FORMAT_VERSION = 6;
+export const PRACTICE_RECOVERY_HOLD_REASON =
+  "Practice data restore pending owner reconciliation";
+
+const PRACTICE_RECOVERY_SNAPSHOT_KEYS = new Set([
+  "id",
+  "createdAt",
+  "updatedAt",
+  "name",
+  "address",
+  "phone",
+  "email",
+  "website",
+  "timezone",
+  "logoUrl",
+  "brandColor",
+  "country",
+  "currency",
+  "taxRatePercent",
+  "vatNumber",
+  "appointmentRemindersEnabled",
+  "appointmentReminderLeadHours",
+]);
 
 type Row = Record<string, unknown>;
 
@@ -267,6 +301,20 @@ export function sanitizePracticeExportRows(
           ...row,
           secret: PRACTICE_EXPORT_SECRET_REPLACEMENTS.webhookSecret,
           active: false,
+        };
+      case "locationMessaging":
+        return {
+          ...row,
+          messagingProfileId: null,
+          senderE164: null,
+          numberSource: null,
+          a2pBrandId: null,
+          a2pCampaignId: null,
+          registrationStatus: "not_started",
+          registrationDetail: null,
+          providerProfileReady: false,
+          providerProfileSyncedAt: null,
+          enabled: false,
         };
       case "auditLog":
         return {
@@ -757,6 +805,72 @@ export function validatePracticeExportRestore(data: unknown): {
       errors.push(message);
     }
   };
+
+  const exportRecord = isRecord(data) ? data : {};
+  if (
+    typeof exportRecord.formatVersion === "number" &&
+    exportRecord.formatVersion > PRACTICE_EXPORT_FORMAT_VERSION
+  ) {
+    pushError(
+      `backup format v${exportRecord.formatVersion} is newer than this release supports.`,
+    );
+  }
+  if (exportRecord.formatVersion === PRACTICE_EXPORT_FORMAT_VERSION) {
+    if (!isRecord(exportRecord.practice)) {
+      pushError("practice recovery metadata is required in backup format v6.");
+    } else if (exportRecord.practice.id !== exportRecord.practiceId) {
+      pushError("practice recovery metadata must match practiceId exactly.");
+    } else {
+      const unknownKeys = Object.keys(exportRecord.practice).filter(
+        (key) => !PRACTICE_RECOVERY_SNAPSHOT_KEYS.has(key),
+      );
+      if (unknownKeys.length > 0) {
+        pushError(
+          `practice recovery metadata contains unsupported keys: ${unknownKeys.join(", ")}.`,
+        );
+      }
+      if (
+        typeof exportRecord.practice.name !== "string" ||
+        exportRecord.practice.name.trim().length === 0 ||
+        exportRecord.practice.name.length > 255
+      ) {
+        pushError("practice recovery metadata name must be 1-255 characters.");
+      }
+    }
+
+    if (!isRecord(exportRecord.counts)) {
+      pushError("canonical section counts are required in backup format v6.");
+    } else {
+      const countKeys = Object.keys(exportRecord.counts);
+      const missingCountKeys = PRACTICE_EXPORT_SECTIONS.filter(
+        (section) =>
+          !Object.prototype.hasOwnProperty.call(exportRecord.counts, section),
+      );
+      const unknownCountKeys = countKeys.filter(
+        (key) => !PRACTICE_EXPORT_SECTIONS.includes(key as never),
+      );
+      if (missingCountKeys.length > 0) {
+        pushError(
+          `backup counts are missing canonical sections: ${missingCountKeys.join(", ")}.`,
+        );
+      }
+      if (unknownCountKeys.length > 0) {
+        pushError(
+          `backup counts contain unsupported sections: ${unknownCountKeys.join(", ")}.`,
+        );
+      }
+      for (const section of PRACTICE_EXPORT_SECTIONS) {
+        const count = exportRecord.counts[section];
+        if (!Number.isSafeInteger(count) || (count as number) < 0) {
+          pushError(
+            `backup count for ${section} must be a non-negative integer.`,
+          );
+        } else if (count !== rowsFor(data, section).length) {
+          pushError(`backup count for ${section} does not match its rows.`);
+        }
+      }
+    }
+  }
 
   validateRestoreRows(data, pushError);
 
@@ -2121,12 +2235,8 @@ async function activeRows(db: Database, table: any, practiceId: string) {
     .where(and(eq(table.practiceId, practiceId), isNull(table.deletedAt)));
 }
 
-/**
- * Keep phase-one application reads compatible while migration 0076 is being
- * applied. New manifest columns are intentionally omitted until the dual-write
- * release starts populating them. Canonicalizing here also prevents a legacy
- * raw-storage or external URL from leaking into a newly generated backup.
- */
+/** Export the portable attachment manifest while keeping provider-specific
+ * replica projections and storage-event evidence out of clinic JSON. */
 async function activeFileRows(db: Database, practiceId: string) {
   const rows = await db
     .select({
@@ -2140,15 +2250,20 @@ async function activeFileRows(db: Database, practiceId: string) {
       fileKey: files.fileKey,
       mimeType: files.mimeType,
       fileSizeBytes: files.fileSizeBytes,
+      checksumSha256: files.checksumSha256,
       category: files.category,
+      title: files.title,
+      documentType: files.documentType,
+      documentDate: files.documentDate,
+      source: files.source,
+      idempotencyKey: files.idempotencyKey,
       entityType: files.entityType,
       entityId: files.entityId,
+      patientId: files.patientId,
       appointmentId: files.appointmentId,
     })
     .from(files)
-    .where(
-      and(eq(files.practiceId, practiceId), isNull(files.deletedAt)),
-    );
+    .where(and(eq(files.practiceId, practiceId), isNull(files.deletedAt)));
 
   return rows.map((row) => ({
     ...row,
@@ -2242,6 +2357,61 @@ export async function exportPracticeData(
   practiceId: string,
   exportedAt: string,
 ): Promise<PracticeExport> {
+  const [practiceRow] = await db
+    .select({
+      id: practices.id,
+      createdAt: practices.createdAt,
+      updatedAt: practices.updatedAt,
+      name: practices.name,
+      address: practices.address,
+      phone: practices.phone,
+      email: practices.email,
+      website: practices.website,
+      timezone: practices.timezone,
+      logoUrl: practices.logoUrl,
+      settings: practices.settings,
+      country: practices.country,
+      currency: practices.currency,
+      taxRatePercent: practices.taxRatePercent,
+      vatNumber: practices.vatNumber,
+      appointmentRemindersEnabled: practices.appointmentRemindersEnabled,
+      appointmentReminderLeadHours: practices.appointmentReminderLeadHours,
+    })
+    .from(practices)
+    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+    .limit(1);
+  if (!practiceRow) {
+    throw new Error("Practice is unavailable for backup");
+  }
+  const practiceSettings = isRecord(practiceRow.settings)
+    ? practiceRow.settings
+    : {};
+  const practiceSnapshot = {
+    id: practiceRow.id,
+    createdAt: practiceRow.createdAt,
+    updatedAt: practiceRow.updatedAt,
+    name: practiceRow.name,
+    address: practiceRow.address,
+    phone: practiceRow.phone,
+    email: practiceRow.email,
+    website: practiceRow.website,
+    timezone: practiceRow.timezone,
+    logoUrl: practiceRow.logoUrl,
+    brandColor:
+      typeof practiceSettings.brandColor === "string" &&
+      practiceSettings.brandColor.length <= 64
+        ? practiceSettings.brandColor
+        : null,
+    country: practiceRow.country,
+    currency: practiceRow.currency,
+    taxRatePercent: practiceRow.taxRatePercent,
+    vatNumber: practiceRow.vatNumber,
+    // Recovery never reactivates outbound reminders before provider and
+    // consent state are reconciled in the destination environment.
+    appointmentRemindersEnabled: false,
+    appointmentReminderLeadHours: practiceRow.appointmentReminderLeadHours,
+  };
+
   const [
     allLocationRows,
     locationMessagingRows,
@@ -2646,7 +2816,10 @@ export async function exportPracticeData(
 
   const sections: Record<PracticeExportSection, unknown[]> = {
     locations: locationRows,
-    locationMessaging: locationMessagingRows,
+    locationMessaging: sanitizePracticeExportRows(
+      "locationMessaging",
+      locationMessagingRows,
+    ),
     smsSuppressions: smsSuppressionRows,
     smsConsentEvents: smsConsentEventRows,
     smsSendAttempts: sanitizePracticeExportRows(
@@ -2721,6 +2894,7 @@ export async function exportPracticeData(
     formatVersion: PRACTICE_EXPORT_FORMAT_VERSION,
     practiceId,
     exportedAt,
+    practice: practiceSnapshot,
     counts: countsFor(sections),
     ...sections,
   };
@@ -2741,22 +2915,6 @@ async function restorePracticeDataRows(
   restored: Record<PracticeExportSection, number>;
   totalRows: number;
 }> {
-  const summary = summarizePracticeExport(data);
-  if (summary.missingSections.length > 0) {
-    throw new Error(
-      `Backup is missing required sections: ${summary.missingSections.join(", ")}`,
-    );
-  }
-  const validation = validatePracticeExportRestore(data);
-  if (!validation.valid) {
-    throw new Error(
-      `Backup contains invalid restore data: ${validation.errors.join("; ")}`,
-    );
-  }
-  const targetValidation = validatePracticeFileRestoreTarget(data, practiceId);
-  if (!targetValidation.valid) {
-    throw new Error(targetValidation.errors.join("; "));
-  }
   const backupRecord = isRecord(data) ? data : {};
   const schedulingRestore = prepareAppointmentLocationRestore(data);
   const hasDispenseChargeQueue = Object.prototype.hasOwnProperty.call(
@@ -2912,7 +3070,16 @@ async function restorePracticeDataRows(
   };
 
   await restorePracticeRows("locations", locations);
-  await restorePracticeRows("locationMessaging", locationMessaging);
+  restored.locationMessaging = await restoreRows(
+    db,
+    locationMessaging,
+    "locationMessaging",
+    sanitizePracticeExportRows(
+      "locationMessaging",
+      rowsFor(data, "locationMessaging"),
+    ),
+    { practiceId },
+  );
   await restorePracticeRows("smsSuppressions", smsSuppressions);
   await restorePracticeRows("emailSuppressions", emailSuppressions);
   await restorePracticeRows("webhooks", webhooks);
@@ -3216,10 +3383,69 @@ export async function restorePracticeData(
   db: Database,
   practiceId: string,
   data: unknown,
+  options: { maxBytes?: number; recoveryHoldDb?: Database } = {},
 ): Promise<{
   restored: Record<PracticeExportSection, number>;
   totalRows: number;
 }> {
+  const requestedMaxBytes = options.maxBytes;
+  const restoreMaxBytes =
+    typeof requestedMaxBytes === "number" && Number.isFinite(requestedMaxBytes)
+      ? Math.max(0, Math.min(PRACTICE_BACKUP_JSON_MAX_BYTES, requestedMaxBytes))
+      : PRACTICE_BACKUP_JSON_MAX_BYTES;
+  if (!isPracticeBackupJsonSizeValid(data, restoreMaxBytes)) {
+    throw new Error(PRACTICE_BACKUP_JSON_SIZE_MESSAGE);
+  }
+
+  // Complete all pure validation before pausing the clinic. Once the hold is
+  // set it is intentionally committed independently of the bulk restore so
+  // concurrent workers and requests can observe it for the entire mutation
+  // window, and a failed restore remains fail-closed for owner reconciliation.
+  const summary = summarizePracticeExport(data);
+  if (summary.missingSections.length > 0) {
+    throw new Error(
+      `Backup is missing required sections: ${summary.missingSections.join(", ")}`,
+    );
+  }
+  const validation = validatePracticeExportRestore(data);
+  if (!validation.valid) {
+    throw new Error(
+      `Backup contains invalid restore data: ${validation.errors.join("; ")}`,
+    );
+  }
+  const targetValidation = validatePracticeFileRestoreTarget(data, practiceId);
+  if (!targetValidation.valid) {
+    throw new Error(targetValidation.errors.join("; "));
+  }
+
+  const setRecoveryHold = async (holdDb: Database) => {
+    const holdSetAt = new Date();
+    const [heldPractice] = await holdDb
+      .update(practices)
+      .set({
+        recoveryHold: true,
+        recoveryHoldReason: PRACTICE_RECOVERY_HOLD_REASON,
+        recoveryHoldSetAt: holdSetAt,
+        recoveryHoldReleasedAt: null,
+        updatedAt: holdSetAt,
+      })
+      .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+      .returning({ id: practices.id });
+    return heldPractice;
+  };
+  // A router passes the root pool here because its `db` argument is already
+  // the outer tenant transaction. withSystem opens and commits an independent
+  // transaction so the hold is visible before that outer transaction mutates
+  // restore rows. Direct/CLI callers use their autocommit database handle.
+  const heldPractice = options.recoveryHoldDb
+    ? await withSystem(options.recoveryHoldDb, setRecoveryHold)
+    : await setRecoveryHold(db);
+  if (!heldPractice) {
+    throw new Error(
+      "Restore target must be an existing active practice before recovery can begin.",
+    );
+  }
+
   const transaction = (
     db as unknown as {
       transaction?: (

--- a/apps/web/lib/backup/replica.ts
+++ b/apps/web/lib/backup/replica.ts
@@ -1,0 +1,51 @@
+import { checksumSha256Hex } from "@/lib/file-replication";
+import { normalizeS3VersionId } from "@/lib/s3";
+
+export function databaseBackupReplicaKey(input: {
+  practiceId: string;
+  backupDate: string;
+  checksumSha256: string;
+}): string {
+  return `database-backups/v2/${input.practiceId}/${input.backupDate}/${input.checksumSha256}.json`;
+}
+
+export function databaseBackupReplicaCatalog(input: {
+  practiceId: string;
+  backupDate: string;
+  exportedAt: string;
+  objectKey: string;
+  checksumSha256: string;
+  fileSizeBytes: number;
+  exportFormatVersion: number;
+  counts: Record<string, number>;
+  objectEtag?: string;
+  objectVersionId: string;
+}): { key: string; body: Buffer; checksumSha256: string } {
+  const objectVersionId = normalizeS3VersionId(input.objectVersionId);
+  if (!objectVersionId) {
+    throw new Error("Backup replica catalog requires an exact object version");
+  }
+  const body = Buffer.from(
+    JSON.stringify({
+      catalogFormatVersion: 2,
+      practiceId: input.practiceId,
+      backupDate: input.backupDate,
+      exportedAt: input.exportedAt,
+      objectKey: input.objectKey,
+      checksumSha256: input.checksumSha256,
+      fileSizeBytes: input.fileSizeBytes,
+      exportFormatVersion: input.exportFormatVersion,
+      counts: input.counts,
+      contentType: "application/json",
+      objectEtag: input.objectEtag ?? null,
+      objectVersionId,
+    }),
+  );
+  const checksumSha256 = checksumSha256Hex(body);
+
+  return {
+    key: `database-backup-catalog/v2/${input.practiceId}/${input.backupDate}/${checksumSha256}.json`,
+    body,
+    checksumSha256,
+  };
+}

--- a/apps/web/lib/billing/__tests__/client-receipts.test.ts
+++ b/apps/web/lib/billing/__tests__/client-receipts.test.ts
@@ -2,6 +2,21 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   sendClientPaymentReceiptEmail: vi.fn(async () => ({ success: true })),
+  lockPracticeForExternalSideEffects: vi.fn(async () => true),
+  withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
+    fn({}),
+  ),
+}));
+
+vi.mock("@openpims/db/client", () => ({ db: {} }));
+
+vi.mock("@/lib/tenant-db", () => ({
+  withSystem: mocks.withSystem,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 vi.mock("@/lib/email", () => ({
@@ -26,6 +41,7 @@ function dbWithRow(row: unknown) {
 afterEach(() => {
   vi.clearAllMocks();
   mocks.sendClientPaymentReceiptEmail.mockResolvedValue({ success: true });
+  mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
 });
 
 describe("loadClientReceipt", () => {
@@ -36,6 +52,7 @@ describe("loadClientReceipt", () => {
         clientFirstName: "Jane",
         clientLastName: "Client",
         patientName: "Biscuit",
+        practiceId: "practice-1",
         practiceName: "Neighborhood Veterinary",
         practicePhone: "(555) 867-5309",
         currency: "usd",
@@ -46,6 +63,7 @@ describe("loadClientReceipt", () => {
     );
 
     expect(receipt).toEqual({
+      practiceId: "practice-1",
       to: "jane@example.com",
       clientName: "Jane Client",
       patientName: "Biscuit",
@@ -77,6 +95,7 @@ describe("loadClientReceipt", () => {
 
 describe("deliverClientReceipt", () => {
   const receipt = {
+    practiceId: "practice-1",
     to: "jane@example.com",
     clientName: "Jane Client",
     patientName: "Biscuit",
@@ -108,6 +127,20 @@ describe("deliverClientReceipt", () => {
     expect(mocks.sendClientPaymentReceiptEmail).toHaveBeenCalledWith(
       expect.objectContaining({ fullyPaid: true })
     );
+  });
+
+  it("does not call the email provider while the practice is held", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+
+    await expect(deliverClientReceipt(receipt)).resolves.toBeUndefined();
+
+    expect(mocks.sendClientPaymentReceiptEmail).not.toHaveBeenCalled();
+    expect(mocks.lockPracticeForExternalSideEffects).toHaveBeenCalledWith(
+      {},
+      "practice-1",
+    );
+    warning.mockRestore();
   });
 
   it("never throws when sending fails", async () => {

--- a/apps/web/lib/billing/__tests__/subscription-sync.test.ts
+++ b/apps/web/lib/billing/__tests__/subscription-sync.test.ts
@@ -1,6 +1,23 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
-import { countBillableStaffRows } from "../subscription-sync";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  retrieve: vi.fn(),
+  update: vi.fn(),
+  create: vi.fn(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  stripe: {
+    subscriptions: { retrieve: mocks.retrieve },
+    subscriptionItems: { update: mocks.update, create: mocks.create },
+  },
+}));
+
+import {
+  countBillableStaffRows,
+  syncPracticeSubscriptionQuantities,
+} from "../subscription-sync";
 
 describe("countBillableStaffRows", () => {
   it("counts every non-deleted staff user and excludes deleted users", () => {
@@ -53,6 +70,32 @@ describe("billing sync practice scoping", () => {
       syncState.indexOf("const counts = await countBillableLocationsAndSeats")
     );
     expect(syncState).toContain("{ locationCount: 0, billableSeatCount: 0 }");
+  });
+
+  it("does not call Stripe or count billable rows while held", async () => {
+    const locked = vi.fn(async () => [
+      { stripeSubscriptionId: "sub_held", recoveryHold: true },
+    ]);
+    const limit = vi.fn(() => ({ for: locked }));
+    const where = vi.fn(() => ({ limit }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+
+    await expect(
+      syncPracticeSubscriptionQuantities({
+        db: { select } as never,
+        practiceId: "practice-held",
+      }),
+    ).resolves.toMatchObject({
+      status: "skipped",
+      locationCount: 0,
+      billableSeatCount: 0,
+    });
+
+    expect(select).toHaveBeenCalledOnce();
+    expect(mocks.retrieve).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(mocks.create).not.toHaveBeenCalled();
   });
 
   it("attaches missing metered overage items idempotently during sync", () => {

--- a/apps/web/lib/billing/__tests__/usage-reconcile.test.ts
+++ b/apps/web/lib/billing/__tests__/usage-reconcile.test.ts
@@ -15,7 +15,12 @@ const mocks = vi.hoisted(() => {
       from: vi.fn(() => builder),
       innerJoin: vi.fn(() => builder),
       where: vi.fn(() => builder),
-      limit: vi.fn(async () => result),
+      limit: vi.fn(() => builder),
+      for: vi.fn(async () => result),
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (error: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject),
     };
     return builder;
   });
@@ -23,13 +28,17 @@ const mocks = vi.hoisted(() => {
   const updateWhere = vi.fn(async (_condition: unknown) => undefined);
   const updateSet = vi.fn((_values: unknown) => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
-  const tx = { select, update };
+  const insertReturning = vi.fn(async () => [{ id: "usage-held" }]);
+  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+  const tx = { select, update, insert };
 
   return {
     selectResults,
     tx,
     updateSet,
     updateWhere,
+    insertValues,
     billingEnforced: vi.fn(() => true),
     recordMeterEvent: vi.fn(async () => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -54,7 +63,7 @@ vi.mock("../stripe-meters", () => ({
   recordMeterEvent: mocks.recordMeterEvent,
 }));
 
-const { reconcileUnmeteredUsage } = await import("../usage");
+const { reconcileUnmeteredUsage, recordUsage } = await import("../usage");
 
 beforeEach(() => {
   mocks.billingEnforced.mockReturnValue(true);
@@ -67,6 +76,24 @@ afterEach(() => {
 });
 
 describe("reconcileUnmeteredUsage", () => {
+  it("records held usage locally without calling the Stripe meter", async () => {
+    mocks.selectResults.push([
+      [{ id: "practice-held", recoveryHold: true }],
+    ]);
+
+    await expect(
+      recordUsage({ practiceId: "practice-held", kind: "ai_run" }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: "practice-held",
+        kind: "ai_run",
+      }),
+    );
+    expect(mocks.recordMeterEvent).not.toHaveBeenCalled();
+  });
+
   it("does not query usage records when hosted billing is disabled", async () => {
     mocks.billingEnforced.mockReturnValue(false);
 

--- a/apps/web/lib/billing/__tests__/usage.test.ts
+++ b/apps/web/lib/billing/__tests__/usage.test.ts
@@ -24,12 +24,14 @@ describe("usage query scoping", () => {
     expect(activePracticeGuard).toBeGreaterThanOrEqual(0);
     expect(usageInsert).toBeGreaterThan(activePracticeGuard);
     expect(source).toMatch(
-      /select\(\{ id: practices\.id \}\)[\s\S]+?where\(\s*and\(\s*eq\(practices\.id, opts\.practiceId\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s
+      /id: practices\.id,\s*recoveryHold: practices\.recoveryHold,[\s\S]+?where\(\s*and\(\s*eq\(practices\.id, opts\.practiceId\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s
     );
     expect(source).toContain("if (!activePractice) return;");
     expect(source).toMatch(
       /eq\(practices\.id, opts\.practiceId\),\s*isNull\(practices\.deletedAt\)/s
     );
+    expect(source).toContain("eq(practices.recoveryHold, false)");
+    expect(source).toContain('.for("share", { of: practices })');
     expect(source).toMatch(
       /eq\(usageRecords\.id, opts\.usageRecordId\),\s*isNull\(usageRecords\.deletedAt\)/s
     );

--- a/apps/web/lib/billing/client-receipts.ts
+++ b/apps/web/lib/billing/client-receipts.ts
@@ -1,9 +1,11 @@
 import { and, eq, isNull } from "drizzle-orm";
 import { clients, invoices, patients, practices } from "@openpims/db";
-import type { Database } from "@openpims/db/client";
+import { db as systemDb, type Database } from "@openpims/db/client";
 import { sendClientPaymentReceiptEmail } from "@/lib/email";
 import { formatCurrency } from "@/lib/locale/format";
 import { centsToMoney } from "@/lib/billing/invoice-balance";
+import { lockPracticeForExternalSideEffects } from "@/lib/recovery-hold";
+import { withSystem } from "@/lib/tenant-db";
 
 /**
  * Everything needed to email a pet owner a receipt after a payment lands —
@@ -11,6 +13,7 @@ import { centsToMoney } from "@/lib/billing/invoice-balance";
  * failed email never rolls back money state.
  */
 export type ClientReceipt = {
+  practiceId: string;
   to: string;
   clientName: string;
   patientName?: string;
@@ -37,6 +40,7 @@ export async function loadClientReceipt(
       clientFirstName: clients.firstName,
       clientLastName: clients.lastName,
       patientName: patients.name,
+      practiceId: practices.id,
       practiceName: practices.name,
       practicePhone: practices.phone,
       currency: practices.currency,
@@ -70,6 +74,7 @@ export async function loadClientReceipt(
   if (!row?.clientEmail) return null;
 
   return {
+    practiceId: row.practiceId,
     to: row.clientEmail,
     clientName: [row.clientFirstName, row.clientLastName]
       .filter(Boolean)
@@ -89,27 +94,39 @@ export async function deliverClientReceipt(
   receipt: ClientReceipt
 ): Promise<void> {
   try {
-    const result = await sendClientPaymentReceiptEmail({
-      to: receipt.to,
-      clientName: receipt.clientName,
-      patientName: receipt.patientName,
-      amountPaid: formatCurrency(
-        centsToMoney(receipt.amountPaidCents),
-        receipt.currency,
-        receipt.country
-      ),
-      balanceRemaining: formatCurrency(
-        centsToMoney(receipt.balanceRemainingCents),
-        receipt.currency,
-        receipt.country
-      ),
-      fullyPaid: receipt.balanceRemainingCents <= 0,
-      practiceName: receipt.practiceName,
-      practicePhone: receipt.practicePhone,
+    await withSystem(systemDb, async (tx) => {
+      const deliveryAllowed = await lockPracticeForExternalSideEffects(
+        tx,
+        receipt.practiceId
+      );
+      if (!deliveryAllowed) {
+        console.warn(
+          `[client-receipt] delivery paused by recovery hold practice=${receipt.practiceId}`
+        );
+        return;
+      }
+      const result = await sendClientPaymentReceiptEmail({
+        to: receipt.to,
+        clientName: receipt.clientName,
+        patientName: receipt.patientName,
+        amountPaid: formatCurrency(
+          centsToMoney(receipt.amountPaidCents),
+          receipt.currency,
+          receipt.country
+        ),
+        balanceRemaining: formatCurrency(
+          centsToMoney(receipt.balanceRemainingCents),
+          receipt.currency,
+          receipt.country
+        ),
+        fullyPaid: receipt.balanceRemainingCents <= 0,
+        practiceName: receipt.practiceName,
+        practicePhone: receipt.practicePhone,
+      });
+      if (!result.success) {
+        console.error("[client-receipt] send failed:", result.error);
+      }
     });
-    if (!result.success) {
-      console.error("[client-receipt] send failed:", result.error);
-    }
   } catch (err) {
     console.error("[client-receipt] send failed:", err);
   }

--- a/apps/web/lib/billing/subscription-sync.ts
+++ b/apps/web/lib/billing/subscription-sync.ts
@@ -111,15 +111,25 @@ export async function syncPracticeSubscriptionQuantities(opts: {
   const [practice] = await db
     .select({
       stripeSubscriptionId: practices.stripeSubscriptionId,
+      recoveryHold: practices.recoveryHold,
     })
     .from(practices)
     .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
-    .limit(1);
+    .limit(1)
+    .for("share", { of: practices });
 
   if (!practice) {
     return buildState(
       "skipped",
       "Practice is unavailable for billing sync.",
+      { locationCount: 0, billableSeatCount: 0 }
+    );
+  }
+
+  if (practice.recoveryHold) {
+    return buildState(
+      "skipped",
+      "Subscription quantity sync is paused during protected recovery.",
       { locationCount: 0, billableSeatCount: 0 }
     );
   }

--- a/apps/web/lib/billing/usage.ts
+++ b/apps/web/lib/billing/usage.ts
@@ -61,7 +61,10 @@ export async function recordUsage(opts: {
   try {
     const [activePractice] = await withSystem(db, (tx) =>
       tx
-        .select({ id: practices.id })
+        .select({
+          id: practices.id,
+          recoveryHold: practices.recoveryHold,
+        })
         .from(practices)
         .where(
           and(
@@ -82,6 +85,9 @@ export async function recordUsage(opts: {
       }).returning({ id: usageRecords.id })
     );
     if (!usageRecord) return;
+    // Keep the local usage ledger complete while a clinic is held, but defer
+    // all provider and ops delivery until recovery is explicitly released.
+    if (activePractice.recoveryHold) return;
     await maybeAlertOnSpike(opts.practiceId, opts.kind, periodMonth, quantity);
     await maybeMeterToStripe({
       usageRecordId: usageRecord.id,
@@ -108,9 +114,12 @@ async function maybeMeterToStripe(opts: {
   quantity: number;
 }): Promise<MeterUsageResult> {
   try {
-    const [practice] = await withSystem(db, (tx) =>
-      tx
-        .select({ stripeCustomerId: practices.stripeCustomerId })
+    return await withSystem(db, async (tx) => {
+      const [practice] = await tx
+        .select({
+          stripeCustomerId: practices.stripeCustomerId,
+          recoveryHold: practices.recoveryHold,
+        })
         .from(practices)
         .where(
           and(
@@ -119,18 +128,19 @@ async function maybeMeterToStripe(opts: {
           )
         )
         .limit(1)
-    );
-    if (!practice?.stripeCustomerId) return "skipped";
-    const identifier = meterIdentifierForUsageRecord(opts.usageRecordId);
-    const metered = await recordMeterEvent({
-      kind: opts.kind,
-      stripeCustomerId: practice.stripeCustomerId,
-      value: opts.quantity,
-      identifier,
-    });
-    if (metered) {
-      await withSystem(db, (tx) =>
-        tx
+        .for("share", { of: practices });
+      if (!practice?.stripeCustomerId || practice.recoveryHold) {
+        return "skipped";
+      }
+      const identifier = meterIdentifierForUsageRecord(opts.usageRecordId);
+      const metered = await recordMeterEvent({
+        kind: opts.kind,
+        stripeCustomerId: practice.stripeCustomerId,
+        value: opts.quantity,
+        identifier,
+      });
+      if (metered) {
+        await tx
           .update(usageRecords)
           .set({
             stripeMeterIdentifier: identifier,
@@ -141,11 +151,11 @@ async function maybeMeterToStripe(opts: {
               eq(usageRecords.id, opts.usageRecordId),
               isNull(usageRecords.deletedAt)
             )
-          )
-      );
-      return "metered";
-    }
-    return "failed";
+          );
+        return "metered";
+      }
+      return "failed";
+    });
   } catch (e) {
     console.error("[usage] meter event failed", opts.kind, e);
     return "failed";
@@ -171,6 +181,7 @@ export async function reconcileUnmeteredUsage(opts: {
         and(
           eq(practices.id, usageRecords.practiceId),
           isNull(practices.deletedAt),
+          eq(practices.recoveryHold, false),
           isNotNull(practices.stripeCustomerId)
         )
       )

--- a/apps/web/lib/consult/__tests__/consent-form-library.test.ts
+++ b/apps/web/lib/consult/__tests__/consent-form-library.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CONSENT_BODY_MAX_LENGTH,
   CONSENT_TITLE_MAX_LENGTH,
+  hasUnresolvedConsentPlaceholders,
 } from "../consent-template";
 import { CONSENT_FORM_LIBRARY } from "../consent-form-library";
 
@@ -49,5 +50,28 @@ describe("consent form starter library", () => {
     ]) {
       expect(slugs.has(required)).toBe(true);
     }
+  });
+
+  it("detects unresolved material blanks and staff-only instructions", () => {
+    for (const unresolved of [
+      "Procedure: ____",
+      "Approved total: {{amount}}",
+      "Call ${phoneNumber}",
+      "Send records to [insert destination]",
+      "I choose (staff: circle before sending): CPR / no CPR.",
+    ]) {
+      expect(hasUnresolvedConsentPlaceholders(unresolved)).toBe(true);
+    }
+  });
+
+  it("allows completed consent copy and ordinary punctuation", () => {
+    expect(
+      hasUnresolvedConsentPlaceholders(
+        "Procedure: dental cleaning. I approve costs up to $850. Call 555-0100.",
+      ),
+    ).toBe(false);
+    expect(hasUnresolvedConsentPlaceholders("I agree [after review].")).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/lib/consult/__tests__/consent-pdf.test.ts
+++ b/apps/web/lib/consult/__tests__/consent-pdf.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildConsentPdf } from "../consent-pdf";
+import { buildConsentPdf, consentSignaturePngDecodes } from "../consent-pdf";
 import {
   DEFAULT_CONSENT_BODY,
   DEFAULT_CONSENT_TITLE,
@@ -8,18 +8,24 @@ import {
 // 1x1 PNG.
 const SIGNATURE_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const DOCUMENT_ID = "00000000-0000-0000-0000-000000000005";
+
+function consentInput() {
+  return {
+    documentId: DOCUMENT_ID,
+    practiceId: "00000000-0000-0000-0000-000000000001",
+    patientId: "00000000-0000-0000-0000-000000000002",
+    title: DEFAULT_CONSENT_TITLE,
+    bodyText: DEFAULT_CONSENT_BODY,
+    signerName: "Jordan Marsh",
+    signedAtIso: "2026-07-10T12:00:00.000Z",
+    signaturePngDataUrl: SIGNATURE_DATA_URL,
+  };
+}
 
 describe("buildConsentPdf", () => {
   it("produces a real PDF with the consent copy and signer", () => {
-    const pdf = buildConsentPdf({
-      practiceName: "Drill Vet",
-      patientName: "Peanut",
-      title: DEFAULT_CONSENT_TITLE,
-      bodyText: DEFAULT_CONSENT_BODY,
-      signerName: "Jordan Marsh",
-      signedAtIso: "2026-07-10T12:00:00.000Z",
-      signaturePngDataUrl: SIGNATURE_DATA_URL,
-    });
+    const pdf = buildConsentPdf(consentInput());
 
     expect(pdf.subarray(0, 4).toString()).toBe("%PDF");
     expect(pdf.length).toBeGreaterThan(1_000);
@@ -28,23 +34,45 @@ describe("buildConsentPdf", () => {
   it("survives long consent bodies by paginating", () => {
     const longBody = Array.from(
       { length: 200 },
-      (_, i) => `Line ${i + 1}: the team explained the plan for my pet.`
+      (_, i) => `Line ${i + 1}: the team explained the plan for my pet.`,
     ).join("\n");
 
     const pdf = buildConsentPdf({
-      practiceName: "Drill Vet",
-      patientName: "Peanut",
-      title: "Long consent",
+      ...consentInput(),
       bodyText: longBody,
-      signerName: "Jordan Marsh",
-      signedAtIso: "2026-07-10T12:00:00.000Z",
-      signaturePngDataUrl: SIGNATURE_DATA_URL,
+      title: "Long consent",
     });
 
     expect(pdf.subarray(0, 4).toString()).toBe("%PDF");
     // Multiple pages: jspdf writes one /Type /Page object per page.
     const pages = pdf.toString("latin1").match(/\/Type \/Page[^s]/g) ?? [];
     expect(pages.length).toBeGreaterThan(1);
+  });
+
+  it("renders identical bytes for the same persisted signing metadata", () => {
+    expect(buildConsentPdf(consentInput())).toEqual(
+      buildConsentPdf(consentInput()),
+    );
+  });
+
+  it("fully decodes PNG chunks before signature evidence is claimed", () => {
+    expect(consentSignaturePngDecodes(SIGNATURE_DATA_URL)).toBe(true);
+
+    const corrupt = Buffer.from(
+      SIGNATURE_DATA_URL.slice("data:image/png;base64,".length),
+      "base64",
+    );
+    corrupt[40] = corrupt[40]! ^ 1;
+    expect(
+      consentSignaturePngDecodes(
+        `data:image/png;base64,${corrupt.toString("base64")}`,
+      ),
+    ).toBe(false);
+    expect(
+      consentSignaturePngDecodes(
+        `data:image/png;base64,${corrupt.subarray(0, 40).toString("base64")}`,
+      ),
+    ).toBe(false);
   });
 
   it("keeps the default template in the product voice", () => {

--- a/apps/web/lib/consult/consent-pdf.ts
+++ b/apps/web/lib/consult/consent-pdf.ts
@@ -13,14 +13,35 @@ const SIGNATURE_WIDTH_MM = 70;
 const SIGNATURE_HEIGHT_MM = 26;
 
 export interface ConsentPdfInput {
-  practiceName: string;
-  patientName: string;
+  /** Stable UUID for deterministic PDF metadata across upload retries. */
+  documentId: string;
+  /** Durable tenant and patient identifiers from the consent snapshot. */
+  practiceId: string;
+  patientId: string;
   title: string;
   bodyText: string;
   signerName: string;
   signedAtIso: string;
   /** PNG data URL of the drawn signature. */
   signaturePngDataUrl: string;
+}
+
+/**
+ * Fully parse a bounded signature with the same PNG decoder used by the final
+ * renderer. Magic bytes and IHDR dimensions alone do not validate chunk CRCs,
+ * truncation, or compressed image data. Callers must apply byte and pixel
+ * bounds before invoking this decoder.
+ */
+export function consentSignaturePngDecodes(
+  signaturePngDataUrl: string,
+): boolean {
+  try {
+    const validator = new jsPDF();
+    validator.addImage(signaturePngDataUrl, "PNG", 0, 0, 1, 1);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function ensureSpace(doc: jsPDF, y: number, needed: number): number {
@@ -34,6 +55,10 @@ function ensureSpace(doc: jsPDF, y: number, needed: number): number {
 
 export function buildConsentPdf(input: ConsentPdfInput): Buffer {
   const doc = new jsPDF();
+  // jsPDF otherwise embeds a fresh document ID and the wall-clock creation
+  // time, making the same consent render to different bytes on every retry.
+  doc.setFileId(input.documentId.replaceAll("-", "").toUpperCase());
+  doc.setCreationDate(new Date(input.signedAtIso));
   let y = PAGE_MARGIN;
 
   doc.setFont("helvetica", "bold");
@@ -45,11 +70,9 @@ export function buildConsentPdf(input: ConsentPdfInput): Buffer {
   doc.setFont("helvetica", "normal");
   doc.setFontSize(10);
   doc.setTextColor(102, 102, 102);
-  doc.text(
-    `${input.practiceName}  ·  Patient: ${input.patientName}`,
-    PAGE_MARGIN,
-    y
-  );
+  doc.text(`Clinic record: ${input.practiceId}`, PAGE_MARGIN, y);
+  y += 5;
+  doc.text(`Patient record: ${input.patientId}`, PAGE_MARGIN, y);
   y += 4;
   doc.setDrawColor(238, 238, 238);
   doc.setLineWidth(0.5);
@@ -78,7 +101,7 @@ export function buildConsentPdf(input: ConsentPdfInput): Buffer {
     PAGE_MARGIN,
     y,
     SIGNATURE_WIDTH_MM,
-    SIGNATURE_HEIGHT_MM
+    SIGNATURE_HEIGHT_MM,
   );
   y += SIGNATURE_HEIGHT_MM + 2;
   doc.setDrawColor(102, 102, 102);
@@ -94,7 +117,7 @@ export function buildConsentPdf(input: ConsentPdfInput): Buffer {
   doc.text(
     `Signed ${new Date(input.signedAtIso).toUTCString()}`,
     PAGE_MARGIN,
-    y
+    y,
   );
 
   return Buffer.from(doc.output("arraybuffer"));

--- a/apps/web/lib/consult/consent-template.ts
+++ b/apps/web/lib/consult/consent-template.ts
@@ -9,6 +9,23 @@ export const CONSENT_TITLE_MAX_LENGTH = 200;
 export const CONSENT_BODY_MAX_LENGTH = 8_000;
 export const CONSENT_SIGNER_NAME_MAX_LENGTH = 120;
 
+/**
+ * Consent templates intentionally ship with fill-in prompts. They are useful
+ * while drafting, but a capability link must never be minted while a material
+ * choice, amount, contact, procedure, or destination is still blank.
+ */
+const HIGH_RISK_PLACEHOLDER_PATTERNS = [
+  /_{3,}/,
+  /\{\{[^}\n]+\}\}/,
+  /\$\{[^}\n]+\}/,
+  /\[(?:insert|enter|fill in|choose|select)[^\]\n]*\]/i,
+  /\bstaff\s*:\s*(?:fill|circle|choose|select|complete)\b/i,
+] as const;
+
+export function hasUnresolvedConsentPlaceholders(value: string): boolean {
+  return HIGH_RISK_PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(value));
+}
+
 export const DEFAULT_CONSENT_TITLE = "Consent to treatment";
 
 export const DEFAULT_CONSENT_BODY = [

--- a/apps/web/lib/cron-heartbeat.ts
+++ b/apps/web/lib/cron-heartbeat.ts
@@ -6,6 +6,7 @@ export const CRON_HEARTBEAT_TIMEOUT_MS = 5_000;
 export const CRON_HEARTBEAT_JOBS = [
   "reminders",
   "backup",
+  "file-replicas",
   "usage-reconcile",
   "billing-lifecycle",
   "wellness-billing",

--- a/apps/web/lib/email-lifecycle.ts
+++ b/apps/web/lib/email-lifecycle.ts
@@ -4,6 +4,11 @@ import { communications } from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
 import { alertOps } from "@/lib/alerts";
 import { marketingEmailEnabledForRecipient } from "@/lib/platform-email-preferences";
+import {
+  lockPracticeForExternalSideEffects,
+  practiceAllowsExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 type SendResult = { success: boolean; id?: string; error?: string };
 type ClaimedLifecycleEmail = { id: string };
@@ -39,6 +44,18 @@ export async function sendLifecycleEmail(
   // Never throw into the caller (Stripe webhook / cron). Any infra error
   // (incl. a not-yet-migrated dedupe column) degrades to "not sent" + an alert.
   try {
+    if (
+      !(await withSystem(db, (tx) =>
+        practiceAllowsExternalSideEffects(tx, opts.practiceId),
+      ))
+    ) {
+      await alertOps(
+        "Lifecycle email blocked by recovery hold",
+        `practice=${opts.practiceId} emailType=${opts.emailType}: ${RECOVERY_HOLD_BLOCK_MESSAGE}`,
+      );
+      return { sent: false, deduped: false, suppressed: true };
+    }
+
     if (opts.category === "marketing") {
       if (!(await marketingEmailEnabledForRecipient(opts.to))) {
         return { sent: false, deduped: false, suppressed: true };
@@ -56,7 +73,24 @@ export async function sendLifecycleEmail(
     // 2. Send.
     let result: SendResult;
     try {
-      result = await opts.send();
+      const delivery = await withSystem(db, async (tx) => {
+        if (
+          !(await lockPracticeForExternalSideEffects(tx, opts.practiceId))
+        ) {
+          return { blocked: true as const };
+        }
+        return { blocked: false as const, result: await opts.send() };
+      });
+      if (delivery.blocked) {
+        // The claim was created before recovery won the serialization race.
+        // Remove it because no provider request occurred; future cron/event
+        // retry can safely claim the same identity after recovery release.
+        await withSystem(db, (tx) =>
+          tx.delete(communications).where(eq(communications.id, row.id)),
+        );
+        return { sent: false, deduped: false, suppressed: true };
+      }
+      result = delivery.result;
     } catch (err) {
       result = {
         success: false,

--- a/apps/web/lib/file-replication.ts
+++ b/apps/web/lib/file-replication.ts
@@ -1,0 +1,1446 @@
+import { createHash, randomUUID } from "node:crypto";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { fileObjectReplicas, files, fileStorageEvents } from "@openpims/db";
+import { db } from "@openpims/db/client";
+import { alertOps } from "@/lib/alerts";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import {
+  FILE_REPLICA_TARGET,
+  normalizeS3VersionId,
+  readPrimaryObject,
+  readReplicaObject,
+  replicaStoragePracticeScope,
+  replicaStorageReadiness,
+  replicaStorageRequired,
+  replicaStorageRolloutEnabled,
+  uploadManagedFile,
+  uploadReplicaFile,
+} from "@/lib/s3";
+import { withSystem } from "@/lib/tenant-db";
+import { UPLOAD_FILE_MAX_BYTES } from "@/lib/upload-limits";
+import { isAllowedUploadCategory } from "@/lib/upload-security";
+
+const DEFAULT_BATCH_SIZE = 25;
+const MAX_BATCH_SIZE = 100;
+const LEASE_MS = 5 * 60 * 1000;
+const VERIFY_AFTER_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_JOB_BUDGET_MS = 240_000;
+
+type ReplicaStatus = "pending" | "available" | "missing" | "corrupt" | "failed";
+type FileStorageStatus = (typeof files.$inferSelect)["storageStatus"];
+
+interface ClaimedReplica {
+  replicaId: string;
+  practiceId: string;
+  fileId: string;
+  fileKey: string;
+  mimeType: string | null;
+  fileChecksum: string | null;
+  fileSize: number | null;
+  fileStorageStatus: FileStorageStatus;
+  replicaObjectKey: string;
+  replicaChecksum: string | null;
+  replicaSize: number | null;
+  replicaStatus: ReplicaStatus;
+  replicaObjectEtag: string | null;
+  replicaObjectVersionId: string | null;
+  replicaReplicatedAt: Date | string | null;
+  replicaVerifiedAt: Date | string | null;
+  attemptCount: number;
+  leaseToken: string;
+}
+
+export interface FileReplicaRunMetrics {
+  intended: boolean;
+  required: boolean;
+  configured: boolean;
+  enabled: boolean;
+  candidates: number;
+  claimed: number;
+  deferred: number;
+  copied: number;
+  alreadyPresent: number;
+  repairedPrimary: number;
+  sourceMissing: number;
+  sourceCorrupt: number;
+  failed: number;
+  bytesCopied: number;
+  backlog: number;
+  available: number;
+  activeFiles: number;
+  coveragePct: number;
+}
+
+export function checksumSha256Hex(body: Uint8Array): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+export function replicaObjectKey(input: {
+  practiceId: string;
+  fileId: string;
+  checksumSha256: string;
+}): string {
+  return `attachments/v1/${input.practiceId}/${input.fileId}/${input.checksumSha256}`;
+}
+
+export function recoveryCatalogKey(
+  practiceId: string,
+  fileId: string,
+  checksumSha256: string,
+): string {
+  return `recovery-catalog/v2/${practiceId}/${fileId}/${checksumSha256}.json`;
+}
+
+async function appendStorageEvent(
+  tx: Parameters<Parameters<typeof withSystem>[1]>[0],
+  input: {
+    practiceId: string;
+    fileId: string;
+    storageTarget: string;
+    eventKey: string;
+    operationId: string;
+    eventKind: string;
+    previousStatus?: string | null;
+    nextStatus: string;
+    expectedChecksumSha256?: string | null;
+    observedChecksumSha256?: string | null;
+    expectedFileSizeBytes?: number | null;
+    observedFileSizeBytes?: number | null;
+    objectEtag?: string | null;
+    objectVersionId?: string | null;
+    failureCode?: string | null;
+    workerRunId?: string | null;
+  },
+): Promise<void> {
+  await tx
+    .insert(fileStorageEvents)
+    .values({
+      practiceId: input.practiceId,
+      fileId: input.fileId,
+      storageTarget: input.storageTarget,
+      eventKey: input.eventKey,
+      operationId: input.operationId,
+      eventKind: input.eventKind,
+      previousStatus: input.previousStatus ?? null,
+      nextStatus: input.nextStatus,
+      expectedChecksumSha256: input.expectedChecksumSha256 ?? null,
+      observedChecksumSha256: input.observedChecksumSha256 ?? null,
+      expectedFileSizeBytes: input.expectedFileSizeBytes ?? null,
+      observedFileSizeBytes: input.observedFileSizeBytes ?? null,
+      objectEtag: input.objectEtag ?? null,
+      objectVersionId: input.objectVersionId ?? null,
+      failureCode: input.failureCode ?? null,
+      workerRunId: input.workerRunId ?? null,
+    })
+    .onConflictDoNothing({ target: fileStorageEvents.eventKey });
+}
+
+/**
+ * Durably queue an independently replicated copy after the primary manifest is
+ * committed. Queue failure never makes the clinic repeat a successful upload;
+ * the reconciliation sweep also materializes any missing queue rows.
+ */
+export async function registerFileForReplication(input: {
+  practiceId: string;
+  fileId: string;
+  fileKey: string;
+  checksumSha256: string;
+  fileSizeBytes: number;
+  objectEtag?: string;
+  objectVersionId?: string;
+}): Promise<boolean> {
+  const operationId = randomUUID();
+  const objectKey = replicaObjectKey(input);
+
+  try {
+    await withSystem(db, async (tx) => {
+      await appendStorageEvent(tx, {
+        practiceId: input.practiceId,
+        fileId: input.fileId,
+        storageTarget: "primary",
+        eventKey: `primary:${input.fileId}:${input.checksumSha256}:verified`,
+        operationId,
+        eventKind: "primary_verified",
+        previousStatus: "pending_upload",
+        nextStatus: "available",
+        expectedChecksumSha256: input.checksumSha256,
+        observedChecksumSha256: input.checksumSha256,
+        expectedFileSizeBytes: input.fileSizeBytes,
+        observedFileSizeBytes: input.fileSizeBytes,
+        objectEtag: input.objectEtag,
+        objectVersionId: input.objectVersionId,
+      });
+
+      await tx
+        .insert(fileObjectReplicas)
+        .values({
+          practiceId: input.practiceId,
+          fileId: input.fileId,
+          replicaTarget: FILE_REPLICA_TARGET,
+          objectKey,
+          checksumSha256: input.checksumSha256,
+          fileSizeBytes: input.fileSizeBytes,
+          status: "pending",
+          nextAttemptAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [fileObjectReplicas.fileId, fileObjectReplicas.replicaTarget],
+          set: {
+            objectKey,
+            checksumSha256: input.checksumSha256,
+            fileSizeBytes: input.fileSizeBytes,
+            status: sql`case
+              when ${fileObjectReplicas.status} = 'available'
+                and ${fileObjectReplicas.checksumSha256} = ${input.checksumSha256}
+              then ${fileObjectReplicas.status}
+              else 'pending'::file_replica_status
+            end`,
+            nextAttemptAt: sql`case
+              when ${fileObjectReplicas.status} = 'available'
+                and ${fileObjectReplicas.checksumSha256} = ${input.checksumSha256}
+              then ${fileObjectReplicas.nextAttemptAt}
+              else now()
+            end`,
+            failureCode: null,
+            lastErrorClass: null,
+            leaseToken: null,
+            leaseExpiresAt: null,
+            deletedAt: null,
+            updatedAt: new Date(),
+          },
+        });
+
+      await appendStorageEvent(tx, {
+        practiceId: input.practiceId,
+        fileId: input.fileId,
+        storageTarget: FILE_REPLICA_TARGET,
+        eventKey: `replica:${input.fileId}:${input.checksumSha256}:queued`,
+        operationId,
+        eventKind: "replica_queued",
+        previousStatus: null,
+        nextStatus: "pending",
+        expectedChecksumSha256: input.checksumSha256,
+        expectedFileSizeBytes: input.fileSizeBytes,
+      });
+    });
+    return true;
+  } catch {
+    await alertOps(
+      "File replica queue write failed",
+      `practice ${input.practiceId}, file ${input.fileId}; reconciliation must recover the missing queue row.`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Make a verified replica fallback actionable without paging once per read.
+ * The manifest transition and queue wake-up are durable; the reconciler owns
+ * provider repair, lease coordination, and alerting.
+ */
+export async function schedulePrimaryRepair(input: {
+  practiceId: string;
+  fileId: string;
+  fileKey: string;
+  checksumSha256: string | null;
+  fileSizeBytes: number | null;
+  storageStatus: FileStorageStatus;
+  observedState: "missing" | "corrupt" | "failed";
+}): Promise<boolean> {
+  const nextStorageStatus =
+    input.observedState === "failed" ? "unverified" : input.observedState;
+
+  try {
+    return await withSystem(db, async (tx) => {
+      const [updatedFile] = await tx
+        .update(files)
+        .set({
+          storageStatus: nextStorageStatus,
+          storageVerifiedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(files.id, input.fileId),
+            eq(files.practiceId, input.practiceId),
+            eq(files.fileKey, input.fileKey),
+            sql`${files.checksumSha256} is not distinct from ${input.checksumSha256}`,
+            sql`${files.fileSizeBytes} is not distinct from ${input.fileSizeBytes}`,
+            eq(files.storageStatus, input.storageStatus),
+            isNull(files.deletedAt),
+          ),
+        )
+        .returning({ id: files.id });
+      if (!updatedFile) return false;
+
+      await tx
+        .update(fileObjectReplicas)
+        .set({ nextAttemptAt: new Date(), updatedAt: new Date() })
+        .where(
+          and(
+            eq(fileObjectReplicas.fileId, input.fileId),
+            eq(fileObjectReplicas.practiceId, input.practiceId),
+            eq(fileObjectReplicas.replicaTarget, FILE_REPLICA_TARGET),
+          ),
+        );
+
+      return true;
+    });
+  } catch {
+    return false;
+  }
+}
+
+function boundedBatchSize(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_BATCH_SIZE;
+  return Math.max(1, Math.min(MAX_BATCH_SIZE, Math.trunc(value!)));
+}
+
+function replicaPracticeScopeSql(scope: string[] | null) {
+  if (scope === null) return sql`true`;
+  if (scope.length === 0) return sql`false`;
+  return sql`f.practice_id in (${sql.join(
+    scope.map((practiceId) => sql`${practiceId}::uuid`),
+    sql`, `,
+  )})`;
+}
+
+async function materializeMissingReplicaRows(
+  limit: number,
+  scope: string[] | null,
+): Promise<number> {
+  return withSystem(db, async (tx) => {
+    const result = await tx.execute(sql`
+      insert into file_object_replicas (
+        practice_id, file_id, replica_target, object_key, status,
+        next_attempt_at
+      )
+      select
+        f.practice_id,
+        f.id,
+        ${FILE_REPLICA_TARGET},
+        'attachments/v1/' || f.practice_id::text || '/' || f.id::text || '/pending',
+        'pending'::file_replica_status,
+        now()
+      from files f
+      join practices p on p.id = f.practice_id and p.deleted_at is null
+      where f.deleted_at is null
+        and f.storage_status not in ('pending_upload', 'cleanup_pending')
+        and ${replicaPracticeScopeSql(scope)}
+        and not exists (
+          select 1
+          from file_object_replicas r
+          where r.file_id = f.id
+            and r.replica_target = ${FILE_REPLICA_TARGET}
+            and r.deleted_at is null
+        )
+      order by f.created_at, f.id
+      limit ${limit}
+      on conflict (file_id, replica_target) do update
+      set practice_id = excluded.practice_id,
+          object_key = excluded.object_key,
+          status = 'pending'::file_replica_status,
+          failure_code = null,
+          last_error_class = null,
+          next_attempt_at = now(),
+          lease_token = null,
+          lease_expires_at = null,
+          deleted_at = null,
+          updated_at = now()
+      returning id
+    `);
+    return rowsFromExecute<{ id: string }>(result).length;
+  });
+}
+
+async function claimReplicaRows(input: {
+  limit: number;
+  staleBefore: Date;
+  scope: string[] | null;
+}): Promise<ClaimedReplica[]> {
+  return withSystem(db, async (tx) => {
+    const result = await tx.execute(sql`
+      with candidates as (
+        select r.id
+        from file_object_replicas r
+        join files f on f.id = r.file_id and f.practice_id = r.practice_id
+        join practices p on p.id = r.practice_id
+        where r.replica_target = ${FILE_REPLICA_TARGET}
+          and r.deleted_at is null
+          and f.deleted_at is null
+          and f.storage_status not in ('pending_upload', 'cleanup_pending')
+          and p.deleted_at is null
+          and ${replicaPracticeScopeSql(input.scope)}
+          and (
+            r.status <> 'available'
+            or r.verified_at is null
+            or r.verified_at < ${input.staleBefore}
+            or f.storage_status <> 'available'
+            or f.storage_verified_at is null
+            or f.storage_verified_at < ${input.staleBefore}
+          )
+          and (r.next_attempt_at is null or r.next_attempt_at <= now())
+          and (r.lease_token is null or r.lease_expires_at < now())
+        order by
+          case when r.status = 'available' then 1 else 0 end,
+          coalesce(r.next_attempt_at, r.created_at),
+          r.id
+        limit ${input.limit}
+        for update of r skip locked
+      )
+      update file_object_replicas r
+      set lease_token = gen_random_uuid(),
+          lease_expires_at = now() + ${LEASE_MS} * interval '1 millisecond',
+          last_attempted_at = now(),
+          attempt_count = r.attempt_count + 1,
+          updated_at = now()
+      from candidates c, files f
+      where r.id = c.id
+        and f.id = r.file_id
+        and f.practice_id = r.practice_id
+      returning
+        r.id as "replicaId",
+        r.practice_id as "practiceId",
+        r.file_id as "fileId",
+        f.file_key as "fileKey",
+        f.mime_type as "mimeType",
+        f.checksum_sha256 as "fileChecksum",
+        f.file_size_bytes as "fileSize",
+        f.storage_status as "fileStorageStatus",
+        r.object_key as "replicaObjectKey",
+        r.checksum_sha256 as "replicaChecksum",
+        r.file_size_bytes as "replicaSize",
+        r.status as "replicaStatus",
+        r.object_etag as "replicaObjectEtag",
+        r.object_version_id as "replicaObjectVersionId",
+        r.replicated_at as "replicaReplicatedAt",
+        r.verified_at as "replicaVerifiedAt",
+        r.attempt_count as "attemptCount",
+        r.lease_token as "leaseToken"
+    `);
+    return rowsFromExecute<ClaimedReplica>(result);
+  });
+}
+
+function bodyMatches(
+  body: Uint8Array,
+  expectedChecksum: string,
+  expectedSize: number,
+): boolean {
+  return (
+    body.byteLength === expectedSize &&
+    checksumSha256Hex(body) === expectedChecksum
+  );
+}
+
+function retryAt(attemptCount: number): Date {
+  const exponent = Math.max(0, Math.min(attemptCount - 1, 4));
+  const delayMs = Math.min(6 * 60 * 60 * 1000, 5 * 60 * 1000 * 3 ** exponent);
+  return new Date(Date.now() + delayMs);
+}
+
+function claimedPrimaryGeneration(item: ClaimedReplica) {
+  return and(
+    eq(files.id, item.fileId),
+    eq(files.practiceId, item.practiceId),
+    eq(files.fileKey, item.fileKey),
+    sql`${files.checksumSha256} is not distinct from ${item.fileChecksum}`,
+    sql`${files.fileSizeBytes} is not distinct from ${item.fileSize}`,
+    eq(files.storageStatus, item.fileStorageStatus),
+    isNull(files.deletedAt),
+  );
+}
+
+function claimedPrimaryGenerationExists(item: ClaimedReplica) {
+  return sql`exists (
+    select 1
+    from ${files}
+    where ${claimedPrimaryGeneration(item)}
+  )`;
+}
+
+function claimedReplicaGeneration(item: ClaimedReplica) {
+  return and(
+    eq(fileObjectReplicas.id, item.replicaId),
+    eq(fileObjectReplicas.practiceId, item.practiceId),
+    eq(fileObjectReplicas.fileId, item.fileId),
+    eq(fileObjectReplicas.replicaTarget, FILE_REPLICA_TARGET),
+    eq(fileObjectReplicas.leaseToken, item.leaseToken),
+    eq(fileObjectReplicas.objectKey, item.replicaObjectKey),
+    sql`${fileObjectReplicas.checksumSha256} is not distinct from ${item.replicaChecksum}`,
+    sql`${fileObjectReplicas.fileSizeBytes} is not distinct from ${item.replicaSize}`,
+    isNull(fileObjectReplicas.deletedAt),
+  );
+}
+
+class StaleClaimedGenerationError extends Error {}
+
+async function finalizeReplica(
+  item: ClaimedReplica,
+  input: {
+    status: ReplicaStatus;
+    operationId: string;
+    eventKind: string;
+    previousStatus?: string;
+    objectKey?: string;
+    checksumSha256?: string | null;
+    fileSizeBytes?: number | null;
+    objectEtag?: string | null;
+    objectVersionId?: string | null;
+    replicatedAt?: Date | null;
+    verifiedAt?: Date | null;
+    failureCode?: string | null;
+    lastErrorClass?: string | null;
+    nextAttemptAt?: Date | null;
+    workerRunId: string;
+    primaryTransition?: {
+      status: "available" | "missing" | "corrupt";
+      eventKind: string;
+      checksumSha256?: string;
+      fileSizeBytes?: number;
+      observedChecksumSha256?: string;
+      observedFileSizeBytes?: number;
+      objectEtag?: string;
+      objectVersionId?: string;
+      failureCode?: string;
+    };
+  },
+): Promise<boolean> {
+  try {
+    return await withSystem(db, async (tx) => {
+      const [updated] = await tx
+        .update(fileObjectReplicas)
+        .set({
+          status: input.status,
+          ...(input.objectKey ? { objectKey: input.objectKey } : {}),
+          checksumSha256:
+            input.checksumSha256 === undefined
+              ? item.replicaChecksum
+              : input.checksumSha256,
+          fileSizeBytes:
+            input.fileSizeBytes === undefined
+              ? item.replicaSize
+              : input.fileSizeBytes,
+          objectEtag:
+            input.objectEtag === undefined
+              ? item.replicaObjectEtag
+              : input.objectEtag,
+          objectVersionId:
+            input.objectVersionId === undefined
+              ? item.replicaObjectVersionId
+              : input.objectVersionId,
+          replicatedAt:
+            input.replicatedAt === undefined
+              ? item.replicaReplicatedAt
+                ? new Date(item.replicaReplicatedAt)
+                : null
+              : input.replicatedAt,
+          verifiedAt:
+            input.verifiedAt === undefined
+              ? item.replicaVerifiedAt
+                ? new Date(item.replicaVerifiedAt)
+                : null
+              : input.verifiedAt,
+          failureCode: input.failureCode ?? null,
+          lastErrorClass: input.lastErrorClass ?? null,
+          nextAttemptAt: input.nextAttemptAt ?? null,
+          leaseToken: null,
+          leaseExpiresAt: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            claimedReplicaGeneration(item),
+            claimedPrimaryGenerationExists(item),
+          ),
+        )
+        .returning({ id: fileObjectReplicas.id });
+      if (!updated) return false;
+
+      if (input.primaryTransition) {
+        const transition = input.primaryTransition;
+        const [updatedFile] = await tx
+          .update(files)
+          .set({
+            storageStatus: transition.status,
+            ...(transition.checksumSha256
+              ? { checksumSha256: transition.checksumSha256 }
+              : {}),
+            ...(typeof transition.fileSizeBytes === "number"
+              ? { fileSizeBytes: transition.fileSizeBytes }
+              : {}),
+            objectEtag: transition.objectEtag ?? null,
+            objectVersionId: transition.objectVersionId ?? null,
+            storageVerifiedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(claimedPrimaryGeneration(item))
+          .returning({ id: files.id });
+        if (!updatedFile) throw new StaleClaimedGenerationError();
+
+        await appendStorageEvent(tx, {
+          practiceId: item.practiceId,
+          fileId: item.fileId,
+          storageTarget: "primary",
+          eventKey: `${input.workerRunId}:${item.fileId}:primary:${transition.eventKind}:${input.operationId}`,
+          operationId: input.operationId,
+          eventKind: transition.eventKind,
+          previousStatus: item.fileStorageStatus,
+          nextStatus: transition.status,
+          expectedChecksumSha256: item.fileChecksum,
+          observedChecksumSha256:
+            transition.observedChecksumSha256 ?? transition.checksumSha256,
+          expectedFileSizeBytes: item.fileSize,
+          observedFileSizeBytes:
+            transition.observedFileSizeBytes ?? transition.fileSizeBytes,
+          objectEtag: transition.objectEtag,
+          objectVersionId: transition.objectVersionId,
+          failureCode: transition.failureCode,
+          workerRunId: input.workerRunId,
+        });
+      }
+
+      await appendStorageEvent(tx, {
+        practiceId: item.practiceId,
+        fileId: item.fileId,
+        storageTarget: FILE_REPLICA_TARGET,
+        eventKey: `${input.workerRunId}:${item.fileId}:${input.eventKind}:${input.operationId}`,
+        operationId: input.operationId,
+        eventKind: input.eventKind,
+        previousStatus: input.previousStatus ?? item.replicaStatus,
+        nextStatus: input.status,
+        expectedChecksumSha256:
+          input.checksumSha256 ?? item.fileChecksum ?? item.replicaChecksum,
+        observedChecksumSha256: input.checksumSha256 ?? null,
+        expectedFileSizeBytes: input.fileSizeBytes ?? item.fileSize,
+        observedFileSizeBytes: input.fileSizeBytes ?? null,
+        objectEtag: input.objectEtag,
+        objectVersionId: input.objectVersionId,
+        failureCode: input.failureCode,
+        workerRunId: input.workerRunId,
+      });
+      return true;
+    });
+  } catch (error) {
+    if (error instanceof StaleClaimedGenerationError) return false;
+    throw error;
+  }
+}
+
+async function writeRecoveryCatalog(input: {
+  item: ClaimedReplica;
+  replicaObjectKey: string;
+  checksumSha256: string;
+  fileSizeBytes: number;
+  objectEtag?: string;
+  objectVersionId: string;
+  verifiedAt: Date;
+}): Promise<void> {
+  const replicaObjectVersionId = normalizeS3VersionId(input.objectVersionId);
+  if (!replicaObjectVersionId) {
+    throw new Error("Recovery catalog requires an exact replica version");
+  }
+  const body = Buffer.from(
+    JSON.stringify({
+      formatVersion: 1,
+      practiceId: input.item.practiceId,
+      fileId: input.item.fileId,
+      primaryObjectKey: input.item.fileKey,
+      replicaObjectKey: input.replicaObjectKey,
+      checksumSha256: input.checksumSha256,
+      fileSizeBytes: input.fileSizeBytes,
+      objectEtag: input.objectEtag ?? null,
+      objectVersionId: replicaObjectVersionId,
+      mimeType: input.item.mimeType,
+      verifiedAt: input.verifiedAt.toISOString(),
+    }),
+  );
+  const catalogChecksum = checksumSha256Hex(body);
+  const catalogKey = recoveryCatalogKey(
+    input.item.practiceId,
+    input.item.fileId,
+    catalogChecksum,
+  );
+  let catalogWrite: { etag?: string; versionId?: string } | undefined;
+  let catalogWriteError: unknown;
+  try {
+    catalogWrite = await uploadReplicaFile(
+      catalogKey,
+      body,
+      "application/json",
+      catalogChecksum,
+    );
+  } catch (error) {
+    // This key is derived from the complete catalog bytes. A provider timeout
+    // can therefore converge through checksum/size read-back without creating
+    // mutable or duplicate recovery evidence.
+    catalogWriteError = error;
+  }
+  const requestedVersionId = normalizeS3VersionId(catalogWrite?.versionId);
+  const verification = await readReplicaObject(catalogKey, {
+    maxBytes: body.byteLength,
+    ...(requestedVersionId ? { versionId: requestedVersionId } : {}),
+  });
+  const verifiedVersionId =
+    verification.status === "available"
+      ? normalizeS3VersionId(verification.versionId)
+      : undefined;
+  if (
+    verification.status !== "available" ||
+    !verifiedVersionId ||
+    (requestedVersionId && verifiedVersionId !== requestedVersionId) ||
+    !bodyMatches(verification.body, catalogChecksum, body.byteLength)
+  ) {
+    if (catalogWriteError) throw catalogWriteError;
+    throw new Error("Recovery catalog verification failed");
+  }
+}
+
+type ProcessOutcome =
+  | "copied"
+  | "already_present"
+  | "repaired_primary"
+  | "source_missing"
+  | "source_corrupt"
+  | "failed";
+
+function validPrimaryObjectKey(item: ClaimedReplica): boolean {
+  const segments = item.fileKey.split("/");
+  return (
+    segments.length === 3 &&
+    segments[0] === item.practiceId &&
+    Boolean(segments[2]) &&
+    isAllowedUploadCategory(segments[1] ?? "")
+  );
+}
+
+async function renewReplicaLease(item: ClaimedReplica): Promise<boolean> {
+  return withSystem(db, async (tx) => {
+    const [renewed] = await tx
+      .update(fileObjectReplicas)
+      .set({
+        leaseExpiresAt: new Date(Date.now() + LEASE_MS),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          claimedReplicaGeneration(item),
+          claimedPrimaryGenerationExists(item),
+        ),
+      )
+      .returning({ id: fileObjectReplicas.id });
+    return Boolean(renewed);
+  });
+}
+
+async function processClaimedReplica(
+  item: ClaimedReplica,
+  workerRunId: string,
+): Promise<{ outcome: ProcessOutcome; bytesCopied: number }> {
+  const operationId = randomUUID();
+  const expectedChecksum = item.fileChecksum ?? item.replicaChecksum;
+  const expectedSize = item.fileSize ?? item.replicaSize;
+  if (!validPrimaryObjectKey(item)) {
+    const finalized = await finalizeReplica(item, {
+      status: "failed",
+      operationId,
+      eventKind: "invalid_primary_object_namespace",
+      failureCode: "invalid_primary_object_namespace",
+      lastErrorClass: "permanent_integrity_error",
+      objectEtag: null,
+      objectVersionId: null,
+      replicatedAt: null,
+      verifiedAt: null,
+      workerRunId,
+    });
+    if (finalized) {
+      await alertOps(
+        "File replica quarantined invalid object key",
+        `practice ${item.practiceId}, file ${item.fileId}; provider I/O was blocked.`,
+      );
+    }
+    return { outcome: "failed", bytesCopied: 0 };
+  }
+
+  const desiredKey =
+    expectedChecksum && expectedSize != null
+      ? replicaObjectKey({
+          practiceId: item.practiceId,
+          fileId: item.fileId,
+          checksumSha256: expectedChecksum,
+        })
+      : null;
+  let replicaProbeState: "not_checked" | "missing" | "failed" | "corrupt" =
+    "not_checked";
+  let verifiedReplica:
+    | {
+        body: Uint8Array;
+        contentType?: string;
+        etag?: string;
+        versionId: string;
+        key: string;
+        verifiedAt: Date;
+      }
+    | undefined;
+
+  if (desiredKey && expectedChecksum && expectedSize != null) {
+    const probe = await readReplicaObject(desiredKey, {
+      maxBytes: UPLOAD_FILE_MAX_BYTES,
+      ...(item.replicaStatus === "available" &&
+      item.replicaObjectKey === desiredKey &&
+      normalizeS3VersionId(item.replicaObjectVersionId)
+        ? { versionId: normalizeS3VersionId(item.replicaObjectVersionId)! }
+        : {}),
+    });
+    const probeVersionId =
+      probe.status === "available"
+        ? normalizeS3VersionId(probe.versionId)
+        : undefined;
+    if (
+      probe.status === "available" &&
+      probeVersionId &&
+      bodyMatches(probe.body, expectedChecksum, expectedSize)
+    ) {
+      verifiedReplica = {
+        body: probe.body,
+        ...(probe.contentType ? { contentType: probe.contentType } : {}),
+        ...(probe.etag ? { etag: probe.etag } : {}),
+        versionId: probeVersionId,
+        key: desiredKey,
+        verifiedAt: new Date(),
+      };
+    } else {
+      replicaProbeState =
+        probe.status === "available" ? "corrupt" : probe.status;
+    }
+  }
+
+  const primary = await readPrimaryObject(item.fileKey, {
+    maxBytes: UPLOAD_FILE_MAX_BYTES,
+  });
+
+  if (primary.status === "failed") {
+    const preserveVerifiedReplica =
+      Boolean(verifiedReplica) ||
+      (item.replicaStatus === "available" &&
+        (replicaProbeState === "failed" ||
+          replicaProbeState === "not_checked"));
+    const finalized = await finalizeReplica(item, {
+      status:
+        verifiedReplica || preserveVerifiedReplica
+          ? "available"
+          : replicaProbeState === "corrupt"
+            ? "corrupt"
+            : "pending",
+      operationId,
+      eventKind: "primary_read_retry_scheduled",
+      ...(verifiedReplica ? { objectKey: verifiedReplica.key } : {}),
+      checksumSha256: expectedChecksum,
+      fileSizeBytes: expectedSize,
+      ...(verifiedReplica
+        ? {
+            objectEtag: verifiedReplica.etag,
+            objectVersionId: verifiedReplica.versionId,
+            replicatedAt: item.replicaReplicatedAt
+              ? new Date(item.replicaReplicatedAt)
+              : verifiedReplica.verifiedAt,
+            verifiedAt: verifiedReplica.verifiedAt,
+          }
+        : {}),
+      failureCode: "primary_unavailable",
+      lastErrorClass: "retryable_provider_error",
+      nextAttemptAt: retryAt(item.attemptCount),
+      ...(verifiedReplica || preserveVerifiedReplica
+        ? {}
+        : {
+            objectEtag: null,
+            objectVersionId: null,
+            replicatedAt: null,
+            verifiedAt: null,
+          }),
+      workerRunId,
+    });
+    void finalized;
+    return { outcome: "failed", bytesCopied: 0 };
+  }
+
+  const primaryMissing = primary.status === "missing";
+  const observedChecksum = primaryMissing
+    ? null
+    : checksumSha256Hex(primary.body);
+  const observedSize = primaryMissing ? null : primary.body.byteLength;
+  const primaryCorrupt =
+    !primaryMissing &&
+    ((item.fileChecksum && item.fileChecksum !== observedChecksum) ||
+      (item.fileSize != null && item.fileSize !== observedSize));
+
+  if ((primaryMissing || primaryCorrupt) && verifiedReplica) {
+    if (!expectedChecksum || expectedSize == null) {
+      throw new Error("Verified replica is missing manifest evidence");
+    }
+    if (!(await renewReplicaLease(item))) {
+      return { outcome: "failed", bytesCopied: 0 };
+    }
+
+    let restored: { etag?: string; versionId?: string } | undefined;
+    try {
+      restored = await uploadManagedFile(
+        item.fileKey,
+        Buffer.from(verifiedReplica.body),
+        item.mimeType ??
+          verifiedReplica.contentType ??
+          "application/octet-stream",
+        expectedChecksum,
+      );
+    } catch {
+      // A timed-out PUT may have committed. The read-back below decides.
+    }
+    const restoredPrimary = await readPrimaryObject(item.fileKey, {
+      maxBytes: UPLOAD_FILE_MAX_BYTES,
+    });
+    if (
+      restoredPrimary.status !== "available" ||
+      !bodyMatches(restoredPrimary.body, expectedChecksum, expectedSize)
+    ) {
+      const finalized = await finalizeReplica(item, {
+        status: "available",
+        operationId,
+        eventKind: "primary_repair_retry_scheduled",
+        objectKey: verifiedReplica.key,
+        checksumSha256: expectedChecksum,
+        fileSizeBytes: expectedSize,
+        objectEtag: verifiedReplica.etag,
+        objectVersionId: verifiedReplica.versionId,
+        replicatedAt: item.replicaReplicatedAt
+          ? new Date(item.replicaReplicatedAt)
+          : verifiedReplica.verifiedAt,
+        verifiedAt: verifiedReplica.verifiedAt,
+        failureCode: primaryMissing ? "primary_missing" : "primary_corrupt",
+        lastErrorClass: "retryable_provider_error",
+        nextAttemptAt: retryAt(item.attemptCount),
+        primaryTransition: {
+          status: primaryMissing ? "missing" : "corrupt",
+          eventKind: primaryMissing
+            ? "primary_missing"
+            : "primary_integrity_mismatch",
+          ...(primaryCorrupt && observedChecksum
+            ? {
+                observedChecksumSha256: observedChecksum,
+                observedFileSizeBytes: observedSize!,
+              }
+            : {}),
+          failureCode: primaryMissing
+            ? "primary_missing"
+            : "checksum_or_size_mismatch",
+        },
+        workerRunId,
+      });
+      void finalized;
+      return { outcome: "failed", bytesCopied: 0 };
+    }
+
+    try {
+      await writeRecoveryCatalog({
+        item,
+        replicaObjectKey: verifiedReplica.key,
+        checksumSha256: expectedChecksum,
+        fileSizeBytes: expectedSize,
+        objectEtag: verifiedReplica.etag,
+        objectVersionId: verifiedReplica.versionId,
+        verifiedAt: verifiedReplica.verifiedAt,
+      });
+    } catch {
+      const keepAvailable =
+        item.replicaStatus === "available" && item.replicaVerifiedAt;
+      const finalized = await finalizeReplica(item, {
+        status: keepAvailable ? "available" : "pending",
+        operationId,
+        eventKind: "recovery_catalog_retry_scheduled",
+        objectKey: verifiedReplica.key,
+        checksumSha256: expectedChecksum,
+        fileSizeBytes: expectedSize,
+        objectEtag: verifiedReplica.etag,
+        objectVersionId: verifiedReplica.versionId,
+        replicatedAt: item.replicaReplicatedAt
+          ? new Date(item.replicaReplicatedAt)
+          : verifiedReplica.verifiedAt,
+        verifiedAt: keepAvailable ? new Date(item.replicaVerifiedAt!) : null,
+        failureCode: "catalog_write_failed",
+        lastErrorClass: "retryable_provider_error",
+        nextAttemptAt: retryAt(item.attemptCount),
+        primaryTransition: {
+          status: "available",
+          eventKind: "primary_restored_from_replica",
+          checksumSha256: expectedChecksum,
+          fileSizeBytes: expectedSize,
+          objectEtag: restoredPrimary.etag ?? restored?.etag,
+          objectVersionId: restoredPrimary.versionId ?? restored?.versionId,
+        },
+        workerRunId,
+      });
+      if (finalized) {
+        await alertOps(
+          "Primary file restored; recovery catalog retry pending",
+          `practice ${item.practiceId}, file ${item.fileId}; restored bytes verified.`,
+        );
+      }
+      return { outcome: "failed", bytesCopied: expectedSize };
+    }
+
+    const finalized = await finalizeReplica(item, {
+      status: "available",
+      operationId,
+      eventKind: "primary_restored_from_replica",
+      objectKey: verifiedReplica.key,
+      checksumSha256: expectedChecksum,
+      fileSizeBytes: expectedSize,
+      objectEtag: verifiedReplica.etag,
+      objectVersionId: verifiedReplica.versionId,
+      replicatedAt: item.replicaReplicatedAt
+        ? new Date(item.replicaReplicatedAt)
+        : verifiedReplica.verifiedAt,
+      verifiedAt: verifiedReplica.verifiedAt,
+      primaryTransition: {
+        status: "available",
+        eventKind: "primary_restored_from_replica",
+        checksumSha256: expectedChecksum,
+        fileSizeBytes: expectedSize,
+        objectEtag: restoredPrimary.etag ?? restored?.etag,
+        objectVersionId: restoredPrimary.versionId ?? restored?.versionId,
+      },
+      workerRunId,
+    });
+    if (finalized) {
+      await alertOps(
+        "Primary file restored from replica",
+        `practice ${item.practiceId}, file ${item.fileId}; integrity verified.`,
+      );
+      return { outcome: "repaired_primary", bytesCopied: expectedSize };
+    }
+    return { outcome: "failed", bytesCopied: expectedSize };
+  }
+
+  if (primaryMissing || primaryCorrupt) {
+    const preservePriorReplica =
+      !verifiedReplica &&
+      replicaProbeState === "failed" &&
+      item.replicaStatus === "available";
+    const replicaStatus = preservePriorReplica
+      ? "available"
+      : replicaProbeState === "corrupt"
+        ? "corrupt"
+        : replicaProbeState === "missing"
+          ? "missing"
+          : "pending";
+    const finalized = await finalizeReplica(item, {
+      status: replicaStatus,
+      operationId,
+      eventKind: primaryMissing
+        ? "primary_missing_no_verified_replica"
+        : "primary_integrity_mismatch",
+      ...(desiredKey ? { objectKey: desiredKey } : {}),
+      checksumSha256: expectedChecksum,
+      fileSizeBytes: expectedSize,
+      failureCode: primaryMissing
+        ? "primary_missing"
+        : "checksum_or_size_mismatch",
+      lastErrorClass: preservePriorReplica
+        ? "retryable_provider_error"
+        : "integrity_error",
+      nextAttemptAt: retryAt(item.attemptCount),
+      ...(preservePriorReplica
+        ? {}
+        : {
+            objectEtag: null,
+            objectVersionId: null,
+            replicatedAt: null,
+            verifiedAt: null,
+          }),
+      primaryTransition: {
+        status: primaryMissing ? "missing" : "corrupt",
+        eventKind: primaryMissing
+          ? "primary_missing"
+          : "primary_integrity_mismatch",
+        ...(primaryCorrupt && observedChecksum
+          ? {
+              observedChecksumSha256: observedChecksum,
+              observedFileSizeBytes: observedSize!,
+            }
+          : {}),
+        failureCode: primaryMissing
+          ? "primary_missing"
+          : "checksum_or_size_mismatch",
+      },
+      workerRunId,
+    });
+    if (finalized) {
+      await alertOps(
+        primaryMissing
+          ? preservePriorReplica
+            ? "Primary file missing; replica recheck unavailable"
+            : "File has no verified recoverable copy"
+          : "Primary file integrity mismatch",
+        `practice ${item.practiceId}, file ${item.fileId}; ${primaryMissing ? "primary returned a definitive miss" : "expected manifest does not match stored bytes"}.`,
+      );
+    }
+    return {
+      outcome: preservePriorReplica
+        ? "failed"
+        : primaryMissing
+          ? "source_missing"
+          : "source_corrupt",
+      bytesCopied: 0,
+    };
+  }
+
+  if (!observedChecksum || observedSize == null) {
+    throw new Error("Available primary is missing integrity evidence");
+  }
+
+  if (verifiedReplica) {
+    try {
+      await writeRecoveryCatalog({
+        item,
+        replicaObjectKey: verifiedReplica.key,
+        checksumSha256: observedChecksum,
+        fileSizeBytes: observedSize,
+        objectEtag: verifiedReplica.etag,
+        objectVersionId: verifiedReplica.versionId,
+        verifiedAt: verifiedReplica.verifiedAt,
+      });
+    } catch {
+      const keepAvailable =
+        item.replicaStatus === "available" && item.replicaVerifiedAt;
+      const finalized = await finalizeReplica(item, {
+        status: keepAvailable ? "available" : "pending",
+        operationId,
+        eventKind: "recovery_catalog_retry_scheduled",
+        objectKey: verifiedReplica.key,
+        checksumSha256: observedChecksum,
+        fileSizeBytes: observedSize,
+        objectEtag: verifiedReplica.etag,
+        objectVersionId: verifiedReplica.versionId,
+        replicatedAt: item.replicaReplicatedAt
+          ? new Date(item.replicaReplicatedAt)
+          : verifiedReplica.verifiedAt,
+        verifiedAt: keepAvailable ? new Date(item.replicaVerifiedAt!) : null,
+        failureCode: "catalog_write_failed",
+        lastErrorClass: "retryable_provider_error",
+        nextAttemptAt: retryAt(item.attemptCount),
+        primaryTransition: {
+          status: "available",
+          eventKind: "primary_verified",
+          checksumSha256: observedChecksum,
+          fileSizeBytes: observedSize,
+          objectEtag: primary.etag,
+          objectVersionId: primary.versionId,
+        },
+        workerRunId,
+      });
+      void finalized;
+      return { outcome: "failed", bytesCopied: 0 };
+    }
+
+    const finalized = await finalizeReplica(item, {
+      status: "available",
+      operationId,
+      eventKind: "replica_verified",
+      objectKey: verifiedReplica.key,
+      checksumSha256: observedChecksum,
+      fileSizeBytes: observedSize,
+      objectEtag: verifiedReplica.etag,
+      objectVersionId: verifiedReplica.versionId,
+      replicatedAt: item.replicaReplicatedAt
+        ? new Date(item.replicaReplicatedAt)
+        : verifiedReplica.verifiedAt,
+      verifiedAt: verifiedReplica.verifiedAt,
+      primaryTransition: {
+        status: "available",
+        eventKind: "primary_verified",
+        checksumSha256: observedChecksum,
+        fileSizeBytes: observedSize,
+        objectEtag: primary.etag,
+        objectVersionId: primary.versionId,
+      },
+      workerRunId,
+    });
+    return {
+      outcome: finalized ? "already_present" : "failed",
+      bytesCopied: 0,
+    };
+  }
+
+  const replicaKey = replicaObjectKey({
+    practiceId: item.practiceId,
+    fileId: item.fileId,
+    checksumSha256: observedChecksum,
+  });
+  let write: { etag?: string; versionId?: string } | undefined;
+  try {
+    write = await uploadReplicaFile(
+      replicaKey,
+      Buffer.from(primary.body),
+      item.mimeType ?? primary.contentType ?? "application/octet-stream",
+      observedChecksum,
+    );
+  } catch {
+    // A timed-out PUT can have succeeded. Verify the deterministic destination
+    // before scheduling a retry so an ambiguous provider result converges.
+  }
+
+  const replica = await readReplicaObject(replicaKey, {
+    maxBytes: UPLOAD_FILE_MAX_BYTES,
+  });
+  if (
+    replica.status !== "available" ||
+    !normalizeS3VersionId(replica.versionId) ||
+    !bodyMatches(replica.body, observedChecksum, observedSize)
+  ) {
+    const finalized = await finalizeReplica(item, {
+      status: "pending",
+      operationId,
+      eventKind: "replica_write_retry_scheduled",
+      objectKey: replicaKey,
+      checksumSha256: observedChecksum,
+      fileSizeBytes: observedSize,
+      failureCode:
+        replica.status === "missing"
+          ? "replica_missing"
+          : "replica_unavailable",
+      lastErrorClass:
+        replica.status === "missing"
+          ? "definitive_missing"
+          : "retryable_provider_error",
+      nextAttemptAt: retryAt(item.attemptCount),
+      objectEtag: null,
+      objectVersionId: null,
+      replicatedAt: null,
+      verifiedAt: null,
+      workerRunId,
+      primaryTransition: {
+        status: "available",
+        eventKind: "primary_verified",
+        checksumSha256: observedChecksum,
+        fileSizeBytes: observedSize,
+        objectEtag: primary.etag,
+        objectVersionId: primary.versionId,
+      },
+    });
+    void finalized;
+    return { outcome: "failed", bytesCopied: 0 };
+  }
+
+  const verifiedAt = new Date();
+  const replicaVersionId = normalizeS3VersionId(replica.versionId)!;
+  try {
+    await writeRecoveryCatalog({
+      item,
+      replicaObjectKey: replicaKey,
+      checksumSha256: observedChecksum,
+      fileSizeBytes: observedSize,
+      objectEtag: replica.etag ?? write?.etag,
+      objectVersionId: replicaVersionId,
+      verifiedAt,
+    });
+  } catch {
+    const finalized = await finalizeReplica(item, {
+      status: "pending",
+      operationId,
+      eventKind: "recovery_catalog_retry_scheduled",
+      objectKey: replicaKey,
+      checksumSha256: observedChecksum,
+      fileSizeBytes: observedSize,
+      objectEtag: replica.etag ?? write?.etag,
+      objectVersionId: replicaVersionId,
+      failureCode: "catalog_write_failed",
+      lastErrorClass: "retryable_provider_error",
+      nextAttemptAt: retryAt(item.attemptCount),
+      replicatedAt: verifiedAt,
+      verifiedAt: null,
+      workerRunId,
+      primaryTransition: {
+        status: "available",
+        eventKind: "primary_verified",
+        checksumSha256: observedChecksum,
+        fileSizeBytes: observedSize,
+        objectEtag: primary.etag,
+        objectVersionId: primary.versionId,
+      },
+    });
+    void finalized;
+    return { outcome: "failed", bytesCopied: observedSize };
+  }
+
+  const finalized = await finalizeReplica(item, {
+    status: "available",
+    operationId,
+    eventKind: "replica_verified",
+    objectKey: replicaKey,
+    checksumSha256: observedChecksum,
+    fileSizeBytes: observedSize,
+    objectEtag: replica.etag ?? write?.etag,
+    objectVersionId: replicaVersionId,
+    replicatedAt: verifiedAt,
+    verifiedAt,
+    workerRunId,
+    primaryTransition: {
+      status: "available",
+      eventKind: "primary_verified",
+      checksumSha256: observedChecksum,
+      fileSizeBytes: observedSize,
+      objectEtag: primary.etag,
+      objectVersionId: primary.versionId,
+    },
+  });
+  return {
+    outcome: finalized ? "copied" : "failed",
+    bytesCopied: observedSize,
+  };
+}
+
+export async function getFileReplicaCoverage(
+  scope: string[] | null = replicaStoragePracticeScope(),
+): Promise<{
+  backlog: number;
+  available: number;
+  activeFiles: number;
+  coveragePct: number;
+}> {
+  const freshAfter = new Date(Date.now() - VERIFY_AFTER_MS);
+  return withSystem(db, async (tx) => {
+    const result = await tx.execute(sql`
+      select
+        count(*) filter (
+          where r.status = 'available' and r.verified_at >= ${freshAfter}
+        )::int as "available",
+        count(*) filter (
+          where r.status is null
+             or r.status <> 'available'
+             or r.verified_at is null
+             or r.verified_at < ${freshAfter}
+        )::int as "backlog",
+        count(*)::int as "activeFiles"
+      from files f
+      join practices p on p.id = f.practice_id and p.deleted_at is null
+      left join file_object_replicas r
+        on r.file_id = f.id
+       and r.replica_target = ${FILE_REPLICA_TARGET}
+       and r.deleted_at is null
+      where f.deleted_at is null
+        and ${replicaPracticeScopeSql(scope)}
+    `);
+    const coverage = rowsFromExecute<{
+      backlog: number | string;
+      available: number | string;
+      activeFiles: number | string;
+    }>(result)[0] ?? { backlog: 0, available: 0, activeFiles: 0 };
+    const backlog = Number(coverage.backlog);
+    const available = Number(coverage.available);
+    const activeFiles = Number(coverage.activeFiles);
+    return {
+      backlog,
+      available,
+      activeFiles,
+      coveragePct:
+        activeFiles === 0
+          ? 100
+          : Number(((available / activeFiles) * 100).toFixed(2)),
+    };
+  });
+}
+
+export async function reconcileFileReplicas(
+  options: { limit?: number; budgetMs?: number } = {},
+): Promise<FileReplicaRunMetrics> {
+  const readiness = replicaStorageReadiness();
+  const required = replicaStorageRequired();
+  const enabled = replicaStorageRolloutEnabled();
+  const empty: FileReplicaRunMetrics = {
+    intended: readiness.intended,
+    required,
+    configured: readiness.ready,
+    enabled,
+    candidates: 0,
+    claimed: 0,
+    deferred: 0,
+    copied: 0,
+    alreadyPresent: 0,
+    repairedPrimary: 0,
+    sourceMissing: 0,
+    sourceCorrupt: 0,
+    failed: 0,
+    bytesCopied: 0,
+    backlog: 0,
+    available: 0,
+    activeFiles: 0,
+    coveragePct: 0,
+  };
+
+  if (!readiness.ready) {
+    if (readiness.intended) {
+      await alertOps("File replica configuration is invalid", readiness.detail);
+    }
+    return empty;
+  }
+  if (!enabled) return empty;
+
+  const limit = boundedBatchSize(options.limit);
+  const scope = replicaStoragePracticeScope();
+  const candidates = await materializeMissingReplicaRows(limit, scope);
+  const workerRunId = randomUUID();
+  const metrics = { ...empty, candidates };
+  const deadline =
+    Date.now() + Math.max(1_000, options.budgetMs ?? DEFAULT_JOB_BUDGET_MS);
+  let processed = 0;
+  let budgetExhausted = false;
+
+  while (processed < limit) {
+    if (Date.now() >= deadline) {
+      budgetExhausted = true;
+      break;
+    }
+
+    const [item] = await claimReplicaRows({
+      limit: 1,
+      staleBefore: new Date(Date.now() - VERIFY_AFTER_MS),
+      scope,
+    });
+    if (!item) break;
+    processed += 1;
+    metrics.claimed += 1;
+
+    try {
+      const result = await processClaimedReplica(item, workerRunId);
+      metrics.bytesCopied += result.bytesCopied;
+      if (result.outcome === "copied") metrics.copied += 1;
+      if (result.outcome === "already_present") metrics.alreadyPresent += 1;
+      if (result.outcome === "repaired_primary") metrics.repairedPrimary += 1;
+      if (result.outcome === "source_missing") metrics.sourceMissing += 1;
+      if (result.outcome === "source_corrupt") metrics.sourceCorrupt += 1;
+      if (result.outcome === "failed") metrics.failed += 1;
+    } catch {
+      metrics.failed += 1;
+      await finalizeReplica(item, {
+        status: item.replicaStatus === "available" ? "available" : "pending",
+        operationId: randomUUID(),
+        eventKind: "replication_attempt_crashed",
+        failureCode: "worker_error",
+        lastErrorClass: "retryable_worker_error",
+        nextAttemptAt: retryAt(item.attemptCount),
+        verifiedAt:
+          item.replicaStatus === "available" && item.replicaVerifiedAt
+            ? new Date(item.replicaVerifiedAt)
+            : null,
+        workerRunId,
+      });
+    }
+  }
+
+  const coverage = await getFileReplicaCoverage(scope);
+  metrics.backlog = coverage.backlog;
+  metrics.available = coverage.available;
+  metrics.activeFiles = coverage.activeFiles;
+  metrics.deferred = budgetExhausted ? coverage.backlog : 0;
+  metrics.coveragePct = coverage.coveragePct;
+  return metrics;
+}

--- a/apps/web/lib/managed-file-upload.ts
+++ b/apps/web/lib/managed-file-upload.ts
@@ -1,0 +1,511 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { files } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+import {
+  readPrimaryObject,
+  uploadManagedFile,
+  type StoredObjectWrite,
+} from "@/lib/s3";
+import {
+  checksumSha256Hex,
+  registerFileForReplication,
+} from "@/lib/file-replication";
+import { UPLOAD_FILE_MAX_BYTES } from "@/lib/upload-limits";
+
+export type ManagedUploadCategory = "branding" | "patient-photos" | "consents";
+export type DashboardUploadCategory = Exclude<
+  ManagedUploadCategory,
+  "consents"
+>;
+
+export class ManagedUploadConflictError extends Error {
+  constructor(
+    message = "Idempotency key was already used for a different upload",
+  ) {
+    super(message);
+    this.name = "ManagedUploadConflictError";
+  }
+}
+
+export class ManagedUploadStateError extends ManagedUploadConflictError {
+  constructor(status: string) {
+    super(`Upload reservation is not retryable from state: ${status}`);
+    this.name = "ManagedUploadStateError";
+  }
+}
+
+export interface ManagedUploadReservation {
+  id: string;
+  practiceId: string;
+  uploadedBy: string;
+  idempotencyKey: string;
+  fileName: string;
+  fileKey: string;
+  fileUrl: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  checksumSha256: string;
+  storageStatus: string;
+  category: ManagedUploadCategory;
+  source: string;
+  entityType: string;
+  entityId: string;
+  patientId: string | null;
+  appointmentId: string | null;
+  created: boolean;
+}
+
+export type ManagedUploadReservationInput = {
+  practiceId: string;
+  uploadedBy: string;
+  idempotencyKey: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  checksumSha256: string;
+  category: ManagedUploadCategory;
+  source: string;
+  entityType: "practice" | "patient";
+  entityId: string;
+  patientId?: string | null;
+  appointmentId?: string | null;
+};
+
+const reservationSelection = {
+  id: files.id,
+  practiceId: files.practiceId,
+  uploadedBy: files.uploadedBy,
+  idempotencyKey: files.idempotencyKey,
+  fileName: files.fileName,
+  fileKey: files.fileKey,
+  fileUrl: files.fileUrl,
+  mimeType: files.mimeType,
+  fileSizeBytes: files.fileSizeBytes,
+  checksumSha256: files.checksumSha256,
+  storageStatus: files.storageStatus,
+  category: files.category,
+  source: files.source,
+  entityType: files.entityType,
+  entityId: files.entityId,
+  patientId: files.patientId,
+  appointmentId: files.appointmentId,
+  deletedAt: files.deletedAt,
+};
+
+function toReservation(
+  row: typeof reservationSelection extends Record<string, infer _T>
+    ? Record<keyof typeof reservationSelection, unknown>
+    : never,
+  created: boolean,
+): ManagedUploadReservation {
+  const { deletedAt, ...reservation } = row as Record<
+    keyof typeof reservationSelection,
+    unknown
+  >;
+  if (deletedAt != null) {
+    throw new ManagedUploadStateError("deleted");
+  }
+  return {
+    ...(reservation as Omit<ManagedUploadReservation, "created">),
+    created,
+  };
+}
+
+function reservationMatches(
+  row: ManagedUploadReservation,
+  input: ManagedUploadReservationInput,
+): boolean {
+  return (
+    row.practiceId === input.practiceId &&
+    row.uploadedBy === input.uploadedBy &&
+    row.idempotencyKey === input.idempotencyKey &&
+    row.fileName === input.fileName &&
+    row.mimeType === input.mimeType &&
+    row.fileSizeBytes === input.fileSizeBytes &&
+    row.checksumSha256 === input.checksumSha256 &&
+    row.category === input.category &&
+    row.source === input.source &&
+    row.entityType === input.entityType &&
+    row.entityId === input.entityId &&
+    row.patientId === (input.patientId ?? null) &&
+    row.appointmentId === (input.appointmentId ?? null)
+  );
+}
+
+function reservedObjectLocation(
+  practiceId: string,
+  category: ManagedUploadCategory,
+  objectId: string,
+): { fileKey: string; fileUrl: string } {
+  const fileKey = `${practiceId}/${category}/${objectId}`;
+  return { fileKey, fileUrl: `/api/files/${fileKey}` };
+}
+
+/**
+ * A corrupt deterministic object must never be overwritten or deleted during
+ * a request: either action could destroy the only committed provider result.
+ * Keep the same manifest/idempotency identity but move its next attempt to a
+ * fresh, unreferenced object key. Recovery keys retain the manifest ID prefix
+ * so the old objects remain discoverable for separate operator inspection or
+ * cleanup without a request-time delete.
+ */
+async function rotateCorruptReservation(
+  tx: Database,
+  reservation: ManagedUploadReservation,
+): Promise<ManagedUploadReservation> {
+  const replacement = reservedObjectLocation(
+    reservation.practiceId,
+    reservation.category,
+    `${reservation.id}-${randomUUID()}`,
+  );
+  const [rotated] = await tx
+    .update(files)
+    .set({
+      ...replacement,
+      storageStatus: "pending_upload",
+      storageVerifiedAt: null,
+      objectEtag: null,
+      objectVersionId: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(files.id, reservation.id),
+        eq(files.practiceId, reservation.practiceId),
+        eq(files.idempotencyKey, reservation.idempotencyKey),
+        eq(files.fileKey, reservation.fileKey),
+        eq(files.fileUrl, reservation.fileUrl),
+        eq(files.checksumSha256, reservation.checksumSha256),
+        eq(files.fileSizeBytes, reservation.fileSizeBytes),
+        eq(files.storageStatus, "corrupt"),
+        isNull(files.deletedAt),
+      ),
+    )
+    .returning(reservationSelection);
+  if (!rotated) {
+    throw new Error("Corrupt upload reservation could not be recovered");
+  }
+
+  // This is an existing idempotency reservation. Returning created=false also
+  // forces a read-before-write of the replacement key.
+  return toReservation(rotated as never, false);
+}
+
+/**
+ * Missing and legacy-unverified manifests may safely retry on their existing
+ * deterministic key. The provider helper reads before writing, so any exact
+ * committed bytes converge without an overwrite. Cleanup-pending and unknown
+ * states remain terminal and must never be revived by a client request.
+ */
+async function reopenRetryableReservation(
+  tx: Database,
+  reservation: ManagedUploadReservation,
+): Promise<ManagedUploadReservation> {
+  const [reopened] = await tx
+    .update(files)
+    .set({
+      storageStatus: "pending_upload",
+      storageVerifiedAt: null,
+      objectEtag: null,
+      objectVersionId: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(files.id, reservation.id),
+        eq(files.practiceId, reservation.practiceId),
+        eq(files.idempotencyKey, reservation.idempotencyKey),
+        eq(files.fileKey, reservation.fileKey),
+        eq(files.fileUrl, reservation.fileUrl),
+        eq(files.checksumSha256, reservation.checksumSha256),
+        eq(files.fileSizeBytes, reservation.fileSizeBytes),
+        inArray(files.storageStatus, ["missing", "unverified"]),
+        isNull(files.deletedAt),
+      ),
+    )
+    .returning(reservationSelection);
+  if (!reopened) {
+    throw new ManagedUploadStateError(reservation.storageStatus);
+  }
+  return toReservation(reopened as never, false);
+}
+
+/** Reserve a durable manifest before any provider write. */
+export async function reserveManagedUpload(
+  tx: Database,
+  input: ManagedUploadReservationInput,
+): Promise<ManagedUploadReservation> {
+  const fileId = randomUUID();
+  const { fileKey, fileUrl } = reservedObjectLocation(
+    input.practiceId,
+    input.category,
+    fileId,
+  );
+  const [inserted] = await tx
+    .insert(files)
+    .values({
+      id: fileId,
+      practiceId: input.practiceId,
+      uploadedBy: input.uploadedBy,
+      idempotencyKey: input.idempotencyKey,
+      fileName: input.fileName,
+      fileKey,
+      fileUrl,
+      mimeType: input.mimeType,
+      fileSizeBytes: input.fileSizeBytes,
+      checksumSha256: input.checksumSha256,
+      storageStatus: "pending_upload",
+      category: input.category,
+      source: input.source,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      patientId: input.patientId ?? null,
+      appointmentId: input.appointmentId ?? null,
+    })
+    .onConflictDoNothing()
+    .returning(reservationSelection);
+
+  if (inserted) {
+    return toReservation(inserted as never, true);
+  }
+
+  const [existing] = await tx
+    .select(reservationSelection)
+    .from(files)
+    .where(
+      and(
+        eq(files.practiceId, input.practiceId),
+        eq(files.idempotencyKey, input.idempotencyKey),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  if (!existing) {
+    throw new Error("Upload reservation conflict could not be resolved");
+  }
+
+  const reservation = toReservation(existing as never, false);
+  if (!reservationMatches(reservation, input)) {
+    throw new ManagedUploadConflictError();
+  }
+  if (reservation.storageStatus === "corrupt") {
+    return rotateCorruptReservation(tx, reservation);
+  }
+  if (
+    reservation.storageStatus === "missing" ||
+    reservation.storageStatus === "unverified"
+  ) {
+    return reopenRetryableReservation(tx, reservation);
+  }
+  if (
+    reservation.storageStatus === "pending_upload" ||
+    reservation.storageStatus === "available"
+  ) {
+    return reservation;
+  }
+  throw new ManagedUploadStateError(reservation.storageStatus);
+}
+
+export type ManagedUploadWriteResult =
+  | { status: "verified"; evidence: StoredObjectWrite }
+  | { status: "unavailable" }
+  | { status: "corrupt" };
+
+function exactBytes(
+  body: Uint8Array,
+  expectedChecksum: string,
+  expectedSize: number,
+): boolean {
+  return (
+    body.byteLength === expectedSize &&
+    checksumSha256Hex(body) === expectedChecksum
+  );
+}
+
+/**
+ * Converge an ambiguous PUT by reading the deterministic reserved key. A
+ * provider error never causes immediate deletion because the write may have
+ * committed; the reservation remains retryable instead.
+ */
+export async function putAndVerifyManagedUpload(input: {
+  reservation: ManagedUploadReservation;
+  body: Buffer;
+}): Promise<ManagedUploadWriteResult> {
+  const { reservation, body } = input;
+  if (!reservation.created) {
+    const existing = await readPrimaryObject(reservation.fileKey, {
+      maxBytes: UPLOAD_FILE_MAX_BYTES,
+    });
+    if (existing.status === "available") {
+      return exactBytes(
+        existing.body,
+        reservation.checksumSha256,
+        reservation.fileSizeBytes,
+      )
+        ? {
+            status: "verified",
+            evidence: {
+              url: reservation.fileUrl,
+              ...(existing.etag ? { etag: existing.etag } : {}),
+              ...(existing.versionId ? { versionId: existing.versionId } : {}),
+            },
+          }
+        : { status: "corrupt" };
+    }
+    if (existing.status === "failed") return { status: "unavailable" };
+  }
+
+  let write: StoredObjectWrite | undefined;
+  try {
+    write = await uploadManagedFile(
+      reservation.fileKey,
+      body,
+      reservation.mimeType,
+      reservation.checksumSha256,
+    );
+  } catch {
+    // A timed-out PUT may have committed; the read-back below is authoritative.
+  }
+
+  const verification = await readPrimaryObject(reservation.fileKey, {
+    maxBytes: UPLOAD_FILE_MAX_BYTES,
+    ...(write?.versionId ? { versionId: write.versionId } : {}),
+  });
+  if (verification.status !== "available") {
+    return { status: "unavailable" };
+  }
+  if (
+    !exactBytes(
+      verification.body,
+      reservation.checksumSha256,
+      reservation.fileSizeBytes,
+    )
+  ) {
+    return { status: "corrupt" };
+  }
+
+  return {
+    status: "verified",
+    evidence: {
+      url: write?.url ?? reservation.fileUrl,
+      etag: verification.etag ?? write?.etag,
+      versionId: verification.versionId ?? write?.versionId,
+    },
+  };
+}
+
+export async function finalizeManagedUploadManifest(
+  tx: Database,
+  reservation: ManagedUploadReservation,
+  evidence: StoredObjectWrite,
+): Promise<boolean> {
+  const [updated] = await tx
+    .update(files)
+    .set({
+      storageStatus: "available",
+      storageVerifiedAt: new Date(),
+      objectEtag: evidence.etag ?? null,
+      objectVersionId: evidence.versionId ?? null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(files.id, reservation.id),
+        eq(files.practiceId, reservation.practiceId),
+        eq(files.idempotencyKey, reservation.idempotencyKey),
+        eq(files.fileKey, reservation.fileKey),
+        eq(files.fileUrl, reservation.fileUrl),
+        eq(files.checksumSha256, reservation.checksumSha256),
+        eq(files.fileSizeBytes, reservation.fileSizeBytes),
+        eq(files.storageStatus, "pending_upload"),
+        isNull(files.deletedAt),
+      ),
+    )
+    .returning({ id: files.id });
+  if (updated) return true;
+
+  // An exact concurrent request may already have completed this generation.
+  // Treat that as success without rewriting its provider/version evidence.
+  // A rotated key, changed checksum, or any other state remains a hard miss.
+  const [alreadyAvailable] = await tx
+    .select({ id: files.id })
+    .from(files)
+    .where(
+      and(
+        eq(files.id, reservation.id),
+        eq(files.practiceId, reservation.practiceId),
+        eq(files.idempotencyKey, reservation.idempotencyKey),
+        eq(files.fileKey, reservation.fileKey),
+        eq(files.fileUrl, reservation.fileUrl),
+        eq(files.checksumSha256, reservation.checksumSha256),
+        eq(files.fileSizeBytes, reservation.fileSizeBytes),
+        eq(files.storageStatus, "available"),
+        isNull(files.deletedAt),
+      ),
+    )
+    .limit(1);
+  return Boolean(alreadyAvailable);
+}
+
+export async function markManagedUploadCorrupt(
+  tx: Database,
+  reservation: ManagedUploadReservation,
+): Promise<boolean> {
+  const [updated] = await tx
+    .update(files)
+    .set({
+      storageStatus: "corrupt",
+      storageVerifiedAt: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(files.id, reservation.id),
+        eq(files.practiceId, reservation.practiceId),
+        eq(files.idempotencyKey, reservation.idempotencyKey),
+        eq(files.fileKey, reservation.fileKey),
+        eq(files.fileUrl, reservation.fileUrl),
+        eq(files.checksumSha256, reservation.checksumSha256),
+        eq(files.fileSizeBytes, reservation.fileSizeBytes),
+        eq(files.storageStatus, "pending_upload"),
+        isNull(files.deletedAt),
+      ),
+    )
+    .returning({ id: files.id });
+  if (updated) return true;
+
+  const [alreadyCorrupt] = await tx
+    .select({ id: files.id })
+    .from(files)
+    .where(
+      and(
+        eq(files.id, reservation.id),
+        eq(files.practiceId, reservation.practiceId),
+        eq(files.idempotencyKey, reservation.idempotencyKey),
+        eq(files.fileKey, reservation.fileKey),
+        eq(files.fileUrl, reservation.fileUrl),
+        eq(files.checksumSha256, reservation.checksumSha256),
+        eq(files.fileSizeBytes, reservation.fileSizeBytes),
+        eq(files.storageStatus, "corrupt"),
+        isNull(files.deletedAt),
+      ),
+    )
+    .limit(1);
+  return Boolean(alreadyCorrupt);
+}
+
+export async function queueManagedUploadReplication(
+  reservation: ManagedUploadReservation,
+  evidence: StoredObjectWrite,
+): Promise<boolean> {
+  return registerFileForReplication({
+    practiceId: reservation.practiceId,
+    fileId: reservation.id,
+    fileKey: reservation.fileKey,
+    checksumSha256: reservation.checksumSha256,
+    fileSizeBytes: reservation.fileSizeBytes,
+    objectEtag: evidence.etag,
+    objectVersionId: evidence.versionId,
+  });
+}

--- a/apps/web/lib/managed-upload-attempt.ts
+++ b/apps/web/lib/managed-upload-attempt.ts
@@ -1,0 +1,47 @@
+export interface ManagedUploadAttempt {
+  file: File;
+  idempotencyKey: string;
+}
+
+export type ManagedUploadOutcome =
+  | { kind: "success" }
+  | { kind: "response"; status: number }
+  | { kind: "ambiguous" };
+
+/** Statuses where the server may have committed the upload or asks us to retry. */
+export function isRetryableUploadStatus(status: number): boolean {
+  return (
+    status === 0 ||
+    status === 408 ||
+    status === 425 ||
+    status === 429 ||
+    status >= 500
+  );
+}
+
+/**
+ * A newly selected File gets one operation ID. Explicit retries pass the same
+ * attempt back through this helper and therefore reuse the same ID.
+ */
+export function selectManagedUploadFile(
+  current: ManagedUploadAttempt | null,
+  file: File,
+  createId: () => string = () => globalThis.crypto.randomUUID(),
+): ManagedUploadAttempt {
+  if (current?.file === file) return current;
+  return { file, idempotencyKey: createId() };
+}
+
+/**
+ * Keep the attempt only when retrying is safe and necessary. A success or a
+ * definitive 4xx response ends the operation; ambiguous/network failures and
+ * retryable responses preserve its idempotency key.
+ */
+export function settleManagedUploadAttempt(
+  attempt: ManagedUploadAttempt,
+  outcome: ManagedUploadOutcome,
+): ManagedUploadAttempt | null {
+  if (outcome.kind === "ambiguous") return attempt;
+  if (outcome.kind === "success") return null;
+  return isRetryableUploadStatus(outcome.status) ? attempt : null;
+}

--- a/apps/web/lib/providers.tsx
+++ b/apps/web/lib/providers.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 import superjson from "superjson";
 import { Analytics } from "@vercel/analytics/next";
+import { filterVercelAnalyticsEvent } from "./analytics-privacy";
 import { createAppQueryClient } from "./query-client";
 import { trpc } from "./trpc";
 
@@ -38,7 +39,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           >
             {children}
             <Toaster richColors position="bottom-right" />
-            <Analytics />
+            <Analytics beforeSend={filterVercelAnalyticsEvent} />
           </ThemeProvider>
         </SessionProvider>
       </QueryClientProvider>

--- a/apps/web/lib/records/prescription-expiry.ts
+++ b/apps/web/lib/records/prescription-expiry.ts
@@ -26,6 +26,7 @@ export async function expireDuePrescriptions(database: Database = db) {
         practices,
         and(
           eq(prescriptions.practiceId, practices.id),
+          eq(practices.recoveryHold, false),
           isNull(practices.deletedAt),
         ),
       )

--- a/apps/web/lib/recovery-hold.ts
+++ b/apps/web/lib/recovery-hold.ts
@@ -1,0 +1,51 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { Database } from "@openpims/db/client";
+import { practices } from "@openpims/db";
+
+type RecoveryHoldDb = Pick<Database, "select">;
+
+export const RECOVERY_HOLD_BLOCK_MESSAGE =
+  "This clinic is in protected recovery mode. External delivery and automated changes remain paused until OpenVPM completes recovery reconciliation.";
+
+export async function practiceAllowsExternalSideEffects(
+  database: RecoveryHoldDb,
+  practiceId: string,
+): Promise<boolean> {
+  const [practice] = await database
+    .select({ recoveryHold: practices.recoveryHold })
+    .from(practices)
+    .where(
+      and(eq(practices.id, practiceId), isNull(practices.deletedAt)),
+    )
+    .limit(1);
+
+  return practice?.recoveryHold === false;
+}
+
+/**
+ * Transactional provider gate. The shared practice-row lock means an external
+ * call that follows inside the same transaction cannot overlap the restore's
+ * committed recovery-hold update.
+ */
+export async function lockPracticeForExternalSideEffects(
+  database: RecoveryHoldDb,
+  practiceId: string,
+): Promise<boolean> {
+  const [practice] = await database
+    .select({ recoveryHold: practices.recoveryHold })
+    .from(practices)
+    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+    .limit(1)
+    .for("share", { of: practices });
+
+  return practice?.recoveryHold === false;
+}
+
+export async function assertPracticeAllowsExternalSideEffects(
+  database: RecoveryHoldDb,
+  practiceId: string,
+): Promise<void> {
+  if (!(await practiceAllowsExternalSideEffects(database, practiceId))) {
+    throw new Error(RECOVERY_HOLD_BLOCK_MESSAGE);
+  }
+}

--- a/apps/web/lib/s3.ts
+++ b/apps/web/lib/s3.ts
@@ -7,33 +7,268 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl as awsGetSignedUrl } from "@aws-sdk/s3-request-presigner";
 
+export const FILE_REPLICA_TARGET = "independent-v1";
+
+const REPLICA_ENV_NAMES = [
+  "FILE_REPLICA_ENABLED",
+  "FILE_REPLICA_ALL_PRACTICES",
+  "FILE_REPLICA_PRACTICE_IDS",
+  "FILE_REPLICA_S3_ENDPOINT",
+  "FILE_REPLICA_S3_REGION",
+  "FILE_REPLICA_S3_ACCESS_KEY",
+  "FILE_REPLICA_S3_SECRET_KEY",
+  "FILE_REPLICA_S3_BUCKET",
+] as const;
+
+interface StorageConfig {
+  endpoint?: string;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+}
+
+export interface StoredObjectWrite {
+  url: string;
+  etag?: string;
+  versionId?: string;
+}
+
+/**
+ * S3-compatible providers use the literal `null` version ID when bucket
+ * versioning is unavailable. That value (and blank provider output) cannot
+ * identify an immutable object version and must never be accepted as exact
+ * recovery evidence.
+ */
+export function normalizeS3VersionId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized && normalized.toLowerCase() !== "null"
+    ? normalized
+    : undefined;
+}
+
+export type ObjectReadResult =
+  | {
+      status: "available";
+      body: Uint8Array;
+      contentType?: string;
+      etag?: string;
+      versionId?: string;
+    }
+  | { status: "missing" }
+  | { status: "failed" };
+
 function storageEnv(name: string): string | undefined {
   const trimmed = process.env[name]?.trim();
   return trimmed ? trimmed : undefined;
 }
 
-function bucketName(): string {
-  return storageEnv("S3_BUCKET") ?? "openpims";
-}
-
-function storageEndpoint(): string | undefined {
-  return storageEnv("S3_ENDPOINT");
-}
-
-function publicStorageEndpoint(): string {
-  return storageEndpoint() ?? "https://s3.amazonaws.com";
-}
-
-function s3Client(): S3Client {
-  return new S3Client({
-    endpoint: storageEndpoint(),
+function primaryStorageConfig(): StorageConfig {
+  return {
+    endpoint: storageEnv("S3_ENDPOINT"),
     region: storageEnv("S3_REGION") ?? "us-east-1",
+    accessKeyId: storageEnv("S3_ACCESS_KEY") ?? "",
+    secretAccessKey: storageEnv("S3_SECRET_KEY") ?? "",
+    bucket: storageEnv("S3_BUCKET") ?? "openpims",
+  };
+}
+
+function replicaStorageConfig(): StorageConfig | null {
+  const readiness = replicaStorageReadiness();
+  if (!readiness.ready) return null;
+
+  return {
+    endpoint: storageEnv("FILE_REPLICA_S3_ENDPOINT"),
+    region: storageEnv("FILE_REPLICA_S3_REGION") ?? "us-east-1",
+    accessKeyId: storageEnv("FILE_REPLICA_S3_ACCESS_KEY")!,
+    secretAccessKey: storageEnv("FILE_REPLICA_S3_SECRET_KEY")!,
+    bucket: storageEnv("FILE_REPLICA_S3_BUCKET")!,
+  };
+}
+
+function publicStorageEndpoint(config: StorageConfig): string {
+  return config.endpoint ?? "https://s3.amazonaws.com";
+}
+
+function s3Client(config: StorageConfig): S3Client {
+  return new S3Client({
+    endpoint: config.endpoint,
+    region: config.region,
     credentials: {
-      accessKeyId: storageEnv("S3_ACCESS_KEY") ?? "",
-      secretAccessKey: storageEnv("S3_SECRET_KEY") ?? "",
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
     },
     forcePathStyle: true, // Required for MinIO / S3-compatible stores
   });
+}
+
+function canonicalStorageIdentity(config: StorageConfig): string {
+  const endpoint = (config.endpoint ?? "https://s3.amazonaws.com")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+  return `${endpoint}/${config.bucket.toLowerCase()}`;
+}
+
+function envFlag(name: string): boolean {
+  return /^(1|true|yes|on)$/i.test(process.env[name]?.trim() ?? "");
+}
+
+export function replicaStorageRolloutIntended(): boolean {
+  return (
+    replicaStorageRequired() ||
+    REPLICA_ENV_NAMES.some((name) => storageEnv(name) !== undefined)
+  );
+}
+
+export function replicaStorageRequired(): boolean {
+  return envFlag("FILE_REPLICA_REQUIRED");
+}
+
+export function replicaStorageRolloutEnabled(): boolean {
+  return envFlag("FILE_REPLICA_ENABLED");
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function configuredReplicaPracticeIds(): string[] {
+  return [
+    ...new Set(
+      (process.env.FILE_REPLICA_PRACTICE_IDS ?? "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+/** Null means every active practice; an array is the exact controlled cohort. */
+export function replicaStoragePracticeScope(): string[] | null {
+  return envFlag("FILE_REPLICA_ALL_PRACTICES")
+    ? null
+    : configuredReplicaPracticeIds();
+}
+
+export function replicaStorageIncludesPractice(practiceId: string): boolean {
+  if (!replicaStorageRolloutEnabled()) return false;
+  const scope = replicaStoragePracticeScope();
+  return scope === null || scope.includes(practiceId);
+}
+
+export function replicaStorageReadiness(): {
+  intended: boolean;
+  ready: boolean;
+  detail: string;
+} {
+  const intended = replicaStorageRolloutIntended();
+  const accessKeyId = storageEnv("FILE_REPLICA_S3_ACCESS_KEY");
+  const secretAccessKey = storageEnv("FILE_REPLICA_S3_SECRET_KEY");
+  const bucket = storageEnv("FILE_REPLICA_S3_BUCKET");
+  const missing = [accessKeyId, secretAccessKey, bucket].filter(
+    (value) => !value,
+  ).length;
+
+  if (missing > 0) {
+    return {
+      intended,
+      ready: false,
+      detail: intended
+        ? `${missing} required replica storage value${missing === 1 ? " is" : "s are"} missing`
+        : "Independent object replica is not configured",
+    };
+  }
+
+  const replica: StorageConfig = {
+    endpoint: storageEnv("FILE_REPLICA_S3_ENDPOINT"),
+    region: storageEnv("FILE_REPLICA_S3_REGION") ?? "us-east-1",
+    accessKeyId: accessKeyId!,
+    secretAccessKey: secretAccessKey!,
+    bucket: bucket!,
+  };
+  if (
+    canonicalStorageIdentity(replica) ===
+    canonicalStorageIdentity(primaryStorageConfig())
+  ) {
+    return {
+      intended,
+      ready: false,
+      detail: "Replica storage must use a different endpoint or bucket",
+    };
+  }
+
+  if (replicaStorageRolloutEnabled()) {
+    const allPractices = envFlag("FILE_REPLICA_ALL_PRACTICES");
+    const practiceIds = configuredReplicaPracticeIds();
+    if (allPractices && practiceIds.length > 0) {
+      return {
+        intended,
+        ready: false,
+        detail:
+          "Replica rollout must choose either all practices or an exact cohort",
+      };
+    }
+    if (!allPractices && practiceIds.length === 0) {
+      return {
+        intended,
+        ready: false,
+        detail: "Replica rollout needs an exact practice cohort",
+      };
+    }
+    if (practiceIds.some((id) => !UUID_PATTERN.test(id))) {
+      return {
+        intended,
+        ready: false,
+        detail: "Replica rollout practice cohort is invalid",
+      };
+    }
+  }
+
+  return { intended, ready: true, detail: "Replica storage envs present" };
+}
+
+function objectUrl(config: StorageConfig, key: string): string {
+  return `${publicStorageEndpoint(config)}/${config.bucket}/${key}`;
+}
+
+export const OBJECT_STORAGE_IO_TIMEOUT_MS = 15_000;
+
+async function putObject(
+  config: StorageConfig,
+  key: string,
+  body: Buffer,
+  contentType: string,
+  checksumSha256?: string,
+): Promise<StoredObjectWrite> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    OBJECT_STORAGE_IO_TIMEOUT_MS,
+  );
+
+  try {
+    const result = await s3Client(config).send(
+      new PutObjectCommand({
+        Bucket: config.bucket,
+        Key: key,
+        Body: body,
+        ContentType: contentType,
+        ...(checksumSha256
+          ? { Metadata: { "openvpm-sha256": checksumSha256 } }
+          : {}),
+      }),
+      { abortSignal: controller.signal },
+    );
+
+    const versionId = normalizeS3VersionId(result.VersionId);
+    return {
+      url: objectUrl(config, key),
+      ...(result.ETag ? { etag: result.ETag } : {}),
+      ...(versionId ? { versionId } : {}),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export const OBJECT_STORAGE_HEALTH_TIMEOUT_MS = 5_000;
@@ -51,18 +286,122 @@ export async function uploadFile(
   body: Buffer,
   contentType: string,
 ): Promise<string> {
-  const bucket = bucketName();
-  await s3Client().send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: body,
-      ContentType: contentType,
-    }),
+  return (await putObject(primaryStorageConfig(), key, body, contentType)).url;
+}
+
+/** Upload a primary file object and retain provider integrity evidence. */
+export async function uploadManagedFile(
+  key: string,
+  body: Buffer,
+  contentType: string,
+  checksumSha256: string,
+): Promise<StoredObjectWrite> {
+  return putObject(
+    primaryStorageConfig(),
+    key,
+    body,
+    contentType,
+    checksumSha256,
+  );
+}
+
+/** Write the independently configured replica target. */
+export async function uploadReplicaFile(
+  key: string,
+  body: Buffer,
+  contentType: string,
+  checksumSha256: string,
+): Promise<StoredObjectWrite> {
+  const config = replicaStorageConfig();
+  if (!config) throw new Error("Replica storage is not ready");
+  return putObject(config, key, body, contentType, checksumSha256);
+}
+
+function isMissingObjectError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    name?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return (
+    candidate.$metadata?.httpStatusCode === 404 ||
+    candidate.name === "NoSuchKey" ||
+    candidate.name === "NotFound"
+  );
+}
+
+async function readObject(
+  config: StorageConfig,
+  key: string,
+  options: { maxBytes?: number; versionId?: string } = {},
+): Promise<ObjectReadResult> {
+  const requestedVersionId = normalizeS3VersionId(options.versionId);
+  if (options.versionId !== undefined && !requestedVersionId) {
+    return { status: "failed" };
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    OBJECT_STORAGE_IO_TIMEOUT_MS,
   );
 
-  // Build the URL from the endpoint so it works for both AWS S3 and MinIO
-  return `${publicStorageEndpoint()}/${bucket}/${key}`;
+  try {
+    const res = await s3Client(config).send(
+      new GetObjectCommand({
+        Bucket: config.bucket,
+        Key: key,
+        ...(requestedVersionId ? { VersionId: requestedVersionId } : {}),
+      }),
+      { abortSignal: controller.signal },
+    );
+    const responseVersionId = normalizeS3VersionId(res.VersionId);
+    if (requestedVersionId && responseVersionId !== requestedVersionId) {
+      return { status: "failed" };
+    }
+    if (
+      typeof options.maxBytes === "number" &&
+      typeof res.ContentLength === "number" &&
+      res.ContentLength > options.maxBytes
+    ) {
+      return { status: "failed" };
+    }
+
+    const body = await res.Body?.transformToByteArray();
+    if (!body) return { status: "failed" };
+    if (
+      typeof options.maxBytes === "number" &&
+      body.byteLength > options.maxBytes
+    ) {
+      return { status: "failed" };
+    }
+    return {
+      status: "available",
+      body,
+      ...(res.ContentType ? { contentType: res.ContentType } : {}),
+      ...(res.ETag ? { etag: res.ETag } : {}),
+      ...(responseVersionId ? { versionId: responseVersionId } : {}),
+    };
+  } catch (error) {
+    return { status: isMissingObjectError(error) ? "missing" : "failed" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function readPrimaryObject(
+  key: string,
+  options: { maxBytes?: number; versionId?: string } = {},
+): Promise<ObjectReadResult> {
+  return readObject(primaryStorageConfig(), key, options);
+}
+
+export async function readReplicaObject(
+  key: string,
+  options: { maxBytes?: number; versionId?: string } = {},
+): Promise<ObjectReadResult> {
+  const config = replicaStorageConfig();
+  if (!config) return { status: "failed" };
+  return readObject(config, key, options);
 }
 
 /**
@@ -78,30 +417,10 @@ export async function getObject(
   key: string,
   options: { maxBytes?: number } = {},
 ): Promise<{ body: Uint8Array; contentType?: string } | null> {
-  try {
-    const res = await s3Client().send(
-      new GetObjectCommand({ Bucket: bucketName(), Key: key }),
-    );
-    if (
-      typeof options.maxBytes === "number" &&
-      typeof res.ContentLength === "number" &&
-      res.ContentLength > options.maxBytes
-    ) {
-      return null;
-    }
-
-    const body = await res.Body?.transformToByteArray();
-    if (!body) return null;
-    if (
-      typeof options.maxBytes === "number" &&
-      body.byteLength > options.maxBytes
-    ) {
-      return null;
-    }
-    return { body, contentType: res.ContentType };
-  } catch {
-    return null;
-  }
+  const result = await readPrimaryObject(key, options);
+  return result.status === "available"
+    ? { body: result.body, contentType: result.contentType }
+    : null;
 }
 
 /**
@@ -116,11 +435,13 @@ export async function getSignedUrl(
   expiresIn = 3600,
 ): Promise<string> {
   const command = new GetObjectCommand({
-    Bucket: bucketName(),
+    Bucket: primaryStorageConfig().bucket,
     Key: key,
   });
 
-  return awsGetSignedUrl(s3Client(), command, { expiresIn });
+  return awsGetSignedUrl(s3Client(primaryStorageConfig()), command, {
+    expiresIn,
+  });
 }
 
 /**
@@ -129,12 +450,24 @@ export async function getSignedUrl(
  * @param key Object key to delete
  */
 export async function deleteFile(key: string): Promise<void> {
-  await s3Client().send(
-    new DeleteObjectCommand({
-      Bucket: bucketName(),
-      Key: key,
-    }),
+  const config = primaryStorageConfig();
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    OBJECT_STORAGE_IO_TIMEOUT_MS,
   );
+
+  try {
+    await s3Client(config).send(
+      new DeleteObjectCommand({
+        Bucket: config.bucket,
+        Key: key,
+      }),
+      { abortSignal: controller.signal },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function checkObjectStorageHealth(
@@ -147,9 +480,10 @@ export async function checkObjectStorageHealth(
   );
 
   try {
-    await s3Client().send(
+    const config = primaryStorageConfig();
+    await s3Client(config).send(
       new HeadBucketCommand({
-        Bucket: bucketName(),
+        Bucket: config.bucket,
       }),
       { abortSignal: controller.signal },
     );
@@ -157,6 +491,32 @@ export async function checkObjectStorageHealth(
   } catch (err) {
     void err;
     return { ok: false, detail: "Object storage check failed" };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function checkReplicaStorageHealth(
+  options: { timeoutMs?: number } = {},
+): Promise<{ ok: boolean; detail: string }> {
+  const readiness = replicaStorageReadiness();
+  if (!readiness.ready) return { ok: false, detail: readiness.detail };
+
+  const config = replicaStorageConfig()!;
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    options.timeoutMs ?? OBJECT_STORAGE_HEALTH_TIMEOUT_MS,
+  );
+
+  try {
+    await s3Client(config).send(
+      new HeadBucketCommand({ Bucket: config.bucket }),
+      { abortSignal: controller.signal },
+    );
+    return { ok: true, detail: "Replica object storage reachable" };
+  } catch {
+    return { ok: false, detail: "Replica object storage check failed" };
   } finally {
     clearTimeout(timeout);
   }

--- a/apps/web/lib/sms-dispatch.ts
+++ b/apps/web/lib/sms-dispatch.ts
@@ -38,6 +38,11 @@ import {
   lockSmsDeliveryIdentity,
   processPendingDeliveryEvidenceForAcceptedSend,
 } from "@/lib/messaging/sms-delivery-ledger";
+import {
+  lockPracticeForExternalSideEffects,
+  practiceAllowsExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 export const SMS_COMPLIANCE_FOOTER = "Reply STOP to opt out or HELP for help.";
 export const SMS_MAX_BODY_LENGTH = 1600;
@@ -604,6 +609,23 @@ async function dispatchWinner(
       await tx.execute(
         sql`select pg_advisory_xact_lock(hashtextextended(${`sms-attempt:${attempt.practiceId}:${attempt.id}`}, 0))`,
       );
+      if (
+        !(await lockPracticeForExternalSideEffects(
+          tx as unknown as Database,
+          attempt.practiceId,
+        ))
+      ) {
+        const rejected: SendMessageResult = {
+          status: "definite_failure",
+          error: RECOVERY_HOLD_BLOCK_MESSAGE,
+        };
+        await appendProviderResult(
+          tx as unknown as Database,
+          attempt,
+          rejected,
+        );
+        return rejected;
+      }
       if (hostedExternalSend) {
         const [practice] = await tx
           .select({
@@ -1038,6 +1060,10 @@ async function sendSmsInternal(
     return failure(
       "SMS source and idempotency values must be nonblank and bounded.",
     );
+  }
+
+  if (!(await practiceAllowsExternalSideEffects(db, options.practiceId))) {
+    return failure(RECOVERY_HOLD_BLOCK_MESSAGE);
   }
 
   const hostedExternalSend =

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -11,6 +11,11 @@ import { envFlagEnabled } from "@/lib/env-bool";
 
 export const STRIPE_TAX_ENABLED_ENV = "STRIPE_TAX_ENABLED";
 export const INVOICE_CHECKOUT_CAPTURE_MODE = "manual_v1";
+export const STRIPE_API_VERSION = "2026-07-29.dahlia";
+export const INVOICE_CHECKOUT_INTEGRATION_IDENTIFIER =
+  "openvpm_invoice_jqkzrmnp";
+export const SUBSCRIPTION_CHECKOUT_INTEGRATION_IDENTIFIER =
+  "openvpm_subscription_vhtxcsla";
 
 function stripeIdempotencyKey(
   scope: string,
@@ -26,7 +31,7 @@ function stripeIdempotencyKey(
 
 const configuredStripeSecretKey = stripeSecretKey();
 const stripe = configuredStripeSecretKey
-  ? new Stripe(configuredStripeSecretKey)
+  ? new Stripe(configuredStripeSecretKey, { apiVersion: STRIPE_API_VERSION })
   : null;
 
 export async function createCheckoutSession(data: {
@@ -85,7 +90,11 @@ export async function captureStripeCheckoutAuthorization(data: {
 
   const accountOptions = checkoutAccountOptions(data.connectedAccountId);
   const current = accountOptions
-    ? await stripe.paymentIntents.retrieve(data.paymentIntentId, accountOptions)
+    ? await stripe.paymentIntents.retrieve(
+        data.paymentIntentId,
+        {},
+        accountOptions
+      )
     : await stripe.paymentIntents.retrieve(data.paymentIntentId);
 
   // A transaction may fail after Stripe accepted the capture. On retry, use
@@ -166,7 +175,11 @@ export async function refundInvalidStripeCheckoutPayment(data: {
 
   const accountOptions = checkoutAccountOptions(parsed.connectedAccountId);
   const session = accountOptions
-    ? await stripe.checkout.sessions.retrieve(parsed.sessionId, accountOptions)
+    ? await stripe.checkout.sessions.retrieve(
+        parsed.sessionId,
+        {},
+        accountOptions
+      )
     : await stripe.checkout.sessions.retrieve(parsed.sessionId);
   const paymentIntentId =
     typeof session.payment_intent === "string"
@@ -181,7 +194,11 @@ export async function refundInvalidStripeCheckoutPayment(data: {
     typeof session.payment_intent === "object" && session.payment_intent
       ? session.payment_intent
       : accountOptions
-        ? await stripe.paymentIntents.retrieve(paymentIntentId, accountOptions)
+        ? await stripe.paymentIntents.retrieve(
+            paymentIntentId,
+            {},
+            accountOptions
+          )
         : await stripe.paymentIntents.retrieve(paymentIntentId);
 
   if (paymentIntent.status === "requires_capture") {
@@ -282,7 +299,11 @@ export async function refundStripeCheckoutPayment(data: {
     ? { stripeAccount: parsed.connectedAccountId }
     : undefined;
   const session = accountOptions
-    ? await stripe.checkout.sessions.retrieve(parsed.sessionId, accountOptions)
+    ? await stripe.checkout.sessions.retrieve(
+        parsed.sessionId,
+        {},
+        accountOptions
+      )
     : await stripe.checkout.sessions.retrieve(parsed.sessionId);
   const paymentIntent =
     typeof session.payment_intent === "string"
@@ -345,8 +366,8 @@ export function buildInvoiceCheckoutSessionParams(data: {
   }
 
   return {
-    payment_method_types: ["card"],
     mode: "payment",
+    integration_identifier: INVOICE_CHECKOUT_INTEGRATION_IDENTIFIER,
     customer_email: checkoutCustomerEmail(data.clientEmail),
     client_reference_id: data.invoiceId,
     line_items: [{
@@ -520,6 +541,7 @@ export function buildSubscriptionCheckoutSessionParams(data: {
   const hasTrial = !!trialEnd || !!data.trialPeriodDays;
   return {
     mode: "subscription",
+    integration_identifier: SUBSCRIPTION_CHECKOUT_INTEGRATION_IDENTIFIER,
     // Hosted trials must collect a card up front so Stripe can charge
     // automatically at trial end instead of creating an uncollectible account.
     payment_method_collection: "always",

--- a/apps/web/lib/tenant-db.ts
+++ b/apps/web/lib/tenant-db.ts
@@ -17,11 +17,32 @@ import type { Database } from "@openpims/db/client";
 export async function withTenant<T>(
   db: Database,
   practiceId: string,
-  fn: (tx: Database) => Promise<T>
+  fn: (tx: Database) => Promise<T>,
 ): Promise<T> {
   return db.transaction(async (tx) => {
     await tx.execute(
-      sql`select set_config('app.current_practice_id', ${practiceId}, true)`
+      sql`select set_config('app.current_practice_id', ${practiceId}, true)`,
+    );
+    return fn(tx as unknown as Database);
+  });
+}
+
+/**
+ * Run a multi-query tenant export against one read-only MVCC snapshot. The
+ * transaction characteristics must be the first statement so Postgres applies
+ * them before the tenant GUC and any export reads.
+ */
+export async function withTenantReadOnlySnapshot<T>(
+  db: Database,
+  practiceId: string,
+  fn: (tx: Database) => Promise<T>,
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`set transaction isolation level repeatable read read only`,
+    );
+    await tx.execute(
+      sql`select set_config('app.current_practice_id', ${practiceId}, true)`,
     );
     return fn(tx as unknown as Database);
   });
@@ -34,7 +55,7 @@ export async function withTenant<T>(
  */
 export async function withSystem<T>(
   db: Database,
-  fn: (tx: Database) => Promise<T>
+  fn: (tx: Database) => Promise<T>,
 ): Promise<T> {
   return db.transaction(async (tx) => {
     await tx.execute(sql`select set_config('app.rls_bypass', 'on', true)`);

--- a/apps/web/lib/webhook-dispatcher.ts
+++ b/apps/web/lib/webhook-dispatcher.ts
@@ -1,10 +1,12 @@
 import { createHmac } from "crypto";
 import { eq, and, isNull } from "drizzle-orm";
 import { db } from "@openpims/db/client";
+import type { Database } from "@openpims/db/client";
 import { webhooks } from "@openpims/db";
 import { alertOps } from "@/lib/alerts";
-import { withTenant } from "@/lib/tenant-db";
+import { withSystem } from "@/lib/tenant-db";
 import { isWebhookDeliveryUrl } from "@/lib/webhook-urls";
+import { lockPracticeForExternalSideEffects } from "@/lib/recovery-hold";
 
 export const WEBHOOK_DELIVERY_TIMEOUT_MS = 10_000;
 
@@ -13,11 +15,21 @@ export async function dispatchWebhookEvent(
   event: string,
   payload: Record<string, any>,
 ): Promise<void> {
-  let activeWebhooks;
   try {
-    // Tenant-scoped read (works under RLS regardless of the caller's context).
-    activeWebhooks = await withTenant(db, practiceId, (tx) =>
-      tx
+    await withSystem(db, async (tx) => {
+      // Keep this shared practice-row lock through the full delivery batch.
+      // Recovery's hold update therefore drains already-started deliveries
+      // before it commits and blocks every new delivery after it commits.
+      if (
+        !(await lockPracticeForExternalSideEffects(
+          tx as unknown as Database,
+          practiceId,
+        ))
+      ) {
+        return;
+      }
+
+      const activeWebhooks = await tx
         .select()
         .from(webhooks)
         .where(
@@ -26,82 +38,83 @@ export async function dispatchWebhookEvent(
             eq(webhooks.active, true),
             isNull(webhooks.deletedAt),
           ),
-        ),
-    );
+        );
+
+      // Filter to webhooks that subscribe to this event
+      const matching = activeWebhooks.filter((wh) => {
+        const events = wh.events as string[];
+        return (
+          Array.isArray(events) &&
+          (events.includes("*") || events.includes(event))
+        );
+      });
+
+      if (matching.length === 0) return;
+
+      const body = JSON.stringify({
+        event,
+        timestamp: new Date().toISOString(),
+        data: payload,
+      });
+
+      const requests = matching.map(async (wh) => {
+        try {
+          if (!isWebhookDeliveryUrl(wh.url)) {
+            throw new Error("Invalid webhook delivery URL");
+          }
+
+          const signature = createHmac("sha256", wh.secret)
+            .update(body)
+            .digest("hex");
+
+          const controller = new AbortController();
+          const timeout = setTimeout(
+            () => controller.abort(),
+            WEBHOOK_DELIVERY_TIMEOUT_MS,
+          );
+          try {
+            const res = await fetch(wh.url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-Webhook-Event": event,
+                "X-Webhook-Signature": signature,
+              },
+              body,
+              signal: controller.signal,
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          } finally {
+            clearTimeout(timeout);
+          }
+          return true;
+        } catch (err) {
+          console.error(
+            `[WebhookDispatcher] Failed to deliver ${event} to ${wh.url}:`,
+            err,
+          );
+          return false;
+        }
+      });
+
+      // Deliver in parallel, but let the returned promise represent the
+      // delivery batch and the recovery serialization lock.
+      const results = await Promise.allSettled(requests);
+      const failed = results.filter(
+        (r) => r.status === "rejected" || r.value === false,
+      ).length;
+      if (failed > 0) {
+        await alertOps(
+          "Webhook delivery failed",
+          `${failed} of ${matching.length} '${event}' webhook deliveries failed for practice ${practiceId}.`,
+        );
+      }
+    });
   } catch (err) {
     console.error("[WebhookDispatcher] Failed to query webhooks:", err);
     await alertOps(
       "Webhook dispatch query failed",
-      `Could not load webhook subscriptions for practice ${practiceId} while dispatching '${event}'.`
-    );
-    return;
-  }
-
-  // Filter to webhooks that subscribe to this event
-  const matching = activeWebhooks.filter((wh) => {
-    const events = wh.events as string[];
-    return Array.isArray(events) && (events.includes("*") || events.includes(event));
-  });
-
-  if (matching.length === 0) return;
-
-  const body = JSON.stringify({
-    event,
-    timestamp: new Date().toISOString(),
-    data: payload,
-  });
-
-  const requests = matching.map(async (wh) => {
-    try {
-      if (!isWebhookDeliveryUrl(wh.url)) {
-        throw new Error("Invalid webhook delivery URL");
-      }
-
-      const signature = createHmac("sha256", wh.secret)
-        .update(body)
-        .digest("hex");
-
-      const controller = new AbortController();
-      const timeout = setTimeout(
-        () => controller.abort(),
-        WEBHOOK_DELIVERY_TIMEOUT_MS,
-      );
-      try {
-        const res = await fetch(wh.url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Webhook-Event": event,
-            "X-Webhook-Signature": signature,
-          },
-          body,
-          signal: controller.signal,
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      } finally {
-        clearTimeout(timeout);
-      }
-      return true;
-    } catch (err) {
-      console.error(
-        `[WebhookDispatcher] Failed to deliver ${event} to ${wh.url}:`,
-        err,
-      );
-      return false;
-    }
-  });
-
-  // Deliver in parallel, but let the returned promise represent the delivery
-  // batch. Most callers await this helper after committing a clinical event;
-  // resolving early risks losing work in serverless runtimes.
-  const results = await Promise.allSettled(requests);
-  const failed = results.filter(
-    (r) => r.status === "rejected" || r.value === false
-  ).length;
-  if (failed > 0) {
-    await alertOps(
-      "Webhook delivery failed",
-      `${failed} of ${matching.length} '${event}' webhook deliveries failed for practice ${practiceId}.`
+      `Could not load webhook subscriptions for practice ${practiceId} while dispatching '${event}'.`,
     );
   }
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,5 +1,11 @@
 const { securityHeaders } = require("./lib/security-headers.js");
 
+const capabilityHeaders = [
+  { key: "Referrer-Policy", value: "no-referrer" },
+  { key: "X-Robots-Tag", value: "noindex, nofollow, noarchive" },
+  { key: "Cache-Control", value: "private, no-store, max-age=0" },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
@@ -11,6 +17,10 @@ const nextConfig = {
         source: "/:path*",
         headers: securityHeaders,
       },
+      { source: "/capture/:path*", headers: capabilityHeaders },
+      { source: "/sign/:path*", headers: capabilityHeaders },
+      { source: "/api/capture/:path*", headers: capabilityHeaders },
+      { source: "/api/sign/:path*", headers: capabilityHeaders },
     ];
   },
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "backup:verify-evidence": "node scripts/verify-backup-evidence.mjs",
+    "backup:recover-practice": "tsx scripts/recover-practice.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.86",
@@ -56,7 +58,7 @@
     "recharts": "^2.15.4",
     "resend": "^6.9.4",
     "sonner": "^2.0.7",
-    "stripe": "^20.4.1",
+    "stripe": "^22.5.0",
     "superjson": "^2.2.0",
     "tailwind-merge": "^3.5.0",
     "twilio": "^5.13.0",
@@ -73,6 +75,7 @@
     "postcss": "^8.5.26",
     "tailwindcss": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "tsx": "^4.23.12",
     "typescript": "^5.5.0",
     "vitest": "^3.2.6"
   }

--- a/apps/web/scripts/recover-practice.ts
+++ b/apps/web/scripts/recover-practice.ts
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+
+import { readFileSync, statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { and, eq, isNull, ne, sql } from "drizzle-orm";
+import {
+  appointments,
+  auditLog,
+  clients,
+  files,
+  invoices,
+  patients,
+  practices,
+  users,
+} from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+import {
+  restorePracticeData,
+  summarizePracticeExport,
+  validatePracticeExportRestore,
+} from "../lib/backup/export";
+import { PRACTICE_BACKUP_JSON_MAX_BYTES } from "../lib/backup/policy";
+import { withSystem } from "../lib/tenant-db";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const RELEASE_FLAGS = [
+  "verified-objects",
+  "verified-user-access",
+  "reconciled-messaging",
+  "reconciled-payments",
+  "reviewed-autonomous-jobs",
+] as const;
+
+type ParsedArgs = {
+  command: "restore" | "release";
+  practiceId: string;
+  execute: boolean;
+  confirmation?: string;
+  backupPath?: string;
+  practiceName?: string;
+  timezone: string;
+  releaseFlags: Record<(typeof RELEASE_FLAGS)[number], boolean>;
+};
+
+function flagValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(`--${name}`);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+export function parseRecoveryArgs(args: string[]): ParsedArgs {
+  const command = args[0];
+  if (command !== "restore" && command !== "release") {
+    throw new Error("First argument must be restore or release.");
+  }
+  const practiceId = flagValue(args, "practice-id")?.trim() ?? "";
+  if (!UUID_PATTERN.test(practiceId)) {
+    throw new Error("--practice-id must be a UUID.");
+  }
+
+  const parsed: ParsedArgs = {
+    command,
+    practiceId,
+    execute: args.includes("--execute"),
+    confirmation: flagValue(args, "confirmation"),
+    backupPath: flagValue(args, "backup"),
+    practiceName: flagValue(args, "practice-name")?.trim(),
+    timezone: flagValue(args, "timezone")?.trim() || "America/New_York",
+    releaseFlags: Object.fromEntries(
+      RELEASE_FLAGS.map((flag) => [flag, args.includes(`--${flag}`)]),
+    ) as ParsedArgs["releaseFlags"],
+  };
+
+  if (command === "restore" && (!parsed.backupPath || !parsed.practiceName)) {
+    throw new Error("restore requires --backup and --practice-name.");
+  }
+  if (parsed.execute) {
+    const expected = `${command.toUpperCase()}:${practiceId}`;
+    if (parsed.confirmation !== expected) {
+      throw new Error(`--confirmation must exactly equal ${expected}.`);
+    }
+  }
+  if (
+    command === "release" &&
+    parsed.execute &&
+    RELEASE_FLAGS.some((flag) => !parsed.releaseFlags[flag])
+  ) {
+    throw new Error(
+      `release requires ${RELEASE_FLAGS.map((flag) => `--${flag}`).join(", ")}.`,
+    );
+  }
+  return parsed;
+}
+
+function readBackup(path: string): unknown {
+  const stat = statSync(path);
+  if (!stat.isFile()) throw new Error("Backup path must be a regular file.");
+  if (stat.size > PRACTICE_BACKUP_JSON_MAX_BYTES) {
+    throw new Error("Backup exceeds the supported restore safety limit.");
+  }
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+async function ownerDatabase(): Promise<Database> {
+  const ownerUrl = process.env.OWNER_RECOVERY_DATABASE_URL?.trim();
+  if (!ownerUrl) {
+    throw new Error(
+      "OWNER_RECOVERY_DATABASE_URL is required for an executed owner recovery operation.",
+    );
+  }
+  process.env.DATABASE_URL = ownerUrl;
+  const { db } = await import("@openpims/db/client");
+  return db;
+}
+
+async function assertFreshOrHeldShell(
+  database: Database,
+  input: Pick<ParsedArgs, "practiceId" | "practiceName" | "timezone">,
+): Promise<"created" | "resumed"> {
+  return withSystem(database, async (tx) => {
+    const [existing] = await tx
+      .select({
+        id: practices.id,
+        recoveryHold: practices.recoveryHold,
+        deletedAt: practices.deletedAt,
+      })
+      .from(practices)
+      .where(eq(practices.id, input.practiceId))
+      .limit(1);
+
+    if (existing && (existing.deletedAt || !existing.recoveryHold)) {
+      throw new Error(
+        "Target practice already exists outside protected recovery mode.",
+      );
+    }
+
+    const coreRows = await Promise.all(
+      [clients, patients, appointments, invoices].map((table) =>
+        tx
+          .select({ id: table.id })
+          .from(table)
+          .where(eq(table.practiceId, input.practiceId))
+          .limit(1),
+      ),
+    );
+    if (coreRows.some((rows) => rows.length > 0)) {
+      throw new Error(
+        "Recovery shell is not empty; owner review is required before retrying.",
+      );
+    }
+
+    if (existing) return "resumed";
+
+    const now = new Date();
+    await tx.insert(practices).values({
+      id: input.practiceId,
+      name: input.practiceName!,
+      timezone: input.timezone,
+      settings: {},
+      subscriptionTier: "free",
+      billingStatus: "none",
+      appointmentRemindersEnabled: false,
+      calendarFeedToken: null,
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      recoveryHold: true,
+      recoveryHoldReason: "Owner disaster recovery pending reconciliation",
+      recoveryHoldSetAt: now,
+      recoveryHoldReleasedAt: null,
+    });
+    await tx.insert(auditLog).values({
+      practiceId: input.practiceId,
+      userId: null,
+      action: "hold_set",
+      entityType: "practice_recovery",
+      entityId: input.practiceId,
+      changes: { source: "owner_recovery_cli", state: "held" },
+    });
+    return "created";
+  });
+}
+
+async function restore(database: Database, args: ParsedArgs, backup: unknown) {
+  const shell = await assertFreshOrHeldShell(database, args);
+  const result = await restorePracticeData(database, args.practiceId, backup);
+  await withSystem(database, (tx) =>
+    tx.insert(auditLog).values({
+      practiceId: args.practiceId,
+      userId: null,
+      action: "restore_complete",
+      entityType: "practice_recovery",
+      entityId: args.practiceId,
+      changes: {
+        source: "owner_recovery_cli",
+        state: "held",
+        restoredRows: result.totalRows,
+      },
+    }),
+  );
+  return { shell, ...result };
+}
+
+async function release(database: Database, args: ParsedArgs) {
+  return withSystem(database, async (tx) => {
+    const [practice] = await tx
+      .select({ recoveryHold: practices.recoveryHold })
+      .from(practices)
+      .where(
+        and(eq(practices.id, args.practiceId), isNull(practices.deletedAt)),
+      )
+      .for("update")
+      .limit(1);
+    if (!practice?.recoveryHold) {
+      throw new Error("Practice is missing or is not on recovery hold.");
+    }
+
+    const [unavailableFiles, activeUsers] = await Promise.all([
+      tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(files)
+        .where(
+          and(
+            eq(files.practiceId, args.practiceId),
+            isNull(files.deletedAt),
+            ne(files.storageStatus, "available"),
+          ),
+        ),
+      tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(users)
+        .where(
+          and(eq(users.practiceId, args.practiceId), isNull(users.deletedAt)),
+        ),
+    ]);
+    if ((unavailableFiles[0]?.count ?? 0) > 0) {
+      throw new Error(
+        "Recovery cannot be released while file manifests remain unavailable.",
+      );
+    }
+    if ((activeUsers[0]?.count ?? 0) < 1) {
+      throw new Error(
+        "Recovery cannot be released until at least one user identity is restored.",
+      );
+    }
+
+    const now = new Date();
+    const [updated] = await tx
+      .update(practices)
+      .set({
+        recoveryHold: false,
+        recoveryHoldReleasedAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(practices.id, args.practiceId),
+          eq(practices.recoveryHold, true),
+          isNull(practices.deletedAt),
+        ),
+      )
+      .returning({ id: practices.id });
+    if (!updated) throw new Error("Recovery hold release lost its database lock.");
+
+    await tx.insert(auditLog).values({
+      practiceId: args.practiceId,
+      userId: null,
+      action: "hold_released",
+      entityType: "practice_recovery",
+      entityId: args.practiceId,
+      changes: {
+        source: "owner_recovery_cli",
+        state: "released",
+        checklist: RELEASE_FLAGS,
+      },
+    });
+    return { releasedAt: now.toISOString() };
+  });
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseRecoveryArgs(argv);
+  if (args.command === "restore") {
+    const backup = readBackup(args.backupPath!);
+    const summary = summarizePracticeExport(backup);
+    const validation = validatePracticeExportRestore(backup);
+    const backupPracticeId =
+      backup && typeof backup === "object" && "practiceId" in backup
+        ? (backup as { practiceId?: unknown }).practiceId
+        : undefined;
+    const backupFormatVersion =
+      backup && typeof backup === "object" && "formatVersion" in backup
+        ? (backup as { formatVersion?: unknown }).formatVersion
+        : undefined;
+    if (backupPracticeId !== args.practiceId) {
+      throw new Error("Backup practiceId does not match --practice-id.");
+    }
+    if (!validation.valid || summary.missingSections.length > 0) {
+      throw new Error("Backup failed the application restore contract.");
+    }
+    if (!args.execute) {
+      console.log(
+        JSON.stringify({
+          status: "verified",
+          dryRun: true,
+          operation: "restore",
+          practiceId: args.practiceId,
+          formatVersion: backupFormatVersion,
+          counts: summary.counts,
+          recoveryHold: "will-remain-held",
+        }),
+      );
+      return;
+    }
+    const database = await ownerDatabase();
+    const result = await restore(database, args, backup);
+    console.log(
+      JSON.stringify({
+        status: "restored",
+        dryRun: false,
+        practiceId: args.practiceId,
+        shell: result.shell,
+        restoredRows: result.totalRows,
+        recoveryHold: "held",
+      }),
+    );
+    return;
+  }
+
+  if (!args.execute) {
+    console.log(
+      JSON.stringify({
+        status: "checklist-required",
+        dryRun: true,
+        operation: "release",
+        practiceId: args.practiceId,
+        requiredChecklist: RELEASE_FLAGS,
+      }),
+    );
+    return;
+  }
+  const database = await ownerDatabase();
+  const result = await release(database, args);
+  console.log(
+    JSON.stringify({
+      status: "released",
+      dryRun: false,
+      practiceId: args.practiceId,
+      releasedAt: result.releasedAt,
+    }),
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/apps/web/scripts/verify-backup-evidence.mjs
+++ b/apps/web/scripts/verify-backup-evidence.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { basename } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MAX_CATALOG_BYTES = 1_000_000;
+const MAX_BACKUP_BYTES = 50_000_000;
+const SUPPORTED_EXPORT_FORMAT_VERSION = 6;
+const PRACTICE_EXPORT_SECTIONS = [
+  "locations",
+  "locationMessaging",
+  "smsSuppressions",
+  "smsConsentEvents",
+  "smsDeliveryEvents",
+  "smsDeliveryEventHistory",
+  "smsSendAttempts",
+  "smsSendAttemptEvents",
+  "emailSuppressions",
+  "webhooks",
+  "apiKeys",
+  "users",
+  "auditLog",
+  "appointmentTypes",
+  "rooms",
+  "recurringSeries",
+  "clients",
+  "patients",
+  "patientMergeEvents",
+  "insurancePolicies",
+  "wellnessPlans",
+  "wellnessEnrollments",
+  "patientWeights",
+  "patientAllergies",
+  "appointments",
+  "appointmentWaitlist",
+  "staffSchedules",
+  "services",
+  "products",
+  "treatmentTemplates",
+  "treatmentTemplateItems",
+  "suppliers",
+  "purchaseOrders",
+  "invoices",
+  "invoiceItems",
+  "payments",
+  "invoiceAdjustments",
+  "insuranceClaims",
+  "soapNotes",
+  "soapNoteAddenda",
+  "soapNoteReplacements",
+  "vaccinationRecords",
+  "labResults",
+  "labResultEvents",
+  "procedures",
+  "clinicalNotes",
+  "problemList",
+  "vitalSigns",
+  "clinicalRecordCorrections",
+  "labResultReplacements",
+  "cases",
+  "caseEntries",
+  "treatmentPlans",
+  "treatmentPlanItems",
+  "prescriptions",
+  "prescriptionEvents",
+  "dispenseChargeQueue",
+  "visitCloseouts",
+  "files",
+  "controlledSubstanceLog",
+  "communications",
+];
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function sha256(body) {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requiredExactVersionId(value, label) {
+  const versionId = requiredString(value, label).trim();
+  if (versionId.toLowerCase() === "null") {
+    throw new Error(`${label} must identify a versioned object`);
+  }
+  return versionId;
+}
+
+function readBoundedFile(path, maxBytes, label) {
+  const stat = statSync(path);
+  if (!stat.isFile()) throw new Error(`${label} must be a regular file`);
+  if (stat.size > maxBytes) {
+    throw new Error(`${label} exceeds the ${maxBytes}-byte verification limit`);
+  }
+  return readFileSync(path);
+}
+
+function parseJson(body, label) {
+  try {
+    return JSON.parse(body.toString("utf8"));
+  } catch {
+    throw new Error(`${label} is not valid JSON`);
+  }
+}
+
+function validateCanonicalCounts(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const keys = Object.keys(value);
+  const missing = PRACTICE_EXPORT_SECTIONS.filter(
+    (section) => !Object.hasOwn(value, section),
+  );
+  const unsupported = keys.filter(
+    (section) => !PRACTICE_EXPORT_SECTIONS.includes(section),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `${label} is missing canonical sections: ${missing.join(", ")}`,
+    );
+  }
+  if (unsupported.length > 0) {
+    throw new Error(
+      `${label} contains unsupported sections: ${unsupported.join(", ")}`,
+    );
+  }
+  for (const section of PRACTICE_EXPORT_SECTIONS) {
+    const count = value[section];
+    if (!Number.isSafeInteger(count) || count < 0) {
+      throw new Error(`${label} contains an invalid section count`);
+    }
+  }
+  return value;
+}
+
+function countsMatch(left, right) {
+  const leftEntries = Object.entries(left).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  const rightEntries = Object.entries(right).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return JSON.stringify(leftEntries) === JSON.stringify(rightEntries);
+}
+
+export function verifyBackupEvidence(input) {
+  const catalogBody = readBoundedFile(
+    input.catalogPath,
+    MAX_CATALOG_BYTES,
+    "catalog",
+  );
+  const catalogChecksumSha256 = sha256(catalogBody);
+  const catalog = parseJson(catalogBody, "catalog");
+
+  if (catalog.catalogFormatVersion !== 2) {
+    throw new Error("catalogFormatVersion must be 2");
+  }
+  const practiceId = requiredString(catalog.practiceId, "practiceId");
+  if (!UUID_PATTERN.test(practiceId)) {
+    throw new Error("practiceId must be a UUID");
+  }
+  const backupDate = requiredString(catalog.backupDate, "backupDate");
+  const parsedBackupDate = new Date(`${backupDate}T00:00:00.000Z`);
+  if (
+    !DATE_PATTERN.test(backupDate) ||
+    Number.isNaN(parsedBackupDate.valueOf()) ||
+    parsedBackupDate.toISOString().slice(0, 10) !== backupDate
+  ) {
+    throw new Error("backupDate must use YYYY-MM-DD");
+  }
+  const exportedAt = requiredString(catalog.exportedAt, "exportedAt");
+  const parsedExportedAt = new Date(exportedAt);
+  if (
+    Number.isNaN(parsedExportedAt.valueOf()) ||
+    parsedExportedAt.toISOString() !== exportedAt
+  ) {
+    throw new Error("exportedAt must be an ISO timestamp");
+  }
+  const objectKey = requiredString(catalog.objectKey, "objectKey");
+  const checksumSha256 = requiredString(
+    catalog.checksumSha256,
+    "checksumSha256",
+  );
+  if (!SHA256_PATTERN.test(checksumSha256)) {
+    throw new Error("checksumSha256 must be a lowercase SHA-256 digest");
+  }
+  if (
+    !Number.isSafeInteger(catalog.fileSizeBytes) ||
+    catalog.fileSizeBytes < 0
+  ) {
+    throw new Error("fileSizeBytes must be a non-negative integer");
+  }
+  if (catalog.fileSizeBytes > MAX_BACKUP_BYTES) {
+    throw new Error("cataloged backup exceeds the supported 50 MB restore cap");
+  }
+  if (catalog.exportFormatVersion !== SUPPORTED_EXPORT_FORMAT_VERSION) {
+    throw new Error(
+      `exportFormatVersion must be ${SUPPORTED_EXPORT_FORMAT_VERSION}`,
+    );
+  }
+  const counts = validateCanonicalCounts(catalog.counts, "catalog counts");
+  const objectVersionId = requiredExactVersionId(
+    catalog.objectVersionId,
+    "objectVersionId",
+  );
+  const expectedObjectKey =
+    `database-backups/v2/${practiceId}/${backupDate}/` +
+    `${checksumSha256}.json`;
+  if (objectKey !== expectedObjectKey) {
+    throw new Error(
+      "objectKey does not match its practice, date, and checksum",
+    );
+  }
+
+  const expectedCatalogKey =
+    `database-backup-catalog/v2/${practiceId}/${backupDate}/` +
+    `${catalogChecksumSha256}.json`;
+  if (input.catalogKey !== expectedCatalogKey) {
+    throw new Error("catalog key does not match its content checksum");
+  }
+  if (input.expectedPractice && input.expectedPractice !== practiceId) {
+    throw new Error("catalog practice does not match --expected-practice");
+  }
+  if (input.expectedDate && input.expectedDate !== backupDate) {
+    throw new Error("catalog date does not match --expected-date");
+  }
+
+  const objectBody = readBoundedFile(
+    input.objectPath,
+    MAX_BACKUP_BYTES,
+    "backup object",
+  );
+  if (objectBody.byteLength !== catalog.fileSizeBytes) {
+    throw new Error("backup object byte length does not match the catalog");
+  }
+  if (sha256(objectBody) !== checksumSha256) {
+    throw new Error("backup object checksum does not match the catalog");
+  }
+
+  const backup = parseJson(objectBody, "backup object");
+  if (backup.practiceId !== practiceId) {
+    throw new Error("backup object practiceId does not match the catalog");
+  }
+  if (backup.exportedAt !== exportedAt) {
+    throw new Error("backup object exportedAt does not match the catalog");
+  }
+  if (backup.formatVersion !== catalog.exportFormatVersion) {
+    throw new Error("backup object formatVersion does not match the catalog");
+  }
+  if (backup.formatVersion !== SUPPORTED_EXPORT_FORMAT_VERSION) {
+    throw new Error(
+      `backup object formatVersion must be ${SUPPORTED_EXPORT_FORMAT_VERSION}`,
+    );
+  }
+  const backupCounts = validateCanonicalCounts(backup.counts, "backup counts");
+  if (!countsMatch(counts, backupCounts)) {
+    throw new Error("backup object counts do not match the catalog");
+  }
+  for (const section of PRACTICE_EXPORT_SECTIONS) {
+    if (!Array.isArray(backup[section])) {
+      throw new Error(`backup object section ${section} must be an array`);
+    }
+    if (backup[section].length !== backupCounts[section]) {
+      throw new Error(
+        `backup object count for ${section} does not match its actual rows`,
+      );
+    }
+  }
+
+  return {
+    status: "artifact_integrity_verified",
+    verificationScope: "artifact_integrity_and_canonical_counts",
+    applicationRestoreValidationPerformed: false,
+    restorePerformed: false,
+    practiceId,
+    backupDate,
+    exportedAt,
+    catalogKey: input.catalogKey,
+    catalogChecksumSha256,
+    objectKey,
+    objectVersionId,
+    objectEtag:
+      typeof catalog.objectEtag === "string" && catalog.objectEtag.trim()
+        ? catalog.objectEtag
+        : null,
+    checksumSha256,
+    fileSizeBytes: catalog.fileSizeBytes,
+    exportFormatVersion: catalog.exportFormatVersion,
+    counts,
+    localFiles: {
+      catalog: basename(input.catalogPath),
+      object: basename(input.objectPath),
+    },
+  };
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  pnpm backup:verify-evidence -- --catalog <catalog.json> --catalog-key <s3-key> --object <backup.json> [--expected-practice <uuid>] [--expected-date <YYYY-MM-DD>]",
+    "",
+    "This is an offline artifact-integrity check. It performs no restore, full application restore validation, or network calls.",
+    "Download the catalog by its exact provider version before running it.",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) return { help: true };
+  const allowed = new Set([
+    "--catalog",
+    "--catalog-key",
+    "--object",
+    "--expected-practice",
+    "--expected-date",
+  ]);
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(flag) || !value || value.startsWith("--")) {
+      throw new Error(`invalid argument near ${flag ?? "end of command"}`);
+    }
+    values[flag] = value;
+  }
+  return {
+    catalogPath: requiredString(values["--catalog"], "--catalog"),
+    catalogKey: requiredString(values["--catalog-key"], "--catalog-key"),
+    objectPath: requiredString(values["--object"], "--object"),
+    expectedPractice: values["--expected-practice"],
+    expectedDate: values["--expected-date"],
+  };
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : undefined;
+if (invokedPath === import.meta.url) {
+  try {
+    const input = parseArgs(process.argv.slice(2));
+    if (input.help) {
+      process.stdout.write(`${usage()}\n`);
+    } else {
+      process.stdout.write(
+        `${JSON.stringify(verifyBackupEvidence(input), null, 2)}\n`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Backup evidence verification failed: ${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
   };
   return {
     db,
+    select,
     selectResults,
     selectLimit,
     update,
@@ -55,6 +56,7 @@ const mocks = vi.hoisted(() => {
       (locationId: string) => `OpenVPM provision ${locationId}`,
     ),
     updateMessagingProfileEnabled: vi.fn(),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
     MockTelnyxError,
     withTenant: vi.fn(
       async (
@@ -77,6 +79,11 @@ vi.mock("@/lib/tenant-db", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   recordAuditLog: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   createA2pBrand: mocks.createA2pBrand,
@@ -372,6 +379,23 @@ describe("platform messaging operations", () => {
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
     expect(mocks.withSystem).not.toHaveBeenCalled();
     expect(mocks.createA2pBrand).not.toHaveBeenCalled();
+  });
+
+  it("does not submit fee-bearing provider work while the clinic is held", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+
+    await expect(
+      caller().submitMessagingBrand({
+        practiceId: PRACTICE_ID,
+        confirmProviderCharges: true,
+        retryAfterProviderReview: false,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(mocks.createA2pBrand).not.toHaveBeenCalled();
+    expect(mocks.select).not.toHaveBeenCalled();
   });
 
   it("requires the explicit charge acknowledgement in the validated input", async () => {

--- a/apps/web/server/__tests__/agent-rate-limit.test.ts
+++ b/apps/web/server/__tests__/agent-rate-limit.test.ts
@@ -25,9 +25,17 @@ const mocks = vi.hoisted(() => {
     }
   }
 
+  class AgentRecoveryHoldError extends Error {
+    constructor() {
+      super("Practice recovery is in progress.");
+      this.name = "AgentRecoveryHoldError";
+    }
+  }
+
   return {
     AgentNotConfiguredError,
     AgentPracticeNotFoundError,
+    AgentRecoveryHoldError,
     AgentRateLimitedError,
     runAgent: vi.fn(),
   };
@@ -39,6 +47,7 @@ vi.mock("@/lib/agent", () => ({
   AGENT_TOOL_NAMES: ["find_client"],
   AgentNotConfiguredError: mocks.AgentNotConfiguredError,
   AgentPracticeNotFoundError: mocks.AgentPracticeNotFoundError,
+  AgentRecoveryHoldError: mocks.AgentRecoveryHoldError,
   AgentRateLimitedError: mocks.AgentRateLimitedError,
 }));
 

--- a/apps/web/server/__tests__/billing-card-checkout.test.ts
+++ b/apps/web/server/__tests__/billing-card-checkout.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   createCheckoutSession: vi.fn(async () => ({ url: "https://stripe.example/checkout" })),
   recordAuditLog: vi.fn(async () => undefined),
+  lockPracticeForExternalSideEffects: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/stripe", () => ({
@@ -15,6 +16,12 @@ vi.mock("@/lib/app-url", () => ({
 
 vi.mock("@/lib/audit", () => ({
   recordAuditLog: mocks.recordAuditLog,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { billingRouter } = await import("../routers/billing");
@@ -121,6 +128,18 @@ afterEach(() => {
 });
 
 describe("billing card checkout", () => {
+  it("does not call Stripe checkout while the practice is held", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+    const { db, select } = createDb([]);
+
+    await expect(
+      callerWithDb(db).createCardPaymentCheckout({ invoiceId: INVOICE_ID }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
   it("keeps card checkout limited to billing roles", async () => {
     const { db, select } = createDb([[baseInvoice]]);
 

--- a/apps/web/server/__tests__/billing-refunds.test.ts
+++ b/apps/web/server/__tests__/billing-refunds.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   refundStripeCheckoutPayment: vi.fn(
     async (): Promise<{ refundId: string } | null> => null
   ),
+  lockPracticeForExternalSideEffects: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/audit", () => ({
@@ -30,6 +31,12 @@ vi.mock("@/lib/stripe", () => ({
   createConnectLoginLink: vi.fn(),
   refundStripeCheckoutPayment: mocks.refundStripeCheckoutPayment,
   retrieveConnectAccount: vi.fn(),
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { billingRouter } = await import("../routers/billing");
@@ -135,6 +142,22 @@ afterEach(() => {
 });
 
 describe("billing refunds", () => {
+  it("does not call Stripe or mutate money state while the practice is held", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+    const { db, insertValues, updateSet } = createDb({ selectResults: [] });
+
+    await expect(
+      callerWithDb(db).refundPayment({
+        paymentId: PAYMENT_ID,
+        reason: "Owner cancelled",
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(mocks.refundStripeCheckoutPayment).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
   it("refunds a card payment through Stripe and reopens the invoice", async () => {
     const { db, insertValues, updateSet } = createDb({
       selectResults: [

--- a/apps/web/server/__tests__/communications-send.test.ts
+++ b/apps/web/server/__tests__/communications-send.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   alertOps: vi.fn(async () => undefined),
   durableDb: {} as Record<string, unknown>,
   withDurableSmsCommunication: vi.fn(),
+  lockPracticeForExternalSideEffects: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/email", () => ({
@@ -28,6 +29,12 @@ vi.mock("@/lib/alerts", () => ({
 
 vi.mock("@/lib/messaging/durable-sms-communication", () => ({
   withDurableSmsCommunication: mocks.withDurableSmsCommunication,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const {

--- a/apps/web/server/__tests__/data-export.test.ts
+++ b/apps/web/server/__tests__/data-export.test.ts
@@ -328,9 +328,12 @@ describe("data full backup restore", () => {
     });
 
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(mocks.restorePracticeData).toHaveBeenCalledWith(tx, PRACTICE_ID, {
-      clients: [],
-    });
+    expect(mocks.restorePracticeData).toHaveBeenCalledWith(
+      tx,
+      PRACTICE_ID,
+      { clients: [] },
+      { recoveryHoldDb: expect.anything() },
+    );
     expect(mocks.recordActivationAfterAppointmentCreated).toHaveBeenCalledWith(
       tx,
       PRACTICE_ID,

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => {
     TelnyxNotConfiguredError: MockTelnyxNotConfiguredError,
     usageForPractice: vi.fn(async () => 0),
     currentPeriodMonth: vi.fn(() => "2026-06"),
+    lockPracticeForExternalSideEffects: vi.fn(async () => true),
   };
 });
 
@@ -61,6 +62,12 @@ vi.mock("@/lib/messaging/provisioning-attempt-gate", () => ({
 vi.mock("@/lib/billing/usage", () => ({
   usageForPractice: mocks.usageForPractice,
   currentPeriodMonth: mocks.currentPeriodMonth,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { messagingRouter } = await import("../routers/messaging");
@@ -352,6 +359,19 @@ describe("messaging provisioning kill-switch", () => {
 });
 
 describe("messaging location target safety", () => {
+  it("does not create a provider profile or buy a number while held", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+    const { db } = createDb();
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput()),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(mocks.reserveMessagingProfileAttempt).not.toHaveBeenCalled();
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
   it("keeps automated appointment reminders admin-controlled and constrained", async () => {
     const { db, updateSet } = createDb({
       updateRows: [{ enabled: true, leadHours: 48 }],

--- a/apps/web/server/__tests__/notifications-safety.test.ts
+++ b/apps/web/server/__tests__/notifications-safety.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   alertOps: vi.fn(async () => undefined),
   durableDb: {} as Record<string, unknown>,
   withDurableSmsCommunication: vi.fn(),
+  lockPracticeForExternalSideEffects: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/email", () => ({
@@ -52,6 +53,12 @@ vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
 
 vi.mock("@/lib/messaging/durable-sms-communication", () => ({
   withDurableSmsCommunication: mocks.withDurableSmsCommunication,
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { REMINDER_BATCH_MAX_TARGETS, notificationsRouter } =

--- a/apps/web/server/__tests__/patients-safety.test.ts
+++ b/apps/web/server/__tests__/patients-safety.test.ts
@@ -213,7 +213,7 @@ describe("patients mutation safety", () => {
       callerWithDb(db).update({
         id: PATIENT_ID,
         photoUrl: "p".repeat(513),
-      }),
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -398,7 +398,6 @@ describe("patients mutation safety", () => {
         breed: "   ",
         color: "  Tricolor  ",
         microchipNumber: "  985112003001234  ",
-        photoUrl: "  https://cdn.example.test/biscuit.jpg  ",
       }),
     ).resolves.toMatchObject({ id: PATIENT_ID });
 
@@ -407,7 +406,6 @@ describe("patients mutation safety", () => {
       breed: undefined,
       color: "Tricolor",
       microchipNumber: "985112003001234",
-      photoUrl: "https://cdn.example.test/biscuit.jpg",
     });
   });
 

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -1881,6 +1881,63 @@ describe("consent requests", () => {
     );
   });
 
+  it("blocks unresolved material blanks before minting a consent link", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        patientRow,
+        [
+          {
+            id: FORM_ID,
+            title: "Dental consent",
+            body: "Approved extraction total: $____ (staff: fill in before sending)",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).createConsentRequest({
+        patientId: PATIENT_ID,
+        formId: FORM_ID,
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Fill in every blank"),
+    });
+
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("allows staff to replace every template blank before dispatch", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        patientRow,
+        [
+          {
+            id: FORM_ID,
+            title: "Dental consent",
+            body: "Approved extraction total: $____",
+          },
+        ],
+      ],
+      insertedRows: [{ id: RECORD_ID }],
+    });
+
+    await expect(
+      callerWithDb(db).createConsentRequest({
+        patientId: PATIENT_ID,
+        formId: FORM_ID,
+        bodyText: "I approve dental extractions up to $850.",
+      })
+    ).resolves.toMatchObject({ id: RECORD_ID });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bodyText: "I approve dental extractions up to $850.",
+      })
+    );
+  });
+
   it("rejects dispatch when the form is not in the practice library", async () => {
     const { db, insertValues } = createDb({
       selectResults: [patientRow, []],
@@ -1944,5 +2001,25 @@ describe("consent requests", () => {
     await expect(
       callerWithDb(db).listConsents({ patientId: PATIENT_ID })
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("publishes only available files and fully signed consent artifacts", () => {
+    const source = readFileSync("server/routers/records.ts", "utf8");
+    const captureList = source.slice(
+      source.indexOf("listCaptureFiles:"),
+      source.indexOf("listPatientFiles:"),
+    );
+    const patientFiles = source.slice(
+      source.indexOf("listPatientFiles:"),
+      source.indexOf("listConsentForms:"),
+    );
+    const consentList = source.slice(source.indexOf("listConsents:"));
+
+    expect(captureList).toContain('eq(files.storageStatus, "available")');
+    expect(patientFiles).toContain('eq(files.storageStatus, "available")');
+    expect(patientFiles).toContain('eq(consentRequests.status, "signed")');
+    expect(consentList).toContain(".innerJoin(");
+    expect(consentList).toContain('eq(files.storageStatus, "available")');
+    expect(consentList).toContain('eq(consentRequests.status, "signed")');
   });
 });

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 const mocks = vi.hoisted(() => ({
   createAuthToken: vi.fn(async () => "invite-token"),
   sendStaffInviteEmail: vi.fn(async () => ({ success: true })),
+  lockPracticeForExternalSideEffects: vi.fn(async () => true),
 }));
 
 const SETTINGS_SOURCE = readFileSync(
@@ -31,6 +32,12 @@ vi.mock("@/lib/billing/subscription-sync", () => ({
     locationCount: 1,
     billableSeatCount: 1,
   })),
+}));
+
+vi.mock("@/lib/recovery-hold", () => ({
+  RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
+  lockPracticeForExternalSideEffects:
+    mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { settingsRouter } = await import("../routers/settings");
@@ -447,6 +454,24 @@ describe("settings admin stale target safety", () => {
 
     expect(insertValues).not.toHaveBeenCalled();
     expect(syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
+  });
+
+  it("does not create or deliver a staff invite while the practice is held", async () => {
+    mocks.lockPracticeForExternalSideEffects.mockResolvedValueOnce(false);
+    const { db, insertValues } = createDb({
+      selectResults: [[{ name: "Neighborhood Veterinary" }]],
+    });
+
+    await expect(
+      callerWithDb(db).inviteStaff({
+        email: "held-invite@example.com",
+        role: "front_desk",
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(mocks.createAuthToken).not.toHaveBeenCalled();
+    expect(mocks.sendStaffInviteEmail).not.toHaveBeenCalled();
   });
 
   it("reports provider refusal and safely retries the same pending staff invite", async () => {

--- a/apps/web/server/__tests__/subscription-checkout.test.ts
+++ b/apps/web/server/__tests__/subscription-checkout.test.ts
@@ -75,13 +75,17 @@ function createDb(selectResults: unknown[][]) {
   const results = [...selectResults];
   const select = vi.fn(() => {
     const result = results.shift() ?? [];
-    return {
-      from: () => ({
-        where: () => ({
-          limit: async () => result,
-        }),
-      }),
+    const builder = {
+      from: () => builder,
+      where: () => builder,
+      limit: () => builder,
+      for: async () => result,
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (error: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject),
     };
+    return builder;
   });
 
   return {
@@ -212,6 +216,24 @@ describe("subscription checkout", () => {
     });
     expect(mocks.createSubscriptionCheckoutSession).not.toHaveBeenCalled();
     expect(mocks.countBillableLocationsAndSeats).not.toHaveBeenCalled();
+  });
+
+  it("does not call Stripe checkout or portal providers while held", async () => {
+    vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION", "price_location");
+    const db = createDb([
+      [practice({ recoveryHold: true })],
+      [practice({ stripeCustomerId: "cus_123", recoveryHold: true })],
+    ]);
+    const caller = callerWithDb(db);
+
+    await expect(
+      caller.createCheckout({ tier: "cloud" }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    await expect(caller.openBillingPortal()).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+    });
+    expect(mocks.createSubscriptionCheckoutSession).not.toHaveBeenCalled();
+    expect(mocks.createBillingPortalSession).not.toHaveBeenCalled();
   });
 
   it("rejects billing reads and actions when the practice is missing or deleted", async () => {

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -90,6 +90,10 @@ import {
   type MessagingRegistrationEventActor,
   type MessagingRegistrationReasonCode,
 } from "@/lib/messaging/registration-events";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 /**
  * Platform-operator only. Crosses tenant boundaries deliberately, so it is
@@ -104,6 +108,21 @@ const platformAdminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
   }
   return next();
 });
+
+async function withMessagingProviderEffectsAllowed<T>(
+  practiceId: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  return withSystem(db, async (tx) => {
+    if (!(await lockPracticeForExternalSideEffects(tx, practiceId))) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: RECOVERY_HOLD_BLOCK_MESSAGE,
+      });
+    }
+    return action();
+  });
+}
 
 const MESSAGING_SUBMISSION_LOCK_STALE_MS = 15 * 60 * 1000;
 const MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
@@ -1472,6 +1491,7 @@ export const adminRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      return withMessagingProviderEffectsAllowed(input.practiceId, async () => {
       const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const sender = await messagingSenderForOperator(
         input.practiceId,
@@ -1601,6 +1621,7 @@ export const adminRouter = createRouter({
         if (error instanceof TRPCError) throw error;
         throw providerFailure(error);
       }
+      });
     }),
 
   /** Fee-bearing TCR brand creation; platform operator only and explicitly confirmed. */
@@ -1614,6 +1635,7 @@ export const adminRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      return withMessagingProviderEffectsAllowed(input.practiceId, async () => {
       const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const registration = await registrationForOperator(input.practiceId);
       if (registration.providerBrandId) {
@@ -1680,6 +1702,7 @@ export const adminRouter = createRouter({
         });
         throw providerFailure(error);
       }
+      });
     }),
 
   /** Fee-bearing campaign submission with reference-id recovery before POST. */
@@ -1693,6 +1716,7 @@ export const adminRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      return withMessagingProviderEffectsAllowed(input.practiceId, async () => {
       const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const registration = await registrationForOperator(input.practiceId);
       if (!registration.providerBrandId) {
@@ -1884,6 +1908,7 @@ export const adminRouter = createRouter({
         });
         throw providerFailure(error);
       }
+      });
     }),
 
   /** Idempotent number-to-campaign assignment; never enables sending. */
@@ -1896,6 +1921,7 @@ export const adminRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       assertMessagingProviderMutationsEnabled();
+      return withMessagingProviderEffectsAllowed(input.practiceId, async () => {
       const actor = platformMessagingRegistrationActor(ctx.session!.user);
       const registration = await registrationForOperator(input.practiceId);
       if (!registration.providerCampaignId || !registration.providerBrandId) {
@@ -2040,6 +2066,7 @@ export const adminRouter = createRouter({
         });
         throw providerFailure(error);
       }
+      });
     }),
 
   smsDeliveryEventQueue: platformAdminProcedure

--- a/apps/web/server/routers/agent.ts
+++ b/apps/web/server/routers/agent.ts
@@ -16,6 +16,7 @@ import {
   AgentNotConfiguredError,
   AgentPracticeNotFoundError,
   AgentRateLimitedError,
+  AgentRecoveryHoldError,
 } from "@/lib/agent";
 import { AGENT_INSTRUCTION_MAX_LENGTH } from "@/lib/agent/policy";
 import { billingEnforced } from "@/lib/billing/plans";
@@ -105,6 +106,12 @@ export const agentRouter = createRouter({
         }
         if (e instanceof AgentRateLimitedError) {
           throw new TRPCError({ code: "TOO_MANY_REQUESTS", message: e.message });
+        }
+        if (e instanceof AgentRecoveryHoldError) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: e.message,
+          });
         }
         if (e instanceof AgentPracticeNotFoundError) {
           throw practiceNotFound();

--- a/apps/web/server/routers/ai.ts
+++ b/apps/web/server/routers/ai.ts
@@ -30,6 +30,10 @@ import {
 import { rateLimit } from "@/lib/rate-limit";
 import { recordUsage } from "@/lib/billing/usage";
 import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
+import {
   dateInputUtcRangeForTimeZone,
   formatDateInputForTimeZone,
 } from "@/lib/date-input";
@@ -396,6 +400,15 @@ export const aiRouter = createRouter({
 
       if (!patient) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Patient not found" });
+      }
+
+      if (
+        !(await lockPracticeForExternalSideEffects(ctx.db, ctx.practiceId))
+      ) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: RECOVERY_HOLD_BLOCK_MESSAGE,
+        });
       }
 
       try {

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -64,6 +64,10 @@ import {
   BILLING_SERVICE_NAME_MAX_LENGTH,
 } from "@/lib/billing/policy";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 import { POSTGRES_INTEGER_MAX } from "./storage-bounds";
 import type { Database } from "@openpims/db/client";
 import {
@@ -414,6 +418,16 @@ async function assertActivePractice(ctx: BillingContext) {
     .where(activePracticeWhere(ctx.practiceId))
     .limit(1);
   if (!practice) throw practiceNotFound();
+}
+
+async function assertBillingProviderActionsAllowed(ctx: BillingContext) {
+  if (await lockPracticeForExternalSideEffects(ctx.db as Database, ctx.practiceId)) {
+    return;
+  }
+  throw new TRPCError({
+    code: "PRECONDITION_FAILED",
+    message: RECOVERY_HOLD_BLOCK_MESSAGE,
+  });
 }
 
 async function throwServiceMutationMiss(
@@ -1671,6 +1685,7 @@ export const billingRouter = createRouter({
       if (!practice) {
         throw practiceNotFound();
       }
+      await assertBillingProviderActionsAllowed(ctx);
 
       try {
         const existing = await getStripeConnectPaymentAccount(ctx);
@@ -1720,6 +1735,7 @@ export const billingRouter = createRouter({
   refreshPaymentAccount: protectedProcedure
     .use(requireRole("admin"))
     .mutation(async ({ ctx }) => {
+      await assertBillingProviderActionsAllowed(ctx);
       if (!stripeConfigured()) {
         throw new TRPCError({
           code: "SERVICE_UNAVAILABLE",
@@ -1764,6 +1780,7 @@ export const billingRouter = createRouter({
   openPaymentAccountDashboard: protectedProcedure
     .use(requireRole("admin"))
     .mutation(async ({ ctx }) => {
+      await assertBillingProviderActionsAllowed(ctx);
       const existing = await getStripeConnectPaymentAccount(ctx);
       if (!existing) {
         throw new TRPCError({
@@ -3371,6 +3388,7 @@ export const billingRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      await assertBillingProviderActionsAllowed(ctx);
       const [payment] = await ctx.db
         .select({
           id: payments.id,
@@ -3698,6 +3716,7 @@ export const billingRouter = createRouter({
     .use(requireRole("admin", "front_desk"))
     .input(z.object({ invoiceId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
+      await assertBillingProviderActionsAllowed(ctx);
       const [invoice] = await ctx.db
         .select({
           id: invoices.id,

--- a/apps/web/server/routers/communications.ts
+++ b/apps/web/server/routers/communications.ts
@@ -29,6 +29,10 @@ import {
   COMMUNICATION_SUBJECT_MAX_LENGTH,
   SMS_COMMUNICATION_CONTENT_MAX_LENGTH,
 } from "@/lib/communications/policy";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 export {
   COMMUNICATION_CONTENT_MAX_LENGTH,
@@ -759,6 +763,20 @@ export const communicationsRouter = createRouter({
       const isDeliverableOutbound =
         input.direction === "outbound" &&
         (input.channel === "sms" || input.channel === "email");
+
+      if (isDeliverableOutbound) {
+        if (
+          !(await lockPracticeForExternalSideEffects(
+            ctx.db,
+            ctx.practiceId,
+          ))
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: RECOVERY_HOLD_BLOCK_MESSAGE,
+          });
+        }
+      }
 
       const [client] = await ctx.db
         .select({

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -14,7 +14,7 @@ import {
   vaccinationRecords,
   soapNotes,
 } from "@openpims/db";
-import type { Database } from "@openpims/db/client";
+import { db as rootDb, type Database } from "@openpims/db/client";
 import {
   type ClientImportRecord,
   type PatientImportRecord,
@@ -2405,6 +2405,7 @@ export const dataRouter = createRouter({
         ctx.db,
         ctx.practiceId,
         input.backup,
+        { recoveryHoldDb: rootDb },
       );
       await recordActivationAfterAppointmentCreated(
         ctx.db,

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -56,6 +56,10 @@ import {
   clinicMessagingRegistrationActor,
   recordMessagingRegistrationEvent,
 } from "@/lib/messaging/registration-events";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 const adminOnly = protectedProcedure.use(requireRole("admin"));
 const MESSAGING_NUMBER_ORDERED_DETAIL =
@@ -1020,6 +1024,14 @@ export const messagingRouter = createRouter({
       assertProvisioningEnabled();
       assertProvisioningPracticeAllowed(ctx.practiceId);
       await assertActivePractice(ctx);
+      if (
+        !(await lockPracticeForExternalSideEffects(ctx.db, ctx.practiceId))
+      ) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: RECOVERY_HOLD_BLOCK_MESSAGE,
+        });
+      }
 
       const webhookUrl = telnyxWebhookUrl();
       const profileName = provisioningProfileName(input.locationId);
@@ -1510,6 +1522,14 @@ export const messagingRouter = createRouter({
       }
 
       if (input.enabled) {
+        if (
+          !(await lockPracticeForExternalSideEffects(ctx.db, ctx.practiceId))
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: RECOVERY_HOLD_BLOCK_MESSAGE,
+          });
+        }
         assertHostedSendingAllowed(ctx.practiceId, input.locationId);
         if (billingEnforced()) {
           await ctx.db.execute(

--- a/apps/web/server/routers/notifications.ts
+++ b/apps/web/server/routers/notifications.ts
@@ -53,6 +53,10 @@ import {
   invoiceBalanceCents,
   moneyToCents,
 } from "@/lib/billing/invoice-balance";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 
 const DEFAULT_PRACTICE_NAME = "your clinic";
 
@@ -164,6 +168,18 @@ async function assertActivePractice(ctx: {
   }
 }
 
+async function assertNotificationsEnabled(ctx: {
+  db: NotificationsDb;
+  practiceId: string;
+}) {
+  if (!(await lockPracticeForExternalSideEffects(ctx.db, ctx.practiceId))) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: RECOVERY_HOLD_BLOCK_MESSAGE,
+    });
+  }
+}
+
 async function practiceNotificationSettings(ctx: {
   db: NotificationsDb;
   practiceId: string;
@@ -250,6 +266,7 @@ export const notificationsRouter = createRouter({
     .input(z.object({ appointmentId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
+      await assertNotificationsEnabled(ctx);
       const [appt] = await ctx.db
         .select({
           id: appointments.id,
@@ -553,6 +570,7 @@ export const notificationsRouter = createRouter({
     .input(z.object({ invoiceId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
+      await assertNotificationsEnabled(ctx);
       const [invoice] = await ctx.db
         .select({
           id: invoices.id,
@@ -782,6 +800,7 @@ export const notificationsRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
+      await assertNotificationsEnabled(ctx);
       if (input.appointmentIds.length === 0) return { sent: 0, failed: 0 };
       const appointmentIds = [...new Set(input.appointmentIds)];
 
@@ -1194,6 +1213,7 @@ export const notificationsRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
+      await assertNotificationsEnabled(ctx);
       const result = await sendVaccinationRecallReminders(
         ctx,
         input.patientIds,

--- a/apps/web/server/routers/patients.ts
+++ b/apps/web/server/routers/patients.ts
@@ -66,7 +66,6 @@ import {
   PATIENT_COLOR_MAX_LENGTH,
   PATIENT_MICROCHIP_NUMBER_MAX_LENGTH,
   PATIENT_NAME_MAX_LENGTH,
-  PATIENT_PHOTO_URL_MAX_LENGTH,
   PATIENT_SEARCH_MAX_LENGTH,
 } from "@/lib/patients/policy";
 import { listOffsetInput } from "./pagination";
@@ -97,7 +96,7 @@ const mergeMovableAppointmentStatuses = ["scheduled", "confirmed"] as const;
 const PATIENT_MERGE_REASON_MIN_LENGTH = 5;
 const PATIENT_MERGE_REASON_MAX_LENGTH = 500;
 const patientManagerProcedure = protectedProcedure.use(
-  requireRole("admin", "veterinarian", "technician", "front_desk")
+  requireRole("admin", "veterinarian", "technician", "front_desk"),
 );
 const patientDobInput = clinicalDateInput("Date of birth").optional();
 const patientDobUpdateInput = clinicalDateInput("Date of birth")
@@ -110,11 +109,11 @@ const patientSearchInput = z
   .optional();
 const patientSearchQueryInput = clinicalTextInput(
   "Search query",
-  PATIENT_SEARCH_MAX_LENGTH
+  PATIENT_SEARCH_MAX_LENGTH,
 );
 const patientNameInput = clinicalTextInput(
   "Patient name",
-  PATIENT_NAME_MAX_LENGTH
+  PATIENT_NAME_MAX_LENGTH,
 );
 const optionalPatientString = (label: string, maxLength: number) =>
   z
@@ -132,7 +131,7 @@ const patientMutableInput = {
   color: optionalPatientString("Color", PATIENT_COLOR_MAX_LENGTH),
   microchipNumber: optionalPatientString(
     "Microchip number",
-    PATIENT_MICROCHIP_NUMBER_MAX_LENGTH
+    PATIENT_MICROCHIP_NUMBER_MAX_LENGTH,
   ),
 };
 const patientWeightInput = z
@@ -356,7 +355,9 @@ function mergeReasons(counts: MergeBlockerCounts): string[] {
     reasons.push("The source patient was already merged.");
   }
   if (counts.targetWasPreviouslyMerged) {
-    reasons.push("The target patient is itself an alias; choose its canonical target.");
+    reasons.push(
+      "The target patient is itself an alias; choose its canonical target.",
+    );
   }
   if (counts.appointmentHistory) {
     reasons.push(
@@ -649,7 +650,7 @@ async function assertActivePractice(ctx: PatientsContext) {
 async function assertClientBelongsToPractice(
   db: Database,
   practiceId: string,
-  clientId: string
+  clientId: string,
 ) {
   const [client] = await db
     .select({ id: clients.id })
@@ -659,8 +660,8 @@ async function assertClientBelongsToPractice(
         eq(clients.id, clientId),
         eq(clients.practiceId, practiceId),
         activePracticePredicate(practiceId),
-        isNull(clients.deletedAt)
-      )
+        isNull(clients.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -672,7 +673,7 @@ async function assertClientBelongsToPractice(
 async function assertPatientBelongsToPractice(
   db: Database,
   practiceId: string,
-  patientId: string
+  patientId: string,
 ) {
   const [patient] = await db
     .select({ id: patients.id })
@@ -682,8 +683,8 @@ async function assertPatientBelongsToPractice(
         eq(patients.id, patientId),
         eq(patients.practiceId, practiceId),
         activePracticePredicate(practiceId),
-        isNull(patients.deletedAt)
-      )
+        isNull(patients.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -798,7 +799,7 @@ export const patientsRouter = createRouter({
         status: patientStatusInput.optional(),
         limit: z.number().int().min(1).max(100).default(25),
         offset: listOffsetInput,
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const conditions: ReturnType<typeof eq>[] = [
@@ -811,8 +812,8 @@ export const patientsRouter = createRouter({
         conditions.push(
           or(
             ilike(patients.name, `%${input.search}%`),
-            ilike(patients.breed, `%${input.search}%`)
-          )!
+            ilike(patients.breed, `%${input.search}%`),
+          )!,
         );
       }
       if (input.species) {
@@ -844,8 +845,8 @@ export const patientsRouter = createRouter({
             and(
               eq(patients.clientId, clients.id),
               eq(clients.practiceId, ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .where(and(...conditions))
           .orderBy(desc(patients.createdAt))
@@ -868,7 +869,7 @@ export const patientsRouter = createRouter({
       z.object({
         query: patientSearchQueryInput,
         status: patientStatusInput.optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const conditions = [
@@ -877,7 +878,7 @@ export const patientsRouter = createRouter({
         isNull(patients.deletedAt),
         or(
           ilike(patients.name, `%${input.query}%`),
-          ilike(patients.breed, `%${input.query}%`)
+          ilike(patients.breed, `%${input.query}%`),
         )!,
       ];
       if (input.status) {
@@ -898,8 +899,8 @@ export const patientsRouter = createRouter({
           and(
             eq(patients.clientId, clients.id),
             eq(clients.practiceId, ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .where(and(...conditions))
         .limit(10);
@@ -914,7 +915,10 @@ export const patientsRouter = createRouter({
         input.id,
       );
       if (!resolved) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Patient not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Patient not found",
+        });
       }
       const { patient, mergeMetadata } = resolved;
 
@@ -933,8 +937,8 @@ export const patientsRouter = createRouter({
                   and ${patients.deletedAt} is null
               )`,
               activePracticePredicate(ctx.practiceId),
-              isNull(patientWeights.deletedAt)
-            )
+              isNull(patientWeights.deletedAt),
+            ),
           )
           .orderBy(desc(patientWeights.recordedAt)),
         ctx.db
@@ -976,8 +980,8 @@ export const patientsRouter = createRouter({
                   and ${patients.practiceId} = ${ctx.practiceId}
                   and ${patients.deletedAt} is null
               )`,
-              activePracticePredicate(ctx.practiceId)
-            )
+              activePracticePredicate(ctx.practiceId),
+            ),
           )
           .orderBy(desc(patientAllergies.notedAt), desc(patientAllergies.id)),
       ]);
@@ -1002,11 +1006,15 @@ export const patientsRouter = createRouter({
       z.object({
         clientId: z.string().uuid(),
         ...patientMutableInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
-      await assertClientBelongsToPractice(ctx.db, ctx.practiceId, input.clientId);
+      await assertClientBelongsToPractice(
+        ctx.db,
+        ctx.practiceId,
+        input.clientId,
+      );
       const [patient] = await ctx.db
         .insert(patients)
         .values({ ...input, practiceId: ctx.practiceId })
@@ -1026,21 +1034,19 @@ export const patientsRouter = createRouter({
 
   update: patientManagerProcedure
     .input(
-      z.object({
-        id: z.string().uuid(),
-        name: patientMutableInput.name.optional(),
-        species: patientMutableInput.species.optional(),
-        breed: patientMutableInput.breed,
-        sex: patientMutableInput.sex,
-        dob: patientDobUpdateInput,
-        color: patientMutableInput.color,
-        microchipNumber: patientMutableInput.microchipNumber,
-        status: patientStatusInput.optional(),
-        photoUrl: optionalPatientString(
-          "Photo URL",
-          PATIENT_PHOTO_URL_MAX_LENGTH
-        ),
-      })
+      z
+        .object({
+          id: z.string().uuid(),
+          name: patientMutableInput.name.optional(),
+          species: patientMutableInput.species.optional(),
+          breed: patientMutableInput.breed,
+          sex: patientMutableInput.sex,
+          dob: patientDobUpdateInput,
+          color: patientMutableInput.color,
+          microchipNumber: patientMutableInput.microchipNumber,
+          status: patientStatusInput.optional(),
+        })
+        .strict(),
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
@@ -1052,12 +1058,15 @@ export const patientsRouter = createRouter({
             eq(patients.id, id),
             eq(patients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .returning();
       if (!patient) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Patient not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Patient not found",
+        });
       }
       return patient;
     }),
@@ -1075,13 +1084,16 @@ export const patientsRouter = createRouter({
               eq(patients.id, input.id),
               eq(patients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(patients.deletedAt)
-            )
+              isNull(patients.deletedAt),
+            ),
           )
           .limit(1);
 
         if (!existingPatient) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Patient not found" });
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Patient not found",
+          });
         }
 
         const [activeAppointment] = await tx
@@ -1093,8 +1105,8 @@ export const patientsRouter = createRouter({
               eq(appointments.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               isNull(appointments.deletedAt),
-              inArray(appointments.status, activeAppointmentStatuses)
-            )
+              inArray(appointments.status, activeAppointmentStatuses),
+            ),
           )
           .limit(1);
 
@@ -1115,8 +1127,8 @@ export const patientsRouter = createRouter({
               eq(appointmentWaitlist.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               eq(appointmentWaitlist.status, "waiting"),
-              isNull(appointmentWaitlist.deletedAt)
-            )
+              isNull(appointmentWaitlist.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -1158,12 +1170,15 @@ export const patientsRouter = createRouter({
               eq(patients.id, input.id),
               eq(patients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(patients.deletedAt)
-            )
+              isNull(patients.deletedAt),
+            ),
           )
           .returning({ id: patients.id });
         if (!patient) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Patient not found" });
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Patient not found",
+          });
         }
       });
       return { success: true };
@@ -1174,10 +1189,14 @@ export const patientsRouter = createRouter({
       z.object({
         patientId: z.string().uuid(),
         weightKg: patientWeightInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
-      await assertPatientBelongsToPractice(ctx.db, ctx.practiceId, input.patientId);
+      await assertPatientBelongsToPractice(
+        ctx.db,
+        ctx.practiceId,
+        input.patientId,
+      );
       const [weight] = await ctx.db
         .insert(patientWeights)
         .values({
@@ -1192,7 +1211,11 @@ export const patientsRouter = createRouter({
   addAllergy: patientManagerProcedure
     .input(patientAllergyInput)
     .mutation(async ({ ctx, input }) => {
-      await assertPatientBelongsToPractice(ctx.db, ctx.practiceId, input.patientId);
+      await assertPatientBelongsToPractice(
+        ctx.db,
+        ctx.practiceId,
+        input.patientId,
+      );
       const [allergy] = await ctx.db
         .insert(patientAllergies)
         .values({
@@ -1214,7 +1237,7 @@ export const patientsRouter = createRouter({
           .trim()
           .min(CLINICAL_CORRECTION_REASON_MIN_LENGTH)
           .max(CLINICAL_CORRECTION_REASON_MAX_LENGTH),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) =>
       ctx.db.transaction(async (tx) => {
@@ -1412,10 +1435,7 @@ export const patientsRouter = createRouter({
           .where(
             and(
               eq(appointmentWaitlist.patientId, input.mergeId),
-              eq(
-                appointmentWaitlist.clientId,
-                analysis.keepPatient.clientId,
-              ),
+              eq(appointmentWaitlist.clientId, analysis.keepPatient.clientId),
               eq(appointmentWaitlist.practiceId, ctx.practiceId),
               eq(appointmentWaitlist.status, "waiting"),
               isNull(appointmentWaitlist.deletedAt),
@@ -1492,7 +1512,8 @@ export const patientsRouter = createRouter({
         if (!retiredSource) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "The source patient changed during merge. Preview and retry.",
+            message:
+              "The source patient changed during merge. Preview and retry.",
           });
         }
 
@@ -1604,7 +1625,11 @@ export const patientsRouter = createRouter({
             isNull(duplicatePatient.deletedAt),
           ),
         )
-        .orderBy(asc(clients.lastName), asc(clients.firstName), asc(patients.name))
+        .orderBy(
+          asc(clients.lastName),
+          asc(clients.firstName),
+          asc(patients.name),
+        )
         .limit(200);
 
       type DuplicatePatient = {
@@ -1674,7 +1699,8 @@ export const patientsRouter = createRouter({
         clientFirstName: group.clientFirstName,
         clientLastName: group.clientLastName,
         patients: group.patients.map(
-          ({ hasImmutableHistory: _hasImmutableHistory, ...patient }) => patient,
+          ({ hasImmutableHistory: _hasImmutableHistory, ...patient }) =>
+            patient,
         ),
         blockerSummary: {
           patientsWithImmutableHistory: group.patients.filter(
@@ -1683,5 +1709,4 @@ export const patientsRouter = createRouter({
         },
       }));
     }),
-
 });

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -99,9 +99,13 @@ import {
 import {
   CONSENT_BODY_MAX_LENGTH,
   CONSENT_TITLE_MAX_LENGTH,
+  hasUnresolvedConsentPlaceholders,
 } from "@/lib/consult/consent-template";
 import { CONSENT_FORM_LIBRARY } from "@/lib/consult/consent-form-library";
-import { PATIENT_PHOTO_CATEGORY } from "@/lib/records/file-kinds";
+import {
+  CONSENT_FILE_CATEGORY,
+  PATIENT_PHOTO_CATEGORY,
+} from "@/lib/records/file-kinds";
 import { appBaseUrl } from "@/lib/app-url";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
 import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
@@ -3749,6 +3753,7 @@ export const recordsRouter = createRouter({
             eq(files.entityId, input.patientId),
             eq(files.category, PATIENT_PHOTO_CATEGORY),
             like(files.mimeType, "image/%"),
+            eq(files.storageStatus, "available"),
             activePracticePredicate(ctx.practiceId),
             isNull(files.deletedAt)
           )
@@ -3758,10 +3763,10 @@ export const recordsRouter = createRouter({
     }),
 
   /**
-   * Everything attached to a patient (photos, signed consents, documents),
-   * newest first, for the patient Documents tab. Optionally narrowed to one
-   * visit for the per-appointment documents view. Signed consents join back
-   * to their request so the UI can say what was signed and by whom.
+   * Every integrity-verified attachment for a patient (photos, signed
+   * consents, documents), newest first, for the patient Documents tab.
+   * Optionally narrowed to one visit for the per-appointment documents view.
+   * Consent artifacts are published only once their request is fully signed.
    */
   listPatientFiles: protectedProcedure
     .input(
@@ -3798,6 +3803,8 @@ export const recordsRouter = createRouter({
           consentRequests,
           and(
             eq(consentRequests.fileId, files.id),
+            eq(consentRequests.practiceId, ctx.practiceId),
+            eq(consentRequests.status, "signed"),
             isNull(consentRequests.deletedAt)
           )
         )
@@ -3809,6 +3816,12 @@ export const recordsRouter = createRouter({
             input.appointmentId
               ? eq(files.appointmentId, input.appointmentId)
               : undefined,
+            eq(files.storageStatus, "available"),
+            or(
+              isNull(files.category),
+              ne(files.category, CONSENT_FILE_CATEGORY),
+              eq(consentRequests.status, "signed")
+            ),
             activePracticePredicate(ctx.practiceId),
             isNull(files.deletedAt)
           )
@@ -3906,6 +3919,18 @@ export const recordsRouter = createRouter({
           message: "Consent form not found",
         });
       }
+      const title = input.title ?? form.title;
+      const bodyText = input.bodyText ?? form.body;
+      if (
+        hasUnresolvedConsentPlaceholders(title) ||
+        hasUnresolvedConsentPlaceholders(bodyText)
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Fill in every blank and resolve each staff instruction before making the consent code.",
+        });
+      }
       const appointmentId = input.appointmentId
         ? (
             await assertAppointmentBelongsToPatient(
@@ -3927,8 +3952,8 @@ export const recordsRouter = createRouter({
           formId: form.id,
           token,
           expiresAt,
-          title: input.title ?? form.title,
-          bodyText: input.bodyText ?? form.body,
+          title,
+          bodyText,
         })
         .returning({ id: consentRequests.id });
       return {
@@ -3940,7 +3965,7 @@ export const recordsRouter = createRouter({
       };
     }),
 
-  /** Consent requests for a patient, newest first (tokens never leave here). */
+  /** Available signed consents for a patient, newest first. */
   listConsents: protectedProcedure
     .input(z.object({ patientId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
@@ -3958,14 +3983,22 @@ export const recordsRouter = createRouter({
           fileUrl: files.fileUrl,
         })
         .from(consentRequests)
-        .leftJoin(
+        .innerJoin(
           files,
-          and(eq(files.id, consentRequests.fileId), isNull(files.deletedAt))
+          and(
+            eq(files.id, consentRequests.fileId),
+            eq(files.practiceId, ctx.practiceId),
+            eq(files.patientId, input.patientId),
+            eq(files.category, CONSENT_FILE_CATEGORY),
+            eq(files.storageStatus, "available"),
+            isNull(files.deletedAt)
+          )
         )
         .where(
           and(
             eq(consentRequests.practiceId, ctx.practiceId),
             eq(consentRequests.patientId, input.patientId),
+            eq(consentRequests.status, "signed"),
             activePracticePredicate(ctx.practiceId),
             isNull(consentRequests.deletedAt)
           )

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -69,6 +69,10 @@ import {
 import { sendStaffInviteEmail } from "@/lib/email";
 import { appBaseUrl, exposeAuthLinksForPreview } from "@/lib/app-url";
 import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
+import {
   ONBOARDING_INTENTS,
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
@@ -683,36 +687,40 @@ export const settingsRouter = createRouter({
 
   updatePractice: adminProcedure
     .input(
-      z.object({
-        name: practiceNameInput.optional(),
-        address: addressInput,
-        phone: phoneInput,
-        email: optionalEmailInput,
-        website: optionalTrimmedString("Website", SETTINGS_WEBSITE_MAX_LENGTH),
-        timezone: timezoneInput.optional(),
-        // Region/locale (Phase 2). country is ISO 3166-1 alpha-2; currency is
-        // ISO 4217 lowercase; taxRatePercent is a percent string e.g. "20.00".
-        country: countryInput.optional(),
-        currency: currencyInput.optional(),
-        taxRatePercent: z
-          .string()
-          .trim()
-          .refine(
-            isValidSettingsTaxRate,
-            "Tax rate must be between 0 and 100 with at most two decimals",
-          )
-          .optional(),
-        vatNumber: optionalTrimmedString(
-          "VAT number",
-          SETTINGS_VAT_NUMBER_MAX_LENGTH,
-        ),
-        // Branding. logoUrl is a real column; brandColor lives in settings.
-        logoUrl: optionalTrimmedString("Logo URL", 512),
-        brandColor: z
-          .string()
-          .regex(/^#[0-9a-fA-F]{6}$/)
-          .optional(),
-      }),
+      z
+        .object({
+          name: practiceNameInput.optional(),
+          address: addressInput,
+          phone: phoneInput,
+          email: optionalEmailInput,
+          website: optionalTrimmedString(
+            "Website",
+            SETTINGS_WEBSITE_MAX_LENGTH,
+          ),
+          timezone: timezoneInput.optional(),
+          // Region/locale (Phase 2). country is ISO 3166-1 alpha-2; currency is
+          // ISO 4217 lowercase; taxRatePercent is a percent string e.g. "20.00".
+          country: countryInput.optional(),
+          currency: currencyInput.optional(),
+          taxRatePercent: z
+            .string()
+            .trim()
+            .refine(
+              isValidSettingsTaxRate,
+              "Tax rate must be between 0 and 100 with at most two decimals",
+            )
+            .optional(),
+          vatNumber: optionalTrimmedString(
+            "VAT number",
+            SETTINGS_VAT_NUMBER_MAX_LENGTH,
+          ),
+          // Logo bytes and the logoUrl link are managed atomically by /api/upload.
+          brandColor: z
+            .string()
+            .regex(/^#[0-9a-fA-F]{6}$/)
+            .optional(),
+        })
+        .strict(),
     )
     .mutation(async ({ ctx, input }) =>
       ctx.db.transaction(async (tx) => {
@@ -2152,6 +2160,14 @@ export const settingsRouter = createRouter({
 
       if (!practice) {
         throw practiceNotFound();
+      }
+      if (
+        !(await lockPracticeForExternalSideEffects(ctx.db, ctx.practiceId))
+      ) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: RECOVERY_HOLD_BLOCK_MESSAGE,
+        });
       }
 
       // The user identity and invite token are one atomic unit. The email lock

--- a/apps/web/server/routers/subscription.ts
+++ b/apps/web/server/routers/subscription.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/billing/subscription-sync";
 import { appBaseUrl } from "@/lib/app-url";
 import { billingContactEmail } from "@/lib/billing/contact";
+import { RECOVERY_HOLD_BLOCK_MESSAGE } from "@/lib/recovery-hold";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
 
@@ -152,13 +153,21 @@ export const subscriptionRouter = createRouter({
           email: practices.email,
           billingStatus: practices.billingStatus,
           trialEndsAt: practices.trialEndsAt,
+          recoveryHold: practices.recoveryHold,
         })
         .from(practices)
         .where(activePracticeWhere(ctx.practiceId))
-        .limit(1);
+        .limit(1)
+        .for("share", { of: practices });
 
       if (!practice) {
         throw practiceNotFound();
+      }
+      if (practice.recoveryHold) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: RECOVERY_HOLD_BLOCK_MESSAGE,
+        });
       }
 
       // A completed Checkout already owns the subscription lifecycle. Starting
@@ -224,13 +233,23 @@ export const subscriptionRouter = createRouter({
   /** Open the Stripe Billing Portal to manage/cancel an existing subscription. */
   openBillingPortal: adminProcedure.mutation(async ({ ctx }) => {
     const [practice] = await ctx.db
-      .select({ stripeCustomerId: practices.stripeCustomerId })
+      .select({
+        stripeCustomerId: practices.stripeCustomerId,
+        recoveryHold: practices.recoveryHold,
+      })
       .from(practices)
       .where(activePracticeWhere(ctx.practiceId))
-      .limit(1);
+      .limit(1)
+      .for("share", { of: practices });
 
     if (!practice) {
       throw practiceNotFound();
+    }
+    if (practice.recoveryHold) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: RECOVERY_HOLD_BLOCK_MESSAGE,
+      });
     }
 
     if (!practice.stripeCustomerId) {

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -15,6 +15,10 @@
       "schedule": "0 3 * * *"
     },
     {
+      "path": "/api/cron/file-replicas",
+      "schedule": "*/5 * * * *"
+    },
+    {
       "path": "/api/cron/usage-reconcile",
       "schedule": "15 * * * *"
     },

--- a/docs/backup-restore-runbook.md
+++ b/docs/backup-restore-runbook.md
@@ -2,12 +2,17 @@
 
 OpenVPM Cloud takes a structured database backup of every practice every day.
 This runbook covers what is in those JSON backups, how to restore one, and the
-drill log for the database path. Attachment-binary disaster recovery remains a
-separate launch gate until the independent replica and restore drill pass.
+drill log for the database path. Attachment-binary disaster recovery is defined
+in [File and Object Recovery Runbook](file-object-recovery-runbook.md) and
+remains a launch gate until its independent target, backfill, and destructive
+drill pass.
 
 ## What gets backed up
 
 - **When:** daily at 3:00 AM UTC (`/api/cron/backup`, see `apps/web/vercel.json`).
+- **Database snapshot:** each practice export runs in its own read-only
+  `REPEATABLE READ` transaction so every section and canonical count describes
+  one consistent point-in-time view.
 - **Where:** object storage, one file per practice per day:
   `backups/{practiceId}/{YYYY-MM-DD}.json` (date in the practice's timezone).
 - **What:** every practice-owned table, active rows only. That includes the
@@ -19,6 +24,10 @@ separate launch gate until the independent replica and restore drill pass.
   (invoices, items, payments, adjustments, claims), inventory, staff, and the
   audit log. The canonical section list is `PRACTICE_EXPORT_SECTIONS` in
   `apps/web/lib/backup/export.ts`.
+- **Recovery identity:** format v6 includes a sanitized top-level `practice`
+  snapshot for a reviewed database-owner bootstrap. It preserves the original
+  practice UUID and safe clinic settings, but excludes Stripe IDs, provider
+  authority, calendar tokens, secrets, and paid status.
 - **What is left out on purpose:** billing meter records, Stripe state,
   rate-limit buckets, sessions, and expiring tokens
   (`PRACTICE_EXPORT_SYSTEM_EXCLUSIONS` documents each reason). The `practices`
@@ -38,13 +47,68 @@ separate launch gate until the independent replica and restore drill pass.
   tokens are cleared, API keys are disabled, webhook secrets are replaced and
   webhooks arrive deactivated.
 - **File binaries are not in the JSON.** The `files` section holds attachment
-  manifests only. A same-practice database recovery can reuse surviving
-  objects. A fresh-practice restore with file manifests is currently rejected
-  before writing because its source-practice keys would be unusable; portable
-  object staging and key rewriting must ship before that path is supported.
+  manifests only. Format v6 includes a sanitized top-level `practice` recovery
+  snapshot and the manifests include checksum, byte size, patient/visit links,
+  and document metadata. Provider ETags/version IDs, replica projections, and
+  storage transition events remain outside clinic JSON. A same-practice
+  database recovery can reuse surviving objects or independently retained
+  copies. A fresh-practice restore with file manifests is rejected because its
+  source-practice keys would be unusable.
+- **Independent evidence:** when the controlled replica rollout includes the
+  practice, the cron also writes a checksum-addressed JSON object beneath
+  `database-backups/v2/{practiceId}/{YYYY-MM-DD}/` and a checksum-addressed
+  catalog beneath `database-backup-catalog/v2/...`. Both are read back and
+  checksum-verified before the independent copy is counted successful. The
+  catalog records the exact provider version ID of the backup object. The
+  export is rejected before upload if it exceeds the same 50 MB restore cap.
+  Backup heartbeat metrics distinguish `oversized` exports from
+  `otherFailed`, count exports at or above 80% of the cap as `nearLimit`, and
+  report `maxExportBytes` against `backupMaxBytes` for capacity planning.
 
 Admins can also download the identical payload on demand:
 **Settings → Data → Export Database Backup**.
+
+## Owner artifact-integrity verification (offline)
+
+Before a restore or disaster drill, a database/storage owner can verify a
+downloaded independent backup and its catalog without connecting this tool to
+storage or writing any application state. Work in a temporary directory
+outside the repository; never commit clinic backup JSON.
+
+1. Select one checksum-addressed catalog key beneath
+   `database-backup-catalog/v2/{practiceId}/{YYYY-MM-DD}/`. Download that
+   catalog by an explicit provider version when the storage provider exposes
+   versioning.
+2. Read `objectKey` and `objectVersionId` from the catalog, then download that
+   exact backup object version. Do not substitute the current/latest object.
+3. Run the local verifier from `apps/web`:
+
+   ```sh
+   pnpm backup:verify-evidence -- \
+     --catalog /tmp/openvpm-recovery/catalog.json \
+     --catalog-key 'database-backup-catalog/v2/PRACTICE_ID/YYYY-MM-DD/CATALOG_SHA256.json' \
+     --object /tmp/openvpm-recovery/backup.json \
+     --expected-practice 'PRACTICE_ID' \
+     --expected-date 'YYYY-MM-DD'
+   ```
+
+The command is intentionally read-only and offline. It bounds both local
+files, verifies the catalog's content-addressed key, requires the catalog's
+exact backup-object version ID, checks the backup bytes/size/checksum, and
+requires the one supported canonical export format and its complete section
+counts to equal the actual section-array lengths. Its JSON output inventories
+only recovery evidence and counts; it does not print clinical rows. A
+successful result has `status: "artifact_integrity_verified"`,
+`verificationScope: "artifact_integrity_and_canonical_counts"`,
+`applicationRestoreValidationPerformed: false`, and
+`restorePerformed: false`.
+
+Stop on any verifier error. Do not edit either JSON file to make it pass, do
+not restore an unverified object, and do not weaken the 50 MB bound. This
+artifact-integrity check proves the downloaded artifacts agree and that their
+canonical counts match their arrays. It does not run the application's full
+row/cross-reference restore validator and does not replace the transactional
+application dry run or the repeatable restore drill below.
 
 ## Restore runbook (clinic data recovery)
 
@@ -106,9 +170,32 @@ a complete recovery source for that incident.
      delivery ledgers are visible in the source export for audit but are not
      replayed by clinic restore.
 
-The restore is transactional and additive: it validates sections and
-cross-references first, inserts everything in one transaction, and skips rows
-that already exist. Backups up to 50 MB of JSON are accepted.
+The restore is additive and fail-closed. It first performs size, section,
+cross-reference, and file-target validation without writing. Its first database
+mutation then places the active target practice on a recovery hold and commits
+that hold independently. Only after other transactions holding an in-flight
+provider lock have drained does the bulk insert transaction begin. A bulk
+insert failure rolls back restored rows but deliberately leaves the committed
+hold active for owner review; it must never silently reopen the clinic. Rows
+that already exist are skipped. The hold remains active until the owner
+reconciliation procedure explicitly releases it. Backups up to 50 MB of JSON
+are accepted.
+
+While held, clinic email/SMS/webhook delivery, AI model calls, Stripe checkout,
+capture, refund, metering and subscription-quantity mutations, and Telnyx
+profile/number/A2P mutations are blocked. These paths take a shared lock on the
+practice row through the provider call; recovery's hold update therefore waits
+for a provider operation that already started, and no provider operation can
+start after the hold commits. Local usage evidence and authenticated inbound
+Stripe facts remain durable for later reconciliation.
+
+Intentional exceptions are narrow: password-reset and verification email stay
+available so authorized staff can recover access; read-only provider searches
+and operator reconciliation reads may inspect authoritative state but may not
+mutate it; backup creation and owner-controlled object replication/recovery
+remain available because they preserve or repair recovery evidence. Disabling
+a sender is safe, but enabling clinic delivery remains blocked until the hold is
+released.
 
 For a same-install database disaster, restore the database snapshot/WAL under
 the database-owner procedure. That trusted owner-maintenance path preserves the
@@ -175,8 +262,11 @@ UI, printing phase timings at the end.
   restore. Documented above (step 4); a clearer in-product hint on the
   restore error is a candidate follow-up.
 - **Known gap:** no in-product way to list or download the stored daily
-  snapshots; retrieval is a manual S3 pull (step 2). Candidate follow-up.
-- **Launch-blocking gap:** file binaries currently exist only in primary
-  object storage. Object-storage loss is not covered by the JSON backups, and
-  file-bearing fresh-practice restore is intentionally fail-closed. Track the
-  independent-copy rollout and destructive primary-loss drill in OPENVPM-41.
+  snapshots; retrieval is still a manual, owner-authorized object-store pull.
+  The local owner verifier now validates the selected checksum/version
+  evidence before restore, but does not perform discovery or download.
+- **Launch-blocking gap at drill time:** file binaries existed only in primary
+  object storage. The independent-copy implementation now has a separate
+  activation gate; it is not operationally complete until provider setup,
+  backfill, and the combined-loss drill in the file/object runbook pass. Track
+  that evidence in OPENVPM-41.

--- a/docs/file-object-recovery-runbook.md
+++ b/docs/file-object-recovery-runbook.md
@@ -1,0 +1,215 @@
+# File and Object Recovery Runbook
+
+This runbook covers OpenVPM attachment and per-practice database-backup
+recovery across an independent object-storage failure domain. The feature is
+not considered operational until every item in **Activation gate** has passed.
+
+## Recovery boundary
+
+The primary store remains the normal read/write path. Clinic uploads commit
+once to primary storage and the database; they do not wait on a second
+provider. A scheduled worker then:
+
+1. finds every active file without a fresh independent copy;
+2. leases work with `FOR UPDATE SKIP LOCKED` so concurrent jobs do not race;
+3. reads and verifies the primary object against its SHA-256/size manifest;
+4. writes a content-addressed replica under
+   `attachments/v1/{practiceId}/{fileId}/{sha256}`;
+5. reads the replica back and verifies its bytes;
+6. writes the checksum-addressed catalog evidence at
+   `recovery-catalog/v2/{practiceId}/{fileId}/{catalogSha256}.json`; and
+7. records the transition in the append-only `file_storage_events` ledger.
+
+The daily per-practice JSON backup is also copied and read-back verified at
+`database-backups/v2/{practiceId}/{YYYY-MM-DD}/{backupSha256}.json`, with an
+independently versioned checksum-addressed catalog. Backup format v6 contains a
+sanitized clinic identity/configuration snapshot plus portable file manifests.
+It excludes storage-provider ETags/version IDs, replica projections, Stripe
+provider IDs, messaging dispatch authority, and capability tokens.
+
+## Independent target requirements
+
+The replica must not share the primary store's account, bucket, credentials,
+deletion authority, or operational blast radius. Before adding any hosted env:
+
+- block all public access and require encryption at rest and TLS;
+- enable versioning;
+- enable immutable retention/Object Lock in governance or compliance mode;
+- give the runtime only list, read, and create/overwrite permissions for its
+  prefixes—no object/version delete and no bucket-policy administration;
+- retain attachment and recovery-catalog objects for the life of the active
+  clinic record; do not attach an expiry rule to those prefixes;
+- retain daily database backups for at least 35 days, with longer retention
+  chosen against the clinic record-retention policy;
+- store break-glass recovery credentials outside Vercel and outside the
+  primary provider account; and
+- configure billing/spend alerts and provider health notifications.
+
+The runtime verifies reachability but cannot prove account independence,
+versioning, immutability, or IAM deletion denial. Record those provider-console
+checks in the drill evidence.
+
+## Hosted configuration
+
+Do not set a partial storage configuration. Setting any replica value makes
+hosted readiness fail until the complete target is valid. A complete target
+can be staged with execution disabled and will perform no replica writes.
+
+```env
+FILE_REPLICA_REQUIRED=true
+FILE_REPLICA_ENABLED=false
+FILE_REPLICA_ALL_PRACTICES=false
+FILE_REPLICA_PRACTICE_IDS=<confirmed-pilot-practice-uuid>
+FILE_REPLICA_S3_ENDPOINT=... # omit only for AWS S3
+FILE_REPLICA_S3_REGION=...
+FILE_REPLICA_S3_ACCESS_KEY=...
+FILE_REPLICA_S3_SECRET_KEY=...
+FILE_REPLICA_S3_BUCKET=...
+CRON_HEARTBEAT_FILE_REPLICAS_URL=...
+```
+
+The target must resolve to a different endpoint/bucket identity from the
+primary. After staging the configuration:
+
+1. run the count-only
+   `packages/db/preflight/0077_file_recovery.sql` query against production and
+   demo and retain the output in the release evidence. Every blocking count
+   must be zero; `patient_id_backfills` and
+   `appointment_patient_id_backfills` are informational counts that migration
+   0077 repairs deterministically;
+2. deploy migrations 0077-0080 as a migration-only release with replica
+   execution disabled; these add existing-table constraints `NOT VALID`, so
+   new writes are protected without a full-table validation lock;
+3. verify migrations, RLS, indexes, and constraint presence in both databases;
+4. rerun the preflight, verify the informational backfill counts have fallen to
+   zero, and validate the staged constraints in a later reviewed migration;
+5. only then deploy the application worker code;
+6. require `/api/health` to report the replica check healthy;
+7. keep `FILE_REPLICA_ENABLED=false` and confirm the cron reports staged but
+   performs no database or object-provider writes;
+8. set `FILE_REPLICA_ENABLED=true` for one explicitly confirmed practice UUID;
+9. manually invoke the authenticated `/api/cron/file-replicas` route;
+10. confirm the cohort backlog falls to zero and fresh coverage reaches 100%;
+11. complete the isolated drill before widening the UUID cohort; and
+12. use `FILE_REPLICA_ALL_PRACTICES=true` only after rollout approval, with
+    `FILE_REPLICA_PRACTICE_IDS` empty.
+
+## Normal operations and alert thresholds
+
+The worker runs every five minutes. A copy is counted available only when its
+checksum/size evidence is present and its verification is less than 24 hours
+old. Expected steady state:
+
+- fresh coverage: 100%;
+- backlog: zero, except briefly after uploads;
+- source missing/corrupt: zero;
+- failed attempts: zero or self-clearing on the next retry; and
+- heartbeat delay: less than 15 minutes.
+
+Page the operator when a run reports a missing/corrupt source, verified
+coverage remains below 100% for 30 minutes, the backlog grows for three runs,
+or the heartbeat is late. Provider errors use bounded retries and preserve
+prior verified evidence; a definitive missing or checksum mismatch downgrades
+the affected copy.
+
+## Recovery procedures
+
+### Primary object missing, database healthy
+
+The reconciliation worker verifies the independent object, restores the exact
+primary key, reads it back, updates the primary manifest, and alerts operations.
+The same-origin file proxy may serve a checksum-verified replica while the
+primary is unavailable; it never serves an unverified or corrupt copy.
+
+After an automatic repair, verify the file through the clinic UI and confirm a
+`primary_restored_from_replica` storage event exists. Do not delete the replica.
+
+### Database healthy, primary provider unavailable
+
+Leave the primary configuration unchanged while provider status is uncertain.
+Verified replica reads keep clinic files available through the app. Pause any
+manual migration that could create competing object keys. Recover or replace
+the primary provider, then let reconciliation restore missing objects and
+verify coverage.
+
+### Database and primary object store lost
+
+1. Isolate a new database and apply the full migration and RLS chain.
+2. List the latest
+   `database-backup-catalog/v2/{practiceId}/{YYYY-MM-DD}/...json` entry on the
+   independent target. Verify the catalog bytes, then fetch its immutable,
+   checksum-addressed `database-backups/v2/...` object and verify checksum,
+   byte size, ETag/version evidence, and the embedded export timestamp.
+3. Use the backup's top-level `practice` snapshot to recreate the original
+   practice ID through a reviewed database-owner recovery procedure. Never
+   replay Stripe IDs, paid status, calendar tokens, API credentials, webhook
+   secrets, or messaging provider authority without external reconciliation.
+4. Restore the clinic JSON into that same practice ID using the existing dry
+   run and transactional restore path.
+5. Configure an empty replacement primary bucket and the independent target.
+6. Run reconciliation. It materializes replica projections from file manifests
+   and restores each checksum-verified object to its original primary key.
+7. Verify database row counts, one attachment in every category, one signed
+   consent, one patient photo/document, one clinic logo, billing state against
+   Stripe, and messaging state against the provider.
+
+The database-owner practice-shell procedure and combined-loss drill must be
+completed before this scenario is declared supported. Do not improvise IDs or
+weaken foreign keys/RLS during an incident.
+
+## Destructive drill
+
+Run only with synthetic data and isolated primary/replica buckets.
+
+1. Create a scratch clinic with a logo, patient photo, document, lab file, and
+   signed consent; record SHA-256 and byte size for each.
+2. Run the backup and replica workers to 100% fresh coverage.
+3. Deny or remove access to the scratch primary bucket.
+4. Verify every file still reads through the app from the replica.
+5. Restore a scratch database from the independent database JSON using the
+   original synthetic practice ID.
+6. Point the scratch environment at a new empty primary bucket and run the
+   worker until every object is restored and verified.
+7. Compare all bytes/checksums and clinical row counts, then exercise the
+   object-version recovery path.
+8. Prove the runtime credential cannot delete either current objects or
+   retained versions.
+
+Pass criteria: no lost bytes or rows, 100% fresh replica coverage, primary
+reconstruction completes without hand-editing manifests, app reads remain
+tenant-authorized, all expected alerts/heartbeats arrive, and actual RTO/RPO
+are recorded. Keep the drill log free of clinic PII and credentials.
+
+## Activation gate
+
+The replica is launch-ready only after:
+
+- code, migration, RLS, unit, integration, build, and production smoke checks
+  are green;
+- Evan approves the independent provider/account and any resulting spend;
+- bucket independence, encryption, versioning, immutability, IAM, retention,
+  and spend alerts are evidenced;
+- production backfill reaches 100% fresh coverage;
+- an isolated combined database/primary-loss drill passes; and
+- the runbook records RPO, RTO, drill date, and operator.
+
+Until then, leave `FILE_REPLICA_ENABLED=false`. Credentials may be staged only
+after the independent bucket controls are evidenced; keep
+`FILE_REPLICA_REQUIRED=false` until the operational gate is complete. Track the
+remaining gate in OPENVPM-41.
+
+## Release evidence — 2026-08-10
+
+The count-only preflight was run read-only against the hosted production and
+demo databases before migration 0077:
+
+- production: every blocking count was zero; both informational backfill
+  counts were zero;
+- demo: every blocking count was zero;
+  `patient_id_backfills` was 4 and is deterministically repaired by migration
+  0077; `appointment_patient_id_backfills` was zero.
+
+This evidence permits the migration-only staging release. It does not permit
+the application worker to run: constraint validation, post-migration drift/RLS
+checks, independent-provider controls, and the destructive synthetic drill are
+still required.

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -82,6 +82,18 @@ S3_SECRET_KEY=...
 S3_BUCKET=...
 S3_REGION=...
 
+# Independent recovery storage. Stage a complete group with execution disabled,
+# then enable only an exact design-partner cohort after bucket controls pass.
+FILE_REPLICA_REQUIRED=false
+FILE_REPLICA_ENABLED=false
+FILE_REPLICA_ALL_PRACTICES=false
+FILE_REPLICA_PRACTICE_IDS=
+FILE_REPLICA_S3_ENDPOINT=
+FILE_REPLICA_S3_ACCESS_KEY=
+FILE_REPLICA_S3_SECRET_KEY=
+FILE_REPLICA_S3_BUCKET=
+FILE_REPLICA_S3_REGION=
+
 RESEND_API_KEY=...
 RESEND_WEBHOOK_SECRET=...
 EMAIL_PREFERENCE_IDENTITY_SECRET=... # stable `openssl rand -base64 32`; never rotate without migrating preference data
@@ -104,10 +116,23 @@ ANTHROPIC_API_KEY=...
 OPS_ALERT_WEBHOOK_URL=...
 CRON_SECRET=...
 CRON_HEARTBEAT_URL=...
+CRON_HEARTBEAT_FILE_REPLICAS_URL=...
 PLATFORM_ADMIN_EMAILS=...
 ```
 
 `STRIPE_PRICE_CLOUD_USER` and `STRIPE_PRICE_CLOUD` are legacy-only. They must not be used for new checkout or required hosted readiness.
+
+Any nonblank `FILE_REPLICA_*` value starts the replica readiness gate. Partial
+storage configuration makes `/api/health` fail, and a complete configuration
+must point to a different endpoint/bucket identity from primary storage.
+Credentials alone do not copy data. `FILE_REPLICA_ENABLED=true` additionally
+requires either an exact comma-separated UUID cohort in
+`FILE_REPLICA_PRACTICE_IDS` or `FILE_REPLICA_ALL_PRACTICES=true`, never both.
+Begin with the design-partner cohort and expand only after its recovery drill.
+Follow
+[`file-object-recovery-runbook.md`](file-object-recovery-runbook.md) for bucket
+controls, backfill, alert thresholds, and the required destructive drill before
+setting `FILE_REPLICA_REQUIRED=true`.
 
 Telnyx is the hosted SMS default. `TELNYX_PUBLIC_KEY` is required for the
 public webhook to verify inbound SMS and delivery-status callbacks. For a
@@ -318,6 +343,14 @@ Store this endpoint secret as `RESEND_WEBHOOK_SECRET`.
 
 ## Stripe Setup
 
+The server pins Stripe API version `2026-07-29.dahlia`. Configure all three
+Dashboard webhook endpoints below to that same version before deploying an SDK
+upgrade, then replay a signed test event for every subscribed event type.
+Checkout uses Stripe's dynamic eligible payment methods; do not force a
+card-only method list in Dashboard rules. Invoice Checkout still uses manual
+capture, so Stripe automatically filters out methods that cannot support the
+authorization-and-capture flow.
+
 Create one Stripe product for OpenVPM Cloud with these recurring monthly prices:
 
 - Cloud location: `$79/month`, env `STRIPE_PRICE_CLOUD_LOCATION` (flat per active location, unlimited staff).
@@ -352,10 +385,13 @@ Store this endpoint secret as `STRIPE_WEBHOOK_SECRET`.
 
 ### Stripe Connect for clinic-owned client payments
 
-OpenVPM Cloud uses Stripe Connect Express for clinics that want to bill pet
-owners by card. This is separate from the OpenVPM Cloud subscription above:
-Cloud subscription charges settle to OpenVPM, while client invoice payments are
-created on the clinic's connected account after onboarding is complete.
+OpenVPM Cloud uses controller-configured connected accounts with a full Stripe
+Dashboard for clinics that want to bill pet owners by card. Stripe owns ongoing
+requirements collection and negative-balance liability, while each clinic pays
+its processing fees. This is separate from the OpenVPM Cloud subscription
+above: Cloud subscription charges settle to OpenVPM, while client invoice
+payments are created on the clinic's connected account after onboarding is
+complete.
 
 Enable Connect in the platform Stripe account, then add the Connect webhook:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,9 +18,11 @@ The hosted application connects as `openpims_app`, a role with only `SELECT`, `I
 
 ## Backups and restore validation
 
-A scheduled job (`apps/web/app/api/cron/backup`, daily at 03:00 UTC) exports each practice's full data set to a private S3-compatible object storage bucket, one restorable snapshot per practice per day. The export includes the complete medical record: persisted SOAP drafts, immutable finalized SOAP attribution, correction and addendum evidence, clinical notes, problem lists, lab results, prescriptions, vaccination records, vital signs, and the controlled substance log, alongside scheduling, client, inventory, and billing data (`apps/web/lib/backup/export.ts`).
+A scheduled job (`apps/web/app/api/cron/backup`, daily at 03:00 UTC) exports each practice's full data set to a private S3-compatible object storage bucket, one restorable snapshot per practice per day. The export includes the complete medical record: persisted SOAP drafts, immutable finalized SOAP attribution, correction and addendum evidence, clinical notes, problem lists, lab results, prescriptions, vaccination records, vital signs, and the controlled substance log, alongside scheduling, client, inventory, and billing data (`apps/web/lib/backup/export.ts`). When the separately gated replica target is configured, the job also writes and read-back verifies each JSON snapshot in an independent failure domain.
 
 Restores are validated before anything is written: the backup file is checked against the expected sections and row shapes, and invalid or oversized files (over 50 MB) are rejected (`validatePracticeExportRestore`, `apps/web/lib/backup/policy.ts`). Backup failures page the operators through the ops alert webhook, and a dead-man heartbeat monitors that the job actually ran.
+
+Attachment objects carry SHA-256/size manifests. A leased background worker copies them asynchronously to content-addressed keys in independent object storage, reads every copy back before marking it available, records append-only transition evidence, and periodically re-verifies coverage. The application may fall back only to a checksum-verified replica; missing, corrupt, and provider-failure states remain distinct. Operational activation additionally requires separate-account IAM without runtime delete authority, versioning/immutable retention, full backfill, and a destructive recovery drill as documented in `docs/file-object-recovery-runbook.md`.
 
 ## Rate limiting
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       stripe:
-        specifier: ^20.4.1
-        version: 20.4.1(@types/node@20.19.37)
+        specifier: ^22.5.0
+        version: 22.5.0(@types/node@20.19.37)
       superjson:
         specifier: ^2.2.0
         version: 2.2.6
@@ -214,6 +214,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.12))
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -3399,11 +3402,11 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  stripe@20.4.1:
-    resolution: {integrity: sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==}
-    engines: {node: '>=16'}
+  stripe@22.5.0:
+    resolution: {integrity: sha512-QVwMwriC0bbySx6R4dpsvJ0W//GojC1kwWVS6rPSoVqDUIZX4Hy3TaUrd2AZeXEAaKbfWIjQjvo3vKAReHZ0vQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=16'
+      '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -6512,7 +6515,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@20.4.1(@types/node@20.19.37):
+  stripe@22.5.0(@types/node@20.19.37):
     optionalDependencies:
       '@types/node': 20.19.37
 


### PR DESCRIPTION
## Summary

- make capture, dashboard uploads, and consent signing durable and idempotent with exact-generation object verification, tombstone safety, atomic expiry, and privacy headers
- add independently verifiable backup/file recovery evidence, replica monitoring, exact-version repair, owner recovery tooling, and fail-closed rollout gates
- commit recovery hold before restore and serialize clinic-mutating provider effects across Stripe, email, SMS, webhooks, AI, provisioning, reminders, and uploads
- upgrade Stripe SDK/API contract, enable dynamic eligible payment methods, and preserve card-up-front hosted trials
- tighten patient/consent file visibility, analytics redaction, recovery runbooks, and hosted health checks

## Release order

1. Database migrations 0082 and 0083 are already applied and verified in production and demo.
2. Deploy this application commit atomically; do not split API/client/provider-gate changes.
3. Keep FILE_REPLICA_ENABLED=false and FILE_REPLICA_REQUIRED=false until the independent provider/versioning drill and exact pilot cohort approval.
4. Keep real SMS provisioning/sends and payment test activity out of the deploy smoke test.

## Validation

- web tests: 357 files passed, 3711 tests passed, 2 integration tests intentionally skipped
- web and database TypeScript checks passed
- production monorepo build passed
- production dependency audit: no known vulnerabilities
- staged secret scan: no leaks found
- git diff check passed
- independent capture/consent/upload/recovery/replica audits: no remaining release blocker
