### PR TITLE
feat: add audited SMS quarantine remediation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,22 @@ jobs:
           SMS_QUEUE_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run lib/messaging/__tests__/sms-operations-queues.integration.test.ts
 
+      # Execute the immutable provider-resolution insert validations and
+      # evidence assertions against the fully migrated disposable database.
+      - name: Execute SMS provider-resolution database contract
+        run: pnpm --filter @openpims/db db:sms-provider-resolutions:test
+
+      # Exercise real PostgreSQL row/advisory locks, savepoints, and durable
+      # event convergence with synthetic data only. No provider adapter is
+      # imported or called, and every hosted SMS capability remains disabled.
+      - name: Execute provider-free SMS concurrency drill
+        env:
+          SMS_CONCURRENCY_DB_INTEGRATION: "1"
+          MESSAGING_PROVISIONING_ENABLED: "false"
+          MESSAGING_INBOUND_ENABLED: "false"
+          MESSAGING_SENDING_ENABLED: "false"
+        run: pnpm --filter @openpims/web exec vitest run lib/messaging/__tests__/sms-concurrency-drill.integration.test.ts
+
       # The reminder sweep is a candidate list. Prove against real PostgreSQL
       # that dispatch-time revalidation honors clinic enablement, each clinic's
       # lead window, cancellation, and rescheduling before a provider claim.

--- a/apps/web/components/admin/sms-recovery-console.tsx
+++ b/apps/web/components/admin/sms-recovery-console.tsx
@@ -17,6 +17,7 @@ import { trpc } from "@/lib/trpc";
 const EMPTY_UUID = "00000000-0000-4000-8000-000000000000";
 const QUEUE_LIMIT = 25;
 const WITHHELD_PHONE_LIKE_OPERATIONAL_ID = "[withheld: phone-like identifier]";
+const PROVIDER_SUPPORT_REFERENCE = /^[A-Za-z0-9][A-Za-z0-9_.:/#-]{2,254}$/;
 
 type AttemptSelection = {
   practiceId: string;
@@ -36,6 +37,32 @@ type DeliverySelection = {
     | "projection_miss";
   pendingHistoryId: string | null;
 };
+
+type ProviderEventSelection = {
+  eventId: string;
+  conflictId: string | null;
+  practiceId: string | null;
+  locationId: string | null;
+  provider: string;
+  kind: "inbound" | "delivery" | "a2p";
+  state:
+    | "pending"
+    | "retry"
+    | "blocked_recovery"
+    | "quarantined"
+    | "identity_conflict";
+  lastErrorCode: string | null;
+};
+
+type ProviderEventResolution =
+  | "authoritative_projection"
+  | "conservative_opt_out"
+  | "carrier_state_reconciled"
+  | "provider_attested_no_projection";
+
+type ProviderSupportReason =
+  | "provider_support_invalid_callback"
+  | "provider_support_duplicate_callback";
 
 type AttemptOutcome = "accepted" | "definite_failure";
 type DeliveryClassification = "sent" | "failed" | "delivered";
@@ -72,6 +99,72 @@ function safeProviderEvidenceId(value: string | null | undefined) {
   return looksLikePhoneNumber(value)
     ? WITHHELD_PHONE_LIKE_OPERATIONAL_ID
     : value;
+}
+
+function providerEventResolutionOptions(
+  selection: ProviderEventSelection | null,
+): Array<{ value: ProviderEventResolution; text: string }> {
+  if (!selection) return [];
+  const isConflict = Boolean(selection.conflictId);
+  if (!isConflict && selection.state !== "quarantined") return [];
+  if (selection.kind === "inbound") {
+    if (isConflict) {
+      return selection.practiceId && selection.locationId
+        ? [
+            {
+              value: "conservative_opt_out",
+              text: "Conservative opt-out for conflicting inbound evidence",
+            },
+          ]
+        : [];
+    }
+    if (!selection.practiceId || !selection.locationId) return [];
+    const options: Array<{
+      value: ProviderEventResolution;
+      text: string;
+    }> = [
+      {
+        value: "authoritative_projection",
+        text: "Repair and verify inbound projection",
+      },
+    ];
+    if (
+      selection.practiceId &&
+      selection.locationId &&
+      (selection.lastErrorCode === "sender_identity_drift" ||
+        selection.lastErrorCode === "immutable_attribution_drift")
+    ) {
+      options.push({
+        value: "conservative_opt_out",
+        text: "Conservative opt-out after sender identity drift",
+      });
+    }
+    return options;
+  }
+  if (selection.kind === "a2p") {
+    return selection.practiceId
+      ? [
+          {
+            value: "carrier_state_reconciled",
+            text: "Read back and reconcile current carrier state",
+          },
+        ]
+      : [];
+  }
+  return [
+    ...(selection.practiceId
+      ? [
+          {
+            value: "authoritative_projection" as const,
+            text: "Repair and verify delivery projection",
+          },
+        ]
+      : []),
+    {
+      value: "provider_attested_no_projection",
+      text: "Provider-attested invalid or duplicate callback",
+    },
+  ];
 }
 
 function EvidenceId({
@@ -174,6 +267,21 @@ export function SmsRecoveryConsole() {
     useState<AttemptSelection | null>(null);
   const [deliverySelection, setDeliverySelection] =
     useState<DeliverySelection | null>(null);
+  const [providerEventSelection, setProviderEventSelection] =
+    useState<ProviderEventSelection | null>(null);
+  const [providerEventResolution, setProviderEventResolution] = useState<
+    ProviderEventResolution | ""
+  >("");
+  const [providerEventOperationId, setProviderEventOperationId] = useState<
+    string | null
+  >(null);
+  const [providerEventReviewed, setProviderEventReviewed] = useState(false);
+  const [providerSupportReference, setProviderSupportReference] = useState("");
+  const [providerSupportReason, setProviderSupportReason] = useState<
+    ProviderSupportReason | ""
+  >("");
+  const [providerAttestationConfirmed, setProviderAttestationConfirmed] =
+    useState(false);
   const [attemptOutcome, setAttemptOutcome] = useState<AttemptOutcome | "">("");
   const [attemptEvidence, setAttemptEvidence] = useState("");
   const [providerMessageId, setProviderMessageId] = useState("");
@@ -209,6 +317,11 @@ export function SmsRecoveryConsole() {
     },
     { enabled: Boolean(deliverySelection), retry: false },
   );
+  const providerEventResolutionHistory =
+    trpc.admin.smsProviderEventResolutionHistory.useQuery(
+      { limit: QUEUE_LIMIT },
+      { retry: false },
+    );
 
   const effectiveAttemptEvent = useMemo(() => {
     const events = attemptDetail.data?.events ?? [];
@@ -226,6 +339,7 @@ export function SmsRecoveryConsole() {
       utils.admin.smsSendAttemptQueue.invalidate(),
       utils.admin.smsDeliveryEventQueue.invalidate(),
       utils.admin.smsProviderEventQueue.invalidate(),
+      utils.admin.smsProviderEventResolutionHistory.invalidate(),
       utils.admin.smsOperationsHealth.invalidate(),
     ]);
   };
@@ -307,10 +421,43 @@ export function SmsRecoveryConsole() {
       setActionError(error.message);
     },
   });
+  const resolveProviderEvent = trpc.admin.resolveSmsProviderEvent.useMutation({
+    onSuccess: (result) => {
+      setActionError(null);
+      setActionMessage(
+        `${result.duplicate ? "Existing" : "New"} audited ${label(result.resolution)} evidence is recorded for the exact provider incident.`,
+      );
+      setProviderEventReviewed(false);
+      setProviderAttestationConfirmed(false);
+      setProviderEventOperationId(operationId());
+      refreshQueues();
+    },
+    onError: (error) => {
+      setActionMessage(null);
+      setActionError(error.message);
+    },
+  });
+  const reconcileProviderA2p =
+    trpc.admin.reconcileMessagingRegistration.useMutation({
+      onSuccess: (result) => {
+        setActionError(null);
+        setActionMessage(
+          `Current carrier state was read back and ${result.resolutionId ? "audited resolution evidence was recorded" : "reconciliation evidence was recorded"}.`,
+        );
+        setProviderEventReviewed(false);
+        setProviderEventOperationId(operationId());
+        refreshQueues();
+      },
+      onError: (error) => {
+        setActionMessage(null);
+        setActionError(error.message);
+      },
+    });
 
   const selectAttempt = (selection: AttemptSelection) => {
     setAttemptSelection(selection);
     setDeliverySelection(null);
+    setProviderEventSelection(null);
     setAttemptOutcome("");
     setAttemptEvidence("");
     setProviderMessageId("");
@@ -326,10 +473,25 @@ export function SmsRecoveryConsole() {
   const selectDelivery = (selection: DeliverySelection) => {
     setDeliverySelection(selection);
     setAttemptSelection(null);
+    setProviderEventSelection(null);
     setDeliveryReason("");
     setDeliveryClassification("");
     setDeliveryReviewed(false);
     setDeliveryReconciliationId(operationId());
+    setActionMessage(null);
+    setActionError(null);
+  };
+
+  const selectProviderEvent = (selection: ProviderEventSelection) => {
+    setProviderEventSelection(selection);
+    setAttemptSelection(null);
+    setDeliverySelection(null);
+    setProviderEventResolution("");
+    setProviderEventOperationId(operationId());
+    setProviderEventReviewed(false);
+    setProviderSupportReference("");
+    setProviderSupportReason("");
+    setProviderAttestationConfirmed(false);
     setActionMessage(null);
     setActionError(null);
   };
@@ -389,6 +551,28 @@ export function SmsRecoveryConsole() {
     (deliveryReason !== "provider_portal_status_review" ||
       deliveryClassification) &&
     !reconcileDelivery.isPending,
+  );
+  const providerEventResolutionOptionsForSelection =
+    providerEventResolutionOptions(providerEventSelection);
+  const providerSupportReferenceInvalid = Boolean(
+    providerSupportReference &&
+    (!PROVIDER_SUPPORT_REFERENCE.test(providerSupportReference) ||
+      looksLikePhoneNumber(providerSupportReference)),
+  );
+  const providerAttestationReady =
+    providerEventResolution !== "provider_attested_no_projection" ||
+    (providerSupportReference.trim().length >= 3 &&
+      !providerSupportReferenceInvalid &&
+      Boolean(providerSupportReason) &&
+      providerAttestationConfirmed);
+  const canResolveProviderEvent = Boolean(
+    providerEventSelection &&
+    providerEventOperationId &&
+    providerEventResolution &&
+    providerEventReviewed &&
+    providerAttestationReady &&
+    !resolveProviderEvent.isPending &&
+    !reconcileProviderA2p.isPending,
   );
 
   return (
@@ -452,11 +636,14 @@ export function SmsRecoveryConsole() {
                     <th className="px-3 py-2 font-medium">Clinic / location</th>
                     <th className="px-3 py-2 font-medium">Kind / state</th>
                     <th className="px-3 py-2 font-medium">Redacted evidence</th>
+                    <th className="px-3 py-2 font-medium">Action</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
                   {providerEventQueue.data.items.map((item, index) => (
-                    <tr key={`${item.eventId}:${item.state}:${index}`}>
+                    <tr
+                      key={`${item.eventId}:${item.conflictId ?? item.state}:${index}`}
+                    >
                       <td className="px-3 py-2 align-top">
                         <p>{formatTimestamp(item.receivedAt)}</p>
                         {item.stale ? (
@@ -481,16 +668,58 @@ export function SmsRecoveryConsole() {
                         <p className="break-all font-mono text-xs">
                           event {item.eventId}
                         </p>
+                        {item.conflictId ? (
+                          <p className="mt-1 break-all font-mono text-xs">
+                            conflict {item.conflictId}
+                          </p>
+                        ) : null}
                         <p className="mt-1 text-xs text-muted-foreground">
                           reason {item.lastErrorCode ?? "—"}
                         </p>
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        {providerEventResolutionOptions({
+                          eventId: item.eventId,
+                          conflictId: item.conflictId,
+                          practiceId: item.practiceId,
+                          locationId: item.locationId,
+                          provider: item.provider,
+                          kind: item.kind,
+                          state: item.state,
+                          lastErrorCode: item.lastErrorCode,
+                        }).length ? (
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              selectProviderEvent({
+                                eventId: item.eventId,
+                                conflictId: item.conflictId,
+                                practiceId: item.practiceId,
+                                locationId: item.locationId,
+                                provider: item.provider,
+                                kind: item.kind,
+                                state: item.state,
+                                lastErrorCode: item.lastErrorCode,
+                              })
+                            }
+                          >
+                            Review incident
+                            <ChevronRight className="ml-1 h-4 w-4" />
+                          </Button>
+                        ) : (
+                          <span className="text-xs font-medium text-amber-700">
+                            Projection or attribution required
+                          </span>
+                        )}
                       </td>
                     </tr>
                   ))}
                   {providerEventQueue.data.items.length === 0 ? (
                     <tr>
                       <td
-                        colSpan={4}
+                        colSpan={5}
                         className="px-3 py-6 text-center text-muted-foreground"
                       >
                         No provider events need projection or operator review.
@@ -509,6 +738,296 @@ export function SmsRecoveryConsole() {
         ) : (
           <p className="mt-3 text-sm text-muted-foreground">
             Loading provider-event evidence…
+          </p>
+        )}
+      </div>
+
+      {providerEventSelection ? (
+        <div className="mt-6 rounded-md border border-amber-300 bg-amber-50 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 className="font-semibold text-amber-950">
+                Exact provider-event incident
+              </h3>
+              <p className="mt-1 break-all font-mono text-xs text-amber-900">
+                event {providerEventSelection.eventId}
+              </p>
+              {providerEventSelection.conflictId ? (
+                <p className="mt-1 break-all font-mono text-xs text-amber-900">
+                  conflict {providerEventSelection.conflictId}
+                </p>
+              ) : null}
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => setProviderEventSelection(null)}
+            >
+              Close
+            </Button>
+          </div>
+          <p className="mt-3 text-xs text-amber-950">
+            {label(providerEventSelection.kind)} ·{" "}
+            {providerEventSelection.provider} ·{" "}
+            {label(providerEventSelection.state)} · reason{" "}
+            {providerEventSelection.lastErrorCode ?? "—"}. Only modes permitted
+            for this exact incident are shown. The backend re-locks and
+            revalidates attribution and evidence before recording a resolution.
+          </p>
+          <label className="mt-4 block text-xs font-medium text-amber-950">
+            Audited resolution
+            <select
+              className={`${selectClassName} mt-1 bg-background`}
+              value={providerEventResolution}
+              onChange={(event) => {
+                setProviderEventResolution(
+                  event.target.value as ProviderEventResolution | "",
+                );
+                setProviderEventReviewed(false);
+                setProviderAttestationConfirmed(false);
+              }}
+            >
+              <option value="">Choose an allowed resolution</option>
+              {providerEventResolutionOptionsForSelection.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.text}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {providerEventResolution === "carrier_state_reconciled" ? (
+            <p className="mt-3 rounded-md border border-amber-300 bg-background px-3 py-2 text-xs text-amber-950">
+              This performs a current carrier readback while the exact clinic is
+              recovery-locked, appends registration evidence under this
+              operation UUID, and keeps the sender disabled until ordinary
+              readiness checks pass.
+            </p>
+          ) : null}
+
+          {providerEventResolution === "provider_attested_no_projection" ? (
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <label className="text-xs font-medium text-amber-950">
+                Provider support ticket/reference
+                <Input
+                  className="mt-1 bg-background font-mono"
+                  value={providerSupportReference}
+                  maxLength={255}
+                  autoComplete="off"
+                  aria-invalid={providerSupportReferenceInvalid}
+                  placeholder="TICKET-12345"
+                  onChange={(event) => {
+                    setProviderSupportReference(event.target.value);
+                    setProviderAttestationConfirmed(false);
+                  }}
+                />
+              </label>
+              <label className="text-xs font-medium text-amber-950">
+                Provider-supported finding
+                <select
+                  className={`${selectClassName} mt-1 bg-background`}
+                  value={providerSupportReason}
+                  onChange={(event) => {
+                    setProviderSupportReason(
+                      event.target.value as ProviderSupportReason | "",
+                    );
+                    setProviderAttestationConfirmed(false);
+                  }}
+                >
+                  <option value="">Choose provider finding</option>
+                  <option value="provider_support_invalid_callback">
+                    Invalid callback; no tenant projection
+                  </option>
+                  <option value="provider_support_duplicate_callback">
+                    Duplicate callback; no new tenant projection
+                  </option>
+                </select>
+              </label>
+              {providerSupportReferenceInvalid ? (
+                <p className="text-xs font-medium text-destructive md:col-span-2">
+                  Phone-like values cannot be used as provider support evidence.
+                </p>
+              ) : null}
+              <label className="flex items-start gap-2 text-xs text-amber-950 md:col-span-2">
+                <Checkbox
+                  checked={providerAttestationConfirmed}
+                  onChange={(event) =>
+                    setProviderAttestationConfirmed(event.target.checked)
+                  }
+                />
+                <span>
+                  I explicitly attest that provider support verified this exact
+                  delivery callback requires no tenant projection, and the
+                  reference contains no phone number, message, client name, or
+                  PHI.
+                </span>
+              </label>
+            </div>
+          ) : null}
+
+          <label className="mt-4 flex items-start gap-2 text-xs text-amber-950">
+            <Checkbox
+              checked={providerEventReviewed}
+              onChange={(event) =>
+                setProviderEventReviewed(event.target.checked)
+              }
+            />
+            <span>
+              I selected this exact event
+              {providerEventSelection.conflictId ? " and conflict" : ""},
+              reviewed the redacted incident state, and understand this appends
+              immutable resolution evidence. Conflict review alone does not
+              clear the incident.
+            </span>
+          </label>
+          <p className="mt-3 break-all font-mono text-[11px] text-amber-900">
+            Resolution UUID: {providerEventOperationId}
+          </p>
+          <Button
+            type="button"
+            className="mt-3"
+            disabled={!canResolveProviderEvent}
+            onClick={() => {
+              if (
+                !providerEventOperationId ||
+                !providerEventResolution ||
+                !providerEventSelection
+              ) {
+                return;
+              }
+              if (
+                !window.confirm(
+                  `Apply ${label(providerEventResolution)} to exact provider event ${providerEventSelection.eventId}${providerEventSelection.conflictId ? ` and conflict ${providerEventSelection.conflictId}` : ""}? This appends immutable audited evidence.`,
+                )
+              ) {
+                return;
+              }
+              setActionError(null);
+              setActionMessage(null);
+              if (providerEventResolution === "carrier_state_reconciled") {
+                if (!providerEventSelection.practiceId) return;
+                reconcileProviderA2p.mutate({
+                  practiceId: providerEventSelection.practiceId,
+                  remediation: {
+                    providerEventId: providerEventSelection.eventId,
+                    conflictId: providerEventSelection.conflictId ?? undefined,
+                    operationId: providerEventOperationId,
+                  },
+                });
+                return;
+              }
+              if (
+                providerEventResolution === "provider_attested_no_projection"
+              ) {
+                if (!providerSupportReason) return;
+                resolveProviderEvent.mutate({
+                  eventId: providerEventSelection.eventId,
+                  conflictId: providerEventSelection.conflictId,
+                  operationId: providerEventOperationId,
+                  resolution: providerEventResolution,
+                  externalEvidenceReference: providerSupportReference.trim(),
+                  reasonCode: providerSupportReason,
+                  providerAttestationConfirmed: true,
+                });
+                return;
+              }
+              resolveProviderEvent.mutate({
+                eventId: providerEventSelection.eventId,
+                conflictId: providerEventSelection.conflictId,
+                operationId: providerEventOperationId,
+                resolution: providerEventResolution,
+              });
+            }}
+          >
+            <ShieldCheck className="mr-2 h-4 w-4" />
+            Apply audited resolution
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="mt-5">
+        <h3 className="text-sm font-semibold">
+          Provider-event resolution history
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Newest {QUEUE_LIMIT} immutable resolution records. This view contains
+          operational UUIDs and resolution classifications only; message,
+          sender, provider detail, and PHI fields are excluded server-side.
+        </p>
+        {providerEventResolutionHistory.error ? (
+          <QueueError>
+            Could not load provider-event resolution history.
+          </QueueError>
+        ) : providerEventResolutionHistory.data ? (
+          <>
+            <div className="mt-3 overflow-x-auto rounded-md border border-border">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                    <th className="px-3 py-2 font-medium">Resolved</th>
+                    <th className="px-3 py-2 font-medium">Incident</th>
+                    <th className="px-3 py-2 font-medium">
+                      Resolution / evidence
+                    </th>
+                    <th className="px-3 py-2 font-medium">Operator</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {providerEventResolutionHistory.data.events.map((item) => (
+                    <tr key={item.resolutionId}>
+                      <td className="px-3 py-2 align-top">
+                        {formatTimestamp(item.resolvedAt)}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <p className="break-all font-mono">
+                          event {item.eventId}
+                        </p>
+                        <p className="mt-1 break-all font-mono text-muted-foreground">
+                          conflict {item.conflictId ?? "—"}
+                        </p>
+                      </td>
+                      <td className="px-3 py-2 align-top capitalize">
+                        {label(item.kind)} · {label(item.resolution)}
+                        <p className="mt-1 text-muted-foreground">
+                          {label(item.reasonCode)} · {label(item.evidenceType)}
+                        </p>
+                        {item.externalEvidenceReference ? (
+                          <p className="mt-1 break-all font-mono text-muted-foreground">
+                            reference{" "}
+                            {safeProviderEvidenceId(
+                              item.externalEvidenceReference,
+                            )}
+                          </p>
+                        ) : null}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        {item.operatorLabel}
+                      </td>
+                    </tr>
+                  ))}
+                  {providerEventResolutionHistory.data.events.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={4}
+                        className="px-3 py-5 text-center text-muted-foreground"
+                      >
+                        No provider-event resolutions are recorded.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+            {providerEventResolutionHistory.data.truncated ? (
+              <p className="mt-2 text-xs font-medium text-amber-700">
+                Resolution history is bounded to the newest {QUEUE_LIMIT} rows.
+              </p>
+            ) : null}
+          </>
+        ) : (
+          <p className="mt-3 text-sm text-muted-foreground">
+            Loading provider-event resolution history…
           </p>
         )}
       </div>

--- a/apps/web/lib/__tests__/admin-sms-recovery-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-sms-recovery-ui.test.ts
@@ -18,6 +18,9 @@ describe("platform-admin SMS recovery console", () => {
     expect(source).toContain("{ staleMinutes: 15, limit: QUEUE_LIMIT }");
     expect(source).toContain("{ staleMinutes: 60, limit: QUEUE_LIMIT }");
     expect(source).toContain("historyLimit: 100");
+    expect(source).toContain("smsProviderEventResolutionHistory.useQuery");
+    expect(source).toContain("{ limit: QUEUE_LIMIT }");
+    expect(source).toContain("data.truncated");
     expect(source).toContain("candidateAttemptsTruncated");
     expect(source).toContain("!deliveryDetail.data.truncated");
   });
@@ -50,6 +53,35 @@ describe("platform-admin SMS recovery console", () => {
     expect(source).toContain("This is an external side effect.");
   });
 
+  it("offers only evidence-valid provider incident remediation modes", () => {
+    expect(source).toContain("providerEventResolutionOptions(");
+    expect(source).toContain('selection.state !== "quarantined"');
+    expect(source).toContain("Boolean(selection.conflictId)");
+    expect(source).toContain('selection.kind === "inbound"');
+    expect(source).toContain('selection.kind === "a2p"');
+    expect(source).toContain("selection.practiceId &&");
+    expect(source).toContain("selection.locationId &&");
+    expect(source).toContain('"sender_identity_drift"');
+    expect(source).toContain('"immutable_attribution_drift"');
+    expect(source).toContain('value: "conservative_opt_out"');
+    expect(source).toContain('value: "carrier_state_reconciled"');
+    expect(source).toContain('value: "provider_attested_no_projection"');
+    expect(source).toContain("conflictId: item.conflictId");
+  });
+
+  it("requires a fresh UUID, explicit attestation and confirmation", () => {
+    expect(source).toContain("setProviderEventOperationId(operationId())");
+    expect(source).toContain("providerEventReviewed &&");
+    expect(source).toContain("providerAttestationConfirmed");
+    expect(source).toContain("providerSupportReferenceInvalid");
+    expect(source).toContain("Phone-like values cannot be used");
+    expect(source).toContain("provider_support_invalid_callback");
+    expect(source).toContain("provider_support_duplicate_callback");
+    expect(source).toContain("reconcileProviderA2p.mutate");
+    expect(source).toContain("resolveProviderEvent.mutate");
+    expect(source).toMatch(/Apply \$\{label\(providerEventResolution\)\}/);
+  });
+
   it("does not render phone, body, raw payload, PHI, or operator identity fields", () => {
     expect(source).not.toContain("destinationE164");
     expect(source).not.toContain("senderE164");
@@ -69,6 +101,9 @@ describe("platform-admin SMS recovery console", () => {
     expect(source).toContain("sensitive content excluded");
     expect(source).toContain("omitted at the");
     expect(source).toContain("server boundary");
+    expect(source).toContain("operatorLabel");
+    expect(source).not.toContain("resolvedByIdentity");
+    expect(source).not.toContain("providerDetail");
   });
 
   it("masks carrier senders and never receives their full E.164 value", () => {

--- a/apps/web/lib/__tests__/sms.test.ts
+++ b/apps/web/lib/__tests__/sms.test.ts
@@ -162,6 +162,7 @@ function createLedgerDb() {
     },
   ];
   const suppressionRows: Array<Record<string, unknown>> = [];
+  const providerAttestedNoProjectionRows: Array<Record<string, unknown>> = [];
   const communicationRows: Array<Record<string, unknown>> = [
     { id: COMMUNICATION_ID, status: "pending" },
   ];
@@ -183,6 +184,9 @@ function createLedgerDb() {
     if (name === "location_messaging") return locationMessagingRows;
     if (name === "practices") return practiceRows;
     if (name === "sms_suppressions") return suppressionRows;
+    if (name === "sms_provider_event_resolutions") {
+      return providerAttestedNoProjectionRows;
+    }
     if (name === "users") {
       return [{ id: ACTOR_ID, name: "Operator", email: "ops@openvpm.com" }];
     }
@@ -252,6 +256,8 @@ function createLedgerDb() {
         table = value;
         return builder;
       },
+      innerJoin: () => builder,
+      leftJoin: () => builder,
       where(value: unknown) {
         condition = value;
         return builder;
@@ -359,6 +365,7 @@ function createLedgerDb() {
     practiceRows,
     clientRows,
     suppressionRows,
+    providerAttestedNoProjectionRows,
     communicationRows,
     communicationProjection,
     throwOnSelect,
@@ -729,6 +736,28 @@ describe("durable SMS dispatch", () => {
       status: "sent",
       providerMessageId: "sms-atomic-1",
     });
+  });
+
+  it("does not persist a live accepted result over provider-attested no-projection evidence", async () => {
+    state().providerAttestedNoProjectionRows.push({
+      id: "00000000-0000-4000-8000-0000000000b2",
+      conflictId: null,
+      resolution: "provider_attested_no_projection",
+    });
+    mocks.providerSend.mockResolvedValue({
+      status: "accepted",
+      id: "sms-provider-attested",
+    });
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+      error: expect.stringContaining("could not be persisted"),
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+    expect(state().events).toHaveLength(0);
+    expect(state().selectedTables).toContain("sms_provider_event_resolutions");
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
   it("returns unknown and alerts if an accepted outcome cannot project", async () => {
@@ -1441,6 +1470,65 @@ describe("durable SMS dispatch", () => {
       actorIdentity: "ops@openvpm.com",
     });
   });
+
+  it.each([
+    ["base event identity", null],
+    ["conflict identity", "00000000-0000-4000-8000-0000000000cf"],
+  ])(
+    "rejects accepted reconciliation after provider-attested no-projection for %s",
+    async (_label, conflictId) => {
+      const ledger = state();
+      const attemptId = "00000000-0000-4000-8000-0000000000a1";
+      ledger.attempts.push({
+        ...sendOptions(),
+        id: attemptId,
+        createdAt: new Date(Date.now() - 20 * 60 * 1000),
+        practiceId: PRACTICE_ID,
+        provider: "telnyx",
+        idempotencyKey: `sms:ambiguous:${conflictId ?? "base"}`,
+        resendOfAttemptId: null,
+      });
+      ledger.events.push({
+        id: "10000000-0000-4000-8000-0000000000a1",
+        createdAt: new Date(Date.now() - 19 * 60 * 1000),
+        practiceId: PRACTICE_ID,
+        attemptId,
+        kind: "provider_result",
+        outcome: "outcome_unknown",
+        providerMessageId: null,
+        detail: "timeout",
+        eventKey: `provider-result:${conflictId ?? "base"}`,
+      });
+      ledger.providerAttestedNoProjectionRows.push({
+        id: "00000000-0000-4000-8000-0000000000b1",
+        conflictId,
+        resolution: "provider_attested_no_projection",
+      });
+
+      await expect(
+        reconcileSmsSendAttempt({
+          practiceId: PRACTICE_ID,
+          attemptId,
+          outcome: "accepted",
+          providerMessageId: "msg-provider-attested",
+          detail: "Provider console reported acceptance.",
+          actorType: "platform_operator",
+          actorUserId: ACTOR_ID,
+          actorIdentity: "ops@openvpm.com",
+          actorName: "OpenVPM Ops",
+          reconciliationKey: `operator-reconciliation:${conflictId ?? "base"}`,
+        }),
+      ).resolves.toMatchObject({
+        success: false,
+        outcome: "outcome_unknown",
+        attemptId,
+        error: expect.stringContaining("no-projection evidence"),
+      });
+      expect(ledger.events).toHaveLength(1);
+      expect(ledger.selectedTables).toContain("sms_provider_event_resolutions");
+      expect(mocks.providerSend).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps reconciliation durable and alerts when communication projection misses", async () => {
     const ledger = state();

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -572,6 +572,7 @@ describe("summarizePracticeExport", () => {
     expect(sections).not.toContain("smsProviderEvents");
     expect(sections).not.toContain("smsProviderEventConflicts");
     expect(sections).not.toContain("smsProviderEventConflictReviews");
+    expect(sections).not.toContain("smsProviderEventResolutions");
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.usageRecords).toContain("billing");
     expect(
       PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.practiceConversionMilestones,
@@ -606,6 +607,9 @@ describe("summarizePracticeExport", () => {
     expect(
       PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.smsProviderEventConflictReviews,
     ).toContain("operator review evidence");
+    expect(
+      PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.smsProviderEventResolutions,
+    ).toContain("remediation evidence");
   });
 
   it("counts present sections and reports missing sections", () => {

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -112,6 +112,8 @@ export const PRACTICE_EXPORT_SYSTEM_EXCLUSIONS = {
     "Global immutable SMS provider idempotency conflict evidence; it is not clinic-owned restore data.",
   smsProviderEventConflictReviews:
     "Global immutable operator review evidence for SMS provider conflicts; it is not clinic-owned restore data.",
+  smsProviderEventResolutions:
+    "Global immutable SMS provider remediation evidence; it is not clinic-owned restore data and must remain bound to the operational provider inbox.",
   captureSessions:
     "Expiring QR photo-capture link tokens; restoring them would resurrect old capture URLs. The photos themselves are in the files section.",
   fileObjectReplicas:

--- a/apps/web/lib/messaging/__tests__/inbound-projection.test.ts
+++ b/apps/web/lib/messaging/__tests__/inbound-projection.test.ts
@@ -113,6 +113,26 @@ const base = {
 beforeEach(() => vi.clearAllMocks());
 
 describe("atomic inbound SMS projection", () => {
+  it("does not reacquire the recipient advisory after the provider event caller already holds it", async () => {
+    const { tx, state } = fakeTransaction({
+      selects: [[{ id: "client-1" }]],
+    });
+
+    await expect(
+      projectInboundSmsReplyInTransaction(tx, {
+        ...base,
+        text: "Can we move tomorrow's appointment?",
+        classification: "other",
+        recipientLockAlreadyHeld: true,
+      }),
+    ).resolves.toEqual({ ok: true, action: "logged" });
+
+    expect(state.executes).toHaveLength(0);
+    expect(state.inserts).toContainEqual(
+      expect.objectContaining({ table: "communications" }),
+    );
+  });
+
   it("applies STOP evidence, suppression, client revocation, and communication together", async () => {
     const { tx, state } = fakeTransaction({
       selects: [[], [{ id: "client-1" }]],

--- a/apps/web/lib/messaging/__tests__/sms-concurrency-drill.integration.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-concurrency-drill.integration.test.ts
@@ -1,0 +1,861 @@
+import { createHash, randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import {
+  auditLog,
+  communications,
+  locationMessaging,
+  locations,
+  practices,
+  smsDeliveryEventHistory,
+  smsDeliveryEvents,
+  smsProviderEventConflicts,
+  smsProviderEvents,
+  smsSendAttemptEvents,
+  smsSendAttempts,
+} from "@openpims/db";
+import { db, type Database } from "@openpims/db/client";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import { lockPracticeForExternalSideEffects } from "@/lib/recovery-hold";
+import { withSystem } from "@/lib/tenant-db";
+import {
+  hasBlockingSmsProviderEventForDispatchInTransaction,
+  loadSmsProviderEventGateSummaryInTransaction,
+} from "../sms-provider-event-operations";
+import {
+  ingestSmsProviderEvent,
+  projectSmsProviderEvent,
+  projectSmsProviderEventForLockedPracticeInTransaction,
+  projectSmsProviderEventInTransaction,
+} from "../sms-provider-events";
+import { acquireSmsRecipientLockInTransaction } from "../suppression";
+
+const describeWithPostgres = process.env.SMS_CONCURRENCY_DB_INTEGRATION
+  ? describe.sequential
+  : describe.skip;
+
+const SMS_FLAGS = [
+  "MESSAGING_PROVISIONING_ENABLED",
+  "MESSAGING_INBOUND_ENABLED",
+  "MESSAGING_SENDING_ENABLED",
+] as const;
+
+type Fixture = {
+  prefix: string;
+  practiceId: string;
+  locationId: string;
+  senderE164: string;
+  recipientE164: string;
+  messagingProfileId: string;
+};
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function within<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = 8_000,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`${label} exceeded ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function syntheticE164(): string {
+  const suffix = String(Math.floor(Math.random() * 10_000_000)).padStart(
+    7,
+    "0",
+  );
+  return `+1555${suffix}`;
+}
+
+async function setDrillTimeouts(tx: Database): Promise<void> {
+  await tx.execute(sql`set local statement_timeout = '7s'`);
+  await tx.execute(sql`set local lock_timeout = '6s'`);
+}
+
+async function backendPid(tx: Database): Promise<number> {
+  const result = await tx.execute(sql`select pg_backend_pid()::int as pid`);
+  const pid = rowsFromExecute<{ pid: number }>(result)[0]?.pid;
+  if (!pid) throw new Error("Concurrency drill could not read backend PID");
+  return Number(pid);
+}
+
+async function waitForBackendBlock(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const result = await db.execute(sql`
+      select cardinality(pg_blocking_pids(${pid}))::int as blockers
+    `);
+    const blockers = Number(
+      rowsFromExecute<{ blockers: number }>(result)[0]?.blockers ?? 0,
+    );
+    if (blockers > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Backend ${pid} never reached an observable lock wait`);
+}
+
+async function advisoryWaiterCount(lockKey: string): Promise<number> {
+  const result = await db.execute(sql`
+    with hashed as (
+      select hashtextextended(${lockKey}, 0)::bigint as value
+    )
+    select count(*)::int as count
+    from pg_locks lock
+    cross join hashed
+    where lock.locktype = 'advisory'
+      and lock.objsubid = 1
+      and lock.classid::bigint = ((hashed.value >> 32) & 4294967295)
+      and lock.objid::bigint = (hashed.value & 4294967295)
+      and not lock.granted
+  `);
+  return Number(rowsFromExecute<{ count: number }>(result)[0]?.count ?? 0);
+}
+
+async function waitForAdvisoryWaiters(
+  lockKey: string,
+  expected: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if ((await advisoryWaiterCount(lockKey)) >= expected) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(
+    `Advisory lock ${lockKey} never reached ${expected} waiter(s)`,
+  );
+}
+
+async function createFixture(
+  options: {
+    recoveryHold?: boolean;
+  } = {},
+): Promise<Fixture> {
+  const prefix = `sms-drill-${randomUUID()}`;
+  const practiceId = randomUUID();
+  const locationId = randomUUID();
+  const senderE164 = syntheticE164();
+  let recipientE164 = syntheticE164();
+  while (recipientE164 === senderE164) recipientE164 = syntheticE164();
+  const messagingProfileId = `${prefix}-profile`;
+  const recoveryHold = options.recoveryHold === true;
+
+  await withSystem(db, async (tx) => {
+    await tx.insert(practices).values({
+      id: practiceId,
+      name: `Synthetic SMS drill ${prefix}`,
+      recoveryHold,
+      recoveryHoldReason: recoveryHold ? "Synthetic concurrency drill" : null,
+      recoveryHoldSetAt: recoveryHold ? new Date() : null,
+    });
+    await tx.insert(locations).values({
+      id: locationId,
+      practiceId,
+      name: "Synthetic drill location",
+      isPrimary: true,
+    });
+    await tx.insert(locationMessaging).values({
+      practiceId,
+      locationId,
+      provider: "telnyx",
+      senderE164,
+      messagingProfileId,
+      registrationStatus: "not_started",
+      providerProfileReady: false,
+      enabled: false,
+    });
+  });
+
+  return {
+    prefix,
+    practiceId,
+    locationId,
+    senderE164,
+    recipientE164,
+    messagingProfileId,
+  };
+}
+
+function assertLocalDrillDatabase(): void {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl)
+    throw new Error("DATABASE_URL is required for the SMS drill");
+  const hostname = new URL(databaseUrl).hostname;
+  if (!["localhost", "127.0.0.1", "::1"].includes(hostname)) {
+    throw new Error(
+      "The SMS concurrency drill is restricted to disposable local PostgreSQL",
+    );
+  }
+}
+
+async function cleanupFixture(fixture: Fixture): Promise<void> {
+  const providerEventPattern = `${fixture.prefix}%`;
+  await withSystem(db, async (tx) => {
+    const resolutionResult = await tx.execute(sql`
+      select count(*)::int as count
+      from sms_provider_event_resolutions resolution
+      join sms_provider_events event on event.id = resolution.event_id
+      where event.practice_id = ${fixture.practiceId}::uuid
+        or event.provider_event_id like ${providerEventPattern}
+    `);
+    const resolutionCount = Number(
+      rowsFromExecute<{ count: number }>(resolutionResult)[0]?.count ?? 0,
+    );
+    if (resolutionCount > 0) {
+      throw new Error(
+        "Concurrency drill unexpectedly created immutable remediation evidence",
+      );
+    }
+    // Provider-event rows are immutable in normal operation. The drill only
+    // runs as the owner of a disposable local database, so use the schema's
+    // explicit disaster-recovery bypass for synthetic fixture cleanup.
+    await tx.execute(
+      sql`select set_config('app.ledger_maintenance', 'on', true)`,
+    );
+    await tx.execute(sql`
+      delete from sms_provider_event_conflict_reviews review
+      using sms_provider_event_conflicts conflict, sms_provider_events event
+      where review.conflict_id = conflict.id
+        and conflict.original_event_id = event.id
+        and (event.practice_id = ${fixture.practiceId}::uuid
+          or event.provider_event_id like ${providerEventPattern})
+    `);
+    await tx.execute(sql`
+      delete from sms_provider_event_conflicts conflict
+      using sms_provider_events event
+      where conflict.original_event_id = event.id
+        and (event.practice_id = ${fixture.practiceId}::uuid
+          or event.provider_event_id like ${providerEventPattern})
+    `);
+    await tx.execute(sql`
+      delete from sms_provider_events
+      where practice_id = ${fixture.practiceId}::uuid
+        or provider_event_id like ${providerEventPattern}
+    `);
+    await tx.execute(sql`
+      delete from sms_delivery_event_history history
+      using sms_delivery_events event
+      where history.delivery_event_id = event.id
+        and (history.practice_id = ${fixture.practiceId}::uuid
+          or event.provider_event_id like ${providerEventPattern})
+    `);
+    await tx.execute(sql`
+      delete from sms_delivery_events
+      where provider_event_id like ${providerEventPattern}
+    `);
+    await tx.execute(sql`
+      delete from sms_send_attempt_events
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from sms_send_attempts
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from sms_consent_events
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from sms_suppressions
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from communications
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from audit_log
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from location_messaging
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from users
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from locations
+      where practice_id = ${fixture.practiceId}::uuid
+    `);
+    await tx.execute(sql`
+      delete from practices where id = ${fixture.practiceId}::uuid
+    `);
+  });
+}
+
+async function createAcceptedSend(
+  fixture: Fixture,
+  suffix: string,
+): Promise<{
+  communicationId: string;
+  attemptId: string;
+  providerMessageId: string;
+}> {
+  const communicationId = randomUUID();
+  const attemptId = randomUUID();
+  const providerMessageId = `${fixture.prefix}-${suffix}-message`;
+  const body = `Synthetic provider-free concurrency drill ${suffix}`;
+
+  await withSystem(db, async (tx) => {
+    await tx.insert(communications).values({
+      id: communicationId,
+      practiceId: fixture.practiceId,
+      channel: "sms",
+      direction: "outbound",
+      content: body,
+      status: "sent",
+      providerMessageId,
+    });
+    await tx.insert(smsSendAttempts).values({
+      id: attemptId,
+      practiceId: fixture.practiceId,
+      locationId: fixture.locationId,
+      communicationId,
+      source: "sms_concurrency_drill",
+      sourceId: `${fixture.prefix}-${suffix}`,
+      idempotencyKey: `${fixture.prefix}-${suffix}`,
+      destinationE164: fixture.recipientE164,
+      registeredDisplayName: "Synthetic Drill Clinic",
+      body,
+      bodySha256: createHash("sha256").update(body).digest("hex"),
+      provider: "telnyx",
+      senderMessagingServiceId: fixture.messagingProfileId,
+      senderE164: fixture.senderE164,
+    });
+    await tx.insert(smsSendAttemptEvents).values({
+      practiceId: fixture.practiceId,
+      attemptId,
+      kind: "provider_result",
+      outcome: "accepted",
+      providerMessageId,
+      eventKey: `${fixture.prefix}-${suffix}-accepted`,
+    });
+  });
+
+  return { communicationId, attemptId, providerMessageId };
+}
+
+function deliveryProviderEventValues(
+  fixture: Fixture,
+  suffix: string,
+  providerMessageId: string,
+) {
+  const providerEventId = `${fixture.prefix}-${suffix}-dlr`;
+  const rawBody = `synthetic:${providerEventId}`;
+  return {
+    id: randomUUID(),
+    provider: "telnyx" as const,
+    kind: "delivery" as const,
+    providerEventId,
+    providerMessageId,
+    providerEventType: "message.delivered",
+    eventKey: `id:${providerEventId}`,
+    rawBodyFingerprintSha256: createHash("sha256")
+      .update(rawBody)
+      .digest("hex"),
+    occurredAt: new Date(),
+    deliveryClassification: "delivered" as const,
+    providerStatus: "delivered",
+    practiceId: fixture.practiceId,
+    locationId: fixture.locationId,
+    state: "pending" as const,
+  };
+}
+
+const originalHostedBilling = process.env.HOSTED_BILLING_ENABLED;
+
+describeWithPostgres("provider-free SMS concurrency drill", () => {
+  beforeAll(() => {
+    assertLocalDrillDatabase();
+    for (const flag of SMS_FLAGS) {
+      const value = process.env[flag]?.trim().toLowerCase();
+      if (value && !["0", "false", "no", "off"].includes(value)) {
+        throw new Error(`${flag} must remain disabled for the SMS drill`);
+      }
+      process.env[flag] = "false";
+    }
+    // Preserve hosted fail-closed inbound behavior without enabling an SMS flag.
+    process.env.HOSTED_BILLING_ENABLED = "true";
+  });
+
+  afterAll(() => {
+    if (originalHostedBilling === undefined) {
+      delete process.env.HOSTED_BILLING_ENABLED;
+    } else {
+      process.env.HOSTED_BILLING_ENABLED = originalHostedBilling;
+    }
+  });
+
+  it("serializes STOP intake ahead of the outbound final barrier", async () => {
+    const fixture = await createFixture();
+    const intakeLocked = deferred();
+    const releaseIntake = deferred();
+    const outboundPid = deferred<number>();
+    let providerCallCount = 0;
+    let outbound: Promise<boolean> | undefined;
+
+    const intake = withSystem(db, async (tx) => {
+      await setDrillTimeouts(tx);
+      expect(
+        await lockPracticeForExternalSideEffects(tx, fixture.practiceId),
+      ).toBe(true);
+      await acquireSmsRecipientLockInTransaction(
+        tx,
+        fixture.practiceId,
+        fixture.recipientE164,
+      );
+      intakeLocked.resolve();
+      await releaseIntake.promise;
+      const providerEventId = `${fixture.prefix}-stop`;
+      await tx.insert(smsProviderEvents).values({
+        provider: "telnyx",
+        kind: "inbound",
+        providerEventId,
+        providerMessageId: `${fixture.prefix}-stop-message`,
+        providerEventType: "message.received",
+        eventKey: `id:${providerEventId}`,
+        rawBodyFingerprintSha256: createHash("sha256")
+          .update(`synthetic:${providerEventId}`)
+          .digest("hex"),
+        occurredAt: new Date(),
+        fromE164: fixture.recipientE164,
+        toE164: fixture.senderE164,
+        messagingProfileId: fixture.messagingProfileId,
+        messageBody: "STOP",
+        inboundClassification: "stop",
+        practiceId: fixture.practiceId,
+        locationId: fixture.locationId,
+        state: "pending",
+      });
+    });
+
+    try {
+      await intakeLocked.promise;
+      outbound = withSystem(db, async (tx) => {
+        await setDrillTimeouts(tx);
+        expect(
+          await lockPracticeForExternalSideEffects(tx, fixture.practiceId),
+        ).toBe(true);
+        outboundPid.resolve(await backendPid(tx));
+        await acquireSmsRecipientLockInTransaction(
+          tx,
+          fixture.practiceId,
+          fixture.recipientE164,
+        );
+        const blocked =
+          await hasBlockingSmsProviderEventForDispatchInTransaction(
+            tx,
+            fixture.practiceId,
+            fixture.recipientE164,
+          );
+        if (!blocked) providerCallCount += 1;
+        return blocked;
+      });
+
+      await waitForBackendBlock(await outboundPid.promise);
+      releaseIntake.resolve();
+      const [blocked] = await within(
+        Promise.all([outbound, intake]),
+        "STOP/outbound serialization",
+      );
+      expect(blocked).toBe(true);
+      expect(providerCallCount).toBe(0);
+    } finally {
+      releaseIntake.resolve();
+      await Promise.allSettled([intake, ...(outbound ? [outbound] : [])]);
+      await cleanupFixture(fixture);
+    }
+  });
+
+  it("serializes conflict replay and projection in practice-sender-recipient-event order", async () => {
+    const fixture = await createFixture();
+    const providerEventId = `${fixture.prefix}-identity`;
+    const original = await ingestSmsProviderEvent({
+      provider: "telnyx",
+      kind: "inbound",
+      providerEventId,
+      providerMessageId: `${fixture.prefix}-inbound-message`,
+      providerEventType: "message.received",
+      rawBody: `synthetic:${providerEventId}:start`,
+      occurredAt: new Date(),
+      fromE164: fixture.recipientE164,
+      toE164: fixture.senderE164,
+      messagingProfileId: fixture.messagingProfileId,
+      messageBody: "START",
+      inboundClassification: "start",
+    });
+    const holderReady = deferred();
+    const releaseHolder = deferred();
+    const holder = withSystem(db, async (tx) => {
+      await setDrillTimeouts(tx);
+      await acquireSmsRecipientLockInTransaction(
+        tx,
+        fixture.practiceId,
+        fixture.recipientE164,
+      );
+      holderReady.resolve();
+      await releaseHolder.promise;
+    });
+    let conflictingReplay:
+      | ReturnType<typeof ingestSmsProviderEvent>
+      | undefined;
+    let projection:
+      | Promise<
+          Awaited<ReturnType<typeof projectSmsProviderEventInTransaction>>
+        >
+      | undefined;
+
+    try {
+      await holderReady.promise;
+      const lockKey = `sms:${fixture.practiceId}:${fixture.recipientE164}`;
+      conflictingReplay = ingestSmsProviderEvent({
+        provider: "telnyx",
+        kind: "inbound",
+        providerEventId,
+        providerMessageId: `${fixture.prefix}-inbound-message`,
+        providerEventType: "message.received",
+        rawBody: `synthetic:${providerEventId}:conflicting-stop`,
+        occurredAt: new Date(),
+        fromE164: fixture.recipientE164,
+        toE164: fixture.senderE164,
+        messagingProfileId: fixture.messagingProfileId,
+        messageBody: "STOP",
+        inboundClassification: "stop",
+      });
+      await waitForAdvisoryWaiters(lockKey, 1);
+
+      const projectionPid = deferred<number>();
+      projection = withSystem(db, async (tx) => {
+        await setDrillTimeouts(tx);
+        projectionPid.resolve(await backendPid(tx));
+        return projectSmsProviderEventInTransaction(tx, original.eventId);
+      });
+      await waitForBackendBlock(await projectionPid.promise);
+      await waitForAdvisoryWaiters(lockKey, 2);
+      releaseHolder.resolve();
+
+      const [conflict, projectionResult] = await within(
+        Promise.all([conflictingReplay, projection]),
+        "conflict/projection lock order",
+      );
+      expect(conflict).toMatchObject({
+        eventId: original.eventId,
+        conflict: true,
+        duplicate: false,
+      });
+      expect(["quarantined", "already_terminal"]).toContain(
+        projectionResult.outcome,
+      );
+
+      const [event] = await db
+        .select({ state: smsProviderEvents.state })
+        .from(smsProviderEvents)
+        .where(eq(smsProviderEvents.id, original.eventId))
+        .limit(1);
+      const conflicts = await db
+        .select({ id: smsProviderEventConflicts.id })
+        .from(smsProviderEventConflicts)
+        .where(eq(smsProviderEventConflicts.originalEventId, original.eventId));
+      expect(event?.state).toBe("quarantined");
+      expect(conflicts).toHaveLength(1);
+    } finally {
+      releaseHolder.resolve();
+      await Promise.allSettled([
+        holder,
+        ...(conflictingReplay ? [conflictingReplay] : []),
+        ...(projection ? [projection] : []),
+      ]);
+      await cleanupFixture(fixture);
+    }
+  });
+
+  it("converges a callback-first DLR after accepted-send evidence arrives", async () => {
+    const fixture = await createFixture();
+    const providerEventId = `${fixture.prefix}-callback-first-dlr`;
+    const providerMessageId = `${fixture.prefix}-callback-first-message`;
+    try {
+      const ingested = await ingestSmsProviderEvent({
+        provider: "telnyx",
+        kind: "delivery",
+        providerEventId,
+        providerMessageId,
+        providerEventType: "message.delivered",
+        rawBody: `synthetic:${providerEventId}:before-attempt`,
+        occurredAt: new Date(),
+        deliveryClassification: "delivered",
+        providerStatus: "delivered",
+      });
+      await expect(projectSmsProviderEvent(ingested.eventId)).resolves.toEqual({
+        outcome: "retry",
+      });
+
+      const communicationId = randomUUID();
+      const attemptId = randomUUID();
+      const body = "Synthetic callback-first DLR drill";
+      await withSystem(db, async (tx) => {
+        await tx.insert(communications).values({
+          id: communicationId,
+          practiceId: fixture.practiceId,
+          channel: "sms",
+          direction: "outbound",
+          content: body,
+          status: "sent",
+          providerMessageId,
+        });
+        await tx.insert(smsSendAttempts).values({
+          id: attemptId,
+          practiceId: fixture.practiceId,
+          locationId: fixture.locationId,
+          communicationId,
+          source: "sms_concurrency_drill",
+          sourceId: `${fixture.prefix}-callback-first`,
+          idempotencyKey: `${fixture.prefix}-callback-first`,
+          destinationE164: fixture.recipientE164,
+          registeredDisplayName: "Synthetic Drill Clinic",
+          body,
+          bodySha256: createHash("sha256").update(body).digest("hex"),
+          provider: "telnyx",
+          senderMessagingServiceId: fixture.messagingProfileId,
+          senderE164: fixture.senderE164,
+        });
+        await tx.insert(smsSendAttemptEvents).values({
+          practiceId: fixture.practiceId,
+          attemptId,
+          kind: "provider_result",
+          outcome: "accepted",
+          providerMessageId,
+          eventKey: `${fixture.prefix}-callback-first-accepted`,
+        });
+        // Make the retry immediately due without violating the invariant that
+        // next_attempt_at remains later than its committed last_attempt_at.
+        await tx
+          .update(smsProviderEvents)
+          .set({ nextAttemptAt: sql`clock_timestamp()` })
+          .where(eq(smsProviderEvents.id, ingested.eventId));
+      });
+
+      await expect(projectSmsProviderEvent(ingested.eventId)).resolves.toEqual({
+        outcome: "projected",
+      });
+      const [event] = await db
+        .select({
+          state: smsProviderEvents.state,
+          practiceId: smsProviderEvents.practiceId,
+        })
+        .from(smsProviderEvents)
+        .where(eq(smsProviderEvents.id, ingested.eventId))
+        .limit(1);
+      const [communication] = await db
+        .select({ status: communications.status })
+        .from(communications)
+        .where(eq(communications.id, communicationId))
+        .limit(1);
+      const [deliveryEvent] = await db
+        .select({ id: smsDeliveryEvents.id })
+        .from(smsDeliveryEvents)
+        .where(eq(smsDeliveryEvents.providerEventId, providerEventId))
+        .limit(1);
+      const history = await db
+        .select({ result: smsDeliveryEventHistory.result })
+        .from(smsDeliveryEventHistory)
+        .where(eq(smsDeliveryEventHistory.deliveryEventId, deliveryEvent!.id));
+      expect(event).toEqual({
+        state: "projected",
+        practiceId: fixture.practiceId,
+      });
+      expect(communication?.status).toBe("delivered");
+      expect(history.map((row) => row.result)).toEqual(
+        expect.arrayContaining(["unmatched", "attributed", "projected"]),
+      );
+    } finally {
+      await cleanupFixture(fixture);
+    }
+  });
+
+  it("preserves prior recovery drain progress across a failed savepoint and releases only after zero backlog", async () => {
+    const fixture = await createFixture({ recoveryHold: true });
+    const firstSend = await createAcceptedSend(fixture, "recovery-first");
+    const secondSend = await createAcceptedSend(fixture, "recovery-second");
+    const firstEvent = deliveryProviderEventValues(
+      fixture,
+      "recovery-first",
+      firstSend.providerMessageId,
+    );
+    const secondEvent = deliveryProviderEventValues(
+      fixture,
+      "recovery-second",
+      secondSend.providerMessageId,
+    );
+    await withSystem(db, (tx) =>
+      tx.insert(smsProviderEvents).values([firstEvent, secondEvent]),
+    );
+
+    try {
+      let projectionErrors = 0;
+      await withSystem(db, async (tx) => {
+        await setDrillTimeouts(tx);
+        const [practice] = await tx
+          .select({ recoveryHold: practices.recoveryHold })
+          .from(practices)
+          .where(eq(practices.id, fixture.practiceId))
+          .for("update")
+          .limit(1);
+        expect(practice?.recoveryHold).toBe(true);
+
+        await tx.transaction((eventTx) =>
+          projectSmsProviderEventForLockedPracticeInTransaction(
+            eventTx as unknown as Database,
+            {
+              practiceId: fixture.practiceId,
+              eventId: firstEvent.id,
+              force: true,
+            },
+          ),
+        );
+        try {
+          await tx.transaction(async (eventTx) => {
+            await eventTx.execute(sql`select 1 / 0`);
+            return projectSmsProviderEventForLockedPracticeInTransaction(
+              eventTx as unknown as Database,
+              {
+                practiceId: fixture.practiceId,
+                eventId: secondEvent.id,
+                force: true,
+              },
+            );
+          });
+        } catch {
+          projectionErrors += 1;
+        }
+
+        const remaining = await loadSmsProviderEventGateSummaryInTransaction(
+          tx,
+          {
+            practiceId: fixture.practiceId,
+          },
+        );
+        expect(remaining.total).toBe(1);
+        await tx.insert(auditLog).values({
+          practiceId: fixture.practiceId,
+          userId: null,
+          action: "hold_release_blocked",
+          entityType: "practice_recovery",
+          entityId: fixture.practiceId,
+          changes: {
+            source: "sms_concurrency_drill",
+            state: "held",
+            projectionErrors,
+            remaining: remaining.total,
+          },
+        });
+      });
+      expect(projectionErrors).toBe(1);
+
+      const firstCheckpoint = await db
+        .select({ id: smsProviderEvents.id, state: smsProviderEvents.state })
+        .from(smsProviderEvents)
+        .where(inArray(smsProviderEvents.id, [firstEvent.id, secondEvent.id]));
+      const [heldPractice] = await db
+        .select({ recoveryHold: practices.recoveryHold })
+        .from(practices)
+        .where(eq(practices.id, fixture.practiceId))
+        .limit(1);
+      expect(firstCheckpoint).toEqual(
+        expect.arrayContaining([
+          { id: firstEvent.id, state: "projected" },
+          { id: secondEvent.id, state: "pending" },
+        ]),
+      );
+      expect(heldPractice?.recoveryHold).toBe(true);
+
+      await withSystem(db, async (tx) => {
+        await setDrillTimeouts(tx);
+        await tx
+          .select({ id: practices.id })
+          .from(practices)
+          .where(eq(practices.id, fixture.practiceId))
+          .for("update")
+          .limit(1);
+        await tx.transaction((eventTx) =>
+          projectSmsProviderEventForLockedPracticeInTransaction(
+            eventTx as unknown as Database,
+            {
+              practiceId: fixture.practiceId,
+              eventId: secondEvent.id,
+              force: true,
+            },
+          ),
+        );
+        const remaining = await loadSmsProviderEventGateSummaryInTransaction(
+          tx,
+          {
+            practiceId: fixture.practiceId,
+          },
+        );
+        expect(remaining.total).toBe(0);
+        await tx
+          .update(practices)
+          .set({
+            recoveryHold: false,
+            recoveryHoldReleasedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(practices.id, fixture.practiceId),
+              eq(practices.recoveryHold, true),
+            ),
+          );
+        await tx.insert(auditLog).values({
+          practiceId: fixture.practiceId,
+          userId: null,
+          action: "hold_released",
+          entityType: "practice_recovery",
+          entityId: fixture.practiceId,
+          changes: { source: "sms_concurrency_drill", state: "released" },
+        });
+      });
+
+      const [releasedPractice] = await db
+        .select({ recoveryHold: practices.recoveryHold })
+        .from(practices)
+        .where(eq(practices.id, fixture.practiceId))
+        .limit(1);
+      const events = await db
+        .select({ state: smsProviderEvents.state })
+        .from(smsProviderEvents)
+        .where(inArray(smsProviderEvents.id, [firstEvent.id, secondEvent.id]));
+      const audits = await db
+        .select({ action: auditLog.action })
+        .from(auditLog)
+        .where(eq(auditLog.practiceId, fixture.practiceId));
+      expect(releasedPractice?.recoveryHold).toBe(false);
+      expect(events).toHaveLength(2);
+      expect(events.every((event) => event.state === "projected")).toBe(true);
+      expect(audits.map((entry) => entry.action)).toEqual(
+        expect.arrayContaining(["hold_release_blocked", "hold_released"]),
+      );
+    } finally {
+      await cleanupFixture(fixture);
+    }
+  });
+});

--- a/apps/web/lib/messaging/__tests__/sms-concurrency-drill.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-concurrency-drill.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const drill = readFileSync(
+  "lib/messaging/__tests__/sms-concurrency-drill.integration.test.ts",
+  "utf8",
+);
+const ci = readFileSync("../../.github/workflows/ci.yml", "utf8");
+const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+  scripts?: Record<string, string>;
+};
+
+describe("provider-free SMS concurrency drill wiring", () => {
+  it("uses real PostgreSQL locks and production event operations without provider adapters", () => {
+    expect(drill).toContain("pg_blocking_pids");
+    expect(drill).toContain("pg_locks");
+    expect(drill).toContain("acquireSmsRecipientLockInTransaction");
+    expect(drill).toContain("projectSmsProviderEventInTransaction");
+    expect(drill).toContain(
+      "projectSmsProviderEventForLockedPracticeInTransaction",
+    );
+    expect(drill).toContain("tx.transaction(async (eventTx)");
+    expect(drill).not.toContain("telnyx-provisioning");
+    expect(drill).not.toContain("twilio-provisioning");
+    expect(drill).not.toContain("sendSms(");
+  });
+
+  it("runs in the real-Postgres CI job with every SMS capability disabled", () => {
+    const resolutionContractIndex = ci.indexOf(
+      "Execute SMS provider-resolution database contract",
+    );
+    const concurrencyDrillIndex = ci.indexOf(
+      "Execute provider-free SMS concurrency drill",
+    );
+    const step = ci.slice(
+      concurrencyDrillIndex,
+      ci.indexOf("Execute appointment reminder policy SQL"),
+    );
+    expect(resolutionContractIndex).toBeGreaterThan(
+      ci.indexOf("pnpm --filter @openpims/db db:rls"),
+    );
+    expect(concurrencyDrillIndex).toBeGreaterThan(resolutionContractIndex);
+    expect(ci).toContain(
+      "pnpm --filter @openpims/db db:sms-provider-resolutions:test",
+    );
+    expect(step).toContain('SMS_CONCURRENCY_DB_INTEGRATION: "1"');
+    expect(step).toContain('MESSAGING_PROVISIONING_ENABLED: "false"');
+    expect(step).toContain('MESSAGING_INBOUND_ENABLED: "false"');
+    expect(step).toContain('MESSAGING_SENDING_ENABLED: "false"');
+    expect(packageJson.scripts?.["test:sms-concurrency"]).toContain(
+      "sms-concurrency-drill.integration.test.ts",
+    );
+  });
+
+  it("restricts execution to disposable local PostgreSQL and protects immutable remediation evidence", () => {
+    expect(drill).toContain("assertLocalDrillDatabase");
+    expect(drill).toContain("sms_provider_event_resolutions");
+    expect(drill).toContain(
+      "Concurrency drill unexpectedly created immutable remediation evidence",
+    );
+    expect(drill).toContain("app.ledger_maintenance");
+  });
+});

--- a/apps/web/lib/messaging/__tests__/sms-delivery-ledger.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-delivery-ledger.test.ts
@@ -127,6 +127,11 @@ describe("SMS delivery evidence and monotone reducer", () => {
     expect(providerResult.indexOf("lockSmsDeliveryIdentity(")).toBeLessThan(
       providerResult.indexOf(".insert(smsSendAttemptEvents)"),
     );
+    expect(
+      providerResult.indexOf(
+        "assertAcceptedProviderIdentityAllowedInTransaction(",
+      ),
+    ).toBeLessThan(providerResult.indexOf(".insert(smsSendAttemptEvents)"));
     expect(providerResult).toContain("identityLockHeld: true");
 
     const reconciliation = SMS_DISPATCH_SOURCE.slice(
@@ -142,7 +147,31 @@ describe("SMS delivery evidence and monotone reducer", () => {
     );
     expect(lockAt).toBeGreaterThan(0);
     expect(acceptedInsertAt).toBeGreaterThan(lockAt);
+    expect(
+      reconciliation.indexOf(
+        "assertAcceptedProviderIdentityAllowedInTransaction(",
+        lockAt,
+      ),
+    ).toBeGreaterThan(lockAt);
     expect(reconciliation).toContain("identityLockHeld: true");
+  });
+
+  it("blocks base and conflict-scoped no-projection identities after the delivery lock", () => {
+    const guard = SMS_DISPATCH_SOURCE.slice(
+      SMS_DISPATCH_SOURCE.indexOf(
+        "async function assertAcceptedProviderIdentityAllowedInTransaction",
+      ),
+      SMS_DISPATCH_SOURCE.indexOf("async function providerCall"),
+    );
+    expect(guard).toContain('"provider_attested_no_projection"');
+    expect(guard).toContain("smsProviderEvents.providerMessageId");
+    expect(guard).toContain(
+      "smsProviderEventConflicts.incomingProviderMessageId",
+    );
+    expect(guard).toContain("isNull(smsProviderEventResolutions.conflictId)");
+    expect(guard).toContain(
+      "isNotNull(smsProviderEventResolutions.conflictId)",
+    );
   });
 
   it("defines the full reducer domain", () => {

--- a/apps/web/lib/messaging/__tests__/sms-provider-event-operations.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-provider-event-operations.test.ts
@@ -31,7 +31,8 @@ describe("SMS provider-event operational gates", () => {
       "event.messaging_profile_id = sender.messaging_profile_id",
     );
     expect(barrier).toContain("event.kind = 'a2p'");
-    expect(barrier).toContain("or event.state = 'quarantined'");
+    expect(barrier).toContain("event.state = 'quarantined'");
+    expect(barrier).toContain("sms_provider_event_resolutions");
     expect(barrier).toContain("sms_provider_event_conflict_reviews");
   });
 

--- a/apps/web/lib/messaging/__tests__/sms-provider-event-remediation-delivery-lock.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-provider-event-remediation-delivery-lock.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fake = vi.hoisted(() => ({
+  calls: [] as string[],
+  lockDelivery: vi.fn(async () => {
+    fake.calls.push("delivery-identity");
+  }),
+}));
+
+vi.mock("@openpims/db/client", () => ({ db: {} }));
+vi.mock("../sms-delivery-ledger", () => ({
+  lockSmsDeliveryIdentity: fake.lockDelivery,
+  recordSmsDeliveryCallbackInTransaction: vi.fn(),
+}));
+
+const { lockSmsProviderEventForRemediationInTransaction } =
+  await import("../sms-provider-events");
+
+const EVENT_ID = "00000000-0000-4000-8000-000000000201";
+const PRACTICE_ID = "00000000-0000-4000-8000-000000000202";
+const event = {
+  id: EVENT_ID,
+  receivedAt: new Date("2026-08-11T12:00:00.000Z"),
+  provider: "telnyx",
+  kind: "delivery",
+  providerEventId: "delivery-event-201",
+  providerMessageId: "provider-message-201",
+  providerEventType: "message.finalized",
+  eventKey: "id:delivery-event-201",
+  rawBodyFingerprintSha256: "a".repeat(64),
+  occurredAt: new Date("2026-08-11T11:59:59.000Z"),
+  fromE164: null,
+  toE164: null,
+  messagingProfileId: null,
+  messageBody: null,
+  inboundClassification: null,
+  deliveryClassification: "delivered",
+  providerStatus: "delivered",
+  providerErrorCode: null,
+  a2pBrandId: null,
+  a2pCampaignId: null,
+  a2pPhoneE164: null,
+  a2pStatus: null,
+  a2pType: null,
+  a2pEventType: null,
+  a2pObservedStatus: null,
+  providerDetail: null,
+  practiceId: null,
+  locationId: null,
+  state: "quarantined",
+  attemptCount: 1,
+  nextAttemptAt: null,
+  lastAttemptAt: new Date("2026-08-11T12:00:01.000Z"),
+  processedAt: new Date("2026-08-11T12:00:01.000Z"),
+  lastErrorCode: "delivery_attribution_pending",
+  lastErrorDetail: "Awaiting exact accepted-send attribution.",
+};
+
+function tableName(table: unknown): string {
+  if (!table || typeof table !== "object") return "unknown";
+  for (const symbol of Object.getOwnPropertySymbols(table)) {
+    if (symbol.description?.includes("Name")) {
+      const value = (table as Record<symbol, unknown>)[symbol];
+      if (typeof value === "string") return value;
+    }
+  }
+  return "unknown";
+}
+
+function database(options: { acceptedOnRevalidation?: boolean } = {}) {
+  let attemptReads = 0;
+  return {
+    execute: vi.fn(async () => undefined),
+    select: vi.fn(() => {
+      let from = "unknown";
+      const rows = () => {
+        fake.calls.push(`select:${from}`);
+        if (from === "sms_provider_events") return [event];
+        if (from === "practices") {
+          return [{ id: PRACTICE_ID, recoveryHold: false }];
+        }
+        if (from === "sms_send_attempts") {
+          attemptReads += 1;
+          return options.acceptedOnRevalidation && attemptReads === 2
+            ? [
+                {
+                  id: "00000000-0000-4000-8000-000000000203",
+                  practiceId: PRACTICE_ID,
+                  locationId: "00000000-0000-4000-8000-000000000204",
+                },
+              ]
+            : [];
+        }
+        return [];
+      };
+      const builder: Record<string, unknown> & PromiseLike<unknown[]> = {
+        then: (resolve, reject) =>
+          Promise.resolve(rows()).then(resolve, reject),
+      };
+      builder.from = vi.fn((table: unknown) => {
+        from = tableName(table);
+        return builder;
+      });
+      for (const method of [
+        "innerJoin",
+        "where",
+        "groupBy",
+        "orderBy",
+        "limit",
+      ]) {
+        builder[method] = vi.fn(() => builder);
+      }
+      builder.for = vi.fn(async () => rows());
+      return builder;
+    }),
+  };
+}
+
+beforeEach(() => {
+  fake.calls.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("globally unattributed delivery remediation locking", () => {
+  it("locks all provider practices, then delivery identity, then the event before accepting zero attribution", async () => {
+    const db = database();
+    await expect(
+      lockSmsProviderEventForRemediationInTransaction(db as never, EVENT_ID, {
+        allowGloballyUnattributedDelivery: true,
+        allowRecoveryHeld: true,
+      }),
+    ).resolves.toMatchObject({ attribution: null });
+
+    expect(fake.calls).toEqual([
+      "select:sms_provider_events",
+      "select:sms_send_attempts",
+      "select:practices",
+      "delivery-identity",
+      "select:sms_provider_events",
+      "select:sms_send_attempts",
+    ]);
+    expect(fake.lockDelivery).toHaveBeenCalledWith(
+      db,
+      "telnyx",
+      "provider-message-201",
+    );
+  });
+
+  it("fails closed when an accepted send becomes visible during final revalidation", async () => {
+    const db = database({ acceptedOnRevalidation: true });
+    await expect(
+      lockSmsProviderEventForRemediationInTransaction(db as never, EVENT_ID, {
+        allowGloballyUnattributedDelivery: true,
+        allowRecoveryHeld: true,
+      }),
+    ).rejects.toThrow("attribution changed during remediation");
+    expect(fake.calls.indexOf("select:practices")).toBeLessThan(
+      fake.calls.indexOf("delivery-identity"),
+    );
+    expect(fake.calls.indexOf("delivery-identity")).toBeLessThan(
+      fake.calls.lastIndexOf("select:sms_provider_events"),
+    );
+  });
+});

--- a/apps/web/lib/messaging/__tests__/sms-provider-event-remediation.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-provider-event-remediation.test.ts
@@ -1,0 +1,464 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  lock: vi.fn(),
+  projectInbound: vi.fn(async () => ({ duplicate: false })),
+  revoke: vi.fn(async () => undefined),
+  delivery: vi.fn(),
+}));
+
+vi.mock("@openpims/db/client", () => ({ db: {} }));
+vi.mock("@/lib/tenant-db", () => ({
+  withSystem: vi.fn(
+    async (database: unknown, action: (tx: unknown) => unknown) =>
+      action(database),
+  ),
+}));
+vi.mock("../sms-provider-events", () => ({
+  lockSmsProviderEventForRemediationInTransaction: mocks.lock,
+}));
+vi.mock("../inbound", () => ({
+  inboundSmsDedupeKey: (provider: string, id: string) =>
+    `sms:inbound:${provider}:${id}`,
+  projectInboundSmsReplyInTransaction: mocks.projectInbound,
+}));
+vi.mock("../consent-events", () => ({
+  inboundSmsConsentEventKey: (provider: string, id: string, action: string) =>
+    `sms:consent:${provider}:${id}:${action}`,
+}));
+vi.mock("../suppression", () => ({
+  revokeSmsConsentAfterRecipientLockInTransaction: mocks.revoke,
+}));
+vi.mock("../sms-delivery-ledger", () => ({
+  recordSmsDeliveryCallbackInTransaction: mocks.delivery,
+}));
+
+const {
+  isValidProviderExternalEvidenceReference,
+  resolveSmsProviderEventInTransaction,
+  smsProviderEventResolutionModesForIncident,
+} = await import("../sms-provider-event-remediation");
+
+const SERVICE_SOURCE = readFileSync(
+  new URL("../sms-provider-event-remediation.ts", import.meta.url),
+  "utf8",
+);
+const STATUS_SOURCE = readFileSync(
+  new URL("../sms-provider-event-resolution-status.ts", import.meta.url),
+  "utf8",
+);
+const OPERATIONS_SOURCE = readFileSync(
+  new URL("../sms-provider-event-operations.ts", import.meta.url),
+  "utf8",
+);
+const PROVIDER_SOURCE = readFileSync(
+  new URL("../sms-provider-events.ts", import.meta.url),
+  "utf8",
+);
+
+const EVENT_ID = "00000000-0000-4000-8000-000000000101";
+const CONFLICT_ID = "00000000-0000-4000-8000-000000000102";
+const OPERATION_ID = "00000000-0000-4000-8000-000000000103";
+const PRACTICE_ID = "00000000-0000-4000-8000-000000000104";
+const LOCATION_ID = "00000000-0000-4000-8000-000000000105";
+const COMMUNICATION_ID = "00000000-0000-4000-8000-000000000106";
+const CONSENT_ID = "00000000-0000-4000-8000-000000000107";
+const REGISTRATION_EVENT_ID = "00000000-0000-4000-8000-000000000108";
+const RESOLUTION_ID = "00000000-0000-4000-8000-000000000109";
+
+type FakeTx = ReturnType<typeof fakeTx>;
+
+function fakeTx(
+  selectResults: unknown[][],
+  returningResults: unknown[][] = [],
+) {
+  const insertedValues: unknown[] = [];
+  const updatedValues: unknown[] = [];
+  const select = vi.fn(() => {
+    const builder: Record<string, unknown> & PromiseLike<unknown[]> = {
+      then: (resolve, reject) =>
+        Promise.resolve(selectResults.shift() ?? []).then(resolve, reject),
+    };
+    for (const method of ["from", "innerJoin", "where", "orderBy", "limit"]) {
+      builder[method] = vi.fn(() => builder);
+    }
+    builder.for = vi.fn(async () => selectResults.shift() ?? []);
+    return builder;
+  });
+  const insert = vi.fn(() => {
+    const builder: Record<string, unknown> & PromiseLike<void> = {
+      then: (resolve, reject) => Promise.resolve().then(resolve, reject),
+    };
+    builder.values = vi.fn((values: unknown) => {
+      insertedValues.push(values);
+      return builder;
+    });
+    builder.onConflictDoNothing = vi.fn(() => builder);
+    builder.returning = vi.fn(async () => returningResults.shift() ?? []);
+    return builder;
+  });
+  const update = vi.fn(() => {
+    const builder: Record<string, unknown> & PromiseLike<void> = {
+      then: (resolve, reject) => Promise.resolve().then(resolve, reject),
+    };
+    builder.set = vi.fn((values: unknown) => {
+      updatedValues.push(values);
+      return builder;
+    });
+    builder.where = vi.fn(() => builder);
+    return builder;
+  });
+  return { select, insert, update, insertedValues, updatedValues };
+}
+
+function inboundEvent(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: EVENT_ID,
+    provider: "telnyx",
+    kind: "inbound",
+    state: "quarantined",
+    practiceId: PRACTICE_ID,
+    locationId: LOCATION_ID,
+    lastErrorCode: "projection_retry_exhausted",
+    fromE164: "+15555550199",
+    toE164: "+15555550100",
+    messageBody: "STOP",
+    providerMessageId: "message-101",
+    inboundClassification: "stop",
+    occurredAt: new Date("2026-08-11T12:00:00.000Z"),
+    receivedAt: new Date("2026-08-11T12:00:01.000Z"),
+    ...overrides,
+  };
+}
+
+function locked(event: Record<string, unknown>, attribution = true) {
+  return {
+    event,
+    attribution: attribution
+      ? { practiceId: PRACTICE_ID, locationId: event.locationId ?? null }
+      : null,
+    resolution: {
+      practiceIds: attribution ? [PRACTICE_ID] : [],
+      attribution: null,
+    },
+    inboundRecipientLockHeld: event.kind === "inbound",
+  };
+}
+
+function resultRow(input: {
+  resolution: string;
+  conflictId?: string | null;
+  practiceId?: string | null;
+  reasonCode: string;
+  inboundCommunicationId?: string | null;
+  smsConsentEventId?: string | null;
+  messagingRegistrationEventId?: string | null;
+  externalEvidenceReference?: string | null;
+}) {
+  return {
+    id: RESOLUTION_ID,
+    eventId: EVENT_ID,
+    conflictId: input.conflictId ?? null,
+    operationId: OPERATION_ID,
+    practiceId: input.practiceId === undefined ? PRACTICE_ID : input.practiceId,
+    resolution: input.resolution,
+    reasonCode: input.reasonCode,
+    resolvedByIdentity: "o***@example.com",
+    resolvedByName: "Operator",
+    inboundCommunicationId: input.inboundCommunicationId ?? null,
+    smsConsentEventId: input.smsConsentEventId ?? null,
+    smsDeliveryEventId: null,
+    messagingRegistrationEventId: input.messagingRegistrationEventId ?? null,
+    externalEvidenceReference: input.externalEvidenceReference ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("provider-event remediation mode and privacy policy", () => {
+  it("restricts base and conflict incidents to evidence-valid modes", () => {
+    expect(
+      smsProviderEventResolutionModesForIncident({
+        kind: "inbound",
+        state: "quarantined",
+        lastErrorCode: "projection_retry_exhausted",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      }),
+    ).toEqual(["authoritative_projection"]);
+    expect(
+      smsProviderEventResolutionModesForIncident({
+        kind: "inbound",
+        state: "projected",
+        lastErrorCode: null,
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        conflictId: CONFLICT_ID,
+      }),
+    ).toEqual(["conservative_opt_out"]);
+    expect(
+      smsProviderEventResolutionModesForIncident({
+        kind: "inbound",
+        state: "projected",
+        lastErrorCode: null,
+        practiceId: null,
+        locationId: null,
+        conflictId: CONFLICT_ID,
+      }),
+    ).toEqual([]);
+    expect(
+      smsProviderEventResolutionModesForIncident({
+        kind: "a2p",
+        state: "ignored",
+        lastErrorCode: null,
+        practiceId: PRACTICE_ID,
+        locationId: null,
+        conflictId: CONFLICT_ID,
+      }),
+    ).toEqual(["carrier_state_reconciled"]);
+    expect(
+      smsProviderEventResolutionModesForIncident({
+        kind: "delivery",
+        state: "quarantined",
+        lastErrorCode: null,
+        practiceId: null,
+        locationId: null,
+      }),
+    ).toEqual(["provider_attested_no_projection"]);
+  });
+
+  it("rejects phone-shaped and malformed provider references", () => {
+    expect(isValidProviderExternalEvidenceReference("TELNYX-TICKET:2048")).toBe(
+      true,
+    );
+    expect(isValidProviderExternalEvidenceReference("+1 (555) 555-0199")).toBe(
+      false,
+    );
+    expect(isValidProviderExternalEvidenceReference("15555550199")).toBe(false);
+    expect(isValidProviderExternalEvidenceReference("contains spaces")).toBe(
+      false,
+    );
+  });
+});
+
+describe("provider-event remediation evidence behavior", () => {
+  it("authoritatively projects inbound STOP and binds communication plus consent", async () => {
+    mocks.lock.mockResolvedValue(locked(inboundEvent()));
+    const tx = fakeTx(
+      [[], [], [{ id: COMMUNICATION_ID }], [{ id: CONSENT_ID }]],
+      [
+        [
+          resultRow({
+            resolution: "authoritative_projection",
+            reasonCode: "projection_repaired",
+            inboundCommunicationId: COMMUNICATION_ID,
+            smsConsentEventId: CONSENT_ID,
+          }),
+        ],
+      ],
+    );
+
+    await expect(
+      resolveSmsProviderEventInTransaction(tx as never, {
+        eventId: EVENT_ID,
+        operationId: OPERATION_ID,
+        resolution: "authoritative_projection",
+        actorIdentity: "o***@example.com",
+        actorName: "Operator",
+      }),
+    ).resolves.toMatchObject({
+      resolutionId: RESOLUTION_ID,
+      duplicate: false,
+    });
+
+    expect(mocks.projectInbound).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        classification: "stop",
+        recipientLockAlreadyHeld: true,
+      }),
+    );
+    expect(mocks.lock).toHaveBeenCalledWith(
+      tx,
+      EVENT_ID,
+      expect.objectContaining({ allowRecoveryHeld: true }),
+    );
+    expect(tx.insertedValues).toContainEqual(
+      expect.objectContaining({
+        reasonCode: "projection_repaired",
+        inboundCommunicationId: COMMUNICATION_ID,
+        smsConsentEventId: CONSENT_ID,
+      }),
+    );
+  });
+
+  it("resolves a projected inbound conflict with system revocation and active suppression", async () => {
+    mocks.lock.mockResolvedValue(
+      locked(inboundEvent({ state: "projected", messageBody: "START" })),
+    );
+    const tx = fakeTx(
+      [
+        [],
+        [{ id: CONFLICT_ID }],
+        [],
+        [{ id: CONSENT_ID }],
+        [{ id: "suppression-1" }],
+        [],
+        [{ id: "review-1" }],
+      ],
+      [
+        [
+          resultRow({
+            resolution: "conservative_opt_out",
+            conflictId: CONFLICT_ID,
+            reasonCode: "provider_identity_conflict_opt_out",
+            smsConsentEventId: CONSENT_ID,
+          }),
+        ],
+      ],
+    );
+
+    await resolveSmsProviderEventInTransaction(tx as never, {
+      eventId: EVENT_ID,
+      conflictId: CONFLICT_ID,
+      operationId: OPERATION_ID,
+      resolution: "conservative_opt_out",
+      actorIdentity: "o***@example.com",
+      actorName: "Operator",
+    });
+
+    expect(mocks.revoke).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        evidence: expect.objectContaining({
+          actorType: "system",
+          source: "provider_event_resolution:v1",
+          eventKey: `provider_event_resolution:${OPERATION_ID}:${CONFLICT_ID}:revoked`,
+        }),
+      }),
+    );
+    expect(tx.insertedValues).toContainEqual(
+      expect.objectContaining({
+        conflictId: CONFLICT_ID,
+        resolution: "conservative_opt_out",
+        reasonCode: "provider_identity_conflict_opt_out",
+        smsConsentEventId: CONSENT_ID,
+      }),
+    );
+  });
+
+  it("makes exact operation replay idempotent before tenant locks or effects", async () => {
+    const prior = resultRow({
+      resolution: "provider_attested_no_projection",
+      practiceId: null,
+      reasonCode: "provider_support_invalid_callback",
+      externalEvidenceReference: "TELNYX-TICKET:2048",
+    });
+    const tx = fakeTx([[prior]]);
+    await expect(
+      resolveSmsProviderEventInTransaction(tx as never, {
+        eventId: EVENT_ID,
+        operationId: OPERATION_ID,
+        resolution: "provider_attested_no_projection",
+        reasonCode: "provider_support_invalid_callback",
+        externalEvidenceReference: "TELNYX-TICKET:2048",
+        providerAttestationConfirmed: true,
+        actorIdentity: "o***@example.com",
+        actorName: "Operator",
+      }),
+    ).resolves.toMatchObject({ duplicate: true, practiceId: null });
+    expect(mocks.lock).not.toHaveBeenCalled();
+    expect(mocks.revoke).not.toHaveBeenCalled();
+    expect(mocks.projectInbound).not.toHaveBeenCalled();
+  });
+
+  it("binds carrier evidence to the remediation operation and keeps senders disabled", async () => {
+    const event = {
+      ...inboundEvent(),
+      kind: "a2p",
+      state: "quarantined",
+      locationId: null,
+      a2pBrandId: "brand-101",
+      a2pCampaignId: "campaign-101",
+      a2pPhoneE164: null,
+    };
+    mocks.lock.mockResolvedValue(locked(event));
+    const tx = fakeTx(
+      [[], [], [{ id: REGISTRATION_EVENT_ID, locationId: null }]],
+      [
+        [
+          resultRow({
+            resolution: "carrier_state_reconciled",
+            reasonCode: "carrier_state_readback_confirmed",
+            messagingRegistrationEventId: REGISTRATION_EVENT_ID,
+          }),
+        ],
+      ],
+    );
+
+    await resolveSmsProviderEventInTransaction(tx as never, {
+      eventId: EVENT_ID,
+      operationId: OPERATION_ID,
+      resolution: "carrier_state_reconciled",
+      messagingRegistrationEventId: REGISTRATION_EVENT_ID,
+      actorIdentity: "o***@example.com",
+      actorName: "Operator",
+    });
+
+    expect(tx.updatedValues).toContainEqual(
+      expect.objectContaining({
+        enabled: false,
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
+      }),
+    );
+    expect(tx.insertedValues).toContainEqual(
+      expect.objectContaining({
+        operationId: OPERATION_ID,
+        messagingRegistrationEventId: REGISTRATION_EVENT_ID,
+        reasonCode: "carrier_state_readback_confirmed",
+      }),
+    );
+  });
+});
+
+describe("provider-event remediation operational gates", () => {
+  it("allows only the audited resolver to cross a recovery hold under a practice update lock", () => {
+    expect(SERVICE_SOURCE).toContain("allowRecoveryHeld: true");
+    expect(PROVIDER_SOURCE).toContain("options: { forUpdate?: boolean } = {}");
+    expect(PROVIDER_SOURCE).toContain('options.forUpdate ? "update" : "share"');
+    expect(PROVIDER_SOURCE).toContain("!options.allowRecoveryHeld &&");
+    expect(SERVICE_SOURCE).not.toContain("recoveryHold:");
+  });
+
+  it("requires base evidence and fresh review plus resolution for every conflict", () => {
+    expect(STATUS_SOURCE).toContain("base_resolution.conflict_id is null");
+    expect(STATUS_SOURCE).toContain(
+      "event.last_error_code = 'provider_identity_conflict'",
+    );
+    expect(STATUS_SOURCE).toContain("conflict_review.conflict_id");
+    expect(STATUS_SOURCE).toContain("conflict_resolution.conflict_id");
+    expect(STATUS_SOURCE).toContain("not exists (");
+    expect(
+      OPERATIONS_SOURCE.match(/smsProviderEventQuarantineIsRemediatedSql/g),
+    ).toHaveLength(5);
+    expect(PROVIDER_SOURCE).toContain(
+      "smsProviderEventQuarantineIsRemediatedSql",
+    );
+    expect(PROVIDER_SOURCE).toMatch(
+      /summary\.quarantined\s*\+\s*summary\.conflicts/,
+    );
+  });
+
+  it("never mutates the terminal provider event during remediation", () => {
+    expect(SERVICE_SOURCE).not.toContain(".update(smsProviderEvents)");
+    expect(SERVICE_SOURCE.indexOf("appendConflictReview(")).toBeLessThan(
+      SERVICE_SOURCE.lastIndexOf(".insert(smsProviderEventResolutions)"),
+    );
+  });
+});

--- a/apps/web/lib/messaging/__tests__/sms-provider-events.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-provider-events.test.ts
@@ -167,21 +167,27 @@ describe("SMS provider event durability contracts", () => {
     expect(intake).not.toContain('original.state === "projected" ||');
   });
 
-  it("locks practice rows before event rows during projection", () => {
+  it("uses practice, sender identity, recipient, event lock order during inbound projection", () => {
     const projection = functionSource(
       SERVICE_SOURCE,
-      "async function projectSmsProviderEventInTransaction(",
+      "async function projectSmsProviderEventWithLocksInTransaction(",
       "export async function projectSmsProviderEvent(",
     );
     expect(projection.indexOf("lockPracticeStatesInTransaction")).toBeLessThan(
-      projection.indexOf('.for("update")'),
-    );
-    expect(projection.indexOf('.for("update")')).toBeLessThan(
       projection.indexOf("lockMessagingLocationIdentityInTransaction"),
     );
     expect(
       projection.indexOf("lockMessagingLocationIdentityInTransaction"),
-    ).toBeLessThan(projection.indexOf("projectLockedEventInTransaction"));
+    ).toBeLessThan(projection.indexOf("acquireSmsRecipientLockInTransaction"));
+    expect(
+      projection.indexOf("acquireSmsRecipientLockInTransaction"),
+    ).toBeLessThan(projection.indexOf('.for("update")'));
+    expect(projection.indexOf('.for("update")')).toBeLessThan(
+      projection.indexOf("resolveStoredEventInTransaction(tx, event)"),
+    );
+    expect(projection).toContain(
+      "inboundRecipientLockAlreadyHeld: inboundRecipientLockHeld",
+    );
   });
 
   it("never silently consumes supported unresolved inbound or A2P evidence", () => {
@@ -232,7 +238,7 @@ describe("SMS provider event durability contracts", () => {
 
   it("counts held and quarantined work in bounded-worker remaining", () => {
     expect(SERVICE_SOURCE).toMatch(
-      /result\.remaining\s*=\s*summary\.pending\s*\+\s*summary\.retry\s*\+\s*summary\.blockedRecovery\s*\+\s*summary\.quarantined/,
+      /result\.remaining\s*=\s*summary\.pending\s*\+\s*summary\.retry\s*\+\s*summary\.blockedRecovery\s*\+\s*summary\.quarantined\s*\+\s*summary\.conflicts/,
     );
   });
 });

--- a/apps/web/lib/messaging/inbound.ts
+++ b/apps/web/lib/messaging/inbound.ts
@@ -555,8 +555,8 @@ export async function logInboundSmsCommunicationInTransaction(
 
 /**
  * Project an already-attributed inbound message inside the durable provider
- * event transaction. The caller must hold the practice row before calling;
- * this function then takes the recipient advisory lock before target rows.
+ * event transaction. The caller must hold the practice row before calling and
+ * may pass through the recipient advisory lock acquired before its event row.
  */
 export async function projectInboundSmsReplyInTransaction(
   tx: Database,
@@ -569,13 +569,16 @@ export async function projectInboundSmsReplyInTransaction(
     providerMessageId: string | null;
     classification: InboundSmsClassification;
     occurredAt: Date;
+    recipientLockAlreadyHeld?: boolean;
   },
 ): Promise<InboundProjectionResult> {
   const fromPhone = normalizeE164(opts.fromPhone);
   const text = opts.text.trim();
   if (!fromPhone || !text) return { ok: true, action: "ignored" };
 
-  await acquireSmsRecipientLockInTransaction(tx, opts.practiceId, fromPhone);
+  if (!opts.recipientLockAlreadyHeld) {
+    await acquireSmsRecipientLockInTransaction(tx, opts.practiceId, fromPhone);
+  }
   const latestDecision =
     opts.classification === "stop" || opts.classification === "start"
       ? await latestInboundConsentDecisionInTransaction(

--- a/apps/web/lib/messaging/sms-provider-event-operations.ts
+++ b/apps/web/lib/messaging/sms-provider-event-operations.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import type { Database } from "@openpims/db/client";
 import { rowsFromExecute } from "@/lib/db/execute-rows";
 import { withSystem } from "@/lib/tenant-db";
+import { smsProviderEventQuarantineIsRemediatedSql } from "./sms-provider-event-resolution-status";
 
 export const SMS_PROVIDER_EVENT_STALE_MINUTES = 15;
 
@@ -29,6 +30,7 @@ export interface SmsProviderEventGateSummary {
 
 export interface SmsProviderEventQueueItem {
   eventId: string;
+  conflictId: string | null;
   receivedAt: Date;
   practiceId: string | null;
   locationId: string | null;
@@ -121,17 +123,27 @@ export async function hasBlockingSmsProviderEventForDispatchInTransaction(
           )
           or (
             event.kind = 'a2p'
-            and event.state in ('pending', 'retry', 'blocked_recovery', 'quarantined')
+            and event.state in ('pending', 'retry', 'blocked_recovery')
           )
-          or event.state = 'quarantined'
+          or (
+            event.state = 'quarantined'
+            and not ${smsProviderEventQuarantineIsRemediatedSql}
+          )
           or exists (
             select 1
             from sms_provider_event_conflicts conflict
             where conflict.original_event_id = event.id
-              and not exists (
-                select 1
-                from sms_provider_event_conflict_reviews review
-                where review.conflict_id = conflict.id
+              and (
+                not exists (
+                  select 1
+                  from sms_provider_event_conflict_reviews review
+                  where review.conflict_id = conflict.id
+                )
+                or not exists (
+                  select 1
+                  from sms_provider_event_resolutions resolution
+                  where resolution.conflict_id = conflict.id
+                )
               )
           )
         )
@@ -205,6 +217,10 @@ export async function loadSmsProviderEventGateSummaryInTransaction(
       from sms_provider_events event
       where event.state in ('pending', 'retry', 'blocked_recovery', 'quarantined')
         and (
+          event.state <> 'quarantined'
+          or not ${smsProviderEventQuarantineIsRemediatedSql}
+        )
+        and (
           event.practice_id = ${input.practiceId}::uuid
           or (
             event.practice_id is null
@@ -257,10 +273,17 @@ export async function loadSmsProviderEventGateSummaryInTransaction(
       select conflict.received_at
       from sms_provider_event_conflicts conflict
       join sms_provider_events event on event.id = conflict.original_event_id
-      where not exists (
-          select 1
-          from sms_provider_event_conflict_reviews review
-          where review.conflict_id = conflict.id
+      where (
+          not exists (
+            select 1
+            from sms_provider_event_conflict_reviews review
+            where review.conflict_id = conflict.id
+          )
+          or not exists (
+            select 1
+            from sms_provider_event_resolutions resolution
+            where resolution.conflict_id = conflict.id
+          )
         )
         and (
           event.practice_id = ${input.practiceId}::uuid
@@ -366,15 +389,26 @@ export async function loadSmsProviderEventQueue(
         from sms_provider_events event
         where ${scope}
           and event.state in ('pending', 'retry', 'blocked_recovery', 'quarantined')
+          and (
+            event.state <> 'quarantined'
+            or not ${smsProviderEventQuarantineIsRemediatedSql}
+          )
       ), scoped_conflicts as (
         select conflict.id
         from sms_provider_event_conflicts conflict
         join sms_provider_events event on event.id = conflict.original_event_id
         where ${scope}
-          and not exists (
-            select 1
-            from sms_provider_event_conflict_reviews review
-            where review.conflict_id = conflict.id
+          and (
+            not exists (
+              select 1
+              from sms_provider_event_conflict_reviews review
+              where review.conflict_id = conflict.id
+            )
+            or not exists (
+              select 1
+              from sms_provider_event_resolutions resolution
+              where resolution.conflict_id = conflict.id
+            )
           )
       )
       select
@@ -396,6 +430,7 @@ export async function loadSmsProviderEventQueue(
       with queue as (
         select
           event.id as "eventId",
+          null::uuid as "conflictId",
           event.received_at as "receivedAt",
           event.practice_id as "practiceId",
           event.location_id as "locationId",
@@ -426,11 +461,16 @@ export async function loadSmsProviderEventQueue(
           and location.practice_id = event.practice_id
         where ${scope}
           and event.state in ('pending', 'retry', 'blocked_recovery', 'quarantined')
+          and (
+            event.state <> 'quarantined'
+            or not ${smsProviderEventQuarantineIsRemediatedSql}
+          )
 
         union all
 
         select
           event.id as "eventId",
+          conflict.id as "conflictId",
           conflict.received_at as "receivedAt",
           event.practice_id as "practiceId",
           event.location_id as "locationId",
@@ -452,10 +492,17 @@ export async function loadSmsProviderEventQueue(
           on location.id = event.location_id
           and location.practice_id = event.practice_id
         where ${scope}
-          and not exists (
-            select 1
-            from sms_provider_event_conflict_reviews review
-            where review.conflict_id = conflict.id
+          and (
+            not exists (
+              select 1
+              from sms_provider_event_conflict_reviews review
+              where review.conflict_id = conflict.id
+            )
+            or not exists (
+              select 1
+              from sms_provider_event_resolutions resolution
+              where resolution.conflict_id = conflict.id
+            )
           )
       )
       select *

--- a/apps/web/lib/messaging/sms-provider-event-remediation.ts
+++ b/apps/web/lib/messaging/sms-provider-event-remediation.ts
@@ -1,0 +1,937 @@
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import {
+  communications,
+  locationMessaging,
+  messagingRegistrationEvents,
+  messagingRegistrations,
+  smsConsentEvents,
+  smsDeliveryEventHistory,
+  smsDeliveryEvents,
+  smsProviderEventConflictReviews,
+  smsProviderEventConflicts,
+  smsProviderEventResolutions,
+  smsProviderEvents,
+  smsSuppressions,
+} from "@openpims/db";
+import { db, type Database } from "@openpims/db/client";
+import { withSystem } from "@/lib/tenant-db";
+import { inboundSmsConsentEventKey } from "./consent-events";
+import {
+  inboundSmsDedupeKey,
+  projectInboundSmsReplyInTransaction,
+} from "./inbound";
+import {
+  lockSmsProviderEventForRemediationInTransaction,
+  type LockedSmsProviderEventRemediation,
+} from "./sms-provider-events";
+import { recordSmsDeliveryCallbackInTransaction } from "./sms-delivery-ledger";
+import { revokeSmsConsentAfterRecipientLockInTransaction } from "./suppression";
+
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const EXTERNAL_EVIDENCE = /^[A-Za-z0-9][A-Za-z0-9_.:/#-]{2,254}$/;
+const PHONE_LIKE_OPERATIONAL_ID = /^\+?\d[\d ().-]{6,18}$/;
+const CARRIER_EVIDENCE_MAX_AGE_MS = 15 * 60 * 1_000;
+
+export type SmsProviderEventResolutionMode =
+  | "authoritative_projection"
+  | "conservative_opt_out"
+  | "carrier_state_reconciled"
+  | "provider_attested_no_projection";
+
+export type SmsProviderEventResolutionIncident = {
+  kind: "inbound" | "delivery" | "a2p";
+  state:
+    | "pending"
+    | "retry"
+    | "blocked_recovery"
+    | "quarantined"
+    | "projected"
+    | "ignored";
+  lastErrorCode: string | null;
+  practiceId: string | null;
+  locationId: string | null;
+  conflictId?: string | null;
+};
+
+export function isValidProviderExternalEvidenceReference(
+  value: string,
+): boolean {
+  return (
+    EXTERNAL_EVIDENCE.test(value) && !PHONE_LIKE_OPERATIONAL_ID.test(value)
+  );
+}
+
+export function smsProviderEventResolutionModesForIncident(
+  incident: SmsProviderEventResolutionIncident,
+): SmsProviderEventResolutionMode[] {
+  const isConflict = Boolean(incident.conflictId);
+  if (!isConflict && incident.state !== "quarantined") return [];
+  if (incident.kind === "inbound") {
+    if (isConflict) {
+      return incident.practiceId && incident.locationId
+        ? ["conservative_opt_out"]
+        : [];
+    }
+    return [
+      ...(incident.practiceId && incident.locationId
+        ? (["authoritative_projection"] as const)
+        : []),
+      ...(incident.practiceId &&
+      incident.locationId &&
+      (incident.lastErrorCode === "sender_identity_drift" ||
+        incident.lastErrorCode === "immutable_attribution_drift")
+        ? (["conservative_opt_out"] as const)
+        : []),
+    ];
+  }
+  if (incident.kind === "a2p") {
+    return incident.practiceId ? ["carrier_state_reconciled"] : [];
+  }
+  return [
+    ...(incident.practiceId ? (["authoritative_projection"] as const) : []),
+    "provider_attested_no_projection",
+  ];
+}
+
+type ResolutionActor = {
+  actorIdentity: string;
+  actorName: string;
+};
+
+type ResolutionBase = ResolutionActor & {
+  eventId: string;
+  conflictId?: string | null;
+  operationId: string;
+};
+
+export type ResolveSmsProviderEventInput =
+  | (ResolutionBase & { resolution: "authoritative_projection" })
+  | (ResolutionBase & { resolution: "conservative_opt_out" })
+  | (ResolutionBase & {
+      resolution: "carrier_state_reconciled";
+      messagingRegistrationEventId: string;
+    })
+  | (ResolutionBase & {
+      resolution: "provider_attested_no_projection";
+      externalEvidenceReference: string;
+      reasonCode:
+        | "provider_support_invalid_callback"
+        | "provider_support_duplicate_callback";
+      providerAttestationConfirmed: true;
+    });
+
+type ResolutionEvidence = {
+  inboundCommunicationId: string | null;
+  smsConsentEventId: string | null;
+  smsDeliveryEventId: string | null;
+  messagingRegistrationEventId: string | null;
+  externalEvidenceReference: string | null;
+};
+
+export type SmsProviderEventResolutionResult = {
+  resolutionId: string;
+  eventId: string;
+  conflictId: string | null;
+  practiceId: string | null;
+  resolution: SmsProviderEventResolutionMode;
+  duplicate: boolean;
+};
+
+export type SmsProviderEventResolutionHistoryItem = {
+  resolutionId: string;
+  resolvedAt: Date;
+  eventId: string;
+  conflictId: string | null;
+  practiceId: string | null;
+  provider: string;
+  kind: "inbound" | "delivery" | "a2p";
+  resolution: SmsProviderEventResolutionMode;
+  reasonCode: string;
+  operatorLabel: string;
+  evidenceType:
+    | "communication"
+    | "consent"
+    | "delivery"
+    | "carrier_registration"
+    | "external_attestation";
+  externalEvidenceReference: string | null;
+};
+
+function bounded(value: string | null | undefined, max: number): string | null {
+  const normalized = value?.trim();
+  if (!normalized || normalized.length > max) return null;
+  return normalized;
+}
+
+function normalizeInput(input: ResolveSmsProviderEventInput) {
+  const actorIdentity = bounded(input.actorIdentity, 255);
+  const actorName = bounded(input.actorName, 255);
+  const conflictId = input.conflictId ?? null;
+  if (
+    !UUID.test(input.eventId) ||
+    !UUID.test(input.operationId) ||
+    (conflictId !== null && !UUID.test(conflictId)) ||
+    !actorIdentity ||
+    !actorName
+  ) {
+    throw new Error(
+      "Complete bounded provider-event resolution evidence is required.",
+    );
+  }
+  if (
+    input.resolution === "carrier_state_reconciled" &&
+    !UUID.test(input.messagingRegistrationEventId)
+  ) {
+    throw new Error("A valid carrier reconciliation evidence id is required.");
+  }
+  if (
+    input.resolution === "provider_attested_no_projection" &&
+    (!input.providerAttestationConfirmed ||
+      !isValidProviderExternalEvidenceReference(
+        input.externalEvidenceReference,
+      ))
+  ) {
+    throw new Error(
+      "Explicit bounded provider-support attestation evidence is required.",
+    );
+  }
+  return { ...input, conflictId, actorIdentity, actorName };
+}
+
+function reasonFor(
+  input: ReturnType<typeof normalizeInput>,
+  locked: LockedSmsProviderEventRemediation,
+): {
+  reasonCode: string;
+  detail: string;
+} {
+  switch (input.resolution) {
+    case "authoritative_projection":
+      return {
+        reasonCode:
+          locked.event.kind === "delivery"
+            ? "delivery_reconciled"
+            : "projection_repaired",
+        detail: "Exact provider evidence was projected and verified.",
+      };
+    case "conservative_opt_out":
+      return {
+        reasonCode: input.conflictId
+          ? "provider_identity_conflict_opt_out"
+          : "sender_identity_drift_opt_out",
+        detail:
+          "Conflicting inbound evidence was resolved conservatively as an opt-out.",
+      };
+    case "carrier_state_reconciled":
+      return {
+        reasonCode: "carrier_state_readback_confirmed",
+        detail:
+          "Current carrier registration state was reconciled before resolution.",
+      };
+    case "provider_attested_no_projection":
+      return {
+        reasonCode: input.reasonCode,
+        detail:
+          "Provider support attested that no tenant projection is required.",
+      };
+  }
+}
+
+function requestReasonMatches(
+  row: typeof smsProviderEventResolutions.$inferSelect,
+  input: ReturnType<typeof normalizeInput>,
+): boolean {
+  if (input.resolution === "authoritative_projection") {
+    return (
+      row.reasonCode === "projection_repaired" ||
+      row.reasonCode === "delivery_reconciled"
+    );
+  }
+  if (input.resolution === "conservative_opt_out") {
+    return (
+      row.reasonCode ===
+      (input.conflictId
+        ? "provider_identity_conflict_opt_out"
+        : "sender_identity_drift_opt_out")
+    );
+  }
+  if (input.resolution === "carrier_state_reconciled") {
+    return row.reasonCode === "carrier_state_readback_confirmed";
+  }
+  return row.reasonCode === input.reasonCode;
+}
+
+function sameRequest(
+  row: typeof smsProviderEventResolutions.$inferSelect,
+  input: ReturnType<typeof normalizeInput>,
+): boolean {
+  return (
+    row.eventId === input.eventId &&
+    row.conflictId === input.conflictId &&
+    row.operationId === input.operationId &&
+    row.resolution === input.resolution &&
+    row.resolvedByIdentity === input.actorIdentity &&
+    row.resolvedByName === input.actorName &&
+    requestReasonMatches(row, input) &&
+    row.messagingRegistrationEventId ===
+      (input.resolution === "carrier_state_reconciled"
+        ? input.messagingRegistrationEventId
+        : null) &&
+    row.externalEvidenceReference ===
+      (input.resolution === "provider_attested_no_projection"
+        ? input.externalEvidenceReference
+        : null)
+  );
+}
+
+function resultFromRow(
+  row: typeof smsProviderEventResolutions.$inferSelect,
+  duplicate: boolean,
+): SmsProviderEventResolutionResult {
+  return {
+    resolutionId: row.id,
+    eventId: row.eventId,
+    conflictId: row.conflictId,
+    practiceId: row.practiceId,
+    resolution: row.resolution,
+    duplicate,
+  };
+}
+
+async function inboundAuthoritativeEvidence(
+  tx: Database,
+  locked: LockedSmsProviderEventRemediation,
+): Promise<ResolutionEvidence> {
+  const { event, attribution } = locked;
+  if (
+    event.kind !== "inbound" ||
+    !attribution?.locationId ||
+    !event.fromE164 ||
+    !event.messageBody ||
+    !event.providerMessageId ||
+    !event.inboundClassification ||
+    !locked.inboundRecipientLockHeld
+  ) {
+    throw new Error("Inbound provider evidence is not exactly projectable.");
+  }
+  await projectInboundSmsReplyInTransaction(tx, {
+    provider: event.provider as "telnyx" | "twilio",
+    practiceId: attribution.practiceId,
+    locationId: attribution.locationId,
+    fromPhone: event.fromE164,
+    text: event.messageBody,
+    providerMessageId: event.providerMessageId,
+    classification: event.inboundClassification,
+    occurredAt: event.occurredAt ?? event.receivedAt,
+    recipientLockAlreadyHeld: true,
+  });
+  const dedupeKey = inboundSmsDedupeKey(
+    event.provider as "telnyx" | "twilio",
+    event.providerMessageId,
+  );
+  const [communication] = await tx
+    .select({ id: communications.id })
+    .from(communications)
+    .where(
+      and(
+        eq(communications.practiceId, attribution.practiceId),
+        eq(communications.channel, "sms"),
+        eq(communications.direction, "inbound"),
+        eq(communications.providerMessageId, event.providerMessageId),
+        eq(communications.dedupeKey, dedupeKey!),
+        eq(communications.content, event.messageBody),
+        isNull(communications.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!communication) {
+    throw new Error("Authoritative inbound communication evidence is missing.");
+  }
+  let consentId: string | null = null;
+  if (
+    event.inboundClassification === "stop" ||
+    event.inboundClassification === "start"
+  ) {
+    const action =
+      event.inboundClassification === "stop" ? "revoked" : "granted";
+    const [consent] = await tx
+      .select({ id: smsConsentEvents.id })
+      .from(smsConsentEvents)
+      .where(
+        and(
+          eq(smsConsentEvents.practiceId, attribution.practiceId),
+          eq(smsConsentEvents.locationId, attribution.locationId),
+          eq(smsConsentEvents.destinationE164, event.fromE164),
+          eq(smsConsentEvents.action, action),
+          eq(smsConsentEvents.provider, event.provider),
+          eq(smsConsentEvents.providerMessageId, event.providerMessageId),
+          eq(
+            smsConsentEvents.eventKey,
+            inboundSmsConsentEventKey(
+              event.provider as "telnyx" | "twilio",
+              event.providerMessageId,
+              action,
+            ),
+          ),
+        ),
+      )
+      .limit(1);
+    if (!consent) {
+      throw new Error("Authoritative inbound consent evidence is missing.");
+    }
+    consentId = consent.id;
+  }
+  return {
+    inboundCommunicationId: communication.id,
+    smsConsentEventId: consentId,
+    smsDeliveryEventId: null,
+    messagingRegistrationEventId: null,
+    externalEvidenceReference: null,
+  };
+}
+
+async function conservativeOptOutEvidence(
+  tx: Database,
+  locked: LockedSmsProviderEventRemediation,
+  input: ReturnType<typeof normalizeInput>,
+): Promise<ResolutionEvidence> {
+  const { event, attribution } = locked;
+  if (
+    event.kind !== "inbound" ||
+    !attribution?.locationId ||
+    !event.fromE164 ||
+    !locked.inboundRecipientLockHeld
+  ) {
+    throw new Error("Conservative opt-out requires exact inbound attribution.");
+  }
+  const evidenceKey = `provider_event_resolution:${input.operationId}:${input.conflictId ?? input.eventId}:revoked`;
+  await revokeSmsConsentAfterRecipientLockInTransaction(tx, {
+    practiceId: attribution.practiceId,
+    locationId: attribution.locationId,
+    phone: event.fromE164,
+    reason: "stop",
+    detail: "Provider event conflict resolved conservatively as an opt-out.",
+    evidence: {
+      source: "provider_event_resolution:v1",
+      detail: "Provider event conflict resolved conservatively as an opt-out.",
+      actorType: "system",
+      eventKey: evidenceKey,
+      occurredAt: new Date(),
+    },
+  });
+  const [consent] = await tx
+    .select({ id: smsConsentEvents.id })
+    .from(smsConsentEvents)
+    .where(
+      and(
+        eq(smsConsentEvents.practiceId, attribution.practiceId),
+        eq(smsConsentEvents.locationId, attribution.locationId),
+        eq(smsConsentEvents.destinationE164, event.fromE164),
+        eq(smsConsentEvents.action, "revoked"),
+        eq(smsConsentEvents.actorType, "system"),
+        eq(smsConsentEvents.source, "provider_event_resolution:v1"),
+        eq(smsConsentEvents.eventKey, evidenceKey),
+        isNull(smsConsentEvents.provider),
+        isNull(smsConsentEvents.providerMessageId),
+      ),
+    )
+    .limit(1);
+  const [suppression] = await tx
+    .select({ id: smsSuppressions.id })
+    .from(smsSuppressions)
+    .where(
+      and(
+        eq(smsSuppressions.practiceId, attribution.practiceId),
+        eq(smsSuppressions.phone, event.fromE164),
+        isNull(smsSuppressions.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!consent || !suppression) {
+    throw new Error("Conservative opt-out evidence is incomplete.");
+  }
+  return {
+    inboundCommunicationId: null,
+    smsConsentEventId: consent.id,
+    smsDeliveryEventId: null,
+    messagingRegistrationEventId: null,
+    externalEvidenceReference: null,
+  };
+}
+
+async function deliveryAuthoritativeEvidence(
+  tx: Database,
+  locked: LockedSmsProviderEventRemediation,
+): Promise<ResolutionEvidence> {
+  const { event, attribution } = locked;
+  if (
+    event.kind !== "delivery" ||
+    !attribution ||
+    !event.providerMessageId ||
+    !event.deliveryClassification
+  ) {
+    throw new Error("Delivery evidence is not exactly projectable.");
+  }
+  const result = await recordSmsDeliveryCallbackInTransaction(tx, {
+    provider: event.provider as "telnyx" | "twilio",
+    providerEventId: event.providerEventId,
+    providerMessageId: event.providerMessageId,
+    providerEventType: event.providerEventType,
+    providerStatus: event.providerStatus,
+    providerErrorCode: event.providerErrorCode,
+    classification: event.deliveryClassification,
+    occurredAt: event.occurredAt,
+  });
+  if (result.result !== "projected") {
+    throw new Error(
+      "Delivery evidence must be exactly attributed and projected before resolution.",
+    );
+  }
+  const [delivery] = await tx
+    .select({ id: smsDeliveryEvents.id })
+    .from(smsDeliveryEvents)
+    .where(
+      and(
+        eq(smsDeliveryEvents.id, result.eventId),
+        eq(smsDeliveryEvents.provider, event.provider),
+        eq(smsDeliveryEvents.providerMessageId, event.providerMessageId),
+        eq(smsDeliveryEvents.providerEventType, event.providerEventType),
+        eq(smsDeliveryEvents.classification, event.deliveryClassification),
+      ),
+    )
+    .limit(1);
+  if (!delivery) throw new Error("Immutable delivery evidence is missing.");
+  const [history] = await tx
+    .select({ id: smsDeliveryEventHistory.id })
+    .from(smsDeliveryEventHistory)
+    .where(
+      and(
+        eq(smsDeliveryEventHistory.deliveryEventId, delivery.id),
+        eq(smsDeliveryEventHistory.practiceId, attribution.practiceId),
+        inArray(smsDeliveryEventHistory.result, ["projected", "reconciled"]),
+      ),
+    )
+    .orderBy(
+      desc(smsDeliveryEventHistory.createdAt),
+      desc(smsDeliveryEventHistory.id),
+    )
+    .limit(1);
+  if (!history) {
+    throw new Error("Delivery projection evidence is missing.");
+  }
+  return {
+    inboundCommunicationId: null,
+    smsConsentEventId: null,
+    smsDeliveryEventId: delivery.id,
+    messagingRegistrationEventId: null,
+    externalEvidenceReference: null,
+  };
+}
+
+async function carrierReconciliationEvidence(
+  tx: Database,
+  locked: LockedSmsProviderEventRemediation,
+  input: ReturnType<typeof normalizeInput>,
+): Promise<ResolutionEvidence> {
+  const { event, attribution } = locked;
+  if (
+    input.resolution !== "carrier_state_reconciled" ||
+    event.kind !== "a2p" ||
+    !attribution
+  ) {
+    throw new Error(
+      "Carrier reconciliation resolution requires exact A2P attribution.",
+    );
+  }
+  const cutoff = new Date(Date.now() - CARRIER_EVIDENCE_MAX_AGE_MS);
+  const [evidence] = await tx
+    .select({
+      id: messagingRegistrationEvents.id,
+      locationId: messagingRegistrationEvents.locationId,
+    })
+    .from(messagingRegistrationEvents)
+    .innerJoin(
+      messagingRegistrations,
+      and(
+        eq(
+          messagingRegistrations.id,
+          messagingRegistrationEvents.registrationId,
+        ),
+        eq(
+          messagingRegistrations.practiceId,
+          messagingRegistrationEvents.practiceId,
+        ),
+        eq(
+          messagingRegistrations.status,
+          messagingRegistrationEvents.statusAfter,
+        ),
+        isNull(messagingRegistrations.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(messagingRegistrationEvents.id, input.messagingRegistrationEventId),
+        eq(messagingRegistrationEvents.practiceId, attribution.practiceId),
+        eq(messagingRegistrationEvents.provider, event.provider),
+        eq(messagingRegistrationEvents.eventType, "provider_state_observed"),
+        eq(
+          messagingRegistrationEvents.operation,
+          "registration_reconciliation",
+        ),
+        eq(messagingRegistrationEvents.operationId, input.operationId),
+        eq(
+          messagingRegistrationEvents.reasonCode,
+          "carrier_registration_reconciled",
+        ),
+        sql`${messagingRegistrationEvents.createdAt} >= ${cutoff}`,
+        event.a2pBrandId
+          ? eq(messagingRegistrationEvents.providerBrandId, event.a2pBrandId)
+          : sql`true`,
+        event.a2pCampaignId
+          ? eq(
+              messagingRegistrationEvents.providerCampaignId,
+              event.a2pCampaignId,
+            )
+          : sql`true`,
+        event.a2pPhoneE164
+          ? eq(messagingRegistrationEvents.locationId, event.locationId!)
+          : sql`true`,
+      ),
+    )
+    .limit(1);
+  if (!evidence) {
+    throw new Error("Current carrier reconciliation evidence is missing.");
+  }
+  await tx
+    .update(locationMessaging)
+    .set({
+      enabled: false,
+      providerProfileReady: false,
+      providerProfileSyncedAt: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(locationMessaging.practiceId, attribution.practiceId),
+        eq(locationMessaging.provider, "telnyx"),
+        isNull(locationMessaging.deletedAt),
+      ),
+    );
+  if (event.a2pPhoneE164) {
+    const [sender] = await tx
+      .select({ id: locationMessaging.id })
+      .from(locationMessaging)
+      .where(
+        and(
+          eq(locationMessaging.practiceId, attribution.practiceId),
+          eq(locationMessaging.locationId, event.locationId!),
+          eq(locationMessaging.provider, "telnyx"),
+          eq(locationMessaging.senderE164, event.a2pPhoneE164),
+          eq(locationMessaging.enabled, false),
+          eq(locationMessaging.providerProfileReady, false),
+          isNull(locationMessaging.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (!sender || evidence.locationId !== event.locationId) {
+      throw new Error(
+        "Phone-level carrier reconciliation is not bound to a disabled exact sender.",
+      );
+    }
+  }
+  return {
+    inboundCommunicationId: null,
+    smsConsentEventId: null,
+    smsDeliveryEventId: null,
+    messagingRegistrationEventId: evidence.id,
+    externalEvidenceReference: null,
+  };
+}
+
+function assertModeAllowed(
+  locked: LockedSmsProviderEventRemediation,
+  input: ReturnType<typeof normalizeInput>,
+): void {
+  const { event } = locked;
+  const allowed = smsProviderEventResolutionModesForIncident({
+    kind: event.kind,
+    state: event.state,
+    lastErrorCode: event.lastErrorCode,
+    practiceId: event.practiceId,
+    locationId: event.locationId,
+    conflictId: input.conflictId,
+  });
+  if (!allowed.includes(input.resolution)) {
+    throw new Error(
+      "This event requires its kind-specific safe resolution mode.",
+    );
+  }
+}
+
+async function appendConflictReview(
+  tx: Database,
+  conflictId: string,
+  input: ReturnType<typeof normalizeInput>,
+): Promise<void> {
+  const [existing] = await tx
+    .select({ id: smsProviderEventConflictReviews.id })
+    .from(smsProviderEventConflictReviews)
+    .where(eq(smsProviderEventConflictReviews.conflictId, conflictId))
+    .limit(1);
+  if (existing) return;
+  const conflictReview =
+    input.resolution === "authoritative_projection"
+      ? {
+          resolution: "semantic_duplicate_confirmed" as const,
+          reasonCode: "signature_evidence_verified" as const,
+        }
+      : input.resolution === "carrier_state_reconciled"
+        ? {
+            resolution: "provider_identity_rotated" as const,
+            reasonCode: "provider_identity_reprovisioned" as const,
+          }
+        : {
+            resolution: "incident_closed_no_projection" as const,
+            reasonCode:
+              input.resolution === "provider_attested_no_projection"
+                ? ("provider_support_incident_closed" as const)
+                : ("security_review_closed" as const),
+          };
+  await tx
+    .insert(smsProviderEventConflictReviews)
+    .values({
+      conflictId,
+      operationId: input.operationId,
+      ...conflictReview,
+      detail: "Conflict closed by audited provider-event remediation.",
+      reviewedByIdentity: input.actorIdentity,
+      reviewedByName: input.actorName,
+    })
+    .onConflictDoNothing();
+  const [review] = await tx
+    .select({ id: smsProviderEventConflictReviews.id })
+    .from(smsProviderEventConflictReviews)
+    .where(eq(smsProviderEventConflictReviews.conflictId, conflictId))
+    .limit(1);
+  if (!review)
+    throw new Error("Provider-event conflict review was not durable.");
+}
+
+async function resolutionEvidence(
+  tx: Database,
+  locked: LockedSmsProviderEventRemediation,
+  input: ReturnType<typeof normalizeInput>,
+): Promise<ResolutionEvidence> {
+  switch (input.resolution) {
+    case "authoritative_projection":
+      return locked.event.kind === "inbound"
+        ? inboundAuthoritativeEvidence(tx, locked)
+        : deliveryAuthoritativeEvidence(tx, locked);
+    case "conservative_opt_out":
+      return conservativeOptOutEvidence(tx, locked, input);
+    case "carrier_state_reconciled":
+      return carrierReconciliationEvidence(tx, locked, input);
+    case "provider_attested_no_projection":
+      return {
+        inboundCommunicationId: null,
+        smsConsentEventId: null,
+        smsDeliveryEventId: null,
+        messagingRegistrationEventId: null,
+        externalEvidenceReference: input.externalEvidenceReference,
+      };
+  }
+}
+
+export async function resolveSmsProviderEventInTransaction(
+  tx: Database,
+  rawInput: ResolveSmsProviderEventInput,
+  options: { lockedPracticeId?: string } = {},
+): Promise<SmsProviderEventResolutionResult> {
+  const input = normalizeInput(rawInput);
+  const [priorOperation] = await tx
+    .select()
+    .from(smsProviderEventResolutions)
+    .where(eq(smsProviderEventResolutions.operationId, input.operationId))
+    .limit(1);
+  if (priorOperation) {
+    if (!sameRequest(priorOperation, input)) {
+      throw new Error("Provider-event resolution operation id collision.");
+    }
+    return resultFromRow(priorOperation, true);
+  }
+
+  const locked = await lockSmsProviderEventForRemediationInTransaction(
+    tx,
+    input.eventId,
+    {
+      lockedPracticeId: options.lockedPracticeId,
+      allowGloballyUnattributedDelivery:
+        input.resolution === "provider_attested_no_projection",
+      allowImmutableInboundOptOut: input.resolution === "conservative_opt_out",
+      // This is the only service path allowed to repair a terminal provider
+      // incident while recovery is held. The lock helper takes the practice
+      // row FOR UPDATE so release and remediation cannot pass one another.
+      allowRecoveryHeld: true,
+    },
+  );
+  if (input.conflictId) {
+    const [conflict] = await tx
+      .select({ id: smsProviderEventConflicts.id })
+      .from(smsProviderEventConflicts)
+      .where(
+        and(
+          eq(smsProviderEventConflicts.id, input.conflictId),
+          eq(smsProviderEventConflicts.originalEventId, input.eventId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!conflict) {
+      throw new Error("Provider-event conflict does not belong to this event.");
+    }
+  }
+  assertModeAllowed(locked, input);
+
+  const [priorTarget] = await tx
+    .select()
+    .from(smsProviderEventResolutions)
+    .where(
+      input.conflictId
+        ? eq(smsProviderEventResolutions.conflictId, input.conflictId)
+        : and(
+            eq(smsProviderEventResolutions.eventId, input.eventId),
+            isNull(smsProviderEventResolutions.conflictId),
+          ),
+    )
+    .limit(1);
+  if (priorTarget) {
+    if (!sameRequest(priorTarget, input)) {
+      throw new Error("Provider event incident is already resolved.");
+    }
+    return resultFromRow(priorTarget, true);
+  }
+
+  const evidence = await resolutionEvidence(tx, locked, input);
+  if (input.conflictId) {
+    await appendConflictReview(tx, input.conflictId, input);
+  }
+  const reason = reasonFor(input, locked);
+  const [inserted] = await tx
+    .insert(smsProviderEventResolutions)
+    .values({
+      eventId: input.eventId,
+      conflictId: input.conflictId,
+      operationId: input.operationId,
+      practiceId: locked.attribution?.practiceId ?? null,
+      resolution: input.resolution,
+      ...evidence,
+      ...reason,
+      resolvedByIdentity: input.actorIdentity,
+      resolvedByName: input.actorName,
+    })
+    .onConflictDoNothing()
+    .returning();
+  if (inserted) return resultFromRow(inserted, false);
+
+  const [winner] = await tx
+    .select()
+    .from(smsProviderEventResolutions)
+    .where(eq(smsProviderEventResolutions.operationId, input.operationId))
+    .limit(1);
+  if (!winner || !sameRequest(winner, input)) {
+    throw new Error(
+      "Provider-event resolution collision; nothing was changed.",
+    );
+  }
+  return resultFromRow(winner, true);
+}
+
+export async function resolveSmsProviderEvent(
+  input: ResolveSmsProviderEventInput,
+): Promise<SmsProviderEventResolutionResult> {
+  return withSystem(db, (tx) =>
+    resolveSmsProviderEventInTransaction(tx, input),
+  );
+}
+
+export async function loadSmsProviderEventResolutionHistory(
+  database: Database,
+  options: { practiceId?: string; limit?: number } = {},
+): Promise<{
+  cacheControl: "no-store";
+  events: SmsProviderEventResolutionHistoryItem[];
+  truncated: boolean;
+}> {
+  const limit = Math.min(100, Math.max(1, options.limit ?? 50));
+  return withSystem(database, async (tx) => {
+    const rows = await tx
+      .select({
+        resolutionId: smsProviderEventResolutions.id,
+        resolvedAt: smsProviderEventResolutions.resolvedAt,
+        eventId: smsProviderEventResolutions.eventId,
+        conflictId: smsProviderEventResolutions.conflictId,
+        practiceId: smsProviderEventResolutions.practiceId,
+        provider: smsProviderEvents.provider,
+        kind: smsProviderEvents.kind,
+        resolution: smsProviderEventResolutions.resolution,
+        reasonCode: smsProviderEventResolutions.reasonCode,
+        resolvedByIdentity: smsProviderEventResolutions.resolvedByIdentity,
+        resolvedByName: smsProviderEventResolutions.resolvedByName,
+        inboundCommunicationId:
+          smsProviderEventResolutions.inboundCommunicationId,
+        smsConsentEventId: smsProviderEventResolutions.smsConsentEventId,
+        smsDeliveryEventId: smsProviderEventResolutions.smsDeliveryEventId,
+        messagingRegistrationEventId:
+          smsProviderEventResolutions.messagingRegistrationEventId,
+        externalEvidenceReference:
+          smsProviderEventResolutions.externalEvidenceReference,
+      })
+      .from(smsProviderEventResolutions)
+      .innerJoin(
+        smsProviderEvents,
+        eq(smsProviderEvents.id, smsProviderEventResolutions.eventId),
+      )
+      .where(
+        options.practiceId
+          ? eq(smsProviderEventResolutions.practiceId, options.practiceId)
+          : sql`true`,
+      )
+      .orderBy(
+        desc(smsProviderEventResolutions.resolvedAt),
+        desc(smsProviderEventResolutions.id),
+      )
+      .limit(limit + 1);
+    return {
+      cacheControl: "no-store" as const,
+      events: rows.slice(0, limit).map((row) => ({
+        resolutionId: row.resolutionId,
+        resolvedAt: row.resolvedAt,
+        eventId: row.eventId,
+        conflictId: row.conflictId,
+        practiceId: row.practiceId,
+        provider: row.provider,
+        kind: row.kind,
+        resolution: row.resolution,
+        reasonCode: row.reasonCode,
+        operatorLabel:
+          row.resolvedByIdentity || row.resolvedByName || "OpenVPM operator",
+        evidenceType: row.externalEvidenceReference
+          ? "external_attestation"
+          : row.messagingRegistrationEventId
+            ? "carrier_registration"
+            : row.smsDeliveryEventId
+              ? "delivery"
+              : row.inboundCommunicationId
+                ? "communication"
+                : "consent",
+        externalEvidenceReference:
+          row.externalEvidenceReference &&
+          !PHONE_LIKE_OPERATIONAL_ID.test(row.externalEvidenceReference)
+            ? row.externalEvidenceReference
+            : null,
+      })),
+      truncated: rows.length > limit,
+    };
+  });
+}

--- a/apps/web/lib/messaging/sms-provider-event-resolution-status.ts
+++ b/apps/web/lib/messaging/sms-provider-event-resolution-status.ts
@@ -1,0 +1,43 @@
+import { sql } from "drizzle-orm";
+
+/**
+ * Shared raw-SQL predicate for queries whose provider-event table alias is
+ * `event`. A terminal quarantine is remediated only when its base incident (if
+ * required) and every independently arriving identity conflict have durable,
+ * typed resolution evidence. A later conflict therefore reopens every gate.
+ */
+export const smsProviderEventQuarantineIsRemediatedSql = sql`(
+  (
+    exists (
+      select 1
+      from sms_provider_event_resolutions base_resolution
+      where base_resolution.event_id = event.id
+        and base_resolution.conflict_id is null
+    )
+    or (
+      event.last_error_code = 'provider_identity_conflict'
+      and exists (
+        select 1
+        from sms_provider_event_conflicts initial_conflict
+        where initial_conflict.original_event_id = event.id
+      )
+    )
+  )
+  and not exists (
+    select 1
+    from sms_provider_event_conflicts unresolved_conflict
+    where unresolved_conflict.original_event_id = event.id
+      and (
+        not exists (
+          select 1
+          from sms_provider_event_conflict_reviews conflict_review
+          where conflict_review.conflict_id = unresolved_conflict.id
+        )
+        or not exists (
+          select 1
+          from sms_provider_event_resolutions conflict_resolution
+          where conflict_resolution.conflict_id = unresolved_conflict.id
+        )
+      )
+  )
+)`;

--- a/apps/web/lib/messaging/sms-provider-events.ts
+++ b/apps/web/lib/messaging/sms-provider-events.ts
@@ -26,8 +26,12 @@ import {
   recordMessagingRegistrationEvent,
   systemMessagingRegistrationActor,
 } from "./registration-events";
-import { recordSmsDeliveryCallbackInTransaction } from "./sms-delivery-ledger";
+import {
+  lockSmsDeliveryIdentity,
+  recordSmsDeliveryCallbackInTransaction,
+} from "./sms-delivery-ledger";
 import { acquireSmsRecipientLockInTransaction } from "./suppression";
+import { smsProviderEventQuarantineIsRemediatedSql } from "./sms-provider-event-resolution-status";
 
 const MAX_IDENTIFIER_LENGTH = 255;
 const MAX_EVENT_TYPE_LENGTH = 80;
@@ -105,6 +109,7 @@ export type SmsProviderEventBacklogSummary = {
   retry: number;
   blockedRecovery: number;
   quarantined: number;
+  conflicts: number;
   oldestUnresolvedAt: Date | null;
 };
 
@@ -667,7 +672,14 @@ export async function ingestSmsProviderEvent(
   });
 }
 
-type StoredSmsProviderEvent = typeof smsProviderEvents.$inferSelect;
+export type StoredSmsProviderEvent = typeof smsProviderEvents.$inferSelect;
+
+export type LockedSmsProviderEventRemediation = {
+  event: StoredSmsProviderEvent;
+  attribution: { practiceId: string; locationId: string | null } | null;
+  resolution: IntakeResolution;
+  inboundRecipientLockHeld: boolean;
+};
 
 function hostedInboundProjectionEnabled(): boolean {
   return (
@@ -679,6 +691,7 @@ function hostedInboundProjectionEnabled(): boolean {
 async function lockPracticeStatesInTransaction(
   tx: Database,
   practiceIds: string[],
+  options: { forUpdate?: boolean } = {},
 ): Promise<Map<string, boolean>> {
   if (practiceIds.length === 0) return new Map();
   const sorted = [...new Set(practiceIds)].sort();
@@ -687,11 +700,214 @@ async function lockPracticeStatesInTransaction(
     .from(practices)
     .where(and(inArray(practices.id, sorted), isNull(practices.deletedAt)))
     .orderBy(practices.id)
-    .for("share", { of: practices });
+    .for(options.forUpdate ? "update" : "share", { of: practices });
   if (rows.length !== sorted.length) {
     throw new Error("Provider event tenant changed before projection");
   }
   return new Map(rows.map((row) => [row.id, row.recoveryHold]));
+}
+
+async function lockAllProviderPracticeStatesInTransaction(
+  tx: Database,
+  provider: InboundSmsProvider,
+): Promise<Map<string, boolean>> {
+  const rows = await tx
+    .select({ id: practices.id, recoveryHold: practices.recoveryHold })
+    .from(practices)
+    .where(
+      and(
+        isNull(practices.deletedAt),
+        sql`(
+          exists (
+            select 1
+            from location_messaging sender
+            where sender.practice_id = ${practices.id}
+              and sender.provider = ${provider}
+              and sender.deleted_at is null
+          )
+          or exists (
+            select 1
+            from sms_send_attempts attempt
+            where attempt.practice_id = ${practices.id}
+              and attempt.provider = ${provider}
+          )
+        )`,
+      ),
+    )
+    .orderBy(practices.id)
+    .for("update", { of: practices });
+  return new Map(rows.map((row) => [row.id, row.recoveryHold]));
+}
+
+/**
+ * Lock and revalidate a terminal provider event for audited remediation. The
+ * event remains immutable; callers may only append durable resolution evidence
+ * in this same transaction. Inbound work follows the intake-compatible order:
+ * practice, exact sender identity, recipient advisory, then event row.
+ */
+export async function lockSmsProviderEventForRemediationInTransaction(
+  tx: Database,
+  eventId: string,
+  options: {
+    lockedPracticeId?: string;
+    allowGloballyUnattributedDelivery?: boolean;
+    allowImmutableInboundOptOut?: boolean;
+    allowRecoveryHeld?: boolean;
+  } = {},
+): Promise<LockedSmsProviderEventRemediation> {
+  const [peek] = await tx
+    .select()
+    .from(smsProviderEvents)
+    .where(eq(smsProviderEvents.id, eventId))
+    .limit(1);
+  if (!peek) throw new Error("SMS provider event not found.");
+  if (!terminalState(peek.state)) {
+    throw new Error("Only terminal provider events may be remediated.");
+  }
+
+  const initialResolution = await resolveStoredEventInTransaction(tx, peek);
+  const practiceIds = [
+    ...new Set([
+      ...initialResolution.practiceIds,
+      ...(peek.practiceId ? [peek.practiceId] : []),
+    ]),
+  ].sort();
+  const globalDeliveryNoProjectionCandidate =
+    options.allowGloballyUnattributedDelivery &&
+    peek.kind === "delivery" &&
+    !peek.practiceId &&
+    practiceIds.length === 0;
+  let practiceStates: Map<string, boolean>;
+  if (options.lockedPracticeId) {
+    if (
+      practiceIds.length !== 1 ||
+      practiceIds[0] !== options.lockedPracticeId
+    ) {
+      throw new Error(
+        "Provider event does not match the already-locked practice.",
+      );
+    }
+    practiceStates = new Map([[options.lockedPracticeId, false]]);
+  } else if (globalDeliveryNoProjectionCandidate) {
+    // A provider callback that currently has no tenant may race an accepted
+    // send whose provider result has not committed yet. Lock every practice
+    // that can or has sent through this provider before taking the canonical
+    // delivery identity lock and repeating attribution. This makes the final
+    // zero-owner proof stable through resolution commit.
+    practiceStates = await lockAllProviderPracticeStatesInTransaction(
+      tx,
+      peek.provider as InboundSmsProvider,
+    );
+  } else {
+    practiceStates = await lockPracticeStatesInTransaction(tx, practiceIds, {
+      forUpdate: true,
+    });
+  }
+  if (
+    !options.allowRecoveryHeld &&
+    [...practiceStates.values()].some(Boolean)
+  ) {
+    throw new Error(
+      "Provider event remediation is paused while the clinic is in recovery.",
+    );
+  }
+
+  if (peek.kind === "delivery") {
+    await lockSmsDeliveryIdentity(tx, peek.provider, peek.providerMessageId);
+  }
+
+  let inboundRecipientLockHeld = false;
+  const immutableInboundOptOut =
+    options.allowImmutableInboundOptOut &&
+    peek.kind === "inbound" &&
+    Boolean(peek.practiceId && peek.locationId && peek.fromE164);
+  if (immutableInboundOptOut) {
+    await acquireSmsRecipientLockInTransaction(
+      tx,
+      peek.practiceId!,
+      peek.fromE164!,
+    );
+    inboundRecipientLockHeld = true;
+  } else if (peek.kind === "inbound" && initialResolution.attribution) {
+    const identityLocked = await lockMessagingLocationIdentityInTransaction(
+      tx,
+      {
+        provider: peek.provider as InboundSmsProvider,
+        practiceId: initialResolution.attribution.practiceId,
+        locationId: initialResolution.attribution.locationId!,
+        senderE164: peek.toE164,
+        messagingProfileId: peek.messagingProfileId,
+      },
+    );
+    if (!identityLocked || !peek.fromE164) {
+      throw new Error(
+        "Inbound provider identity changed before remediation could be locked.",
+      );
+    }
+    await acquireSmsRecipientLockInTransaction(
+      tx,
+      initialResolution.attribution.practiceId,
+      peek.fromE164,
+    );
+    inboundRecipientLockHeld = true;
+  }
+
+  const [event] = await tx
+    .select()
+    .from(smsProviderEvents)
+    .where(eq(smsProviderEvents.id, eventId))
+    .limit(1)
+    .for("update");
+  if (!event) throw new Error("SMS provider event not found.");
+  if (!terminalState(event.state)) {
+    throw new Error("Provider event state changed during remediation.");
+  }
+  const resolution = await resolveStoredEventInTransaction(tx, event);
+  if (
+    !immutableInboundOptOut &&
+    !sameResolution(initialResolution, resolution)
+  ) {
+    throw new Error("Provider event attribution changed during remediation.");
+  }
+  if (
+    !immutableInboundOptOut &&
+    event.practiceId &&
+    (!resolution.attribution ||
+      resolution.attribution.practiceId !== event.practiceId ||
+      (event.locationId !== null &&
+        resolution.attribution.locationId !== event.locationId))
+  ) {
+    throw new Error(
+      "Current provider identity does not match immutable event attribution.",
+    );
+  }
+  const attribution = event.practiceId
+    ? { practiceId: event.practiceId, locationId: event.locationId }
+    : resolution.attribution;
+  if (!attribution) {
+    if (
+      options.allowGloballyUnattributedDelivery &&
+      event.kind === "delivery" &&
+      !event.practiceId &&
+      resolution.practiceIds.length === 0
+    ) {
+      return {
+        event,
+        attribution: null,
+        resolution,
+        inboundRecipientLockHeld,
+      };
+    }
+    throw new Error(
+      "Provider event remediation requires exact current tenant attribution.",
+    );
+  }
+  if (event.kind === "inbound" && !attribution.locationId) {
+    throw new Error(
+      "Inbound provider event remediation requires an exact sender location.",
+    );
+  }
+  return { event, attribution, resolution, inboundRecipientLockHeld };
 }
 
 async function resolveStoredEventInTransaction(
@@ -990,7 +1206,10 @@ async function projectLockedEventInTransaction(
   tx: Database,
   event: StoredSmsProviderEvent,
   resolution: IntakeResolution,
-  options: { allowDisabledInbound?: boolean } = {},
+  options: {
+    allowDisabledInbound?: boolean;
+    inboundRecipientLockAlreadyHeld?: boolean;
+  } = {},
 ): Promise<{ outcome: SmsProviderEventProjectionOutcome }> {
   const attribution = event.practiceId
     ? {
@@ -1032,6 +1251,8 @@ async function projectLockedEventInTransaction(
       providerMessageId: event.providerMessageId,
       classification: event.inboundClassification,
       occurredAt: event.occurredAt ?? event.receivedAt,
+      recipientLockAlreadyHeld:
+        options.inboundRecipientLockAlreadyHeld === true,
     });
     await markTerminalInTransaction(tx, event, {
       state: "projected",
@@ -1123,7 +1344,7 @@ async function projectLockedEventInTransaction(
   return { outcome: "projected" };
 }
 
-async function projectSmsProviderEventInTransaction(
+async function projectSmsProviderEventWithLocksInTransaction(
   tx: Database,
   eventId: string,
   options: { lockedPracticeId?: string; force?: boolean } = {},
@@ -1165,6 +1386,29 @@ async function projectSmsProviderEventInTransaction(
     practiceStates = await lockPracticeStatesInTransaction(tx, practiceIds);
   }
 
+  let inboundIdentityLocked = true;
+  let inboundRecipientLockHeld = false;
+  if (peek.kind === "inbound" && initialResolution.attribution) {
+    inboundIdentityLocked = await lockMessagingLocationIdentityInTransaction(
+      tx,
+      {
+        provider: peek.provider as InboundSmsProvider,
+        practiceId: initialResolution.attribution.practiceId,
+        locationId: initialResolution.attribution.locationId!,
+        senderE164: peek.toE164,
+        messagingProfileId: peek.messagingProfileId,
+      },
+    );
+    if (inboundIdentityLocked && peek.fromE164) {
+      await acquireSmsRecipientLockInTransaction(
+        tx,
+        initialResolution.attribution.practiceId,
+        peek.fromE164,
+      );
+      inboundRecipientLockHeld = true;
+    }
+  }
+
   const [event] = await tx
     .select()
     .from(smsProviderEvents)
@@ -1194,13 +1438,12 @@ async function projectSmsProviderEventInTransaction(
   if (
     event.kind === "inbound" &&
     resolution.attribution &&
-    !(await lockMessagingLocationIdentityInTransaction(tx, {
-      provider: event.provider as InboundSmsProvider,
-      practiceId: resolution.attribution.practiceId,
-      locationId: resolution.attribution.locationId!,
-      senderE164: event.toE164,
-      messagingProfileId: event.messagingProfileId,
-    }))
+    (!inboundIdentityLocked ||
+      !initialResolution.attribution ||
+      initialResolution.attribution.practiceId !==
+        resolution.attribution.practiceId ||
+      initialResolution.attribution.locationId !==
+        resolution.attribution.locationId)
   ) {
     await markTerminalInTransaction(tx, event, {
       state: "quarantined",
@@ -1244,6 +1487,7 @@ async function projectSmsProviderEventInTransaction(
   }
   return projectLockedEventInTransaction(tx, event, resolution, {
     allowDisabledInbound: Boolean(options.lockedPracticeId && options.force),
+    inboundRecipientLockAlreadyHeld: inboundRecipientLockHeld,
   });
 }
 
@@ -1252,7 +1496,7 @@ export async function projectSmsProviderEvent(
 ): Promise<{ outcome: SmsProviderEventProjectionOutcome }> {
   try {
     return await withSystem(db, (tx) =>
-      projectSmsProviderEventInTransaction(tx, eventId),
+      projectSmsProviderEventWithLocksInTransaction(tx, eventId),
     );
   } catch {
     return withSystem(db, async (tx) => {
@@ -1290,11 +1534,19 @@ export async function projectSmsProviderEvent(
   }
 }
 
+/** Transactional worker entry point used by recovery/concurrency orchestration. */
+export async function projectSmsProviderEventInTransaction(
+  tx: Database,
+  eventId: string,
+): Promise<{ outcome: SmsProviderEventProjectionOutcome }> {
+  return projectSmsProviderEventWithLocksInTransaction(tx, eventId);
+}
+
 export async function projectSmsProviderEventForLockedPracticeInTransaction(
   tx: Database,
   opts: { practiceId: string; eventId: string; force: true },
 ): Promise<{ outcome: SmsProviderEventProjectionOutcome }> {
-  return projectSmsProviderEventInTransaction(tx, opts.eventId, {
+  return projectSmsProviderEventWithLocksInTransaction(tx, opts.eventId, {
     lockedPracticeId: opts.practiceId,
     force: true,
   });
@@ -1359,7 +1611,8 @@ export async function processSmsProviderEventBatch(
     summary.pending +
     summary.retry +
     summary.blockedRecovery +
-    summary.quarantined;
+    summary.quarantined +
+    summary.conflicts;
   return result;
 }
 
@@ -1368,6 +1621,7 @@ type BacklogRow = {
   retry: number | string;
   blockedRecovery: number | string;
   quarantined: number | string;
+  conflicts: number | string;
   oldestUnresolvedAt: Date | string | null;
 };
 
@@ -1377,16 +1631,44 @@ export async function getSmsProviderEventBacklogSummary(
 ): Promise<SmsProviderEventBacklogSummary> {
   const load = async (database: Database) => {
     const result = await database.execute(sql`
+      with unresolved_conflicts as (
+        select conflict.received_at
+        from sms_provider_event_conflicts conflict
+        join sms_provider_events event
+          on event.id = conflict.original_event_id
+        where (
+            not exists (
+              select 1
+              from sms_provider_event_conflict_reviews review
+              where review.conflict_id = conflict.id
+            )
+            or not exists (
+              select 1
+              from sms_provider_event_resolutions resolution
+              where resolution.conflict_id = conflict.id
+            )
+          )
+          and (${opts.practiceId ?? null}::uuid is null or event.practice_id = ${opts.practiceId ?? null}::uuid)
+          and (${opts.since ?? null}::timestamptz is null or conflict.received_at >= ${opts.since ?? null}::timestamptz)
+      )
       select
         count(*) filter (where state = 'pending')::int as pending,
         count(*) filter (where state = 'retry')::int as retry,
         count(*) filter (where state = 'blocked_recovery')::int as "blockedRecovery",
         count(*) filter (where state = 'quarantined')::int as quarantined,
-        min(received_at) as "oldestUnresolvedAt"
-      from sms_provider_events
-      where state in ('pending', 'retry', 'blocked_recovery', 'quarantined')
-        and (${opts.practiceId ?? null}::uuid is null or practice_id = ${opts.practiceId ?? null}::uuid)
-        and (${opts.since ?? null}::timestamptz is null or received_at >= ${opts.since ?? null}::timestamptz)
+        (select count(*)::int from unresolved_conflicts) as conflicts,
+        least(
+          min(received_at),
+          (select min(received_at) from unresolved_conflicts)
+        ) as "oldestUnresolvedAt"
+      from sms_provider_events event
+      where event.state in ('pending', 'retry', 'blocked_recovery', 'quarantined')
+        and (
+          event.state <> 'quarantined'
+          or not ${smsProviderEventQuarantineIsRemediatedSql}
+        )
+        and (${opts.practiceId ?? null}::uuid is null or event.practice_id = ${opts.practiceId ?? null}::uuid)
+        and (${opts.since ?? null}::timestamptz is null or event.received_at >= ${opts.since ?? null}::timestamptz)
     `);
     const row = rowsFromExecute<BacklogRow>(result)[0];
     const oldest = row?.oldestUnresolvedAt;
@@ -1395,6 +1677,7 @@ export async function getSmsProviderEventBacklogSummary(
       retry: Number(row?.retry ?? 0),
       blockedRecovery: Number(row?.blockedRecovery ?? 0),
       quarantined: Number(row?.quarantined ?? 0),
+      conflicts: Number(row?.conflicts ?? 0),
       oldestUnresolvedAt:
         oldest instanceof Date ? oldest : oldest ? new Date(oldest) : null,
     };

--- a/apps/web/lib/sms-dispatch.ts
+++ b/apps/web/lib/sms-dispatch.ts
@@ -1,5 +1,15 @@
 import { createHash } from "node:crypto";
-import { and, desc, eq, gte, isNull, ne, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  gte,
+  isNotNull,
+  isNull,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import type { Database } from "@openpims/db/client";
 import {
@@ -8,6 +18,9 @@ import {
   locationMessaging,
   messagingRegistrations,
   practices,
+  smsProviderEventConflicts,
+  smsProviderEventResolutions,
+  smsProviderEvents,
   smsSendAttemptEvents,
   smsSendAttempts,
   smsSuppressions,
@@ -50,6 +63,14 @@ export const SMS_COMPLIANCE_FOOTER = "Reply STOP to opt out or HELP for help.";
 export const SMS_MAX_BODY_LENGTH = 1600;
 export const SMS_AMBIGUITY_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
 export const SMS_RECONCILIATION_STALE_MS = 15 * 60 * 1000;
+
+class ProviderAttestedNoProjectionConflictError extends Error {
+  constructor() {
+    super(
+      "Accepted provider identity conflicts with audited no-projection evidence.",
+    );
+  }
+}
 
 const EMBEDDED_COMPLIANCE_COPY =
   /\breply\s+(?:stop|help)\b|\bstop\s+to\s+opt\s*out\b|\bhelp\s+for\s+help\b/i;
@@ -515,6 +536,11 @@ async function appendProviderResult(
   const normalized = normalizeProviderResult(result);
   if (normalized.status === "accepted") {
     await lockSmsDeliveryIdentity(tx, attempt.provider, normalized.id);
+    await assertAcceptedProviderIdentityAllowedInTransaction(
+      tx,
+      attempt.provider,
+      normalized.id,
+    );
   }
   await tx.insert(smsSendAttemptEvents).values({
     practiceId: attempt.practiceId,
@@ -560,6 +586,48 @@ async function appendProviderResult(
       { identityLockHeld: true },
     );
   }
+}
+
+async function assertAcceptedProviderIdentityAllowedInTransaction(
+  tx: Database,
+  provider: string,
+  providerMessageId: string,
+): Promise<void> {
+  const [blocked] = await tx
+    .select({ id: smsProviderEventResolutions.id })
+    .from(smsProviderEventResolutions)
+    .innerJoin(
+      smsProviderEvents,
+      eq(smsProviderEvents.id, smsProviderEventResolutions.eventId),
+    )
+    .leftJoin(
+      smsProviderEventConflicts,
+      eq(smsProviderEventConflicts.id, smsProviderEventResolutions.conflictId),
+    )
+    .where(
+      and(
+        eq(
+          smsProviderEventResolutions.resolution,
+          "provider_attested_no_projection",
+        ),
+        eq(smsProviderEvents.provider, provider),
+        or(
+          and(
+            isNull(smsProviderEventResolutions.conflictId),
+            eq(smsProviderEvents.providerMessageId, providerMessageId),
+          ),
+          and(
+            isNotNull(smsProviderEventResolutions.conflictId),
+            eq(
+              smsProviderEventConflicts.incomingProviderMessageId,
+              providerMessageId,
+            ),
+          ),
+        ),
+      ),
+    )
+    .limit(1);
+  if (blocked) throw new ProviderAttestedNoProjectionConflictError();
 }
 
 async function providerCall(
@@ -1344,6 +1412,11 @@ export async function reconcileSmsSendAttempt(options: {
           attempt.provider,
           providerMessageId,
         );
+        await assertAcceptedProviderIdentityAllowedInTransaction(
+          tx as unknown as Database,
+          attempt.provider,
+          providerMessageId,
+        );
       }
       const [event] = await tx
         .insert(smsSendAttemptEvents)
@@ -1430,6 +1503,12 @@ export async function reconcileSmsSendAttempt(options: {
     return result;
   } catch (error) {
     console.error("[messaging] SMS reconciliation failed", error);
+    if (error instanceof ProviderAttestedNoProjectionConflictError) {
+      return failure(
+        "Accepted provider identity conflicts with audited no-projection evidence; no reconciliation was recorded.",
+        { outcome: "outcome_unknown", attemptId: options.attemptId },
+      );
+    }
     return failure("Could not persist SMS reconciliation.");
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:sms-concurrency": "MESSAGING_PROVISIONING_ENABLED=false MESSAGING_INBOUND_ENABLED=false MESSAGING_SENDING_ENABLED=false SMS_CONCURRENCY_DB_INTEGRATION=1 vitest run lib/messaging/__tests__/sms-concurrency-drill.integration.test.ts",
     "backup:verify-evidence": "node scripts/verify-backup-evidence.mjs",
     "backup:recover-practice": "tsx scripts/recover-practice.ts"
   },

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => {
   return {
     db,
     select,
+    selectFor,
     selectResults,
     selectLimit,
     update,
@@ -72,6 +73,15 @@ const mocks = vi.hoisted(() => {
     ensureMessagingProfileAutoresponses: vi.fn(async () => []),
     messagingProfileAutoresponsesForClinic: vi.fn(() => []),
     lockPracticeForExternalSideEffects: vi.fn(async () => true),
+    resolveSmsProviderEvent: vi.fn(async () => ({
+      resolutionId: "00000000-0000-0000-0000-000000000020",
+      eventId: "00000000-0000-0000-0000-000000000021",
+      conflictId: null,
+      practiceId: "00000000-0000-0000-0000-0000000000aa",
+      resolution: "provider_attested_no_projection",
+      duplicate: false,
+    })),
+    loadSmsProviderEventResolutionHistory: vi.fn(),
     MockTelnyxError,
     withTenant: vi.fn(
       async (
@@ -98,6 +108,12 @@ vi.mock("@/lib/audit", () => ({
 vi.mock("@/lib/recovery-hold", () => ({
   RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
   lockPracticeForExternalSideEffects: mocks.lockPracticeForExternalSideEffects,
+}));
+vi.mock("@/lib/messaging/sms-provider-event-remediation", () => ({
+  resolveSmsProviderEvent: mocks.resolveSmsProviderEvent,
+  resolveSmsProviderEventInTransaction: mocks.resolveSmsProviderEvent,
+  loadSmsProviderEventResolutionHistory:
+    mocks.loadSmsProviderEventResolutionHistory,
 }));
 vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   createA2pBrand: mocks.createA2pBrand,
@@ -194,9 +210,82 @@ afterEach(() => {
   ]);
   mocks.db.execute.mockResolvedValue(undefined);
   mocks.selectResults.length = 0;
+  mocks.resolveSmsProviderEvent.mockResolvedValue({
+    resolutionId: "00000000-0000-0000-0000-000000000020",
+    eventId: "00000000-0000-0000-0000-000000000021",
+    conflictId: null,
+    practiceId: PRACTICE_ID,
+    resolution: "provider_attested_no_projection",
+    duplicate: false,
+  });
+  mocks.loadSmsProviderEventResolutionHistory.mockResolvedValue({
+    cacheControl: "no-store",
+    events: [],
+    truncated: false,
+  });
 });
 
 describe("platform messaging operations", () => {
+  it("binds provider-event remediation to a redacted platform operator and explicit attestation", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    const eventId = "00000000-0000-0000-0000-000000000021";
+    const operationId = "00000000-0000-0000-0000-000000000022";
+
+    await expect(
+      caller().resolveSmsProviderEvent({
+        eventId,
+        operationId,
+        resolution: "provider_attested_no_projection",
+        reasonCode: "provider_support_invalid_callback",
+        externalEvidenceReference: "support-ticket:TEL-2048",
+        providerAttestationConfirmed: true,
+      }),
+    ).resolves.toMatchObject({ eventId, duplicate: false });
+
+    expect(mocks.resolveSmsProviderEvent).toHaveBeenCalledWith({
+      eventId,
+      conflictId: null,
+      operationId,
+      resolution: "provider_attested_no_projection",
+      reasonCode: "provider_support_invalid_callback",
+      externalEvidenceReference: "support-ticket:TEL-2048",
+      providerAttestationConfirmed: true,
+      actorIdentity: "o***@example.com",
+      actorName: "Ops",
+    });
+  });
+
+  it("rejects provider-event remediation without platform-admin authorization", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    await expect(
+      caller("clinic@example.com").resolveSmsProviderEvent({
+        eventId: "00000000-0000-0000-0000-000000000021",
+        operationId: "00000000-0000-0000-0000-000000000022",
+        resolution: "conservative_opt_out",
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.resolveSmsProviderEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns PHI-free provider-event resolution history through no-store", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    await expect(
+      caller().smsProviderEventResolutionHistory({
+        practiceId: PRACTICE_ID,
+        limit: 25,
+      }),
+    ).resolves.toEqual({
+      cacheControl: "no-store",
+      events: [],
+      truncated: false,
+    });
+    expect(mocks.loadSmsProviderEventResolutionHistory).toHaveBeenCalledWith(
+      mocks.db,
+      { practiceId: PRACTICE_ID, limit: 25 },
+    );
+    expect(mocks.noStore).toHaveBeenCalled();
+  });
+
   it("returns actionable SMS credential shapes without secret values", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     vi.stubEnv("MESSAGING_PROVIDER", "telnyx");
@@ -600,7 +689,12 @@ describe("platform messaging operations", () => {
 
   it("fails reconciliation closed when attached provider identities do not match", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
-    mocks.selectResults.push([activeRegistration()], []);
+    mocks.selectResults.push(
+      [activeRegistration()],
+      [],
+      [],
+      [{ id: "00000000-0000-0000-0000-000000000012" }],
+    );
     mocks.getA2pBrand.mockResolvedValue({
       brandId: "brand-123",
       identityStatus: "VERIFIED",
@@ -637,6 +731,98 @@ describe("platform messaging operations", () => {
         providerProfileReady: false,
       }),
     );
+  });
+
+  it("allows exact A2P remediation while recovery is held and records operation-bound evidence", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    const eventId = "00000000-0000-4000-8000-000000000021";
+    const operationId = "00000000-0000-4000-8000-000000000022";
+    const evidenceId = "00000000-0000-4000-8000-000000000023";
+    mocks.selectFor.mockResolvedValueOnce([{ recoveryHold: true }]);
+    mocks.selectResults.push(
+      [],
+      [
+        {
+          id: eventId,
+          practiceId: PRACTICE_ID,
+          kind: "a2p",
+          state: "quarantined",
+          lastErrorCode: "projection_retry_exhausted",
+          locationId: null,
+          a2pPhoneE164: null,
+        },
+      ],
+      [activeRegistration()],
+      [],
+      [],
+      [{ id: evidenceId }],
+    );
+    mocks.getA2pBrand.mockResolvedValue({
+      brandId: "brand-123",
+      identityStatus: "VERIFIED",
+      status: null,
+      failureReasons: null,
+      displayName: "Healthy Pets",
+      entityType: "PRIVATE_PROFIT",
+      country: "US",
+      companyName: "Healthy Pets LLC",
+      website: "https://healthy.example",
+    });
+    mocks.getA2pCampaign.mockResolvedValue({
+      campaignId: "campaign-123",
+      brandId: "brand-123",
+      referenceId: `openvpm-clinic-${PRACTICE_ID}`,
+      status: "ACTIVE",
+      campaignStatus: "MNO_PROVISIONED",
+      submissionStatus: null,
+      failureReasons: null,
+    });
+    mocks.resolveSmsProviderEvent.mockResolvedValueOnce({
+      resolutionId: "00000000-0000-4000-8000-000000000024",
+      eventId,
+      conflictId: null,
+      practiceId: PRACTICE_ID,
+      resolution: "carrier_state_reconciled",
+      duplicate: false,
+    });
+
+    await expect(
+      caller().reconcileMessagingRegistration({
+        practiceId: PRACTICE_ID,
+        remediation: { providerEventId: eventId, operationId },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      messagingRegistrationEventId: evidenceId,
+      duplicate: false,
+    });
+
+    expect(mocks.resolveSmsProviderEvent).toHaveBeenCalledWith(
+      mocks.db,
+      expect.objectContaining({
+        eventId,
+        operationId,
+        resolution: "carrier_state_reconciled",
+        messagingRegistrationEventId: evidenceId,
+      }),
+      { lockedPracticeId: PRACTICE_ID },
+    );
+    expect(mocks.createA2pBrand).not.toHaveBeenCalled();
+    expect(mocks.createA2pCampaign).not.toHaveBeenCalled();
+    expect(mocks.ensureA2pNumberAssignment).not.toHaveBeenCalled();
+    expect(mocks.updateMessagingProfileEnabled).not.toHaveBeenCalled();
+  });
+
+  it("keeps ordinary carrier reconciliation blocked during recovery", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.selectFor.mockResolvedValueOnce([{ recoveryHold: true }]);
+
+    await expect(
+      caller().reconcileMessagingRegistration({ practiceId: PRACTICE_ID }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    expect(mocks.getA2pBrand).not.toHaveBeenCalled();
+    expect(mocks.getA2pCampaign).not.toHaveBeenCalled();
+    expect(mocks.resolveSmsProviderEvent).not.toHaveBeenCalled();
   });
 
   it("enables an exact safe provider profile but keeps clinic sending off", async () => {

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -19,6 +19,9 @@ import {
   smsDeliveryEvents,
   smsSendAttemptEvents,
   smsSendAttempts,
+  smsProviderEventConflicts,
+  smsProviderEventResolutions,
+  smsProviderEvents,
 } from "@openpims/db";
 import { isPlatformAdmin } from "@/lib/platform-admin";
 import { computeActivationFunnel } from "@/lib/admin/activation-funnel";
@@ -81,6 +84,11 @@ import {
   loadSmsProviderEventGateSummaryInTransaction,
   loadSmsProviderEventQueue,
 } from "@/lib/messaging/sms-provider-event-operations";
+import {
+  loadSmsProviderEventResolutionHistory,
+  resolveSmsProviderEvent,
+  resolveSmsProviderEventInTransaction,
+} from "@/lib/messaging/sms-provider-event-remediation";
 import {
   decryptRegistrationTaxId,
   MessagingRegistrationEncryptionError,
@@ -168,6 +176,40 @@ async function withMessagingProviderEffectsAllowed<T>(
 const MESSAGING_SUBMISSION_LOCK_STALE_MS = 15 * 60 * 1000;
 const MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
 const WITHHELD_PHONE_LIKE_OPERATIONAL_ID = "[withheld: phone-like identifier]";
+
+const smsProviderEventResolutionBaseInput = z
+  .object({
+    eventId: z.string().uuid(),
+    conflictId: z.string().uuid().nullable().optional(),
+    operationId: z.string().uuid(),
+  })
+  .strict();
+
+const smsProviderEventResolutionInput = z.discriminatedUnion("resolution", [
+  smsProviderEventResolutionBaseInput.extend({
+    resolution: z.literal("authoritative_projection"),
+  }),
+  smsProviderEventResolutionBaseInput.extend({
+    resolution: z.literal("conservative_opt_out"),
+  }),
+  smsProviderEventResolutionBaseInput.extend({
+    resolution: z.literal("carrier_state_reconciled"),
+    messagingRegistrationEventId: z.string().uuid(),
+  }),
+  smsProviderEventResolutionBaseInput.extend({
+    resolution: z.literal("provider_attested_no_projection"),
+    externalEvidenceReference: z
+      .string()
+      .min(3)
+      .max(255)
+      .regex(/^[A-Za-z0-9][A-Za-z0-9_.:/#-]{2,254}$/),
+    reasonCode: z.enum([
+      "provider_support_invalid_callback",
+      "provider_support_duplicate_callback",
+    ]),
+    providerAttestationConfirmed: z.literal(true),
+  }),
+]);
 
 const clinicPilotQualificationInput = z
   .object({
@@ -1422,6 +1464,54 @@ export const adminRouter = createRouter({
     .query(({ input }) => {
       noStore();
       return loadSmsProviderEventQueue(db, input);
+    }),
+
+  /** Append an audited, evidence-bound resolution for one exact incident. */
+  resolveSmsProviderEvent: platformAdminProcedure
+    .input(smsProviderEventResolutionInput)
+    .mutation(async ({ ctx, input }) => {
+      const actor = platformMessagingRegistrationActor(ctx.session!.user);
+      if (actor.actorType !== "platform_operator") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Platform admin access only.",
+        });
+      }
+      try {
+        return await resolveSmsProviderEvent({
+          ...input,
+          conflictId: input.conflictId ?? null,
+          actorIdentity: actor.actorIdentity,
+          actorName: actor.actorName,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "";
+        throw new TRPCError({
+          code:
+            message.includes("collision") ||
+            message.includes("already resolved")
+              ? "CONFLICT"
+              : "PRECONDITION_FAILED",
+          message:
+            message ||
+            "Provider-event resolution evidence could not be validated.",
+        });
+      }
+    }),
+
+  /** PHI-free append-only history; resolved work is separate from the live queue. */
+  smsProviderEventResolutionHistory: platformAdminProcedure
+    .input(
+      z
+        .object({
+          practiceId: z.string().uuid().optional(),
+          limit: z.number().int().min(1).max(100).default(50),
+        })
+        .strict(),
+    )
+    .query(({ input }) => {
+      noStore();
+      return loadSmsProviderEventResolutionHistory(db, input);
     }),
 
   /** Secret-free structural configuration state for the platform operator. */
@@ -2814,23 +2904,243 @@ export const adminRouter = createRouter({
 
   /** Read-only provider reconciliation. Safe to retry and never enables sending. */
   reconcileMessagingRegistration: platformAdminProcedure
-    .input(z.object({ practiceId: z.string().uuid() }))
+    .input(
+      z
+        .object({
+          practiceId: z.string().uuid(),
+          remediation: z
+            .object({
+              providerEventId: z.string().uuid(),
+              conflictId: z.string().uuid().nullable().optional(),
+              operationId: z.string().uuid(),
+            })
+            .strict()
+            .optional(),
+        })
+        .strict(),
+    )
     .mutation(async ({ ctx, input }) => {
       const actor = platformMessagingRegistrationActor(ctx.session!.user);
-      const registration = await registrationForOperator(input.practiceId);
-      if (!registration.providerBrandId) {
+      if (actor.actorType !== "platform_operator") {
         throw new TRPCError({
-          code: "PRECONDITION_FAILED",
-          message: "No provider brand has been submitted.",
+          code: "FORBIDDEN",
+          message: "Platform admin access only.",
         });
       }
+      const operationId = input.remediation?.operationId ?? randomUUID();
       try {
-        const brand = await getA2pBrand(registration.providerBrandId);
-        const campaign = registration.providerCampaignId
-          ? await getA2pCampaign(registration.providerCampaignId)
-          : null;
-        const senders = await withSystem(db, async (tx) =>
-          tx
+        return await withSystem(db, async (tx) => {
+          const [practice] = await tx
+            .select({ recoveryHold: practices.recoveryHold })
+            .from(practices)
+            .where(
+              and(
+                eq(practices.id, input.practiceId),
+                isNull(practices.deletedAt),
+              ),
+            )
+            .limit(1)
+            .for(input.remediation ? "update" : "share", { of: practices });
+          if (
+            !practice ||
+            (!input.remediation && practice.recoveryHold !== false)
+          ) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: RECOVERY_HOLD_BLOCK_MESSAGE,
+            });
+          }
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${`sms-provider-resolution:${operationId}`}, 0))`,
+          );
+
+          let remediationEventLocationId: string | null = null;
+          if (input.remediation) {
+            const [priorResolution] = await tx
+              .select()
+              .from(smsProviderEventResolutions)
+              .where(eq(smsProviderEventResolutions.operationId, operationId))
+              .limit(1);
+            if (priorResolution) {
+              if (
+                priorResolution.eventId !== input.remediation.providerEventId ||
+                priorResolution.conflictId !==
+                  (input.remediation.conflictId ?? null) ||
+                priorResolution.practiceId !== input.practiceId ||
+                priorResolution.resolution !== "carrier_state_reconciled" ||
+                !priorResolution.messagingRegistrationEventId
+              ) {
+                throw new TRPCError({
+                  code: "CONFLICT",
+                  message: "Provider-event resolution operation id collision.",
+                });
+              }
+              return {
+                ok: true,
+                status: "reconciled" as const,
+                assignments: 0,
+                messagingRegistrationEventId:
+                  priorResolution.messagingRegistrationEventId,
+                resolutionId: priorResolution.id,
+                duplicate: true,
+              };
+            }
+
+            const [providerEvent] = await tx
+              .select({
+                id: smsProviderEvents.id,
+                practiceId: smsProviderEvents.practiceId,
+                kind: smsProviderEvents.kind,
+                state: smsProviderEvents.state,
+                lastErrorCode: smsProviderEvents.lastErrorCode,
+                locationId: smsProviderEvents.locationId,
+                a2pPhoneE164: smsProviderEvents.a2pPhoneE164,
+              })
+              .from(smsProviderEvents)
+              .where(
+                eq(smsProviderEvents.id, input.remediation.providerEventId),
+              )
+              .limit(1);
+            if (
+              !providerEvent ||
+              providerEvent.kind !== "a2p" ||
+              providerEvent.practiceId !== input.practiceId ||
+              !["quarantined", "projected", "ignored"].includes(
+                providerEvent.state,
+              )
+            ) {
+              throw new TRPCError({
+                code: "PRECONDITION_FAILED",
+                message:
+                  "Carrier remediation requires an exact terminal A2P event for this clinic.",
+              });
+            }
+            if (
+              providerEvent.state !== "quarantined" &&
+              !input.remediation.conflictId
+            ) {
+              throw new TRPCError({
+                code: "PRECONDITION_FAILED",
+                message:
+                  "A projected or ignored event requires its exact conflict id.",
+              });
+            }
+            if (
+              providerEvent.lastErrorCode === "provider_identity_conflict" &&
+              !input.remediation.conflictId
+            ) {
+              throw new TRPCError({
+                code: "PRECONDITION_FAILED",
+                message:
+                  "Identity-conflict quarantine must resolve one exact conflict.",
+              });
+            }
+            if (input.remediation.conflictId) {
+              const [conflict] = await tx
+                .select({ id: smsProviderEventConflicts.id })
+                .from(smsProviderEventConflicts)
+                .where(
+                  and(
+                    eq(
+                      smsProviderEventConflicts.id,
+                      input.remediation.conflictId,
+                    ),
+                    eq(
+                      smsProviderEventConflicts.originalEventId,
+                      providerEvent.id,
+                    ),
+                  ),
+                )
+                .limit(1);
+              if (!conflict) {
+                throw new TRPCError({
+                  code: "PRECONDITION_FAILED",
+                  message:
+                    "Provider-event conflict does not belong to this event.",
+                });
+              }
+            }
+            if (providerEvent.a2pPhoneE164 && !providerEvent.locationId) {
+              throw new TRPCError({
+                code: "PRECONDITION_FAILED",
+                message:
+                  "Phone-level carrier evidence requires an exact sender location.",
+              });
+            }
+            remediationEventLocationId = providerEvent.locationId;
+          }
+
+          const [registration] = await tx
+            .select()
+            .from(messagingRegistrations)
+            .where(
+              and(
+                eq(messagingRegistrations.practiceId, input.practiceId),
+                isNull(messagingRegistrations.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!registration) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                "The clinic has not completed carrier registration details.",
+            });
+          }
+          if (!registration.providerBrandId) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "No provider brand has been submitted.",
+            });
+          }
+
+          const [priorEvidence] = await tx
+            .select({ id: messagingRegistrationEvents.id })
+            .from(messagingRegistrationEvents)
+            .where(
+              and(
+                eq(messagingRegistrationEvents.practiceId, input.practiceId),
+                eq(messagingRegistrationEvents.operationId, operationId),
+                eq(
+                  messagingRegistrationEvents.eventType,
+                  "provider_state_observed",
+                ),
+                eq(
+                  messagingRegistrationEvents.operation,
+                  "registration_reconciliation",
+                ),
+              ),
+            )
+            .limit(1);
+          if (priorEvidence && input.remediation) {
+            const resolution = await resolveSmsProviderEventInTransaction(
+              tx,
+              {
+                eventId: input.remediation.providerEventId,
+                conflictId: input.remediation.conflictId ?? null,
+                operationId,
+                resolution: "carrier_state_reconciled",
+                messagingRegistrationEventId: priorEvidence.id,
+                actorIdentity: actor.actorIdentity,
+                actorName: actor.actorName,
+              },
+              { lockedPracticeId: input.practiceId },
+            );
+            return {
+              ok: true,
+              status: registration.status,
+              assignments: 0,
+              messagingRegistrationEventId: priorEvidence.id,
+              resolutionId: resolution.resolutionId,
+              duplicate: resolution.duplicate,
+            };
+          }
+
+          const brand = await getA2pBrand(registration.providerBrandId);
+          const campaign = registration.providerCampaignId
+            ? await getA2pCampaign(registration.providerCampaignId)
+            : null;
+          const senders = await tx
             .select({ phoneNumber: locationMessaging.senderE164 })
             .from(locationMessaging)
             .where(
@@ -2840,49 +3150,49 @@ export const adminRouter = createRouter({
                 isNull(locationMessaging.deletedAt),
                 sql`nullif(trim(${locationMessaging.senderE164}), '') is not null`,
               ),
-            ),
-        );
-        const assignments: Array<TelnyxNumberAssignment | null> = [];
-        if (campaign) {
-          for (const sender of senders) {
-            if (!sender.phoneNumber) continue;
-            assignments.push(await getA2pNumberAssignment(sender.phoneNumber));
+            );
+          const assignments: Array<TelnyxNumberAssignment | null> = [];
+          if (campaign) {
+            for (const sender of senders) {
+              if (!sender.phoneNumber) continue;
+              assignments.push(
+                await getA2pNumberAssignment(sender.phoneNumber),
+              );
+            }
           }
-        }
-        const providerIdentityMatches = providerRegistrationIdentityMatches({
-          practiceId: input.practiceId,
-          registration,
-          brand,
-          campaign,
-        });
-        const observed = providerIdentityMatches
-          ? observedRegistrationStatus({
-              brandIdentityStatus: brand.identityStatus,
-              brandStatus: brand.status,
-              campaignStatuses: [
-                campaign?.status,
-                campaign?.campaignStatus,
-                campaign?.submissionStatus,
-              ],
-              campaignSubmissionStatus: campaign?.submissionStatus,
-              assignmentStatuses: assignments.map(
-                (row) => row?.assignmentStatus,
-              ),
-            })
-          : ("action_required" as const);
-        const next = mergeRegistrationStatus(registration.status, observed);
-        const failureDetail = [
-          providerIdentityMatches
-            ? null
-            : "Provider registration identity does not match this clinic.",
-          brand.failureReasons,
-          campaign?.failureReasons,
-          ...assignments.map((row) => row?.failureReasons),
-        ]
-          .filter(Boolean)
-          .join("; ")
-          .slice(0, 1000);
-        await withSystem(db, async (tx) => {
+          const providerIdentityMatches = providerRegistrationIdentityMatches({
+            practiceId: input.practiceId,
+            registration,
+            brand,
+            campaign,
+          });
+          const observed = providerIdentityMatches
+            ? observedRegistrationStatus({
+                brandIdentityStatus: brand.identityStatus,
+                brandStatus: brand.status,
+                campaignStatuses: [
+                  campaign?.status,
+                  campaign?.campaignStatus,
+                  campaign?.submissionStatus,
+                ],
+                campaignSubmissionStatus: campaign?.submissionStatus,
+                assignmentStatuses: assignments.map(
+                  (row) => row?.assignmentStatus,
+                ),
+              })
+            : ("action_required" as const);
+          const next = mergeRegistrationStatus(registration.status, observed);
+          const failureDetail = [
+            providerIdentityMatches
+              ? null
+              : "Provider registration identity does not match this clinic.",
+            brand.failureReasons,
+            campaign?.failureReasons,
+            ...assignments.map((row) => row?.failureReasons),
+          ]
+            .filter(Boolean)
+            .join("; ")
+            .slice(0, 1000);
           const [updated] = await tx
             .update(messagingRegistrations)
             .set({
@@ -2924,9 +3234,10 @@ export const adminRouter = createRouter({
             eventType: "provider_state_observed",
             operation: "registration_reconciliation",
             statusBefore: registration.status,
-            operationId: randomUUID(),
+            operationId,
             reasonCode: "carrier_registration_reconciled",
             actor,
+            locationId: remediationEventLocationId,
           });
           await tx
             .update(locationMessaging)
@@ -2942,7 +3253,7 @@ export const adminRouter = createRouter({
                       next === "suspended"
                     ? "Carrier registration needs OpenVPM review."
                     : "Carrier registration is pending.",
-              ...(next === "active"
+              ...(next === "active" && !input.remediation
                 ? {}
                 : {
                     enabled: false,
@@ -2958,9 +3269,62 @@ export const adminRouter = createRouter({
                 isNull(locationMessaging.deletedAt),
               ),
             );
+          const [registrationEvidence] = await tx
+            .select({ id: messagingRegistrationEvents.id })
+            .from(messagingRegistrationEvents)
+            .where(
+              and(
+                eq(messagingRegistrationEvents.practiceId, input.practiceId),
+                eq(messagingRegistrationEvents.operationId, operationId),
+                eq(
+                  messagingRegistrationEvents.eventType,
+                  "provider_state_observed",
+                ),
+                eq(
+                  messagingRegistrationEvents.operation,
+                  "registration_reconciliation",
+                ),
+              ),
+            )
+            .limit(1);
+          if (!registrationEvidence) {
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Carrier reconciliation evidence was not durable.",
+            });
+          }
+          const resolution = input.remediation
+            ? await resolveSmsProviderEventInTransaction(
+                tx,
+                {
+                  eventId: input.remediation.providerEventId,
+                  conflictId: input.remediation.conflictId ?? null,
+                  operationId,
+                  resolution: "carrier_state_reconciled",
+                  messagingRegistrationEventId: registrationEvidence.id,
+                  actorIdentity: actor.actorIdentity,
+                  actorName: actor.actorName,
+                },
+                { lockedPracticeId: input.practiceId },
+              )
+            : null;
+          return input.remediation
+            ? {
+                ok: true,
+                status: next,
+                assignments: assignments.length,
+                messagingRegistrationEventId: registrationEvidence.id,
+                resolutionId: resolution!.resolutionId,
+                duplicate: resolution!.duplicate,
+              }
+            : {
+                ok: true,
+                status: next,
+                assignments: assignments.length,
+              };
         });
-        return { ok: true, status: next, assignments: assignments.length };
       } catch (error) {
+        if (error instanceof TRPCError) throw error;
         throw providerFailure(error);
       }
     }),

--- a/docs/backup-restore-runbook.md
+++ b/docs/backup-restore-runbook.md
@@ -199,9 +199,18 @@ The successful `hold_released` audit stores before/after counts, projection
 outcomes, the event watermark, and whether the bounded drain filled.
 
 An identity-conflict review does not by itself make a quarantined original event
-safe. The review closes only that conflict incident; quarantine continues to
-block release and activation until a separate audited remediation establishes a
-safe projection. Never use a review to bypass unresolved STOP evidence.
+safe. From the platform-admin **SMS evidence recovery** console, select the exact
+event/conflict and use its evidence-specific remediation. Inbound conflicts are
+resolved conservatively as an opt-out; ordinary inbound quarantine requires an
+exact replayed communication/consent projection; A2P requires current read-only
+carrier reconciliation and leaves senders disabled; delivery-only no-projection
+requires a PHI-free provider-support reference and explicit attestation. The
+remediation transaction may run while the practice is held, but it takes the
+practice row `FOR UPDATE`, never clears the hold, and never sends or performs a
+fee-bearing provider mutation. Rerun the owner release only after the redacted
+queue and immutable resolution history show that the base incident and every
+conflict have durable evidence. A later conflict re-blocks release. Never use a
+review or support reference to bypass unresolved STOP evidence.
 
 While held, clinic email/SMS/webhook delivery, AI model calls, Stripe checkout,
 capture, refund, metering and subscription-quantity mutations, and Telnyx

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -278,10 +278,28 @@ Use these fixed thresholds and responses:
 - **Provider-event projection:** pending/retry work older than 15 minutes and
   recovery-blocked work are P1. A quarantined event or unreviewed provider-event
   identity conflict is P0 and keeps activation closed. A conflict review clears
-  only the identity-conflict alert: the original event remains quarantined and
-  still blocks activation/recovery release until a separate audited remediation
-  safely resolves the event. For STOP evidence, consent/suppression projection
-  must be authoritative before any remediation can reopen sending.
+  only the identity-conflict alert; it never clears the incident by itself. Use
+  the platform-admin **SMS evidence recovery** console to select the exact event
+  and, when present, the exact conflict. The console offers only the resolution
+  supported by durable evidence:
+
+  - inbound projection repair must produce the exact communication and any
+    required START/STOP consent event;
+  - conflicting inbound evidence is resolved conservatively as a system-actor
+    opt-out with an active suppression;
+  - A2P evidence requires a current read-only carrier reconciliation and leaves
+    every sender disabled and unready; and
+  - delivery-only closure requires an explicit provider-support finding and a
+    bounded reference containing no phone number, message, client name, or PHI.
+
+  Each action uses a fresh operation UUID and appends an immutable resolution
+  row; it never changes or deletes the terminal provider event. A later conflict
+  reopens the gate until that new conflict has both review and resolution
+  evidence. During practice recovery, audited remediation is serialized under
+  the practice row lock and may append proof while the hold remains set. Recovery
+  release, provider-profile activation, clinic sender enablement, and final SMS
+  dispatch all remain blocked until the base incident and every conflict have
+  their required evidence.
 
 Alerts contain only bounded counts and reason codes. They must not contain phone
 numbers, recipients, message bodies, clinic/patient/client names, raw provider

--- a/docs/sms-concurrency-drill.md
+++ b/docs/sms-concurrency-drill.md
@@ -1,0 +1,75 @@
+# Provider-free SMS concurrency drill
+
+This drill proves the clinic-safe SMS lock and recovery invariants against real
+PostgreSQL. It uses only synthetic UUIDs, phone numbers, provider identifiers,
+and message text. It never loads a Telnyx or Twilio adapter, calls a provider,
+or requires provider credentials.
+
+The drill is intentionally restricted to a PostgreSQL URL whose host is
+`localhost`, `127.0.0.1`, or `::1`. Do not point it at production, demo,
+staging, a Supabase pooler, or any shared database. Each scenario cleans up its
+synthetic rows with the schema's owner-only `app.ledger_maintenance` bypass,
+which is available only because the disposable test connection owns the tables.
+Cleanup fails closed before enabling that bypass if a scenario unexpectedly
+creates an immutable `sms_provider_event_resolutions` row.
+
+## What it proves
+
+1. **STOP versus outbound send.** Intake holds the practice row and exact
+   recipient advisory lock, commits a durable STOP, and only then allows the
+   outbound final barrier to continue. The barrier observes the STOP and the
+   synthetic provider-call counter stays zero.
+2. **Conflict replay versus projection.** A replay and the projector both use
+   `practice -> exact sender -> recipient -> provider event`. PostgreSQL lock
+   waiters are observed directly before release. Both transactions finish
+   without a deadlock, the conflicting body is recorded, and the original
+   event remains quarantined.
+3. **Callback-first DLR convergence.** A delivery callback arrives before its
+   accepted send, remains durable as retryable evidence, and later converges to
+   one attributed, projected delivery after the exact accepted-send identity is
+   inserted. The linked communication becomes delivered.
+4. **Recovery drain, savepoint, and release.** One event projects successfully;
+   a deliberate PostgreSQL error aborts only the next event savepoint. The
+   outer recovery transaction commits the first projection and a blocked-release
+   audit while keeping the hold true. A later locked drain reaches zero backlog
+   before the synthetic hold is released.
+
+## Run locally
+
+Start a disposable PostgreSQL 16 database, apply every committed migration,
+then run the dedicated command from the repository root:
+
+```sh
+export DATABASE_URL=postgresql://openpims:openpims@localhost:5432/openpims
+pnpm --filter @openpims/db db:migrate
+pnpm --filter @openpims/web test:sms-concurrency
+```
+
+The command forces these flags off regardless of the surrounding shell:
+
+```text
+MESSAGING_PROVISIONING_ENABLED=false
+MESSAGING_INBOUND_ENABLED=false
+MESSAGING_SENDING_ENABLED=false
+```
+
+Expected result: one test file and four tests pass. A skip means the dedicated
+command was not used. A timeout, PostgreSQL deadlock, residual backlog, provider
+call, or cleanup failure is a release blocker; do not “fix” the drill by
+increasing timeouts or enabling an SMS capability.
+
+## CI
+
+The `RLS tenant isolation` job applies all migrations and RLS to its disposable
+PostgreSQL 16 service, first executes the live provider-resolution trigger and
+evidence contract, then runs this drill with
+`SMS_CONCURRENCY_DB_INTEGRATION=1` and all three SMS flags explicitly false.
+The ordinary unit-test job leaves the file skipped because it has no database
+service.
+
+When changing intake, projection, suppression, DLR attribution, recovery drain,
+or provider-event remediation, keep this drill green and preserve the canonical
+lock order. If a new immutable evidence table references synthetic event rows,
+the drill must assert it created no such evidence before entering local
+maintenance cleanup. The bypass must never be added to production recovery or
+remediation flows.

--- a/packages/db/drizzle/0085_foamy_rick_jones.sql
+++ b/packages/db/drizzle/0085_foamy_rick_jones.sql
@@ -1,0 +1,509 @@
+CREATE TYPE "public"."sms_provider_event_resolution" AS ENUM('authoritative_projection', 'conservative_opt_out', 'carrier_state_reconciled', 'provider_attested_no_projection');--> statement-breakpoint
+CREATE TABLE "sms_provider_event_resolutions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"resolved_at" timestamp with time zone DEFAULT clock_timestamp() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"conflict_id" uuid,
+	"operation_id" uuid NOT NULL,
+	"practice_id" uuid,
+	"resolution" "sms_provider_event_resolution" NOT NULL,
+	"inbound_communication_id" uuid,
+	"sms_consent_event_id" uuid,
+	"sms_delivery_event_id" uuid,
+	"messaging_registration_event_id" uuid,
+	"external_evidence_reference" varchar(255),
+	"reason_code" varchar(64) NOT NULL,
+	"detail" varchar(2000),
+	"resolved_by_identity" varchar(255) NOT NULL,
+	"resolved_by_name" varchar(255) NOT NULL,
+	CONSTRAINT "sms_provider_event_resolutions_shape_check" CHECK ("sms_provider_event_resolutions"."reason_code" ~ '^[a-z0-9_]{3,64}$'
+        and ("sms_provider_event_resolutions"."resolution" = 'provider_attested_no_projection' or "sms_provider_event_resolutions"."practice_id" is not null)
+        and (
+          ("sms_provider_event_resolutions"."resolution" = 'authoritative_projection' and "sms_provider_event_resolutions"."reason_code" in (
+            'projection_repaired', 'delivery_reconciled'
+          ))
+          or ("sms_provider_event_resolutions"."resolution" = 'conservative_opt_out' and "sms_provider_event_resolutions"."reason_code" in (
+            'provider_identity_conflict_opt_out', 'sender_identity_drift_opt_out'
+          ))
+          or ("sms_provider_event_resolutions"."resolution" = 'carrier_state_reconciled'
+            and "sms_provider_event_resolutions"."reason_code" = 'carrier_state_readback_confirmed')
+          or ("sms_provider_event_resolutions"."resolution" = 'provider_attested_no_projection' and "sms_provider_event_resolutions"."reason_code" in (
+            'provider_support_invalid_callback', 'provider_support_duplicate_callback'
+          ))
+        )
+        and "sms_provider_event_resolutions"."resolved_by_identity" = btrim("sms_provider_event_resolutions"."resolved_by_identity")
+        and length("sms_provider_event_resolutions"."resolved_by_identity") between 1 and 255
+        and "sms_provider_event_resolutions"."resolved_by_name" = btrim("sms_provider_event_resolutions"."resolved_by_name")
+        and length("sms_provider_event_resolutions"."resolved_by_name") between 1 and 255
+        and ("sms_provider_event_resolutions"."detail" is null or length(btrim("sms_provider_event_resolutions"."detail")) between 1 and 2000)
+        and ("sms_provider_event_resolutions"."external_evidence_reference" is null or (
+          "sms_provider_event_resolutions"."external_evidence_reference" = btrim("sms_provider_event_resolutions"."external_evidence_reference")
+          and length("sms_provider_event_resolutions"."external_evidence_reference") between 3 and 255
+          and "sms_provider_event_resolutions"."external_evidence_reference" ~ '^[A-Za-z0-9][A-Za-z0-9_.:/#-]{2,254}$'
+        ))
+        and (
+          ("sms_provider_event_resolutions"."resolution" = 'authoritative_projection'
+            and "sms_provider_event_resolutions"."external_evidence_reference" is null
+            and num_nonnulls(
+              "sms_provider_event_resolutions"."inbound_communication_id",
+              "sms_provider_event_resolutions"."sms_consent_event_id",
+              "sms_provider_event_resolutions"."sms_delivery_event_id",
+              "sms_provider_event_resolutions"."messaging_registration_event_id"
+            ) between 1 and 2)
+          or ("sms_provider_event_resolutions"."resolution" = 'conservative_opt_out'
+            and "sms_provider_event_resolutions"."inbound_communication_id" is null
+            and "sms_provider_event_resolutions"."sms_consent_event_id" is not null
+            and "sms_provider_event_resolutions"."sms_delivery_event_id" is null
+            and "sms_provider_event_resolutions"."messaging_registration_event_id" is null
+            and "sms_provider_event_resolutions"."external_evidence_reference" is null)
+          or ("sms_provider_event_resolutions"."resolution" = 'carrier_state_reconciled'
+            and "sms_provider_event_resolutions"."inbound_communication_id" is null
+            and "sms_provider_event_resolutions"."sms_consent_event_id" is null
+            and "sms_provider_event_resolutions"."sms_delivery_event_id" is null
+            and "sms_provider_event_resolutions"."messaging_registration_event_id" is not null
+            and "sms_provider_event_resolutions"."external_evidence_reference" is null)
+          or ("sms_provider_event_resolutions"."resolution" = 'provider_attested_no_projection'
+            and "sms_provider_event_resolutions"."inbound_communication_id" is null
+            and "sms_provider_event_resolutions"."sms_consent_event_id" is null
+            and "sms_provider_event_resolutions"."sms_delivery_event_id" is null
+            and "sms_provider_event_resolutions"."messaging_registration_event_id" is null
+            and "sms_provider_event_resolutions"."external_evidence_reference" is not null)
+        ))
+);
+--> statement-breakpoint
+ALTER TABLE "sms_provider_event_resolutions" ADD CONSTRAINT "sms_provider_event_resolutions_event_id_sms_provider_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."sms_provider_events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_provider_event_resolutions" ADD CONSTRAINT "sms_provider_event_resolutions_conflict_id_sms_provider_event_conflicts_id_fk" FOREIGN KEY ("conflict_id") REFERENCES "public"."sms_provider_event_conflicts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_provider_event_resolutions" ADD CONSTRAINT "sms_provider_event_resolutions_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_provider_event_resolutions" ADD CONSTRAINT "sms_provider_event_resolutions_inbound_communication_id_communications_id_fk" FOREIGN KEY ("inbound_communication_id") REFERENCES "public"."communications"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_provider_event_resolutions" ADD CONSTRAINT "sms_provider_event_resolutions_sms_consent_event_id_sms_consent_events_id_fk" FOREIGN KEY ("sms_consent_event_id") REFERENCES "public"."sms_consent_events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_provider_event_resolutions" ADD CONSTRAINT "sms_provider_event_resolutions_sms_delivery_event_id_sms_delivery_events_id_fk" FOREIGN KEY ("sms_delivery_event_id") REFERENCES "public"."sms_delivery_events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_provider_event_resolutions" ADD CONSTRAINT "sms_provider_event_resolutions_messaging_registration_event_id_messaging_registration_events_id_fk" FOREIGN KEY ("messaging_registration_event_id") REFERENCES "public"."messaging_registration_events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_provider_event_resolutions_base_event_uq" ON "sms_provider_event_resolutions" USING btree ("event_id") WHERE "sms_provider_event_resolutions"."conflict_id" is null;--> statement-breakpoint
+CREATE INDEX "sms_provider_event_resolutions_event_idx" ON "sms_provider_event_resolutions" USING btree ("event_id","resolved_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_provider_event_resolutions_conflict_uq" ON "sms_provider_event_resolutions" USING btree ("conflict_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_provider_event_resolutions_operation_uq" ON "sms_provider_event_resolutions" USING btree ("operation_id");--> statement-breakpoint
+CREATE INDEX "sms_provider_event_resolutions_practice_history_idx" ON "sms_provider_event_resolutions" USING btree ("practice_id","resolved_at","id");--> statement-breakpoint
+CREATE INDEX "sms_provider_event_resolutions_communication_evidence_idx" ON "sms_provider_event_resolutions" USING btree ("inbound_communication_id") WHERE "sms_provider_event_resolutions"."inbound_communication_id" is not null;--> statement-breakpoint
+CREATE INDEX "sms_provider_event_resolutions_consent_evidence_idx" ON "sms_provider_event_resolutions" USING btree ("sms_consent_event_id") WHERE "sms_provider_event_resolutions"."sms_consent_event_id" is not null;--> statement-breakpoint
+CREATE INDEX "sms_provider_event_resolutions_delivery_evidence_idx" ON "sms_provider_event_resolutions" USING btree ("sms_delivery_event_id") WHERE "sms_provider_event_resolutions"."sms_delivery_event_id" is not null;--> statement-breakpoint
+CREATE INDEX "sms_provider_event_resolutions_registration_evidence_idx" ON "sms_provider_event_resolutions" USING btree ("messaging_registration_event_id") WHERE "sms_provider_event_resolutions"."messaging_registration_event_id" is not null;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION validate_sms_provider_event_resolution_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	provider_event public.sms_provider_events%ROWTYPE;
+	provider_conflict public.sms_provider_event_conflicts%ROWTYPE;
+	communication_evidence public.communications%ROWTYPE;
+	consent_evidence public.sms_consent_events%ROWTYPE;
+	delivery_evidence public.sms_delivery_events%ROWTYPE;
+	registration_evidence public.messaging_registration_events%ROWTYPE;
+	accepted_send_practice_id uuid;
+	accepted_send_practice_count integer;
+BEGIN
+	SELECT * INTO provider_event
+	FROM public.sms_provider_events
+	WHERE id = NEW.event_id;
+	IF NOT FOUND THEN
+		RAISE EXCEPTION USING ERRCODE = '23503', MESSAGE = 'SMS provider resolution event does not exist.';
+	END IF;
+	IF NEW.resolution = 'provider_attested_no_projection'
+		AND NEW.practice_id IS NULL
+		AND provider_event.kind = 'delivery'
+		AND provider_event.practice_id IS NULL
+	THEN
+		-- Send transactions lock their practice row FOR SHARE before calling the
+		-- provider and retain it through accepted-result persistence. Take every
+		-- active practice with a current sender or historical attempt for this
+		-- provider FOR UPDATE, matching the service lock set and deterministic
+		-- ordering. This drains those calls before proving that this delivery
+		-- identity has no accepted-send owner. Practice-before-event ordering also
+		-- avoids inversion with attributed provider-event ingest.
+		PERFORM practice.id
+		FROM public.practices practice
+		WHERE practice.deleted_at IS NULL
+			AND (
+				EXISTS (
+					SELECT 1
+					FROM public.location_messaging sender
+					WHERE sender.practice_id = practice.id
+						AND sender.provider = provider_event.provider
+						AND sender.deleted_at IS NULL
+				)
+				OR EXISTS (
+					SELECT 1
+					FROM public.sms_send_attempts attempt
+					WHERE attempt.practice_id = practice.id
+						AND attempt.provider = provider_event.provider
+				)
+			)
+		ORDER BY practice.id
+		FOR UPDATE;
+	END IF;
+	SELECT * INTO provider_event
+	FROM public.sms_provider_events
+	WHERE id = NEW.event_id
+	FOR SHARE;
+	IF NOT FOUND THEN
+		RAISE EXCEPTION USING ERRCODE = '23503', MESSAGE = 'SMS provider resolution event disappeared during serialization.';
+	END IF;
+	IF provider_event.state NOT IN ('projected', 'ignored', 'quarantined') THEN
+		RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Only terminal SMS provider events can be resolved.';
+	END IF;
+	IF provider_event.practice_id IS NOT NULL
+		AND provider_event.practice_id IS DISTINCT FROM NEW.practice_id
+	THEN
+		RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'SMS provider resolution practice does not match its event.';
+	END IF;
+
+	IF NEW.conflict_id IS NULL THEN
+		IF provider_event.state <> 'quarantined' THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'A base resolution requires a quarantined event.';
+		END IF;
+		IF provider_event.last_error_code = 'provider_identity_conflict' THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'A conflict-caused quarantine requires conflict-scoped resolution evidence.';
+		END IF;
+	ELSE
+		SELECT * INTO provider_conflict
+		FROM public.sms_provider_event_conflicts
+		WHERE id = NEW.conflict_id
+		FOR SHARE;
+		IF NOT FOUND OR provider_conflict.original_event_id IS DISTINCT FROM NEW.event_id THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'SMS provider conflict does not belong to its resolution event.';
+		END IF;
+	END IF;
+
+	IF provider_event.kind = 'inbound' THEN
+		IF NEW.conflict_id IS NOT NULL AND NEW.resolution <> 'conservative_opt_out' THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Conflicting inbound evidence can only be resolved by conservative opt-out.';
+		END IF;
+		IF NEW.resolution NOT IN ('authoritative_projection', 'conservative_opt_out') THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Inbound SMS resolution kind is invalid.';
+		END IF;
+	ELSIF provider_event.kind = 'delivery' THEN
+		IF NEW.resolution NOT IN ('authoritative_projection', 'provider_attested_no_projection') THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Delivery SMS resolution kind is invalid.';
+		END IF;
+	ELSIF provider_event.kind = 'a2p' THEN
+		IF NEW.resolution <> 'carrier_state_reconciled' THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'A2P resolution requires carrier reconciliation evidence.';
+		END IF;
+	ELSE
+		RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'SMS provider resolution event kind is invalid.';
+	END IF;
+	IF (NEW.resolution = 'authoritative_projection' AND (
+		(provider_event.kind = 'inbound' AND NEW.reason_code <> 'projection_repaired')
+		OR (provider_event.kind = 'delivery' AND NEW.reason_code <> 'delivery_reconciled')
+	))
+		OR (NEW.resolution = 'conservative_opt_out' AND (
+			(NEW.conflict_id IS NULL AND NEW.reason_code <> 'sender_identity_drift_opt_out')
+			OR (NEW.conflict_id IS NOT NULL AND NEW.reason_code <> 'provider_identity_conflict_opt_out')
+		))
+	THEN
+		RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'SMS provider resolution reason does not match its incident.';
+	END IF;
+
+	IF NEW.resolution = 'authoritative_projection' AND provider_event.kind = 'inbound' THEN
+		IF NEW.inbound_communication_id IS NULL
+			OR NEW.sms_delivery_event_id IS NOT NULL
+			OR NEW.messaging_registration_event_id IS NOT NULL
+			OR NEW.external_evidence_reference IS NOT NULL
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Inbound projection evidence shape is invalid.';
+		END IF;
+
+		SELECT * INTO communication_evidence
+		FROM public.communications
+		WHERE id = NEW.inbound_communication_id
+		FOR SHARE;
+		IF NOT FOUND
+			OR communication_evidence.practice_id IS DISTINCT FROM NEW.practice_id
+			OR communication_evidence.deleted_at IS NOT NULL
+			OR communication_evidence.channel <> 'sms'
+			OR communication_evidence.direction <> 'inbound'
+			OR communication_evidence.status <> 'delivered'
+			OR communication_evidence.provider_message_id IS DISTINCT FROM provider_event.provider_message_id
+			OR btrim(communication_evidence.content) IS DISTINCT FROM btrim(provider_event.message_body)
+			OR communication_evidence.created_at IS DISTINCT FROM coalesce(provider_event.occurred_at, provider_event.received_at)
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Inbound communication does not prove exact provider-event projection.';
+		END IF;
+
+		IF provider_event.inbound_classification IN ('stop', 'start') THEN
+			IF NEW.sms_consent_event_id IS NULL THEN
+				RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'STOP and START projection require consent evidence.';
+			END IF;
+			SELECT * INTO consent_evidence
+			FROM public.sms_consent_events
+			WHERE id = NEW.sms_consent_event_id
+			FOR SHARE;
+			IF NOT FOUND
+				OR consent_evidence.practice_id IS DISTINCT FROM NEW.practice_id
+				OR consent_evidence.destination_e164 IS DISTINCT FROM provider_event.from_e164
+				OR consent_evidence.provider IS DISTINCT FROM provider_event.provider
+				OR consent_evidence.provider_message_id IS DISTINCT FROM provider_event.provider_message_id
+				OR consent_evidence.actor_type <> 'client'
+				OR consent_evidence.occurred_at IS DISTINCT FROM coalesce(provider_event.occurred_at, provider_event.received_at)
+				OR (provider_event.location_id IS NOT NULL AND consent_evidence.location_id IS DISTINCT FROM provider_event.location_id)
+				OR (provider_event.inbound_classification = 'stop' AND consent_evidence.action <> 'revoked')
+				OR (provider_event.inbound_classification = 'start' AND consent_evidence.action <> 'granted')
+			THEN
+				RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Consent evidence does not prove exact provider-event projection.';
+			END IF;
+			IF provider_event.inbound_classification = 'stop'
+				AND NOT EXISTS (
+					SELECT 1
+					FROM public.sms_suppressions suppression
+					WHERE suppression.practice_id = NEW.practice_id
+						AND suppression.phone = provider_event.from_e164
+						AND suppression.deleted_at IS NULL
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM public.sms_consent_events newer_consent
+					WHERE newer_consent.practice_id = NEW.practice_id
+						AND newer_consent.destination_e164 = provider_event.from_e164
+						AND newer_consent.action = 'granted'
+						AND newer_consent.occurred_at > coalesce(provider_event.occurred_at, provider_event.received_at)
+				)
+			THEN
+				RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'STOP resolution requires an active suppression or a strictly newer durable grant.';
+			END IF;
+		ELSIF provider_event.inbound_classification IN ('help', 'other') THEN
+			IF NEW.sms_consent_event_id IS NOT NULL THEN
+				RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'HELP and other inbound projection use communication evidence only.';
+			END IF;
+		ELSE
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Inbound classification is invalid.';
+		END IF;
+
+	ELSIF NEW.resolution = 'conservative_opt_out' THEN
+		IF provider_event.kind <> 'inbound'
+			OR NEW.inbound_communication_id IS NOT NULL
+			OR NEW.sms_consent_event_id IS NULL
+			OR NEW.sms_delivery_event_id IS NOT NULL
+			OR NEW.messaging_registration_event_id IS NOT NULL
+			OR NEW.external_evidence_reference IS NOT NULL
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Conservative opt-out evidence shape is invalid.';
+		END IF;
+		IF NEW.conflict_id IS NULL AND (
+			provider_event.last_error_code IS NULL
+			OR provider_event.last_error_code NOT IN ('sender_identity_drift', 'immutable_attribution_drift')
+			OR provider_event.practice_id IS NULL
+			OR provider_event.location_id IS NULL
+			OR provider_event.from_e164 IS NULL
+		) THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Base conservative opt-out requires immutable, fully attributed sender-drift evidence.';
+		END IF;
+		SELECT * INTO consent_evidence
+		FROM public.sms_consent_events
+		WHERE id = NEW.sms_consent_event_id
+		FOR SHARE;
+		IF NOT FOUND
+			OR consent_evidence.practice_id IS DISTINCT FROM NEW.practice_id
+			OR consent_evidence.destination_e164 IS DISTINCT FROM provider_event.from_e164
+			OR consent_evidence.action <> 'revoked'
+			OR consent_evidence.actor_type <> 'system'
+			OR consent_evidence.provider IS NOT NULL
+			OR consent_evidence.provider_message_id IS NOT NULL
+			OR consent_evidence.source <> 'provider_event_resolution:v1'
+			OR consent_evidence.event_key IS DISTINCT FROM format(
+				'provider_event_resolution:%s:%s:revoked',
+				NEW.operation_id,
+				coalesce(NEW.conflict_id, NEW.event_id)
+			)
+			OR (provider_event.location_id IS NOT NULL AND consent_evidence.location_id IS DISTINCT FROM provider_event.location_id)
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Conservative opt-out requires matching revoked consent evidence.';
+		END IF;
+		IF NOT EXISTS (
+			SELECT 1
+			FROM public.sms_suppressions suppression
+			WHERE suppression.practice_id = NEW.practice_id
+				AND suppression.phone = consent_evidence.destination_e164
+				AND suppression.deleted_at IS NULL
+		) THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Conservative opt-out requires an active durable SMS suppression.';
+		END IF;
+
+	ELSIF NEW.resolution = 'authoritative_projection' AND provider_event.kind = 'delivery' THEN
+		IF NEW.inbound_communication_id IS NOT NULL
+			OR NEW.sms_consent_event_id IS NOT NULL
+			OR NEW.sms_delivery_event_id IS NULL
+			OR NEW.messaging_registration_event_id IS NOT NULL
+			OR NEW.external_evidence_reference IS NOT NULL
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Delivery projection evidence shape is invalid.';
+		END IF;
+		SELECT * INTO delivery_evidence
+		FROM public.sms_delivery_events
+		WHERE id = NEW.sms_delivery_event_id
+		FOR SHARE;
+		IF NOT FOUND
+			OR delivery_evidence.provider IS DISTINCT FROM provider_event.provider
+			OR delivery_evidence.provider_event_type IS DISTINCT FROM coalesce(provider_conflict.incoming_provider_event_type, provider_event.provider_event_type)
+			OR delivery_evidence.provider_message_id IS DISTINCT FROM coalesce(provider_conflict.incoming_provider_message_id, provider_event.provider_message_id)
+			OR (coalesce(provider_conflict.incoming_provider_event_id, provider_event.provider_event_id) IS NOT NULL
+				AND delivery_evidence.provider_event_id IS DISTINCT FROM coalesce(provider_conflict.incoming_provider_event_id, provider_event.provider_event_id))
+			OR (NEW.conflict_id IS NULL AND (
+				delivery_evidence.classification IS DISTINCT FROM provider_event.delivery_classification
+				OR delivery_evidence.provider_status IS DISTINCT FROM provider_event.provider_status
+				OR delivery_evidence.provider_error_code IS DISTINCT FROM provider_event.provider_error_code
+			))
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Delivery evidence does not match the provider incident.';
+		END IF;
+		IF NOT EXISTS (
+			SELECT 1
+			FROM public.sms_delivery_event_history history
+			WHERE history.delivery_event_id = NEW.sms_delivery_event_id
+				AND history.practice_id = NEW.practice_id
+				AND history.result IN ('projected', 'reconciled')
+		) THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Delivery resolution requires durable projected or reconciled history.';
+		END IF;
+
+	ELSIF NEW.resolution = 'carrier_state_reconciled' THEN
+		IF provider_event.kind <> 'a2p'
+			OR NEW.inbound_communication_id IS NOT NULL
+			OR NEW.sms_consent_event_id IS NOT NULL
+			OR NEW.sms_delivery_event_id IS NOT NULL
+			OR NEW.messaging_registration_event_id IS NULL
+			OR NEW.external_evidence_reference IS NOT NULL
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Carrier reconciliation evidence shape is invalid.';
+		END IF;
+		SELECT * INTO registration_evidence
+		FROM public.messaging_registration_events
+		WHERE id = NEW.messaging_registration_event_id
+		FOR SHARE;
+		IF NOT FOUND
+			OR registration_evidence.practice_id IS DISTINCT FROM NEW.practice_id
+			OR registration_evidence.provider IS DISTINCT FROM provider_event.provider
+			OR registration_evidence.event_type <> 'provider_state_observed'
+			OR registration_evidence.operation <> 'registration_reconciliation'
+			OR registration_evidence.status_after NOT IN ('pending', 'active', 'action_required', 'failed', 'suspended')
+			OR registration_evidence.operation_id IS DISTINCT FROM NEW.operation_id
+			OR registration_evidence.reason_code <> 'carrier_registration_reconciled'
+			OR (provider_event.a2p_brand_id IS NOT NULL AND registration_evidence.provider_brand_id IS DISTINCT FROM provider_event.a2p_brand_id)
+			OR (provider_event.a2p_campaign_id IS NOT NULL AND registration_evidence.provider_campaign_id IS DISTINCT FROM provider_event.a2p_campaign_id)
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Carrier evidence does not prove the exact provider incident reconciliation.';
+		END IF;
+		IF provider_event.a2p_phone_e164 IS NOT NULL AND NOT EXISTS (
+			SELECT 1
+			FROM public.location_messaging sender
+			WHERE sender.practice_id = NEW.practice_id
+				AND sender.location_id = registration_evidence.location_id
+				AND sender.provider = provider_event.provider
+				AND sender.sender_e164 = provider_event.a2p_phone_e164
+				AND sender.deleted_at IS NULL
+				AND sender.enabled = false
+				AND sender.provider_profile_ready = false
+				AND (
+					SELECT count(*)
+					FROM public.location_messaging exact_sender
+					WHERE exact_sender.practice_id = NEW.practice_id
+						AND exact_sender.provider = provider_event.provider
+						AND exact_sender.sender_e164 = provider_event.a2p_phone_e164
+						AND exact_sender.deleted_at IS NULL
+				) = 1
+		) THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Carrier phone evidence requires one exact disabled, unready sender identity.';
+		END IF;
+
+	ELSIF NEW.resolution = 'provider_attested_no_projection' THEN
+		IF provider_event.kind <> 'delivery'
+			OR NEW.inbound_communication_id IS NOT NULL
+			OR NEW.sms_consent_event_id IS NOT NULL
+			OR NEW.sms_delivery_event_id IS NOT NULL
+			OR NEW.messaging_registration_event_id IS NOT NULL
+			OR NEW.external_evidence_reference IS NULL
+		THEN
+			RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Provider-attested no-projection evidence shape is invalid.';
+		END IF;
+		IF provider_event.practice_id IS NULL THEN
+			SELECT count(DISTINCT attempt.practice_id), min(attempt.practice_id::text)::uuid
+			INTO accepted_send_practice_count, accepted_send_practice_id
+			FROM public.sms_send_attempt_events attempt_event
+			JOIN public.sms_send_attempts attempt
+				ON attempt.practice_id = attempt_event.practice_id
+				AND attempt.id = attempt_event.attempt_id
+			WHERE attempt_event.outcome = 'accepted'
+				AND attempt_event.provider_message_id = coalesce(
+					provider_conflict.incoming_provider_message_id,
+					provider_event.provider_message_id
+				)
+				AND attempt.provider = provider_event.provider;
+			IF accepted_send_practice_count = 1
+				AND NEW.practice_id IS DISTINCT FROM accepted_send_practice_id
+			THEN
+				RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Provider-attested resolution practice must match the exact accepted send.';
+			END IF;
+			IF accepted_send_practice_count <> 1 AND NEW.practice_id IS NOT NULL THEN
+				RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'Unattributed provider-attested resolution cannot claim an arbitrary practice.';
+			END IF;
+		END IF;
+	ELSE
+		RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'SMS provider resolution evidence is invalid.';
+	END IF;
+
+	RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+CREATE TRIGGER sms_provider_event_resolutions_validate_insert
+	BEFORE INSERT ON sms_provider_event_resolutions
+	FOR EACH ROW EXECUTE FUNCTION validate_sms_provider_event_resolution_insert();
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION reject_sms_provider_event_resolution_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+	IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+		AND current_user = (
+			SELECT pg_catalog.pg_get_userbyid(class.relowner)
+			FROM pg_catalog.pg_class class
+			JOIN pg_catalog.pg_namespace namespace ON namespace.oid = class.relnamespace
+			WHERE namespace.nspname = TG_TABLE_SCHEMA AND class.relname = TG_TABLE_NAME
+		)
+	THEN
+		IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+		RETURN NEW;
+	END IF;
+	RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'SMS provider event resolution evidence is immutable.';
+END;
+$$;
+--> statement-breakpoint
+CREATE TRIGGER sms_provider_event_resolutions_immutable
+	BEFORE UPDATE OR DELETE ON sms_provider_event_resolutions
+	FOR EACH ROW EXECUTE FUNCTION reject_sms_provider_event_resolution_mutation();
+--> statement-breakpoint
+ALTER TABLE sms_provider_event_resolutions ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE POLICY system_only ON sms_provider_event_resolutions
+	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
+	WITH CHECK (coalesce(current_setting('app.rls_bypass', true), '') = 'on');
+--> statement-breakpoint
+REVOKE ALL ON sms_provider_event_resolutions FROM PUBLIC;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+		REVOKE ALL ON sms_provider_event_resolutions FROM openpims_app;
+		GRANT SELECT, INSERT ON sms_provider_event_resolutions TO openpims_app;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+		REVOKE ALL ON sms_provider_event_resolutions FROM anon;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+		REVOKE ALL ON sms_provider_event_resolutions FROM authenticated;
+	END IF;
+END
+$$;

--- a/packages/db/drizzle/meta/0085_snapshot.json
+++ b/packages/db/drizzle/meta/0085_snapshot.json
@@ -1,0 +1,22228 @@
+{
+  "id": "a41fe931-7525-410c-bab3-8dccd2ed3779",
+  "prevId": "85527641-6e16-4728-abbe-b5ffefd42a06",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_reminders_enabled": {
+          "name": "appointment_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appointment_reminder_lead_hours": {
+          "name": "appointment_reminder_lead_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "recovery_hold": {
+          "name": "recovery_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recovery_hold_reason": {
+          "name": "recovery_hold_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_hold_set_at": {
+          "name": "recovery_hold_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_hold_released_at": {
+          "name": "recovery_hold_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practices_appointment_reminder_lead_hours_check": {
+          "name": "practices_appointment_reminder_lead_hours_check",
+          "value": "\"practices\".\"appointment_reminder_lead_hours\" in (24, 48, 72)"
+        },
+        "practices_recovery_hold_evidence_check": {
+          "name": "practices_recovery_hold_evidence_check",
+          "value": "not \"practices\".\"recovery_hold\" or (\"practices\".\"recovery_hold_set_at\" is not null and \"practices\".\"recovery_hold_reason\" is not null and \"practices\".\"recovery_hold_reason\" ~ '[^[:space:]]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "is_veterinarian": {
+          "name": "is_veterinarian",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_veterinarian_idx": {
+          "name": "users_veterinarian_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_veterinarian",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_id_patient_uq": {
+          "name": "patient_allergies_id_patient_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": ["noted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": ["recorded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["source_patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["target_patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "source_patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "target_patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "performed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": ["type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_location_time_idx": {
+          "name": "appointments_location_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_id_locations_id_fk": {
+          "name": "appointments_location_id_locations_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": ["type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": ["doctor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": ["recurring_series_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_tenant_fk": {
+          "name": "appointments_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_location_tenant_fk": {
+          "name": "appointments_room_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": ["practice_id", "location_id", "room_id"],
+          "columnsTo": ["practice_id", "location_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "appointments_time_range_check": {
+          "name": "appointments_time_range_check",
+          "value": "\"appointments\".\"start_time\" < \"appointments\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_practice_location_id_uq": {
+          "name": "rooms_practice_location_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_tenant_fk": {
+          "name": "rooms_location_tenant_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_active_day_idx": {
+          "name": "staff_schedules_active_day_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"staff_schedules\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_window_uq": {
+          "name": "staff_schedules_active_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_null_location_window_uq": {
+          "name": "staff_schedules_active_null_location_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_tenant_fk": {
+          "name": "staff_schedules_user_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_tenant_fk": {
+          "name": "staff_schedules_location_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "staff_schedules_day_of_week_check": {
+          "name": "staff_schedules_day_of_week_check",
+          "value": "\"staff_schedules\".\"day_of_week\" between 0 and 6"
+        },
+        "staff_schedules_time_range_check": {
+          "name": "staff_schedules_time_range_check",
+          "value": "\"staff_schedules\".\"start_time\" < \"staff_schedules\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": ["case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": ["primary_vet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["ordered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_completed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "ordered_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "reviewed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_assigned_to"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_completed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "author_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "author_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "finalized_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": ["administered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": ["recorded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_assigned_to"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_allergy_id": {
+          "name": "patient_allergy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_patient_allergy_uq": {
+          "name": "clinical_record_corrections_patient_allergy_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_allergy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"patient_allergy_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_soap_source_uq": {
+          "name": "clinical_record_corrections_practice_record_soap_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["soap_note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": ["vital_sign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["vaccination_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_allergy_id_patient_allergies_id_fk": {
+          "name": "clinical_record_corrections_patient_allergy_id_patient_allergies_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patient_allergies",
+          "columnsFrom": ["patient_allergy_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": ["corrected_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "corrected_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": ["practice_id", "vital_sign_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["practice_id", "vaccination_record_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_allergy_source_fk": {
+          "name": "clinical_record_corrections_patient_allergy_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patient_allergies",
+          "columnsFrom": ["patient_allergy_id", "patient_id"],
+          "columnsTo": ["id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'patient_allergy'\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"appointment_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": ["correction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["source_lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["replacement_lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "source_lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "replacement_lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": ["practice_id", "id", "lab_result_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_note_replacements": {
+      "name": "soap_note_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_soap_note_id": {
+          "name": "source_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_soap_note_id": {
+          "name": "replacement_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_replacements_source_history_idx": {
+          "name": "soap_note_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_source_uq": {
+          "name": "soap_note_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_replacement_uq": {
+          "name": "soap_note_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_operation_uq": {
+          "name": "soap_note_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_replacements_practice_id_practices_id_fk": {
+          "name": "soap_note_replacements_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "soap_note_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": ["correction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_source_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["source_soap_note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["replacement_soap_note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_id_users_id_fk": {
+          "name": "soap_note_replacements_actor_id_users_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_tenant_fk": {
+          "name": "soap_note_replacements_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "source_soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_tenant_fk": {
+          "name": "soap_note_replacements_replacement_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "replacement_soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_source_tenant_fk": {
+          "name": "soap_note_replacements_correction_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": ["practice_id", "id", "soap_note_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_tenant_fk": {
+          "name": "soap_note_replacements_actor_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_replacements_shape_check": {
+          "name": "soap_note_replacements_shape_check",
+          "value": "\"soap_note_replacements\".\"source_soap_note_id\" <> \"soap_note_replacements\".\"replacement_soap_note_id\"\n        and \"soap_note_replacements\".\"actor_name\" = btrim(\"soap_note_replacements\".\"actor_name\")\n        and length(btrim(\"soap_note_replacements\".\"actor_name\")) between 1 and 255\n        and \"soap_note_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": ["prescribed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "prescription_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": ["practice_id", "product_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["source_prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": ["received_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": ["prescription_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": ["practice_id", "prescription_event_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "prescription_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": ["practice_id", "product_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_id", "invoice_item_id"],
+          "columnsTo": ["invoice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": ["witnessed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_tenant_fk": {
+          "name": "capture_sessions_patient_tenant_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_creator_tenant_fk": {
+          "name": "capture_sessions_creator_tenant_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "created_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_patient_tenant_fk": {
+          "name": "capture_sessions_appointment_patient_tenant_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_object_replicas": {
+      "name": "file_object_replicas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replica_target": {
+          "name": "replica_target",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_etag": {
+          "name": "object_etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_version_id": {
+          "name": "object_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "file_replica_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "replicated_at": {
+          "name": "replicated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_object_replicas_file_target_uq": {
+          "name": "file_object_replicas_file_target_uq",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replica_target",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_object_replicas_practice_status_idx": {
+          "name": "file_object_replicas_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_object_replicas_due_idx": {
+          "name": "file_object_replicas_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_object_replicas_practice_id_practices_id_fk": {
+          "name": "file_object_replicas_practice_id_practices_id_fk",
+          "tableFrom": "file_object_replicas",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_object_replicas_file_tenant_fk": {
+          "name": "file_object_replicas_file_tenant_fk",
+          "tableFrom": "file_object_replicas",
+          "tableTo": "files",
+          "columnsFrom": ["practice_id", "file_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_object_replicas_attempt_count_check": {
+          "name": "file_object_replicas_attempt_count_check",
+          "value": "\"file_object_replicas\".\"attempt_count\" >= 0"
+        },
+        "file_object_replicas_checksum_sha256_format_check": {
+          "name": "file_object_replicas_checksum_sha256_format_check",
+          "value": "\"file_object_replicas\".\"checksum_sha256\" is null or \"file_object_replicas\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "file_object_replicas_file_size_bytes_check": {
+          "name": "file_object_replicas_file_size_bytes_check",
+          "value": "\"file_object_replicas\".\"file_size_bytes\" is null or \"file_object_replicas\".\"file_size_bytes\" >= 0"
+        },
+        "file_object_replicas_available_evidence_check": {
+          "name": "file_object_replicas_available_evidence_check",
+          "value": "\"file_object_replicas\".\"status\" <> 'available' or (\"file_object_replicas\".\"checksum_sha256\" is not null and \"file_object_replicas\".\"file_size_bytes\" is not null and \"file_object_replicas\".\"replicated_at\" is not null and \"file_object_replicas\".\"verified_at\" is not null)"
+        },
+        "file_object_replicas_independent_object_key_check": {
+          "name": "file_object_replicas_independent_object_key_check",
+          "value": "\"file_object_replicas\".\"replica_target\" <> 'independent-v1' or (\"file_object_replicas\".\"object_key\" ~ ('^attachments/v1/' || \"file_object_replicas\".\"practice_id\"::text || '/' || \"file_object_replicas\".\"file_id\"::text || '/(pending|[0-9a-f]{64})$') and (\"file_object_replicas\".\"status\" <> 'available' or (\"file_object_replicas\".\"checksum_sha256\" is not null and \"file_object_replicas\".\"object_key\" = 'attachments/v1/' || \"file_object_replicas\".\"practice_id\"::text || '/' || \"file_object_replicas\".\"file_id\"::text || '/' || \"file_object_replicas\".\"checksum_sha256\" and \"file_object_replicas\".\"object_version_id\" is not null)))"
+        },
+        "file_object_replicas_lease_coherence_check": {
+          "name": "file_object_replicas_lease_coherence_check",
+          "value": "(\"file_object_replicas\".\"lease_token\" is null and \"file_object_replicas\".\"lease_expires_at\" is null) or (\"file_object_replicas\".\"lease_token\" is not null and \"file_object_replicas\".\"lease_expires_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.file_storage_events": {
+      "name": "file_storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_target": {
+          "name": "storage_target",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_status": {
+          "name": "next_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_checksum_sha256": {
+          "name": "expected_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_checksum_sha256": {
+          "name": "observed_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_file_size_bytes": {
+          "name": "expected_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_file_size_bytes": {
+          "name": "observed_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_etag": {
+          "name": "object_etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_version_id": {
+          "name": "object_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_run_id": {
+          "name": "worker_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_storage_events_event_key_uq": {
+          "name": "file_storage_events_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_events_file_created_idx": {
+          "name": "file_storage_events_file_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_events_operation_idx": {
+          "name": "file_storage_events_operation_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_storage_events_practice_id_practices_id_fk": {
+          "name": "file_storage_events_practice_id_practices_id_fk",
+          "tableFrom": "file_storage_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_events_file_tenant_fk": {
+          "name": "file_storage_events_file_tenant_fk",
+          "tableFrom": "file_storage_events",
+          "tableTo": "files",
+          "columnsFrom": ["practice_id", "file_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_storage_events_expected_checksum_format_check": {
+          "name": "file_storage_events_expected_checksum_format_check",
+          "value": "\"file_storage_events\".\"expected_checksum_sha256\" is null or \"file_storage_events\".\"expected_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "file_storage_events_observed_checksum_format_check": {
+          "name": "file_storage_events_observed_checksum_format_check",
+          "value": "\"file_storage_events\".\"observed_checksum_sha256\" is null or \"file_storage_events\".\"observed_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "file_storage_events_expected_file_size_bytes_check": {
+          "name": "file_storage_events_expected_file_size_bytes_check",
+          "value": "\"file_storage_events\".\"expected_file_size_bytes\" is null or \"file_storage_events\".\"expected_file_size_bytes\" >= 0"
+        },
+        "file_storage_events_observed_file_size_bytes_check": {
+          "name": "file_storage_events_observed_file_size_bytes_check",
+          "value": "\"file_storage_events\".\"observed_file_size_bytes\" is null or \"file_storage_events\".\"observed_file_size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_etag": {
+          "name": "object_etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_version_id": {
+          "name": "object_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_status": {
+          "name": "storage_status",
+          "type": "file_storage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "storage_verified_at": {
+          "name": "storage_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_date": {
+          "name": "document_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_practice_id_uq": {
+          "name": "files_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_practice_file_key_uq": {
+          "name": "files_practice_file_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_practice_idempotency_key_uq": {
+          "name": "files_practice_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_patient_created_idx": {
+          "name": "files_patient_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_patient_tenant_fk": {
+          "name": "files_patient_tenant_fk",
+          "tableFrom": "files",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_patient_tenant_fk": {
+          "name": "files_appointment_patient_tenant_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploader_tenant_fk": {
+          "name": "files_uploader_tenant_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "uploaded_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "files_checksum_sha256_format_check": {
+          "name": "files_checksum_sha256_format_check",
+          "value": "\"files\".\"checksum_sha256\" is null or \"files\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "files_file_size_bytes_check": {
+          "name": "files_file_size_bytes_check",
+          "value": "\"files\".\"file_size_bytes\" is null or \"files\".\"file_size_bytes\" >= 0"
+        },
+        "files_available_evidence_check": {
+          "name": "files_available_evidence_check",
+          "value": "\"files\".\"storage_status\" <> 'available' or (\"files\".\"checksum_sha256\" is not null and \"files\".\"file_size_bytes\" is not null and \"files\".\"storage_verified_at\" is not null)"
+        },
+        "files_primary_namespace_check": {
+          "name": "files_primary_namespace_check",
+          "value": "\"files\".\"category\" in ('patient-photos', 'documents', 'lab-results', 'branding', 'consents') and \"files\".\"file_key\" ~ ('^' || \"files\".\"practice_id\"::text || '/' || \"files\".\"category\" || '/[^/]+$') and \"files\".\"file_url\" = '/api/files/' || \"files\".\"file_key\""
+        },
+        "files_category_required_check": {
+          "name": "files_category_required_check",
+          "value": "\"files\".\"category\" is not null"
+        },
+        "files_patient_entity_consistency_check": {
+          "name": "files_patient_entity_consistency_check",
+          "value": "\"files\".\"entity_type\" is distinct from 'patient' or (\"files\".\"patient_id\" is not null and \"files\".\"entity_id\" is not null and \"files\".\"entity_id\" = \"files\".\"patient_id\")"
+        },
+        "files_appointment_requires_patient_check": {
+          "name": "files_appointment_requires_patient_check",
+          "value": "\"files\".\"appointment_id\" is null or \"files\".\"patient_id\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_id_uq": {
+          "name": "consent_forms_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_png_bytes": {
+          "name": "signature_png_bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_sha256": {
+          "name": "signature_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_tenant_fk": {
+          "name": "consent_requests_patient_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_creator_tenant_fk": {
+          "name": "consent_requests_creator_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "created_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_patient_tenant_fk": {
+          "name": "consent_requests_appointment_patient_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_tenant_fk": {
+          "name": "consent_requests_form_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": ["practice_id", "form_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_tenant_fk": {
+          "name": "consent_requests_file_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": ["practice_id", "file_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "consent_requests_status_check": {
+          "name": "consent_requests_status_check",
+          "value": "\"consent_requests\".\"status\" in ('pending', 'signing', 'signed')"
+        },
+        "consent_requests_signing_evidence_check": {
+          "name": "consent_requests_signing_evidence_check",
+          "value": "(\"consent_requests\".\"status\" = 'pending' and \"consent_requests\".\"signer_name\" is null and \"consent_requests\".\"signed_at\" is null and \"consent_requests\".\"file_id\" is null and \"consent_requests\".\"signature_png_bytes\" is null and \"consent_requests\".\"signature_sha256\" is null) or (\"consent_requests\".\"status\" = 'signing' and \"consent_requests\".\"signer_name\" is not null and \"consent_requests\".\"signed_at\" is not null and \"consent_requests\".\"signature_png_bytes\" is not null and \"consent_requests\".\"signature_sha256\" is not null) or (\"consent_requests\".\"status\" = 'signed' and \"consent_requests\".\"signer_name\" is not null and \"consent_requests\".\"signed_at\" is not null and \"consent_requests\".\"file_id\" is not null)"
+        },
+        "consent_requests_signature_evidence_pair_check": {
+          "name": "consent_requests_signature_evidence_pair_check",
+          "value": "(\"consent_requests\".\"signature_png_bytes\" is null and \"consent_requests\".\"signature_sha256\" is null) or (\"consent_requests\".\"signature_png_bytes\" is not null and \"consent_requests\".\"signature_sha256\" is not null)"
+        },
+        "consent_requests_signature_evidence_size_check": {
+          "name": "consent_requests_signature_evidence_size_check",
+          "value": "\"consent_requests\".\"signature_png_bytes\" is null or octet_length(\"consent_requests\".\"signature_png_bytes\") between 1 and 500000"
+        },
+        "consent_requests_signature_evidence_hash_check": {
+          "name": "consent_requests_signature_evidence_hash_check",
+          "value": "\"consent_requests\".\"signature_sha256\" is null or (\"consent_requests\".\"signature_sha256\" ~ '^[0-9a-f]{64}$' and \"consent_requests\".\"signature_sha256\" = pg_catalog.encode(pg_catalog.sha256(\"consent_requests\".\"signature_png_bytes\"), 'hex'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": ["event_id", "endpoint"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": ["attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": ["attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": ["original_webhook_id"],
+          "columnsTo": ["webhook_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["location_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_practice_id_uq": {
+          "name": "messaging_registrations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": ["compliance_attested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registration_events": {
+      "name": "messaging_registration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "messaging_registration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "messaging_registration_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "messaging_registration_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messaging_registration_events_registration_history_idx": {
+          "name": "messaging_registration_events_registration_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_practice_time_idx": {
+          "name": "messaging_registration_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_operation_event_uq": {
+          "name": "messaging_registration_events_operation_event_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registration_events_practice_id_practices_id_fk": {
+          "name": "messaging_registration_events_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_id_messaging_registrations_id_fk": {
+          "name": "messaging_registration_events_registration_id_messaging_registrations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": ["registration_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_id_locations_id_fk": {
+          "name": "messaging_registration_events_location_id_locations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_user_id_users_id_fk": {
+          "name": "messaging_registration_events_actor_user_id_users_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_tenant_fk": {
+          "name": "messaging_registration_events_registration_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": ["practice_id", "registration_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_tenant_fk": {
+          "name": "messaging_registration_events_location_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_tenant_fk": {
+          "name": "messaging_registration_events_actor_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registration_events_shape_check": {
+          "name": "messaging_registration_events_shape_check",
+          "value": "\"messaging_registration_events\".\"provider\" in ('telnyx', 'twilio')\n        and \"messaging_registration_events\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and \"messaging_registration_events\".\"actor_name\" = btrim(\"messaging_registration_events\".\"actor_name\")\n        and length(\"messaging_registration_events\".\"actor_name\") between 1 and 255\n        and (\n          (\"messaging_registration_events\".\"actor_type\" = 'clinic_user'\n            and \"messaging_registration_events\".\"actor_user_id\" is not null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n          or (\"messaging_registration_events\".\"actor_type\" = 'platform_operator'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and length(btrim(coalesce(\"messaging_registration_events\".\"actor_identity\", ''))) between 1 and 255)\n          or (\"messaging_registration_events\".\"actor_type\" = 'system'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n        )\n        and (\"messaging_registration_events\".\"provider_brand_id\" is null or (\n          \"messaging_registration_events\".\"provider_brand_id\" = btrim(\"messaging_registration_events\".\"provider_brand_id\")\n          and length(\"messaging_registration_events\".\"provider_brand_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_campaign_id\" is null or (\n          \"messaging_registration_events\".\"provider_campaign_id\" = btrim(\"messaging_registration_events\".\"provider_campaign_id\")\n          and length(\"messaging_registration_events\".\"provider_campaign_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"messaging_profile_id\" is null or (\n          \"messaging_registration_events\".\"messaging_profile_id\" = btrim(\"messaging_registration_events\".\"messaging_profile_id\")\n          and length(\"messaging_registration_events\".\"messaging_profile_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_brand_status\" is null\n          or length(\"messaging_registration_events\".\"provider_brand_status\") between 1 and 64)\n        and (\"messaging_registration_events\".\"provider_campaign_status\" is null\n          or length(\"messaging_registration_events\".\"provider_campaign_status\") between 1 and 64)\n        and (\n          (\"messaging_registration_events\".\"event_type\" = 'details_saved'\n            and \"messaging_registration_events\".\"operation\" = 'registration_details')\n          or (\"messaging_registration_events\".\"event_type\" in (\n              'provider_operation_started',\n              'provider_operation_succeeded',\n              'provider_operation_failed'\n            ) and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'number_assignment'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_state_observed'\n            and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'registration_reconciliation'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_ids_attached'\n            and \"messaging_registration_events\".\"operation\" = 'provider_id_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'stale_lock_cleared'\n            and \"messaging_registration_events\".\"operation\" = 'submission_lock_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_enabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_activation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_disabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_deactivation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_verified'\n            and \"messaging_registration_events\".\"operation\" = 'profile_verification'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": ["delivery_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": ["communication_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": ["practice_id", "communication_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": ["delivery_event_id", "reviewed_history_id"],
+          "columnsTo": ["delivery_event_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": ["communication_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "resend_of_attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": ["practice_id", "communication_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "requested_by_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_event_conflict_reviews": {
+      "name": "sms_provider_event_conflict_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "conflict_id": {
+          "name": "conflict_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "sms_provider_event_conflict_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_identity": {
+          "name": "reviewed_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_by_name": {
+          "name": "reviewed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_provider_event_conflict_reviews_conflict_uq": {
+          "name": "sms_provider_event_conflict_reviews_conflict_uq",
+          "columns": [
+            {
+              "expression": "conflict_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_conflict_reviews_operation_uq": {
+          "name": "sms_provider_event_conflict_reviews_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_conflict_reviews_history_idx": {
+          "name": "sms_provider_event_conflict_reviews_history_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_event_conflict_reviews_conflict_id_sms_provider_event_conflicts_id_fk": {
+          "name": "sms_provider_event_conflict_reviews_conflict_id_sms_provider_event_conflicts_id_fk",
+          "tableFrom": "sms_provider_event_conflict_reviews",
+          "tableTo": "sms_provider_event_conflicts",
+          "columnsFrom": ["conflict_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_event_conflict_reviews_shape_check": {
+          "name": "sms_provider_event_conflict_reviews_shape_check",
+          "value": "(\n          (\"sms_provider_event_conflict_reviews\".\"resolution\" = 'semantic_duplicate_confirmed' and \"sms_provider_event_conflict_reviews\".\"reason_code\" in (\n            'provider_replay_verified', 'signature_evidence_verified'\n          ))\n          or (\"sms_provider_event_conflict_reviews\".\"resolution\" = 'provider_identity_rotated' and \"sms_provider_event_conflict_reviews\".\"reason_code\" in (\n            'sender_identity_rotated', 'provider_identity_reprovisioned'\n          ))\n          or (\"sms_provider_event_conflict_reviews\".\"resolution\" = 'incident_closed_no_projection' and \"sms_provider_event_conflict_reviews\".\"reason_code\" in (\n            'provider_support_incident_closed', 'security_review_closed'\n          ))\n        )\n        and \"sms_provider_event_conflict_reviews\".\"reviewed_by_identity\" = btrim(\"sms_provider_event_conflict_reviews\".\"reviewed_by_identity\")\n        and length(\"sms_provider_event_conflict_reviews\".\"reviewed_by_identity\") between 1 and 255\n        and \"sms_provider_event_conflict_reviews\".\"reviewed_by_name\" = btrim(\"sms_provider_event_conflict_reviews\".\"reviewed_by_name\")\n        and length(\"sms_provider_event_conflict_reviews\".\"reviewed_by_name\") between 1 and 255\n        and (\"sms_provider_event_conflict_reviews\".\"detail\" is null or length(btrim(\"sms_provider_event_conflict_reviews\".\"detail\")) between 1 and 2000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_event_conflicts": {
+      "name": "sms_provider_event_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "original_event_id": {
+          "name": "original_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint_sha256": {
+          "name": "incoming_raw_body_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_provider_event_type": {
+          "name": "incoming_provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_provider_event_id": {
+          "name": "incoming_provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_provider_event_conflicts_identity_uq": {
+          "name": "sms_provider_event_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_conflicts_recovery_idx": {
+          "name": "sms_provider_event_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_event_conflicts_original_event_id_sms_provider_events_id_fk": {
+          "name": "sms_provider_event_conflicts_original_event_id_sms_provider_events_id_fk",
+          "tableFrom": "sms_provider_event_conflicts",
+          "tableTo": "sms_provider_events",
+          "columnsFrom": ["original_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_event_conflicts_shape_check": {
+          "name": "sms_provider_event_conflicts_shape_check",
+          "value": "\"sms_provider_event_conflicts\".\"incoming_raw_body_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'\n        and length(btrim(\"sms_provider_event_conflicts\".\"incoming_provider_event_type\")) between 1 and 80\n        and \"sms_provider_event_conflicts\".\"incoming_provider_event_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        and (\"sms_provider_event_conflicts\".\"incoming_provider_event_id\" is null or (\n          \"sms_provider_event_conflicts\".\"incoming_provider_event_id\" = btrim(\"sms_provider_event_conflicts\".\"incoming_provider_event_id\")\n          and length(\"sms_provider_event_conflicts\".\"incoming_provider_event_id\") between 1 and 255\n        ))\n        and (\"sms_provider_event_conflicts\".\"incoming_provider_message_id\" is null or (\n          \"sms_provider_event_conflicts\".\"incoming_provider_message_id\" = btrim(\"sms_provider_event_conflicts\".\"incoming_provider_message_id\")\n          and length(\"sms_provider_event_conflicts\".\"incoming_provider_message_id\") between 1 and 255\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_event_resolutions": {
+      "name": "sms_provider_event_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflict_id": {
+          "name": "conflict_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "sms_provider_event_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_communication_id": {
+          "name": "inbound_communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_event_id": {
+          "name": "sms_consent_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_delivery_event_id": {
+          "name": "sms_delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_registration_event_id": {
+          "name": "messaging_registration_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_evidence_reference": {
+          "name": "external_evidence_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_identity": {
+          "name": "resolved_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_provider_event_resolutions_base_event_uq": {
+          "name": "sms_provider_event_resolutions_base_event_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_provider_event_resolutions\".\"conflict_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_event_idx": {
+          "name": "sms_provider_event_resolutions_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_conflict_uq": {
+          "name": "sms_provider_event_resolutions_conflict_uq",
+          "columns": [
+            {
+              "expression": "conflict_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_operation_uq": {
+          "name": "sms_provider_event_resolutions_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_practice_history_idx": {
+          "name": "sms_provider_event_resolutions_practice_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_communication_evidence_idx": {
+          "name": "sms_provider_event_resolutions_communication_evidence_idx",
+          "columns": [
+            {
+              "expression": "inbound_communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"inbound_communication_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_consent_evidence_idx": {
+          "name": "sms_provider_event_resolutions_consent_evidence_idx",
+          "columns": [
+            {
+              "expression": "sms_consent_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"sms_consent_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_delivery_evidence_idx": {
+          "name": "sms_provider_event_resolutions_delivery_evidence_idx",
+          "columns": [
+            {
+              "expression": "sms_delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_registration_evidence_idx": {
+          "name": "sms_provider_event_resolutions_registration_evidence_idx",
+          "columns": [
+            {
+              "expression": "messaging_registration_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_event_resolutions_event_id_sms_provider_events_id_fk": {
+          "name": "sms_provider_event_resolutions_event_id_sms_provider_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_provider_events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_conflict_id_sms_provider_event_conflicts_id_fk": {
+          "name": "sms_provider_event_resolutions_conflict_id_sms_provider_event_conflicts_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_provider_event_conflicts",
+          "columnsFrom": ["conflict_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_practice_id_practices_id_fk": {
+          "name": "sms_provider_event_resolutions_practice_id_practices_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_inbound_communication_id_communications_id_fk": {
+          "name": "sms_provider_event_resolutions_inbound_communication_id_communications_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "communications",
+          "columnsFrom": ["inbound_communication_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_sms_consent_event_id_sms_consent_events_id_fk": {
+          "name": "sms_provider_event_resolutions_sms_consent_event_id_sms_consent_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_consent_events",
+          "columnsFrom": ["sms_consent_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_sms_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_provider_event_resolutions_sms_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": ["sms_delivery_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_messaging_registration_event_id_messaging_registration_events_id_fk": {
+          "name": "sms_provider_event_resolutions_messaging_registration_event_id_messaging_registration_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "messaging_registration_events",
+          "columnsFrom": ["messaging_registration_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_event_resolutions_shape_check": {
+          "name": "sms_provider_event_resolutions_shape_check",
+          "value": "\"sms_provider_event_resolutions\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and (\"sms_provider_event_resolutions\".\"resolution\" = 'provider_attested_no_projection' or \"sms_provider_event_resolutions\".\"practice_id\" is not null)\n        and (\n          (\"sms_provider_event_resolutions\".\"resolution\" = 'authoritative_projection' and \"sms_provider_event_resolutions\".\"reason_code\" in (\n            'projection_repaired', 'delivery_reconciled'\n          ))\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'conservative_opt_out' and \"sms_provider_event_resolutions\".\"reason_code\" in (\n            'provider_identity_conflict_opt_out', 'sender_identity_drift_opt_out'\n          ))\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'carrier_state_reconciled'\n            and \"sms_provider_event_resolutions\".\"reason_code\" = 'carrier_state_readback_confirmed')\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'provider_attested_no_projection' and \"sms_provider_event_resolutions\".\"reason_code\" in (\n            'provider_support_invalid_callback', 'provider_support_duplicate_callback'\n          ))\n        )\n        and \"sms_provider_event_resolutions\".\"resolved_by_identity\" = btrim(\"sms_provider_event_resolutions\".\"resolved_by_identity\")\n        and length(\"sms_provider_event_resolutions\".\"resolved_by_identity\") between 1 and 255\n        and \"sms_provider_event_resolutions\".\"resolved_by_name\" = btrim(\"sms_provider_event_resolutions\".\"resolved_by_name\")\n        and length(\"sms_provider_event_resolutions\".\"resolved_by_name\") between 1 and 255\n        and (\"sms_provider_event_resolutions\".\"detail\" is null or length(btrim(\"sms_provider_event_resolutions\".\"detail\")) between 1 and 2000)\n        and (\"sms_provider_event_resolutions\".\"external_evidence_reference\" is null or (\n          \"sms_provider_event_resolutions\".\"external_evidence_reference\" = btrim(\"sms_provider_event_resolutions\".\"external_evidence_reference\")\n          and length(\"sms_provider_event_resolutions\".\"external_evidence_reference\") between 3 and 255\n          and \"sms_provider_event_resolutions\".\"external_evidence_reference\" ~ '^[A-Za-z0-9][A-Za-z0-9_.:/#-]{2,254}$'\n        ))\n        and (\n          (\"sms_provider_event_resolutions\".\"resolution\" = 'authoritative_projection'\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is null\n            and num_nonnulls(\n              \"sms_provider_event_resolutions\".\"inbound_communication_id\",\n              \"sms_provider_event_resolutions\".\"sms_consent_event_id\",\n              \"sms_provider_event_resolutions\".\"sms_delivery_event_id\",\n              \"sms_provider_event_resolutions\".\"messaging_registration_event_id\"\n            ) between 1 and 2)\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'conservative_opt_out'\n            and \"sms_provider_event_resolutions\".\"inbound_communication_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_consent_event_id\" is not null\n            and \"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is null)\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'carrier_state_reconciled'\n            and \"sms_provider_event_resolutions\".\"inbound_communication_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_consent_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is not null\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is null)\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'provider_attested_no_projection'\n            and \"sms_provider_event_resolutions\".\"inbound_communication_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_consent_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_events": {
+      "name": "sms_provider_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_provider_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint_sha256": {
+          "name": "raw_body_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_e164": {
+          "name": "from_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_e164": {
+          "name": "to_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_body": {
+          "name": "message_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbound_classification": {
+          "name": "inbound_classification",
+          "type": "sms_provider_inbound_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_classification": {
+          "name": "delivery_classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_phone_e164": {
+          "name": "a2p_phone_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_status": {
+          "name": "a2p_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_type": {
+          "name": "a2p_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_event_type": {
+          "name": "a2p_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_observed_status": {
+          "name": "a2p_observed_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_detail": {
+          "name": "provider_detail",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_provider_event_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "clock_timestamp()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_detail": {
+          "name": "last_error_detail",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_provider_events_provider_event_key_uq": {
+          "name": "sms_provider_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_due_idx": {
+          "name": "sms_provider_events_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"state\" in ('pending', 'retry')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_practice_idx": {
+          "name": "sms_provider_events_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"practice_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_blocked_idx": {
+          "name": "sms_provider_events_blocked_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"state\" = 'blocked_recovery'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_provider_message_idx": {
+          "name": "sms_provider_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_consent_order_idx": {
+          "name": "sms_provider_events_consent_order_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"occurred_at\", \"received_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"kind\" = 'inbound'\n          and \"sms_provider_events\".\"inbound_classification\" in ('stop', 'start')\n          and \"sms_provider_events\".\"practice_id\" is not null\n          and \"sms_provider_events\".\"from_e164\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_location_idx": {
+          "name": "sms_provider_events_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"location_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_events_practice_id_practices_id_fk": {
+          "name": "sms_provider_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_provider_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_events_location_tenant_fk": {
+          "name": "sms_provider_events_location_tenant_fk",
+          "tableFrom": "sms_provider_events",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_events_provider_check": {
+          "name": "sms_provider_events_provider_check",
+          "value": "\"sms_provider_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_provider_events_identifiers_check": {
+          "name": "sms_provider_events_identifiers_check",
+          "value": "(\"sms_provider_events\".\"provider_event_id\" is null or (\n          \"sms_provider_events\".\"provider_event_id\" = btrim(\"sms_provider_events\".\"provider_event_id\")\n          and length(\"sms_provider_events\".\"provider_event_id\") between 1 and 255\n        ))\n        and (\"sms_provider_events\".\"provider_message_id\" is null or (\n          \"sms_provider_events\".\"provider_message_id\" = btrim(\"sms_provider_events\".\"provider_message_id\")\n          and length(\"sms_provider_events\".\"provider_message_id\") between 1 and 255\n        ))\n        and length(btrim(\"sms_provider_events\".\"provider_event_type\")) between 1 and 80\n        and \"sms_provider_events\".\"provider_event_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        and length(\"sms_provider_events\".\"event_key\") between 1 and 255\n        and \"sms_provider_events\".\"event_key\" ~ '^[A-Za-z0-9_.:-]+$'\n        and \"sms_provider_events\".\"raw_body_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_provider_events_e164_check": {
+          "name": "sms_provider_events_e164_check",
+          "value": "(\"sms_provider_events\".\"from_e164\" is null or \"sms_provider_events\".\"from_e164\" ~ '^\\+[1-9][0-9]{7,14}$')\n        and (\"sms_provider_events\".\"to_e164\" is null or \"sms_provider_events\".\"to_e164\" ~ '^\\+[1-9][0-9]{7,14}$')\n        and (\"sms_provider_events\".\"a2p_phone_e164\" is null or \"sms_provider_events\".\"a2p_phone_e164\" ~ '^\\+[1-9][0-9]{7,14}$')"
+        },
+        "sms_provider_events_bounded_facts_check": {
+          "name": "sms_provider_events_bounded_facts_check",
+          "value": "(\"sms_provider_events\".\"messaging_profile_id\" is null or (\n          \"sms_provider_events\".\"messaging_profile_id\" = btrim(\"sms_provider_events\".\"messaging_profile_id\")\n          and length(\"sms_provider_events\".\"messaging_profile_id\") between 1 and 128\n        ))\n        and (\"sms_provider_events\".\"provider_status\" is null or (\n          length(btrim(\"sms_provider_events\".\"provider_status\")) between 1 and 80\n          and \"sms_provider_events\".\"provider_status\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"provider_error_code\" is null or (\n          length(btrim(\"sms_provider_events\".\"provider_error_code\")) between 1 and 80\n          and \"sms_provider_events\".\"provider_error_code\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"a2p_brand_id\" is null or (\n          \"sms_provider_events\".\"a2p_brand_id\" = btrim(\"sms_provider_events\".\"a2p_brand_id\")\n          and length(\"sms_provider_events\".\"a2p_brand_id\") between 1 and 128\n        ))\n        and (\"sms_provider_events\".\"a2p_campaign_id\" is null or (\n          \"sms_provider_events\".\"a2p_campaign_id\" = btrim(\"sms_provider_events\".\"a2p_campaign_id\")\n          and length(\"sms_provider_events\".\"a2p_campaign_id\") between 1 and 128\n        ))\n        and (\"sms_provider_events\".\"a2p_status\" is null or (\n          length(btrim(\"sms_provider_events\".\"a2p_status\")) between 1 and 80\n          and \"sms_provider_events\".\"a2p_status\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"a2p_type\" is null or (\n          length(btrim(\"sms_provider_events\".\"a2p_type\")) between 1 and 80\n          and \"sms_provider_events\".\"a2p_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"a2p_event_type\" is null or (\n          length(btrim(\"sms_provider_events\".\"a2p_event_type\")) between 1 and 80\n          and \"sms_provider_events\".\"a2p_event_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"provider_detail\" is null or length(btrim(\"sms_provider_events\".\"provider_detail\")) between 1 and 1000)\n        and (\"sms_provider_events\".\"last_error_code\" is null or (\n          length(btrim(\"sms_provider_events\".\"last_error_code\")) between 1 and 64\n          and \"sms_provider_events\".\"last_error_code\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"last_error_detail\" is null or length(btrim(\"sms_provider_events\".\"last_error_detail\")) between 1 and 2000)"
+        },
+        "sms_provider_events_attribution_check": {
+          "name": "sms_provider_events_attribution_check",
+          "value": "\"sms_provider_events\".\"location_id\" is null or \"sms_provider_events\".\"practice_id\" is not null"
+        },
+        "sms_provider_events_kind_shape_check": {
+          "name": "sms_provider_events_kind_shape_check",
+          "value": "(\n          \"sms_provider_events\".\"kind\" = 'inbound'\n          and \"sms_provider_events\".\"provider_event_type\" = 'message.received'\n          and \"sms_provider_events\".\"provider_message_id\" is not null\n          and \"sms_provider_events\".\"from_e164\" is not null\n          and (\"sms_provider_events\".\"to_e164\" is not null or \"sms_provider_events\".\"messaging_profile_id\" is not null)\n          and \"sms_provider_events\".\"message_body\" is not null\n          and length(btrim(\"sms_provider_events\".\"message_body\")) >= 1\n          and length(\"sms_provider_events\".\"message_body\") <= 1600\n          and \"sms_provider_events\".\"inbound_classification\" is not null\n          and \"sms_provider_events\".\"delivery_classification\" is null\n          and \"sms_provider_events\".\"provider_status\" is null\n          and \"sms_provider_events\".\"provider_error_code\" is null\n          and \"sms_provider_events\".\"a2p_brand_id\" is null\n          and \"sms_provider_events\".\"a2p_campaign_id\" is null\n          and \"sms_provider_events\".\"a2p_phone_e164\" is null\n          and \"sms_provider_events\".\"a2p_status\" is null\n          and \"sms_provider_events\".\"a2p_type\" is null\n          and \"sms_provider_events\".\"a2p_event_type\" is null\n          and \"sms_provider_events\".\"a2p_observed_status\" is null\n          and \"sms_provider_events\".\"provider_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"kind\" = 'delivery'\n          and \"sms_provider_events\".\"provider_event_type\" like 'message.%'\n          and \"sms_provider_events\".\"provider_event_type\" <> 'message.received'\n          and \"sms_provider_events\".\"provider_message_id\" is not null\n          and \"sms_provider_events\".\"from_e164\" is null\n          and \"sms_provider_events\".\"to_e164\" is null\n          and \"sms_provider_events\".\"messaging_profile_id\" is null\n          and \"sms_provider_events\".\"message_body\" is null\n          and \"sms_provider_events\".\"inbound_classification\" is null\n          and \"sms_provider_events\".\"delivery_classification\" is not null\n          and \"sms_provider_events\".\"a2p_brand_id\" is null\n          and \"sms_provider_events\".\"a2p_campaign_id\" is null\n          and \"sms_provider_events\".\"a2p_phone_e164\" is null\n          and \"sms_provider_events\".\"a2p_status\" is null\n          and \"sms_provider_events\".\"a2p_type\" is null\n          and \"sms_provider_events\".\"a2p_event_type\" is null\n          and \"sms_provider_events\".\"a2p_observed_status\" is null\n          and \"sms_provider_events\".\"provider_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"kind\" = 'a2p'\n          and \"sms_provider_events\".\"provider\" = 'telnyx'\n          and \"sms_provider_events\".\"provider_event_type\" in (\n            '10dlc.brand.update',\n            '10dlc.campaign.update',\n            '10dlc.phone_number.update'\n          )\n          and (\n            \"sms_provider_events\".\"a2p_brand_id\" is not null\n            or \"sms_provider_events\".\"a2p_campaign_id\" is not null\n            or \"sms_provider_events\".\"a2p_phone_e164\" is not null\n          )\n          and \"sms_provider_events\".\"a2p_observed_status\" is not null\n          and \"sms_provider_events\".\"a2p_observed_status\" in ('pending', 'action_required', 'failed', 'suspended')\n          and \"sms_provider_events\".\"provider_message_id\" is null\n          and \"sms_provider_events\".\"from_e164\" is null\n          and \"sms_provider_events\".\"to_e164\" is null\n          and \"sms_provider_events\".\"messaging_profile_id\" is null\n          and \"sms_provider_events\".\"message_body\" is null\n          and \"sms_provider_events\".\"inbound_classification\" is null\n          and \"sms_provider_events\".\"delivery_classification\" is null\n          and \"sms_provider_events\".\"provider_error_code\" is null\n        )"
+        },
+        "sms_provider_events_state_shape_check": {
+          "name": "sms_provider_events_state_shape_check",
+          "value": "\"sms_provider_events\".\"attempt_count\" >= 0 and (\n        (\n          \"sms_provider_events\".\"state\" = 'pending'\n          and \"sms_provider_events\".\"attempt_count\" = 0\n          and \"sms_provider_events\".\"next_attempt_at\" is not null\n          and \"sms_provider_events\".\"next_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"last_attempt_at\" is null\n          and \"sms_provider_events\".\"processed_at\" is null\n          and \"sms_provider_events\".\"last_error_code\" is null\n          and \"sms_provider_events\".\"last_error_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'retry'\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"next_attempt_at\" > \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"processed_at\" is null\n          and \"sms_provider_events\".\"last_error_code\" is not null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'blocked_recovery'\n          and \"sms_provider_events\".\"practice_id\" is not null\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'projected'\n          and (\"sms_provider_events\".\"practice_id\" is not null or \"sms_provider_events\".\"kind\" = 'delivery')\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is not null\n          and \"sms_provider_events\".\"processed_at\" >= \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"last_error_code\" is null\n          and \"sms_provider_events\".\"last_error_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'ignored'\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is not null\n          and \"sms_provider_events\".\"processed_at\" >= \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"last_error_code\" is null\n          and \"sms_provider_events\".\"last_error_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'quarantined'\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is not null\n          and \"sms_provider_events\".\"processed_at\" >= \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"last_error_code\" is not null\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_email_identity": {
+      "name": "platform_email_identity",
+      "schema": "",
+      "columns": {
+        "key_slot": {
+          "name": "key_slot",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_identity_singleton_check": {
+          "name": "platform_email_identity_singleton_check",
+          "value": "\"platform_email_identity\".\"key_slot\" = 1"
+        },
+        "platform_email_identity_fingerprint_check": {
+          "name": "platform_email_identity_fingerprint_check",
+          "value": "\"platform_email_identity\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preference_events": {
+      "name": "platform_email_preference_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_marketing_enabled": {
+          "name": "requested_marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_key_hash": {
+          "name": "provider_event_key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preference_events_recipient_timeline_idx": {
+          "name": "platform_email_preference_events_recipient_timeline_idx",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preference_events_provider_event_key_uq": {
+          "name": "platform_email_preference_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider_event_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preference_events_email_hash_check": {
+          "name": "platform_email_preference_events_email_hash_check",
+          "value": "\"platform_email_preference_events\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_identity_fingerprint_check": {
+          "name": "platform_email_preference_events_identity_fingerprint_check",
+          "value": "\"platform_email_preference_events\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_provider_event_key_hash_check": {
+          "name": "platform_email_preference_events_provider_event_key_hash_check",
+          "value": "\"platform_email_preference_events\".\"provider_event_key_hash\" IS NULL OR \"platform_email_preference_events\".\"provider_event_key_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_source_check": {
+          "name": "platform_email_preference_events_source_check",
+          "value": "\"platform_email_preference_events\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preference_events_reason_check": {
+          "name": "platform_email_preference_events_reason_check",
+          "value": "\"platform_email_preference_events\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preference_events_request_state_check": {
+          "name": "platform_email_preference_events_request_state_check",
+          "value": "(\"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preferences": {
+      "name": "platform_email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing_enabled": {
+          "name": "marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preferences_email_hash_uq": {
+          "name": "platform_email_preferences_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preferences_identity_fingerprint_idx": {
+          "name": "platform_email_preferences_identity_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "identity_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preferences_email_hash_check": {
+          "name": "platform_email_preferences_email_hash_check",
+          "value": "\"platform_email_preferences\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_identity_fingerprint_check": {
+          "name": "platform_email_preferences_identity_fingerprint_check",
+          "value": "\"platform_email_preferences\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_source_check": {
+          "name": "platform_email_preferences_source_check",
+          "value": "\"platform_email_preferences\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preferences_reason_check": {
+          "name": "platform_email_preferences_reason_check",
+          "value": "\"platform_email_preferences\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preferences_state_check": {
+          "name": "platform_email_preferences_state_check",
+          "value": "(\"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": ["practice_id", "milestone"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["committed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["follow_up_appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["clinical_finalized_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["completed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["follow_up_resolution_appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["vaccination_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": ["procedure_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "appointment_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": ["practice_id", "appointment_id", "procedure_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "appointment_id", "prescription_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["practice_id", "appointment_id", "invoice_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_id", "invoice_item_id"],
+          "columnsTo": ["invoice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilot_events": {
+      "name": "clinic_pilot_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clinic_pilot_id": {
+          "name": "clinic_pilot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "clinic_pilot_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "clinic_pilot_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_closeout_id": {
+          "name": "first_visit_validated_closeout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_hash": {
+          "name": "clinic_use_validated_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_version": {
+          "name": "projection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_snapshot": {
+          "name": "evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilot_events_operation_uq": {
+          "name": "clinic_pilot_events_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilot_events_history_idx": {
+          "name": "clinic_pilot_events_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk": {
+          "name": "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": ["clinic_pilot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_practice_id_practices_id_fk": {
+          "name": "clinic_pilot_events_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_first_visit_validated_closeout_id_visit_closeouts_id_fk": {
+          "name": "clinic_pilot_events_first_visit_validated_closeout_id_visit_closeouts_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "visit_closeouts",
+          "columnsFrom": ["first_visit_validated_closeout_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_pilot_practice_fk": {
+          "name": "clinic_pilot_events_pilot_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": ["clinic_pilot_id", "practice_id"],
+          "columnsTo": ["id", "practice_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_acceptance_user_practice_fk": {
+          "name": "clinic_pilot_events_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "clinic_acceptance_by_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilot_events_snapshot_check": {
+          "name": "clinic_pilot_events_snapshot_check",
+          "value": "\"clinic_pilot_events\".\"projection_version\" > 0\n        and \"clinic_pilot_events\".\"payload_hash\" ~ '^[a-f0-9]{64}$'\n        and \"clinic_pilot_events\".\"actor_identity\" = btrim(\"clinic_pilot_events\".\"actor_identity\")\n        and length(\"clinic_pilot_events\".\"actor_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"owner_identity\" = btrim(\"clinic_pilot_events\".\"owner_identity\")\n        and length(\"clinic_pilot_events\".\"owner_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilot_events\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"readiness_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"evidence_snapshot\") = 'object'\n        and (\"clinic_pilot_events\".\"last_contact_at\" is null) = (\"clinic_pilot_events\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilot_events\".\"clinic_acceptance_at\" is null) = (\"clinic_pilot_events\".\"clinic_acceptance_by_user_id\" is null)\n        and (\"clinic_pilot_events\".\"first_visit_validated_at\" is null) = (\"clinic_pilot_events\".\"first_visit_validated_closeout_id\" is null)\n        and (\"clinic_pilot_events\".\"clinic_use_validated_at\" is null) = (\"clinic_pilot_events\".\"clinic_use_validated_hash\" is null)\n        and (\"clinic_pilot_events\".\"clinic_use_validated_hash\" is null or \"clinic_pilot_events\".\"clinic_use_validated_hash\" ~ '^[a-f0-9]{64}$')\n        and \"clinic_pilot_events\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilot_events\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilot_events\".\"blocker_codes\", null) is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilots": {
+      "name": "clinic_pilots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"supportedClinicType\":false,\"supportedJurisdictionConfirmed\":false,\"singleLocation\":false,\"connectedModeAccepted\":false,\"parallelRunAccepted\":false,\"championConfirmed\":false,\"supportedWorkflowConfirmed\":false,\"noUnsupportedMustHave\":false}'::jsonb"
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"rolesAndDevicesValidated\":false,\"migrationPlanAccepted\":false,\"sampleValidationAccepted\":false,\"firstVisitScheduled\":false,\"exportAndRollbackConfirmed\":false,\"supportCadenceConfirmed\":false}'::jsonb"
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirm_fit'"
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email_only'"
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_closeout_id": {
+          "name": "first_visit_validated_closeout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_hash": {
+          "name": "clinic_use_validated_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilots_practice_uq": {
+          "name": "clinic_pilots_practice_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_id_practice_uq": {
+          "name": "clinic_pilots_id_practice_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_review_idx": {
+          "name": "clinic_pilots_review_idx",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilots_practice_id_practices_id_fk": {
+          "name": "clinic_pilots_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilots_first_visit_validated_closeout_id_visit_closeouts_id_fk": {
+          "name": "clinic_pilots_first_visit_validated_closeout_id_visit_closeouts_id_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "visit_closeouts",
+          "columnsFrom": ["first_visit_validated_closeout_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilots_acceptance_user_practice_fk": {
+          "name": "clinic_pilots_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "clinic_acceptance_by_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilots_version_check": {
+          "name": "clinic_pilots_version_check",
+          "value": "\"clinic_pilots\".\"version\" > 0"
+        },
+        "clinic_pilots_operating_shape_check": {
+          "name": "clinic_pilots_operating_shape_check",
+          "value": "\"clinic_pilots\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilots\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilots\".\"readiness_checklist\") = 'object'\n        and \"clinic_pilots\".\"owner_identity\" = btrim(\"clinic_pilots\".\"owner_identity\")\n        and length(\"clinic_pilots\".\"owner_identity\") between 3 and 255\n        and (\"clinic_pilots\".\"last_contact_at\" is null) = (\"clinic_pilots\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilots\".\"clinic_acceptance_at\" is null) = (\"clinic_pilots\".\"clinic_acceptance_by_user_id\" is null)\n        and (\"clinic_pilots\".\"first_visit_validated_at\" is null) = (\"clinic_pilots\".\"first_visit_validated_closeout_id\" is null)\n        and (\"clinic_pilots\".\"clinic_use_validated_at\" is null) = (\"clinic_pilots\".\"clinic_use_validated_hash\" is null)\n        and (\"clinic_pilots\".\"clinic_use_validated_hash\" is null or \"clinic_pilots\".\"clinic_use_validated_hash\" ~ '^[a-f0-9]{64}$')"
+        },
+        "clinic_pilots_blocker_codes_check": {
+          "name": "clinic_pilots_blocker_codes_check",
+          "value": "\"clinic_pilots\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilots\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilots\".\"blocker_codes\", null) is null"
+        },
+        "clinic_pilots_lifecycle_check": {
+          "name": "clinic_pilots_lifecycle_check",
+          "value": "(\n          \"clinic_pilots\".\"stage\" = 'completed'\n          and \"clinic_pilots\".\"decision\" = 'graduated'\n          and cardinality(\"clinic_pilots\".\"blocker_codes\") = 0\n          and \"clinic_pilots\".\"next_action\" = 'support_retention'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" = 'closed'\n          and \"clinic_pilots\".\"decision\" = 'not_a_fit'\n          and \"clinic_pilots\".\"next_action\" = 'revisit_fit'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" not in ('completed', 'closed')\n          and \"clinic_pilots\".\"decision\" not in ('graduated', 'not_a_fit')\n          and \"clinic_pilots\".\"next_review_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "veterinarian", "technician", "front_desk", "viewer"]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": ["phone", "email", "sms", "portal"]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": ["mild", "moderate", "severe"]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": ["active", "inactive", "deceased"]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": ["male", "female", "male_neutered", "female_spayed"]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": ["weekly", "monthly", "annual"]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": ["exam", "surgery", "treatment", "boarding"]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": ["waiting", "scheduled", "cancelled"]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": ["open", "closed"]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": ["not_required", "open", "completed"]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": ["unknown", "normal", "abnormal", "critical"]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": ["pending", "completed", "reviewed"]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": ["general", "follow_up", "phone_call"]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": ["active", "resolved", "chronic"]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": ["draft", "finalized"]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": ["pending", "in_progress", "done", "skipped"]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": ["active", "completed", "discontinued"]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": ["entered_in_error"]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result",
+        "patient_allergy"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": ["minor", "moderate", "major"]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": ["active", "completed", "cancelled", "expired"]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": ["credit", "write_off"]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": ["service", "product"]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": ["draft", "sent", "paid", "overdue", "void"]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": ["pending", "active", "action_required", "disabled"]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": ["draft", "ordered", "received"]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": ["pending", "invoiced", "waived"]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": ["phone", "sms", "email", "portal"]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": ["pending", "sent", "delivered", "read", "failed"]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": ["inbound", "outbound"]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": ["received", "administered", "wasted", "returned"]
+    },
+    "public.file_replica_status": {
+      "name": "file_replica_status",
+      "schema": "public",
+      "values": ["pending", "available", "missing", "corrupt", "failed"]
+    },
+    "public.file_storage_status": {
+      "name": "file_storage_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "pending_upload",
+        "available",
+        "missing",
+        "corrupt",
+        "cleanup_pending"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": ["monthly", "annual"]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": ["active", "cancelled"]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": ["reserved", "accepted", "definite_failure", "outcome_unknown"]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": ["registration", "authenticated_resend"]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": ["manual", "bounce", "complaint", "suppressed"]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": ["PRIVATE_PROFIT", "NON_PROFIT"]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": ["hosted", "purchased", "toll_free"]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": ["stop", "manual", "bounce", "complaint"]
+    },
+    "public.messaging_registration_actor_type": {
+      "name": "messaging_registration_actor_type",
+      "schema": "public",
+      "values": ["clinic_user", "platform_operator", "system"]
+    },
+    "public.messaging_registration_event_type": {
+      "name": "messaging_registration_event_type",
+      "schema": "public",
+      "values": [
+        "details_saved",
+        "provider_operation_started",
+        "provider_operation_succeeded",
+        "provider_operation_failed",
+        "provider_state_observed",
+        "provider_ids_attached",
+        "stale_lock_cleared",
+        "provider_profile_enabled",
+        "provider_profile_disabled",
+        "provider_profile_verified"
+      ]
+    },
+    "public.messaging_registration_operation": {
+      "name": "messaging_registration_operation",
+      "schema": "public",
+      "values": [
+        "registration_details",
+        "brand_submission",
+        "campaign_submission",
+        "number_assignment",
+        "registration_reconciliation",
+        "provider_id_recovery",
+        "submission_lock_recovery",
+        "profile_activation",
+        "profile_deactivation",
+        "profile_verification"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": ["granted", "revoked"]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": ["staff", "client", "system"]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": ["unknown", "sent", "failed", "delivered"]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": ["automatic", "operator_reconciliation"]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": ["clinic_user", "platform_operator"]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": ["provider_result", "reconciliation"]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": ["accepted", "definite_failure", "outcome_unknown"]
+    },
+    "public.sms_provider_event_conflict_resolution": {
+      "name": "sms_provider_event_conflict_resolution",
+      "schema": "public",
+      "values": [
+        "semantic_duplicate_confirmed",
+        "provider_identity_rotated",
+        "incident_closed_no_projection"
+      ]
+    },
+    "public.sms_provider_event_kind": {
+      "name": "sms_provider_event_kind",
+      "schema": "public",
+      "values": ["inbound", "delivery", "a2p"]
+    },
+    "public.sms_provider_event_resolution": {
+      "name": "sms_provider_event_resolution",
+      "schema": "public",
+      "values": [
+        "authoritative_projection",
+        "conservative_opt_out",
+        "carrier_state_reconciled",
+        "provider_attested_no_projection"
+      ]
+    },
+    "public.sms_provider_event_state": {
+      "name": "sms_provider_event_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "retry",
+        "blocked_recovery",
+        "projected",
+        "ignored",
+        "quarantined"
+      ]
+    },
+    "public.sms_provider_inbound_classification": {
+      "name": "sms_provider_inbound_classification",
+      "schema": "public",
+      "values": ["stop", "start", "help", "other"]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": ["practice_created", "product_records", "stripe_webhook"]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": ["clients", "patients", "vaccinations", "soap_notes"]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": ["previewed", "superseded", "committing", "committed"]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": ["paid", "accounts_receivable", "no_charge"]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": ["draft", "clinical_finalized", "completed"]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": ["none", "needed", "scheduled"]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": ["scheduled", "completed", "not_needed"]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": ["print", "verbal", "declined"]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": ["prescribed", "not_needed"]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": ["unresolved", "charged", "no_charge", "voided"]
+    },
+    "public.clinic_pilot_communication_mode": {
+      "name": "clinic_pilot_communication_mode",
+      "schema": "public",
+      "values": ["email_only", "email_and_sms"]
+    },
+    "public.clinic_pilot_contact_outcome": {
+      "name": "clinic_pilot_contact_outcome",
+      "schema": "public",
+      "values": ["replied", "no_reply", "scheduled", "completed", "declined"]
+    },
+    "public.clinic_pilot_decision": {
+      "name": "clinic_pilot_decision",
+      "schema": "public",
+      "values": [
+        "pending",
+        "eligible",
+        "approved",
+        "paused",
+        "not_a_fit",
+        "graduated"
+      ]
+    },
+    "public.clinic_pilot_event_type": {
+      "name": "clinic_pilot_event_type",
+      "schema": "public",
+      "values": ["enrolled", "updated"]
+    },
+    "public.clinic_pilot_next_action": {
+      "name": "clinic_pilot_next_action",
+      "schema": "public",
+      "values": [
+        "confirm_fit",
+        "schedule_setup",
+        "validate_import",
+        "complete_first_visit",
+        "review_communications",
+        "configure_payment",
+        "review_clinic_week",
+        "resolve_blockers",
+        "decide_graduation",
+        "support_retention",
+        "revisit_fit"
+      ]
+    },
+    "public.clinic_pilot_reason": {
+      "name": "clinic_pilot_reason",
+      "schema": "public",
+      "values": [
+        "initial_review",
+        "clinic_feedback",
+        "product_evidence",
+        "support_review",
+        "blocker_review",
+        "graduation_decision"
+      ]
+    },
+    "public.clinic_pilot_stage": {
+      "name": "clinic_pilot_stage",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "parallel_setup",
+        "visit_validation",
+        "pilot_week",
+        "graduation_review",
+        "completed",
+        "closed"
+      ]
+    },
+    "public.clinic_pilot_support_cadence": {
+      "name": "clinic_pilot_support_cadence",
+      "schema": "public",
+      "values": ["daily", "twice_weekly", "weekly"]
+    },
+    "public.clinic_pilot_workflow": {
+      "name": "clinic_pilot_workflow",
+      "schema": "public",
+      "values": ["general_practice", "house_call"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1786425155753,
       "tag": "0084_wakeful_silk_fever",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1786428459802,
+      "tag": "0085_foamy_rick_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
     "db:reset": "tsx reset.ts",
     "db:rls": "tsx apply-rls.ts",
     "db:rls:test": "tsx test-rls.ts",
+    "db:sms-provider-resolutions:test": "tsx test-sms-provider-event-resolutions.ts",
     "db:migration-runs:test": "tsx test-migration-runs.ts",
     "db:drift": "tsx check-drift.ts",
     "db:baseline": "tsx baseline.ts",

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -6,6 +6,7 @@ import { db } from "./client";
 // Order doesn't matter with CASCADE, but we TRUNCATE every table the seed touches.
 // RESTART IDENTITY resets any serial sequences (none in this schema, but cheap).
 const TABLES = [
+  "sms_provider_event_resolutions",
   "messaging_registration_events",
   "sms_provider_event_conflict_reviews",
   "sms_provider_event_conflicts",

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -254,10 +254,16 @@ CREATE POLICY system_only ON sms_provider_event_conflict_reviews
   USING (app_rls_bypass())
   WITH CHECK (app_rls_bypass());
 
-REVOKE ALL ON sms_provider_events, sms_provider_event_conflicts, sms_provider_event_conflict_reviews FROM PUBLIC;
-REVOKE ALL ON sms_provider_events, sms_provider_event_conflicts, sms_provider_event_conflict_reviews FROM openpims_app;
+ALTER TABLE sms_provider_event_resolutions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS system_only ON sms_provider_event_resolutions;
+CREATE POLICY system_only ON sms_provider_event_resolutions
+  USING (app_rls_bypass())
+  WITH CHECK (app_rls_bypass());
+
+REVOKE ALL ON sms_provider_events, sms_provider_event_conflicts, sms_provider_event_conflict_reviews, sms_provider_event_resolutions FROM PUBLIC;
+REVOKE ALL ON sms_provider_events, sms_provider_event_conflicts, sms_provider_event_conflict_reviews, sms_provider_event_resolutions FROM openpims_app;
 GRANT SELECT, INSERT, UPDATE ON sms_provider_events TO openpims_app;
-GRANT SELECT, INSERT ON sms_provider_event_conflicts, sms_provider_event_conflict_reviews TO openpims_app;
+GRANT SELECT, INSERT ON sms_provider_event_conflicts, sms_provider_event_conflict_reviews, sms_provider_event_resolutions TO openpims_app;
 
 -- Dispense charge snapshots are durable revenue work. The app may advance or
 -- reopen their attributed workflow status, while database triggers prevent
@@ -484,7 +490,7 @@ BEGIN
   FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
       EXECUTE format(
-        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_provider_identity_conflicts, auth_email_webhook_conflicts, auth_tokens, clinic_pilot_events, clinic_pilots, clinical_record_corrections, demo_accesses, dispense_charge_queue, file_object_replicas, file_storage_events, funnel_events, lab_result_events, lab_result_replacements, messaging_registration_events, patient_allergies, patient_merge_events, platform_email_identity, platform_email_preference_events, platform_email_preferences, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_provider_event_conflict_reviews, sms_provider_event_conflicts, sms_provider_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
+        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_provider_identity_conflicts, auth_email_webhook_conflicts, auth_tokens, clinic_pilot_events, clinic_pilots, clinical_record_corrections, demo_accesses, dispense_charge_queue, file_object_replicas, file_storage_events, funnel_events, lab_result_events, lab_result_replacements, messaging_registration_events, patient_allergies, patient_merge_events, platform_email_identity, platform_email_preference_events, platform_email_preferences, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_provider_event_conflict_reviews, sms_provider_event_conflicts, sms_provider_event_resolutions, sms_provider_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
       );
     END IF;
   END LOOP;

--- a/packages/db/schema-drift.ts
+++ b/packages/db/schema-drift.ts
@@ -367,6 +367,61 @@ export function criticalDatabaseContract(): DeclaredDatabaseObject[] {
       table: "sms_provider_event_conflict_reviews",
       name,
     })),
+    {
+      kind: "constraint",
+      table: "sms_provider_event_resolutions",
+      name: "sms_provider_event_resolutions_shape_check",
+    },
+    ...[
+      "sms_provider_event_resolutions_event_id_sms_provider_events_id_",
+      "sms_provider_event_resolutions_conflict_id_sms_provider_event_c",
+      "sms_provider_event_resolutions_practice_id_practices_id_fk",
+      "sms_provider_event_resolutions_inbound_communication_id_communi",
+      "sms_provider_event_resolutions_sms_consent_event_id_sms_consent",
+      "sms_provider_event_resolutions_sms_delivery_event_id_sms_delive",
+      "sms_provider_event_resolutions_messaging_registration_event_id_",
+    ].map((name) => ({
+      kind: "constraint" as const,
+      table: "sms_provider_event_resolutions",
+      name,
+    })),
+    ...[
+      "sms_provider_event_resolutions_base_event_uq",
+      "sms_provider_event_resolutions_event_idx",
+      "sms_provider_event_resolutions_conflict_uq",
+      "sms_provider_event_resolutions_operation_uq",
+      "sms_provider_event_resolutions_communication_evidence_idx",
+      "sms_provider_event_resolutions_consent_evidence_idx",
+      "sms_provider_event_resolutions_delivery_evidence_idx",
+      "sms_provider_event_resolutions_registration_evidence_idx",
+    ].map((name) => ({
+      kind: "index" as const,
+      table: "sms_provider_event_resolutions",
+      name,
+    })),
+    ...[
+      "sms_provider_event_resolutions_validate_insert",
+      "sms_provider_event_resolutions_immutable",
+    ].map((name) => ({
+      kind: "trigger" as const,
+      table: "sms_provider_event_resolutions",
+      name,
+    })),
+    {
+      kind: "rls_policy",
+      table: "sms_provider_event_resolutions",
+      name: "system_only",
+    },
+    ...["SELECT", "INSERT"].map((name) => ({
+      kind: "table_privilege" as const,
+      table: "sms_provider_event_resolutions",
+      name,
+    })),
+    ...["UPDATE", "DELETE"].map((name) => ({
+      kind: "forbidden_table_privilege" as const,
+      table: "sms_provider_event_resolutions",
+      name,
+    })),
   ];
 
   return objects;
@@ -513,7 +568,9 @@ export async function findSchemaDrift(db: Queryable): Promise<SchemaDrift> {
       ('sms_provider_event_conflicts'::text, 'UPDATE'::text),
       ('sms_provider_event_conflicts'::text, 'DELETE'::text),
       ('sms_provider_event_conflict_reviews'::text, 'UPDATE'::text),
-      ('sms_provider_event_conflict_reviews'::text, 'DELETE'::text)
+      ('sms_provider_event_conflict_reviews'::text, 'DELETE'::text),
+      ('sms_provider_event_resolutions'::text, 'UPDATE'::text),
+      ('sms_provider_event_resolutions'::text, 'DELETE'::text)
     ) required_absence(table_name, privilege_type)
   `);
 

--- a/packages/db/schema/sms-provider-events.ts
+++ b/packages/db/schema/sms-provider-events.ts
@@ -12,9 +12,15 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import { communications } from "./communications";
 import { messagingRegistrationStatusEnum } from "./messaging";
+import { messagingRegistrationEvents } from "./messaging-registration-events";
 import { locations, practices } from "./practices";
-import { smsDeliveryClassificationEnum } from "./sms-send-attempts";
+import { smsConsentEvents } from "./sms-consent-events";
+import {
+  smsDeliveryClassificationEnum,
+  smsDeliveryEvents,
+} from "./sms-send-attempts";
 
 export const smsProviderEventKindEnum = pgEnum("sms_provider_event_kind", [
   "inbound",
@@ -44,6 +50,28 @@ export const smsProviderEventConflictResolutionEnum = pgEnum(
     "incident_closed_no_projection",
   ],
 );
+
+export const smsProviderEventResolutionEnum = pgEnum(
+  "sms_provider_event_resolution",
+  [
+    "authoritative_projection",
+    "conservative_opt_out",
+    "carrier_state_reconciled",
+    "provider_attested_no_projection",
+  ],
+);
+
+/**
+ * System-only SMS provider evidence must never be included in clinic backup
+ * artifacts. Keeping the denylist beside the schema gives backup consumers a
+ * stable, exported contract instead of relying on an undocumented omission.
+ */
+export const smsProviderEventSystemOnlyBackupExcludedTables = [
+  "sms_provider_events",
+  "sms_provider_event_conflicts",
+  "sms_provider_event_conflict_reviews",
+  "sms_provider_event_resolutions",
+] as const;
 
 /**
  * Durable, provider-neutral inbox for signed SMS provider facts. The webhook
@@ -448,6 +476,147 @@ export const smsProviderEventConflictReviews = pgTable(
         and ${table.reviewedByName} = btrim(${table.reviewedByName})
         and length(${table.reviewedByName}) between 1 and 255
         and (${table.detail} is null or length(btrim(${table.detail})) between 1 and 2000)`,
+    ),
+  }),
+);
+
+/**
+ * Append-only, system-only evidence that a terminal provider incident has been
+ * handled. Base rows cover a non-conflict quarantine; conflict-scoped rows also
+ * cover conflicts appended after projection. The ledger never changes the
+ * inbox event itself: callers must present durable evidence.
+ */
+export const smsProviderEventResolutions = pgTable(
+  "sms_provider_event_resolutions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true })
+      .notNull()
+      .default(sql`clock_timestamp()`),
+    eventId: uuid("event_id")
+      .notNull()
+      .references(() => smsProviderEvents.id),
+    conflictId: uuid("conflict_id").references(
+      () => smsProviderEventConflicts.id,
+    ),
+    operationId: uuid("operation_id").notNull(),
+    practiceId: uuid("practice_id").references(() => practices.id),
+    resolution: smsProviderEventResolutionEnum("resolution").notNull(),
+    inboundCommunicationId: uuid("inbound_communication_id").references(
+      () => communications.id,
+    ),
+    smsConsentEventId: uuid("sms_consent_event_id").references(
+      () => smsConsentEvents.id,
+    ),
+    smsDeliveryEventId: uuid("sms_delivery_event_id").references(
+      () => smsDeliveryEvents.id,
+    ),
+    messagingRegistrationEventId: uuid(
+      "messaging_registration_event_id",
+    ).references(() => messagingRegistrationEvents.id),
+    externalEvidenceReference: varchar("external_evidence_reference", {
+      length: 255,
+    }),
+    reasonCode: varchar("reason_code", { length: 64 }).notNull(),
+    detail: varchar("detail", { length: 2000 }),
+    resolvedByIdentity: varchar("resolved_by_identity", {
+      length: 255,
+    }).notNull(),
+    resolvedByName: varchar("resolved_by_name", { length: 255 }).notNull(),
+  },
+  (table) => ({
+    baseEventUq: uniqueIndex("sms_provider_event_resolutions_base_event_uq")
+      .on(table.eventId)
+      .where(sql`${table.conflictId} is null`),
+    eventIdx: index("sms_provider_event_resolutions_event_idx").on(
+      table.eventId,
+      table.resolvedAt,
+      table.id,
+    ),
+    conflictUq: uniqueIndex("sms_provider_event_resolutions_conflict_uq").on(
+      table.conflictId,
+    ),
+    operationUq: uniqueIndex("sms_provider_event_resolutions_operation_uq").on(
+      table.operationId,
+    ),
+    practiceHistoryIdx: index(
+      "sms_provider_event_resolutions_practice_history_idx",
+    ).on(table.practiceId, table.resolvedAt, table.id),
+    communicationEvidenceIdx: index(
+      "sms_provider_event_resolutions_communication_evidence_idx",
+    )
+      .on(table.inboundCommunicationId)
+      .where(sql`${table.inboundCommunicationId} is not null`),
+    consentEvidenceIdx: index(
+      "sms_provider_event_resolutions_consent_evidence_idx",
+    )
+      .on(table.smsConsentEventId)
+      .where(sql`${table.smsConsentEventId} is not null`),
+    deliveryEvidenceIdx: index(
+      "sms_provider_event_resolutions_delivery_evidence_idx",
+    )
+      .on(table.smsDeliveryEventId)
+      .where(sql`${table.smsDeliveryEventId} is not null`),
+    registrationEvidenceIdx: index(
+      "sms_provider_event_resolutions_registration_evidence_idx",
+    )
+      .on(table.messagingRegistrationEventId)
+      .where(sql`${table.messagingRegistrationEventId} is not null`),
+    shapeCheck: check(
+      "sms_provider_event_resolutions_shape_check",
+      sql`${table.reasonCode} ~ '^[a-z0-9_]{3,64}$'
+        and (${table.resolution} = 'provider_attested_no_projection' or ${table.practiceId} is not null)
+        and (
+          (${table.resolution} = 'authoritative_projection' and ${table.reasonCode} in (
+            'projection_repaired', 'delivery_reconciled'
+          ))
+          or (${table.resolution} = 'conservative_opt_out' and ${table.reasonCode} in (
+            'provider_identity_conflict_opt_out', 'sender_identity_drift_opt_out'
+          ))
+          or (${table.resolution} = 'carrier_state_reconciled'
+            and ${table.reasonCode} = 'carrier_state_readback_confirmed')
+          or (${table.resolution} = 'provider_attested_no_projection' and ${table.reasonCode} in (
+            'provider_support_invalid_callback', 'provider_support_duplicate_callback'
+          ))
+        )
+        and ${table.resolvedByIdentity} = btrim(${table.resolvedByIdentity})
+        and length(${table.resolvedByIdentity}) between 1 and 255
+        and ${table.resolvedByName} = btrim(${table.resolvedByName})
+        and length(${table.resolvedByName}) between 1 and 255
+        and (${table.detail} is null or length(btrim(${table.detail})) between 1 and 2000)
+        and (${table.externalEvidenceReference} is null or (
+          ${table.externalEvidenceReference} = btrim(${table.externalEvidenceReference})
+          and length(${table.externalEvidenceReference}) between 3 and 255
+          and ${table.externalEvidenceReference} ~ '^[A-Za-z0-9][A-Za-z0-9_.:/#-]{2,254}$'
+        ))
+        and (
+          (${table.resolution} = 'authoritative_projection'
+            and ${table.externalEvidenceReference} is null
+            and num_nonnulls(
+              ${table.inboundCommunicationId},
+              ${table.smsConsentEventId},
+              ${table.smsDeliveryEventId},
+              ${table.messagingRegistrationEventId}
+            ) between 1 and 2)
+          or (${table.resolution} = 'conservative_opt_out'
+            and ${table.inboundCommunicationId} is null
+            and ${table.smsConsentEventId} is not null
+            and ${table.smsDeliveryEventId} is null
+            and ${table.messagingRegistrationEventId} is null
+            and ${table.externalEvidenceReference} is null)
+          or (${table.resolution} = 'carrier_state_reconciled'
+            and ${table.inboundCommunicationId} is null
+            and ${table.smsConsentEventId} is null
+            and ${table.smsDeliveryEventId} is null
+            and ${table.messagingRegistrationEventId} is not null
+            and ${table.externalEvidenceReference} is null)
+          or (${table.resolution} = 'provider_attested_no_projection'
+            and ${table.inboundCommunicationId} is null
+            and ${table.smsConsentEventId} is null
+            and ${table.smsDeliveryEventId} is null
+            and ${table.messagingRegistrationEventId} is null
+            and ${table.externalEvidenceReference} is not null)
+        )`,
     ),
   }),
 );

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -189,6 +189,18 @@ const aAttributedSmsProviderEvent = randomUUID();
 const aSmsProviderConflict = randomUUID();
 const aSmsProviderConflictReview = randomUUID();
 const aSmsProviderConflictReviewOperation = randomUUID();
+const resolutionBaseEvent = randomUUID();
+const resolutionBaseConflict = randomUUID();
+const resolutionBaseCommunication = randomUUID();
+const resolutionConflictConsent = randomUUID();
+const resolutionBase = randomUUID();
+const resolutionBaseOperation = randomUUID();
+const resolutionConflict = randomUUID();
+const resolutionConflictOperation = randomUUID();
+const resolutionGlobalDeliveryEvent = randomUUID();
+const resolutionGlobalDelivery = randomUUID();
+const resolutionGlobalDeliveryOperation = randomUUID();
+const resolutionOccurredAt = new Date(Date.now() - 5 * 60 * 1000);
 const funnelEventId = randomUUID();
 const platformEmailPreferenceId = randomUUID();
 const systemUpsertPlatformEmailPreferenceId = randomUUID();
@@ -373,6 +385,60 @@ try {
     values (${aSmsProviderConflict}, ${aSmsProviderEvent}, ${"5".repeat(64)},
       'message.received', ${`provider-conflict-${aSmsProviderConflict}`},
       ${`provider-message-${aSmsProviderEvent}`})`;
+  await owner`insert into sms_provider_events
+    (id, occurred_at, provider, kind, provider_event_id, provider_message_id,
+     provider_event_type, event_key, raw_body_fingerprint_sha256,
+     from_e164, to_e164, message_body, inbound_classification)
+    values (${resolutionBaseEvent}, ${resolutionOccurredAt}, 'telnyx', 'inbound',
+      ${`provider-event-${resolutionBaseEvent}`},
+      ${`provider-message-${resolutionBaseEvent}`}, 'message.received',
+      ${`telnyx:event:${resolutionBaseEvent}`}, ${"b".repeat(64)},
+      '+15555550121', '+15555550122', 'Resolution base projection', 'other')`;
+  await owner`update sms_provider_events
+    set practice_id = ${aId}, location_id = ${aLocation}, state = 'quarantined',
+        attempt_count = 1, next_attempt_at = null,
+        last_attempt_at = statement_timestamp(), processed_at = statement_timestamp(),
+        last_error_code = 'sender_identity_drift',
+        last_error_detail = 'Sender identity changed during projection.'
+    where id = ${resolutionBaseEvent}`;
+  await owner`insert into communications
+    (id, created_at, practice_id, channel, direction, content, status,
+     provider_message_id, dedupe_key)
+    values (${resolutionBaseCommunication}, ${resolutionOccurredAt}, ${aId},
+      'sms', 'inbound', 'Resolution base projection', 'delivered',
+      ${`provider-message-${resolutionBaseEvent}`},
+      ${`resolution:${resolutionBaseCommunication}`})`;
+  await owner`insert into sms_provider_event_conflicts
+    (id, original_event_id, incoming_raw_body_fingerprint_sha256,
+     incoming_provider_event_type, incoming_provider_event_id,
+     incoming_provider_message_id)
+    values (${resolutionBaseConflict}, ${resolutionBaseEvent}, ${"c".repeat(64)},
+      'message.received', ${`provider-conflict-${resolutionBaseConflict}`},
+      ${`provider-conflict-message-${resolutionBaseConflict}`})`;
+  await owner`insert into sms_consent_events
+    (id, practice_id, location_id, destination_e164, action, source, detail,
+     actor_type, event_key)
+    values (${resolutionConflictConsent}, ${aId}, ${aLocation}, '+15555550121',
+      'revoked', 'provider_event_resolution:v1',
+      'Conservative conflict opt-out for RLS verification.', 'system',
+      ${`provider_event_resolution:${resolutionConflictOperation}:${resolutionBaseConflict}:revoked`})`;
+  await owner`insert into sms_suppressions
+    (practice_id, location_id, phone, reason, detail)
+    values (${aId}, ${aLocation}, '+15555550121', 'stop',
+      'Provider event conflict resolved conservatively.')`;
+  await owner`insert into sms_provider_events
+    (id, provider, kind, provider_message_id, provider_event_type, event_key,
+     raw_body_fingerprint_sha256, delivery_classification)
+    values (${resolutionGlobalDeliveryEvent}, 'telnyx', 'delivery',
+      ${`global-provider-message-${resolutionGlobalDeliveryEvent}`},
+      'message.sent', ${`telnyx:event:${resolutionGlobalDeliveryEvent}`},
+      ${"d".repeat(64)}, 'sent')`;
+  await owner`update sms_provider_events
+    set state = 'quarantined', attempt_count = 1, next_attempt_at = null,
+        last_attempt_at = statement_timestamp(), processed_at = statement_timestamp(),
+        last_error_code = 'delivery_attribution_pending',
+        last_error_detail = 'No exact accepted send could be attributed.'
+    where id = ${resolutionGlobalDeliveryEvent}`;
   const [smsProviderPrivileges] = await owner<
     Array<{
       event_select: boolean;
@@ -387,6 +453,10 @@ try {
       review_insert: boolean;
       review_update: boolean;
       review_delete: boolean;
+      resolution_select: boolean;
+      resolution_insert: boolean;
+      resolution_update: boolean;
+      resolution_delete: boolean;
     }>
   >`select
       has_table_privilege('openpims_app', 'sms_provider_events', 'select') event_select,
@@ -400,7 +470,11 @@ try {
       has_table_privilege('openpims_app', 'sms_provider_event_conflict_reviews', 'select') review_select,
       has_table_privilege('openpims_app', 'sms_provider_event_conflict_reviews', 'insert') review_insert,
       has_table_privilege('openpims_app', 'sms_provider_event_conflict_reviews', 'update') review_update,
-      has_table_privilege('openpims_app', 'sms_provider_event_conflict_reviews', 'delete') review_delete`;
+      has_table_privilege('openpims_app', 'sms_provider_event_conflict_reviews', 'delete') review_delete,
+      has_table_privilege('openpims_app', 'sms_provider_event_resolutions', 'select') resolution_select,
+      has_table_privilege('openpims_app', 'sms_provider_event_resolutions', 'insert') resolution_insert,
+      has_table_privilege('openpims_app', 'sms_provider_event_resolutions', 'update') resolution_update,
+      has_table_privilege('openpims_app', 'sms_provider_event_resolutions', 'delete') resolution_delete`;
   check(
     "SMS provider inbox grants only projection privileges to the application role",
     smsProviderPrivileges?.event_select === true &&
@@ -414,7 +488,11 @@ try {
       smsProviderPrivileges.review_select === true &&
       smsProviderPrivileges.review_insert === true &&
       smsProviderPrivileges.review_update === false &&
-      smsProviderPrivileges.review_delete === false,
+      smsProviderPrivileges.review_delete === false &&
+      smsProviderPrivileges.resolution_select === true &&
+      smsProviderPrivileges.resolution_insert === true &&
+      smsProviderPrivileges.resolution_update === false &&
+      smsProviderPrivileges.resolution_delete === false,
   );
   await owner`insert into patients (id, practice_id, client_id, name, species)
     select ${aPatient}, ${aId}, id, 'RLS Pet A', 'canine'
@@ -1583,6 +1661,167 @@ try {
   check(
     "application role cannot delete provider conflicts even with maintenance GUCs",
     smsProviderConflictDeleteBlocked,
+  );
+
+  const reviewOnlyResolution = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id from sms_provider_event_resolutions
+      where conflict_id = ${aSmsProviderConflict}`;
+  });
+  check(
+    "a conflict review does not fabricate gate-clearing resolution evidence",
+    reviewOnlyResolution.length === 0,
+  );
+
+  const insertedBaseResolution = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`insert into sms_provider_event_resolutions
+      (id, event_id, operation_id, practice_id, resolution,
+       inbound_communication_id, reason_code, detail,
+       resolved_by_identity, resolved_by_name)
+      values (${resolutionBase}, ${resolutionBaseEvent},
+        ${resolutionBaseOperation}, ${aId}, 'authoritative_projection',
+        ${resolutionBaseCommunication}, 'projection_repaired',
+        'Exact inbound communication projection verified.',
+        'rls-operator', 'RLS Operator')
+      returning id`;
+  });
+  check(
+    "a non-conflict quarantine retains independent base resolution after a later conflict",
+    insertedBaseResolution.length === 1 &&
+      insertedBaseResolution[0]!.id === resolutionBase,
+  );
+
+  const insertedConflictResolution = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`insert into sms_provider_event_resolutions
+      (id, event_id, conflict_id, operation_id, practice_id, resolution,
+       sms_consent_event_id, reason_code, detail,
+       resolved_by_identity, resolved_by_name)
+      values (${resolutionConflict}, ${resolutionBaseEvent},
+        ${resolutionBaseConflict}, ${resolutionConflictOperation}, ${aId},
+        'conservative_opt_out', ${resolutionConflictConsent},
+        'provider_identity_conflict_opt_out',
+        'Conflicting inbound callback suppressed conservatively.',
+        'rls-operator', 'RLS Operator')
+      returning id`;
+  });
+  const baseAndConflictResolutions = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id, conflict_id from sms_provider_event_resolutions
+      where event_id = ${resolutionBaseEvent} order by conflict_id nulls first`;
+  });
+  check(
+    "base and later-conflict incidents each require fresh typed resolution evidence",
+    insertedConflictResolution.length === 1 &&
+      insertedConflictResolution[0]!.id === resolutionConflict &&
+      baseAndConflictResolutions.length === 2 &&
+      baseAndConflictResolutions.some(
+        (row) => row.id === resolutionBase && row.conflict_id === null,
+      ) &&
+      baseAndConflictResolutions.some(
+        (row) =>
+          row.id === resolutionConflict &&
+          row.conflict_id === resolutionBaseConflict,
+      ),
+  );
+
+  let duplicateConflictResolutionBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`insert into sms_provider_event_resolutions
+        (event_id, conflict_id, operation_id, practice_id, resolution,
+         sms_consent_event_id, reason_code,
+         resolved_by_identity, resolved_by_name)
+        values (${resolutionBaseEvent}, ${resolutionBaseConflict},
+          ${resolutionConflictOperation}, ${aId}, 'conservative_opt_out',
+          ${resolutionConflictConsent}, 'provider_identity_conflict_opt_out',
+          'rls-operator', 'RLS Operator')`;
+    });
+  } catch {
+    duplicateConflictResolutionBlocked = true;
+  }
+  check(
+    "conflict and operation identities are each append-only idempotency boundaries",
+    duplicateConflictResolutionBlocked,
+  );
+
+  let arbitraryGlobalResolutionPracticeBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`insert into sms_provider_event_resolutions
+        (event_id, operation_id, practice_id, resolution,
+         external_evidence_reference, reason_code,
+         resolved_by_identity, resolved_by_name)
+        values (${resolutionGlobalDeliveryEvent}, ${randomUUID()}, ${aId},
+          'provider_attested_no_projection', 'telnyx-support:case-invalid',
+          'provider_support_invalid_callback',
+          'rls-operator', 'RLS Operator')`;
+    });
+  } catch {
+    arbitraryGlobalResolutionPracticeBlocked = true;
+  }
+  check(
+    "an unattributed delivery incident cannot claim an arbitrary practice",
+    arbitraryGlobalResolutionPracticeBlocked,
+  );
+
+  const insertedGlobalResolution = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`insert into sms_provider_event_resolutions
+      (id, event_id, operation_id, resolution, external_evidence_reference,
+       reason_code, detail, resolved_by_identity, resolved_by_name)
+      values (${resolutionGlobalDelivery}, ${resolutionGlobalDeliveryEvent},
+        ${resolutionGlobalDeliveryOperation}, 'provider_attested_no_projection',
+        'telnyx-support:case-closed', 'provider_support_invalid_callback',
+        'Provider confirmed callback was invalid and had no accepted send.',
+        'rls-operator', 'RLS Operator')
+      returning id, practice_id`;
+  });
+  check(
+    "provider-attested no-projection can close a genuinely global delivery incident",
+    insertedGlobalResolution.length === 1 &&
+      insertedGlobalResolution[0]!.id === resolutionGlobalDelivery &&
+      insertedGlobalResolution[0]!.practice_id === null,
+  );
+
+  const hiddenSmsProviderResolutions = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id from sms_provider_event_resolutions
+      where id in (${resolutionBase}, ${resolutionConflict}, ${resolutionGlobalDelivery})`;
+  });
+  check(
+    "tenant context cannot read system-only SMS provider resolutions",
+    hiddenSmsProviderResolutions.length === 0,
+  );
+
+  let ownerSmsProviderResolutionMutationBlocked = false;
+  try {
+    await owner`update sms_provider_event_resolutions
+      set detail = detail where id = ${resolutionBase}`;
+  } catch {
+    ownerSmsProviderResolutionMutationBlocked = true;
+  }
+  check(
+    "SMS provider resolution evidence is immutable for the owner",
+    ownerSmsProviderResolutionMutationBlocked,
+  );
+
+  let appSmsProviderResolutionDeleteBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`select set_config('app.ledger_maintenance', 'on', true)`;
+      await tx`delete from sms_provider_event_resolutions where id = ${resolutionBase}`;
+    });
+  } catch {
+    appSmsProviderResolutionDeleteBlocked = true;
+  }
+  check(
+    "application role cannot delete resolution evidence even with maintenance GUCs",
+    appSmsProviderResolutionDeleteBlocked,
   );
 
   let tenantAuthEmailInsertBlocked = false;
@@ -3791,9 +4030,13 @@ try {
     if (createdPlatformEmailIdentity) {
       await cleanup`delete from platform_email_identity where key_slot = 1`;
     }
+    await cleanup`delete from sms_provider_event_resolutions
+      where id in (${resolutionBase}, ${resolutionConflict}, ${resolutionGlobalDelivery})`;
     await cleanup`delete from sms_provider_event_conflict_reviews where id = ${aSmsProviderConflictReview}`;
-    await cleanup`delete from sms_provider_event_conflicts where id = ${aSmsProviderConflict}`;
-    await cleanup`delete from sms_provider_events where id in (${aSmsProviderEvent}, ${aAttributedSmsProviderEvent})`;
+    await cleanup`delete from sms_provider_event_conflicts
+      where id in (${aSmsProviderConflict}, ${resolutionBaseConflict})`;
+    await cleanup`delete from sms_provider_events
+      where id in (${aSmsProviderEvent}, ${aAttributedSmsProviderEvent}, ${resolutionBaseEvent}, ${resolutionGlobalDeliveryEvent})`;
     await cleanup`delete from sms_delivery_event_history where id in (${aSmsDeliveryHistory}, ${bSmsDeliveryHistory}, ${bSmsDeliveryConflictHistory})`;
     await cleanup`delete from sms_delivery_events where id in (${aSmsDeliveryEvent}, ${bSmsDeliveryEvent}, ${unmatchedSmsDeliveryEvent})`;
     await cleanup`delete from lab_result_events where id in (${aLabResultEvent}, ${bLabResultEvent})`;
@@ -3806,8 +4049,12 @@ try {
     await cleanup`delete from lab_results where id in (${aLabResult}, ${bLabResult}, ${aReplacementLabResult}, ${bReplacementLabResult})`;
     await cleanup`delete from sms_send_attempt_events where id in (${aSmsSendAttemptEvent}, ${bSmsSendAttemptEvent}, ${aAppSmsSendAttemptEvent})`;
     await cleanup`delete from sms_send_attempts where id in (${aSmsSendAttempt}, ${bSmsSendAttempt}, ${aAppSmsSendAttempt})`;
-    await cleanup`delete from sms_consent_events where id in (${aSmsConsentEvent}, ${bSmsConsentEvent})`;
-    await cleanup`delete from communications where id in (${aCommunication}, ${bCommunication})`;
+    await cleanup`delete from sms_consent_events
+      where id in (${aSmsConsentEvent}, ${bSmsConsentEvent}, ${resolutionConflictConsent})`;
+    await cleanup`delete from sms_suppressions
+      where practice_id = ${aId} and phone = '+15555550121'`;
+    await cleanup`delete from communications
+      where id in (${aCommunication}, ${bCommunication}, ${resolutionBaseCommunication})`;
     await cleanup`delete from patient_merge_events where id in (${aPatientMergeEvent}, ${bPatientMergeEvent})`;
     await cleanup`delete from dispense_charge_queue where id in (${aDispenseCharge}, ${bDispenseCharge})`;
     await cleanup`delete from invoice_adjustments where invoice_id in (${aInvoice}, ${bInvoice})`;

--- a/packages/db/test-sms-provider-event-resolutions.ts
+++ b/packages/db/test-sms-provider-event-resolutions.ts
@@ -1,0 +1,872 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(packageRoot, relativePath), "utf8");
+}
+
+function requireText(source: string, text: string, contract: string): void {
+  if (!source.includes(text)) {
+    throw new Error(`Missing SMS provider resolution contract: ${contract}`);
+  }
+}
+
+const schema = read("schema/sms-provider-events.ts");
+const migration = read("drizzle/0085_foamy_rick_jones.sql");
+const snapshot = JSON.parse(read("drizzle/meta/0085_snapshot.json")) as {
+  tables: Record<
+    string,
+    {
+      columns: Record<string, { notNull: boolean }>;
+      indexes: Record<string, unknown>;
+      checkConstraints: Record<string, unknown>;
+    }
+  >;
+};
+const journal = read("drizzle/meta/_journal.json");
+const rls = read("rls/enable-rls.sql");
+const reset = read("reset.ts");
+const drift = read("schema-drift.ts");
+
+for (const symbol of [
+  "smsProviderEventResolutionEnum",
+  "smsProviderEventResolutions",
+  "smsProviderEventSystemOnlyBackupExcludedTables",
+]) {
+  requireText(schema, `export const ${symbol}`, `export ${symbol}`);
+}
+for (const resolution of [
+  "authoritative_projection",
+  "conservative_opt_out",
+  "carrier_state_reconciled",
+  "provider_attested_no_projection",
+]) {
+  requireText(schema, `"${resolution}"`, `resolution enum ${resolution}`);
+}
+for (const table of [
+  "sms_provider_events",
+  "sms_provider_event_conflicts",
+  "sms_provider_event_conflict_reviews",
+  "sms_provider_event_resolutions",
+]) {
+  requireText(schema, `"${table}"`, `system-only backup exclusion ${table}`);
+}
+
+for (const contract of [
+  "sms_provider_event_resolutions_base_event_uq",
+  "sms_provider_event_resolutions_event_idx",
+  "sms_provider_event_resolutions_conflict_uq",
+  "sms_provider_event_resolutions_operation_uq",
+  "sms_provider_event_resolutions_communication_evidence_idx",
+  "sms_provider_event_resolutions_consent_evidence_idx",
+  "sms_provider_event_resolutions_delivery_evidence_idx",
+  "sms_provider_event_resolutions_registration_evidence_idx",
+  "validate_sms_provider_event_resolution_insert",
+  "SECURITY DEFINER",
+  "sms_provider_event_resolutions_validate_insert",
+  "sms_provider_event_resolutions_immutable",
+  "Only terminal SMS provider events can be resolved.",
+  "A conflict-caused quarantine requires conflict-scoped resolution evidence.",
+  "Conflicting inbound evidence can only be resolved by conservative opt-out.",
+  "provider_event_resolution:%s:%s:revoked",
+  "Base conservative opt-out requires immutable, fully attributed sender-drift evidence.",
+  "STOP resolution requires an active suppression or a strictly newer durable grant.",
+  "registration_evidence.operation_id IS DISTINCT FROM NEW.operation_id",
+  "Carrier phone evidence requires one exact disabled, unready sender identity.",
+  "Unattributed provider-attested resolution cannot claim an arbitrary practice.",
+  "matching the service lock set and deterministic",
+  "sender.provider = provider_event.provider",
+  "attempt.provider = provider_event.provider",
+  "ORDER BY practice.id",
+  "FOR UPDATE;",
+]) {
+  requireText(migration, contract, contract);
+}
+for (const reason of [
+  "projection_repaired",
+  "delivery_reconciled",
+  "provider_identity_conflict_opt_out",
+  "sender_identity_drift_opt_out",
+  "carrier_state_readback_confirmed",
+  "provider_support_invalid_callback",
+  "provider_support_duplicate_callback",
+]) {
+  requireText(migration, `'${reason}'`, `bounded reason ${reason}`);
+}
+if (
+  /\b(?:update|delete\s+from)\s+(?:public\.)?"?sms_provider_events\b/i.test(
+    migration,
+  )
+) {
+  throw new Error(
+    "Migration 0085 must not mutate terminal SMS provider inbox events.",
+  );
+}
+
+const resolutionSnapshot =
+  snapshot.tables["public.sms_provider_event_resolutions"];
+if (!resolutionSnapshot) {
+  throw new Error("Snapshot 0085 is missing sms_provider_event_resolutions.");
+}
+if (resolutionSnapshot.columns.practice_id?.notNull !== false) {
+  throw new Error(
+    "Resolution practice_id must remain nullable for unattributed delivery-only provider attestations.",
+  );
+}
+for (const index of [
+  "sms_provider_event_resolutions_base_event_uq",
+  "sms_provider_event_resolutions_event_idx",
+  "sms_provider_event_resolutions_conflict_uq",
+  "sms_provider_event_resolutions_operation_uq",
+]) {
+  if (!(index in resolutionSnapshot.indexes)) {
+    throw new Error(`Snapshot 0085 is missing index ${index}.`);
+  }
+}
+if (
+  !(
+    "sms_provider_event_resolutions_shape_check" in
+    resolutionSnapshot.checkConstraints
+  )
+) {
+  throw new Error("Snapshot 0085 is missing the resolution shape constraint.");
+}
+requireText(journal, '"tag": "0085_foamy_rick_jones"', "migration journal");
+
+for (const contract of [
+  "ALTER TABLE sms_provider_event_resolutions ENABLE ROW LEVEL SECURITY",
+  "CREATE POLICY system_only ON sms_provider_event_resolutions",
+  "GRANT SELECT, INSERT ON sms_provider_event_conflicts, sms_provider_event_conflict_reviews, sms_provider_event_resolutions TO openpims_app",
+]) {
+  requireText(rls, contract, `RLS ${contract}`);
+}
+requireText(
+  reset,
+  '"sms_provider_event_resolutions"',
+  "reset deletes resolution children before evidence parents",
+);
+for (const contract of [
+  "sms_provider_event_resolutions_shape_check",
+  "sms_provider_event_resolutions_validate_insert",
+  "sms_provider_event_resolutions_immutable",
+  'table: "sms_provider_event_resolutions"',
+]) {
+  requireText(drift, contract, `drift contract ${contract}`);
+}
+
+console.log("✓ SMS provider event resolution static contracts passed");
+
+const databaseUrl = process.env.DATABASE_URL?.trim();
+if (!databaseUrl) {
+  throw new Error(
+    "DATABASE_URL is required for the SMS provider resolution PostgreSQL contract test.",
+  );
+}
+const parsedDatabaseUrl = new URL(databaseUrl);
+if (
+  !new Set(["localhost", "127.0.0.1", "::1"]).has(parsedDatabaseUrl.hostname)
+) {
+  throw new Error(
+    "SMS provider resolution PostgreSQL contracts only run against a local disposable database.",
+  );
+}
+
+const owner = postgres(databaseUrl, { max: 1 });
+const concurrentOwner = postgres(databaseUrl, { max: 1 });
+type ResolutionTransaction = typeof owner & {
+  savepoint<T>(
+    callback: (sql: ResolutionTransaction) => T | Promise<T>,
+  ): Promise<T>;
+};
+let activeOwnerTransaction: ResolutionTransaction | null = null;
+
+async function appSystem<T>(
+  fn: (tx: ResolutionTransaction) => Promise<T>,
+): Promise<T> {
+  if (!activeOwnerTransaction) {
+    throw new Error("SMS provider resolution test transaction is not active.");
+  }
+  return activeOwnerTransaction.savepoint(async (savepoint) => {
+    await savepoint`set local role openpims_app`;
+    await savepoint`select set_config('app.rls_bypass', 'on', true)`;
+    const result = await fn(savepoint);
+    await savepoint`select set_config('app.rls_bypass', '', true)`;
+    await savepoint`reset role`;
+    return result;
+  }) as Promise<T>;
+}
+
+async function appTenant<T>(
+  practiceId: string,
+  fn: (tx: ResolutionTransaction) => Promise<T>,
+): Promise<T> {
+  if (!activeOwnerTransaction) {
+    throw new Error("SMS provider resolution test transaction is not active.");
+  }
+  return activeOwnerTransaction.savepoint(async (savepoint) => {
+    await savepoint`set local role openpims_app`;
+    await savepoint`select set_config('app.rls_bypass', '', true)`;
+    await savepoint`select set_config('app.current_practice_id', ${practiceId}, true)`;
+    const result = await fn(savepoint);
+    await savepoint`select set_config('app.current_practice_id', '', true)`;
+    await savepoint`reset role`;
+    return result;
+  }) as Promise<T>;
+}
+
+async function expectRejected(
+  label: string,
+  fn: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    await fn();
+  } catch {
+    console.log(`  ✓ ${label}`);
+    return;
+  }
+  throw new Error(`Expected PostgreSQL to reject: ${label}`);
+}
+
+function requireResult(label: string, ok: boolean): void {
+  if (!ok) throw new Error(`PostgreSQL contract failed: ${label}`);
+  console.log(`  ✓ ${label}`);
+}
+
+const ids = {
+  practiceA: randomUUID(),
+  practiceB: randomUUID(),
+  locationA: randomUUID(),
+  locationB: randomUUID(),
+  userA: randomUUID(),
+  registrationA: randomUUID(),
+  locationMessagingA: randomUUID(),
+  baseEvent: randomUUID(),
+  baseConflict: randomUUID(),
+  lateConflict: randomUUID(),
+  conflictCausedEvent: randomUUID(),
+  conflictCausedConflict: randomUUID(),
+  unsafeStopEvent: randomUUID(),
+  staleStopEvent: randomUUID(),
+  deliveryEvent: randomUUID(),
+  globalDeliveryEvent: randomUUID(),
+  racingGlobalDeliveryEvent: randomUUID(),
+  a2pEvent: randomUUID(),
+  pendingEvent: randomUUID(),
+  baseCommunication: randomUUID(),
+  crossTenantCommunication: randomUUID(),
+  conflictCausedCommunication: randomUUID(),
+  unsafeStopCommunication: randomUUID(),
+  staleStopCommunication: randomUUID(),
+  deliveryCommunication: randomUUID(),
+  baseConflictConsent: randomUUID(),
+  unsafeStopConsent: randomUUID(),
+  staleStopConsent: randomUUID(),
+  staleStopNewerGrant: randomUUID(),
+  sendAttempt: randomUUID(),
+  sendAttemptEvent: randomUUID(),
+  racingPractice: randomUUID(),
+  racingSendAttempt: randomUUID(),
+  racingSendAttemptEvent: randomUUID(),
+  deliveryEvidence: randomUUID(),
+  deliveryHistory: randomUUID(),
+  registrationEvidence: randomUUID(),
+  baseResolution: randomUUID(),
+  baseOperation: randomUUID(),
+  conflictResolution: randomUUID(),
+  conflictOperation: randomUUID(),
+  staleStopResolution: randomUUID(),
+  staleStopOperation: randomUUID(),
+  deliveryResolution: randomUUID(),
+  deliveryOperation: randomUUID(),
+  carrierResolution: randomUUID(),
+  carrierOperation: randomUUID(),
+  globalResolution: randomUUID(),
+  globalOperation: randomUUID(),
+};
+
+const eventTime = new Date(Date.now() - 10 * 60 * 1000);
+const newerGrantTime = new Date(eventTime.getTime() + 60 * 1000);
+const baseMessageId = `base-${ids.baseEvent}`;
+const conflictMessageId = `conflict-${ids.baseConflict}`;
+const unsafeStopMessageId = `stop-unsafe-${ids.unsafeStopEvent}`;
+const staleStopMessageId = `stop-stale-${ids.staleStopEvent}`;
+const deliveryMessageId = `delivery-${ids.deliveryEvent}`;
+const globalDeliveryMessageId = `global-${ids.globalDeliveryEvent}`;
+const racingGlobalDeliveryMessageId = `global-race-${ids.racingGlobalDeliveryEvent}`;
+const a2pPhone = "+15555550241";
+
+const providerEventIds = [
+  ids.baseEvent,
+  ids.conflictCausedEvent,
+  ids.unsafeStopEvent,
+  ids.staleStopEvent,
+  ids.deliveryEvent,
+  ids.globalDeliveryEvent,
+  ids.racingGlobalDeliveryEvent,
+  ids.a2pEvent,
+  ids.pendingEvent,
+];
+const resolutionIds = [
+  ids.baseResolution,
+  ids.conflictResolution,
+  ids.staleStopResolution,
+  ids.deliveryResolution,
+  ids.carrierResolution,
+  ids.globalResolution,
+];
+const rollbackSentinel = new Error("rollback SMS provider resolution fixtures");
+
+try {
+  // The practice and reserved attempt must be committed so a second session can
+  // model a provider call that already holds its practice row while the main
+  // transaction attempts a global no-projection resolution. All immutable
+  // provider-event fixtures remain inside the rollback-only main transaction.
+  await concurrentOwner`insert into practices (id, name)
+    values (${ids.racingPractice}, 'Resolution DB Concurrency Test')`;
+  await concurrentOwner`insert into sms_send_attempts
+    (id, practice_id, source, source_id, idempotency_key, destination_e164,
+     registered_display_name, body, body_sha256, provider, sender_e164)
+    values (${ids.racingSendAttempt}, ${ids.racingPractice}, 'resolution_test',
+      ${ids.racingSendAttempt}, ${`resolution-race:${ids.racingSendAttempt}`},
+      '+15555550261', 'Resolution Race Clinic', 'Concurrency proof',
+      ${"f".repeat(64)}, 'telnyx', '+15555550262')`;
+  await owner.begin(async (rawTx) => {
+    const tx = rawTx as unknown as ResolutionTransaction;
+    activeOwnerTransaction = tx;
+    await tx`insert into practices (id, name) values
+      (${ids.practiceA}, 'Resolution DB Test A'),
+      (${ids.practiceB}, 'Resolution DB Test B')`;
+    await tx`insert into locations (id, practice_id, name, is_primary) values
+      (${ids.locationA}, ${ids.practiceA}, 'Resolution Location A', true),
+      (${ids.locationB}, ${ids.practiceB}, 'Resolution Location B', true)`;
+    await tx`insert into users
+      (id, email, password_hash, name, role, practice_id)
+      values (${ids.userA}, ${`resolution-${ids.userA}@example.test`},
+        'not-a-real-hash', 'Resolution Operator', 'admin', ${ids.practiceA})`;
+
+    await tx`insert into sms_provider_events
+      (id, occurred_at, provider, kind, provider_event_id,
+       provider_message_id, provider_event_type, event_key,
+       raw_body_fingerprint_sha256, from_e164, to_e164, message_body,
+       inbound_classification, practice_id, location_id)
+      values
+      (${ids.baseEvent}, ${eventTime}, 'telnyx', 'inbound',
+        ${`event-${ids.baseEvent}`}, ${baseMessageId}, 'message.received',
+        ${`telnyx:event:${ids.baseEvent}`}, ${"1".repeat(64)},
+        '+15555550201', '+15555550202', 'Base resolution message', 'other',
+        ${ids.practiceA}, ${ids.locationA}),
+      (${ids.conflictCausedEvent}, ${eventTime}, 'telnyx', 'inbound',
+        ${`event-${ids.conflictCausedEvent}`},
+        ${`message-${ids.conflictCausedEvent}`}, 'message.received',
+        ${`telnyx:event:${ids.conflictCausedEvent}`}, ${"2".repeat(64)},
+        '+15555550203', '+15555550202', 'Conflict-caused quarantine', 'other',
+        ${ids.practiceA}, ${ids.locationA}),
+      (${ids.unsafeStopEvent}, ${eventTime}, 'telnyx', 'inbound',
+        ${`event-${ids.unsafeStopEvent}`}, ${unsafeStopMessageId},
+        'message.received', ${`telnyx:event:${ids.unsafeStopEvent}`},
+        ${"3".repeat(64)}, '+15555550204', '+15555550202', 'STOP', 'stop',
+        ${ids.practiceA}, ${ids.locationA}),
+      (${ids.staleStopEvent}, ${eventTime}, 'telnyx', 'inbound',
+        ${`event-${ids.staleStopEvent}`}, ${staleStopMessageId},
+        'message.received', ${`telnyx:event:${ids.staleStopEvent}`},
+        ${"4".repeat(64)}, '+15555550205', '+15555550202', 'STOP', 'stop',
+        ${ids.practiceA}, ${ids.locationA})`;
+
+    await tx`insert into sms_provider_events
+      (id, occurred_at, provider, kind, provider_event_id,
+       provider_message_id, provider_event_type, event_key,
+       raw_body_fingerprint_sha256, delivery_classification, provider_status,
+       practice_id)
+      values (${ids.deliveryEvent}, ${eventTime}, 'telnyx', 'delivery',
+        ${`event-${ids.deliveryEvent}`}, ${deliveryMessageId},
+        'message.delivered', ${`telnyx:event:${ids.deliveryEvent}`},
+        ${"5".repeat(64)}, 'delivered', 'delivered', ${ids.practiceA})`;
+    await tx`insert into sms_provider_events
+      (id, occurred_at, provider, kind, provider_message_id,
+       provider_event_type, event_key, raw_body_fingerprint_sha256,
+       delivery_classification)
+      values
+      (${ids.globalDeliveryEvent}, ${eventTime}, 'telnyx', 'delivery',
+        ${globalDeliveryMessageId}, 'message.sent',
+        ${`telnyx:event:${ids.globalDeliveryEvent}`}, ${"6".repeat(64)}, 'sent'),
+      (${ids.racingGlobalDeliveryEvent}, ${eventTime}, 'telnyx', 'delivery',
+        ${racingGlobalDeliveryMessageId}, 'message.sent',
+        ${`telnyx:event:${ids.racingGlobalDeliveryEvent}`}, ${"e".repeat(64)}, 'sent'),
+      (${ids.pendingEvent}, ${eventTime}, 'telnyx', 'delivery',
+        ${`pending-${ids.pendingEvent}`}, 'message.sent',
+        ${`telnyx:event:${ids.pendingEvent}`}, ${"7".repeat(64)}, 'sent')`;
+    await tx`insert into sms_provider_events
+      (id, occurred_at, provider, kind, provider_event_id,
+       provider_event_type, event_key, raw_body_fingerprint_sha256,
+       a2p_phone_e164, a2p_status, a2p_type, a2p_event_type,
+       a2p_observed_status, practice_id, location_id)
+      values (${ids.a2pEvent}, ${eventTime}, 'telnyx', 'a2p',
+        ${`event-${ids.a2pEvent}`}, '10dlc.phone_number.update',
+        ${`telnyx:event:${ids.a2pEvent}`}, ${"8".repeat(64)}, ${a2pPhone},
+        'SUSPENDED', 'phone_number', 'status_changed', 'suspended',
+        ${ids.practiceA}, ${ids.locationA})`;
+
+    await tx`update sms_provider_events
+      set state = 'quarantined', attempt_count = 1, next_attempt_at = null,
+          last_attempt_at = statement_timestamp(),
+          processed_at = statement_timestamp(),
+          last_error_code = case
+            when id = ${ids.baseEvent} then 'sender_identity_drift'
+            when id = ${ids.conflictCausedEvent} then 'provider_identity_conflict'
+            when id = ${ids.globalDeliveryEvent} then 'delivery_attribution_pending'
+            when id = ${ids.a2pEvent} then 'a2p_identity_conflict'
+            else 'projection_failed'
+          end,
+          last_error_detail = 'Synthetic provider resolution contract fixture.'
+      where id = any(${providerEventIds.filter((id) => id !== ids.pendingEvent)}::uuid[])`;
+
+    await tx`insert into communications
+      (id, created_at, practice_id, channel, direction, content, status,
+       provider_message_id, dedupe_key)
+      values
+      (${ids.baseCommunication}, ${eventTime}, ${ids.practiceA}, 'sms',
+        'inbound', 'Base resolution message', 'delivered', ${baseMessageId},
+        ${`resolution:${ids.baseCommunication}`}),
+      (${ids.crossTenantCommunication}, ${eventTime}, ${ids.practiceB}, 'sms',
+        'inbound', 'Base resolution message', 'delivered', ${baseMessageId},
+        ${`resolution:${ids.crossTenantCommunication}`}),
+      (${ids.conflictCausedCommunication}, ${eventTime}, ${ids.practiceA}, 'sms',
+        'inbound', 'Conflict-caused quarantine', 'delivered',
+        ${`message-${ids.conflictCausedEvent}`},
+        ${`resolution:${ids.conflictCausedCommunication}`}),
+      (${ids.unsafeStopCommunication}, ${eventTime}, ${ids.practiceA}, 'sms',
+        'inbound', 'STOP', 'delivered', ${unsafeStopMessageId},
+        ${`resolution:${ids.unsafeStopCommunication}`}),
+      (${ids.staleStopCommunication}, ${eventTime}, ${ids.practiceA}, 'sms',
+        'inbound', 'STOP', 'delivered', ${staleStopMessageId},
+        ${`resolution:${ids.staleStopCommunication}`}),
+      (${ids.deliveryCommunication}, ${eventTime}, ${ids.practiceA}, 'sms',
+        'outbound', 'Delivery projection body', 'delivered', ${deliveryMessageId},
+        ${`resolution:${ids.deliveryCommunication}`})`;
+
+    await tx`insert into sms_provider_event_conflicts
+      (id, original_event_id, incoming_raw_body_fingerprint_sha256,
+       incoming_provider_event_type, incoming_provider_event_id,
+       incoming_provider_message_id)
+      values
+      (${ids.baseConflict}, ${ids.baseEvent}, ${"9".repeat(64)},
+        'message.received', ${`conflict-${ids.baseConflict}`},
+        ${conflictMessageId}),
+      (${ids.conflictCausedConflict}, ${ids.conflictCausedEvent},
+        ${"a".repeat(64)}, 'message.received',
+        ${`conflict-${ids.conflictCausedConflict}`},
+        ${`conflict-message-${ids.conflictCausedConflict}`})`;
+
+    await tx`insert into sms_consent_events
+      (id, occurred_at, practice_id, location_id, destination_e164, action,
+       source, detail, actor_type, provider, provider_message_id, event_key)
+      values
+      (${ids.unsafeStopConsent}, ${eventTime}, ${ids.practiceA}, ${ids.locationA},
+        '+15555550204', 'revoked', 'inbound_opt_out:v1',
+        'Synthetic exact STOP revocation.', 'client', 'telnyx',
+        ${unsafeStopMessageId}, ${`stop:${ids.unsafeStopConsent}`}),
+      (${ids.staleStopConsent}, ${eventTime}, ${ids.practiceA}, ${ids.locationA},
+        '+15555550205', 'revoked', 'inbound_opt_out:v1',
+        'Synthetic exact stale STOP revocation.', 'client', 'telnyx',
+        ${staleStopMessageId}, ${`stop:${ids.staleStopConsent}`}),
+      (${ids.baseConflictConsent}, ${eventTime}, ${ids.practiceA}, ${ids.locationA},
+        '+15555550201', 'revoked', 'provider_event_resolution:v1',
+        'Synthetic conservative conflict opt-out.', 'system', null, null,
+        ${`provider_event_resolution:${ids.conflictOperation}:${ids.baseConflict}:revoked`})`;
+    await tx`insert into sms_consent_events
+      (id, occurred_at, practice_id, location_id, destination_e164, action,
+       source, disclosure_version, disclosure, detail, actor_type, provider,
+       provider_message_id, event_key)
+      values (${ids.staleStopNewerGrant}, ${newerGrantTime}, ${ids.practiceA},
+        ${ids.locationA}, '+15555550205', 'granted', 'inbound_keyword:v1',
+        'v1', 'Synthetic newer grant after stale STOP.',
+        'Synthetic newer grant.', 'client', 'telnyx',
+        ${`grant-${ids.staleStopNewerGrant}`},
+        ${`grant:${ids.staleStopNewerGrant}`})`;
+    await tx`insert into sms_suppressions
+      (practice_id, location_id, phone, reason, detail)
+      values (${ids.practiceA}, ${ids.locationA}, '+15555550201', 'stop',
+        'Synthetic conservative conflict suppression.')`;
+
+    await tx`insert into sms_send_attempts
+      (id, practice_id, communication_id, source, source_id, idempotency_key,
+       destination_e164, registered_display_name, body, body_sha256, provider,
+       sender_e164)
+      values (${ids.sendAttempt}, ${ids.practiceA}, ${ids.deliveryCommunication},
+        'resolution_test', ${ids.sendAttempt}, ${`resolution:${ids.sendAttempt}`},
+        '+15555550231', 'Resolution Clinic', 'Delivery projection body',
+        ${"b".repeat(64)}, 'telnyx', '+15555550232')`;
+    await tx`insert into sms_send_attempt_events
+      (id, practice_id, attempt_id, kind, outcome, provider_message_id, event_key)
+      values (${ids.sendAttemptEvent}, ${ids.practiceA}, ${ids.sendAttempt},
+        'provider_result', 'accepted', ${deliveryMessageId},
+        ${`resolution:${ids.sendAttemptEvent}`})`;
+    await tx`insert into sms_delivery_events
+      (id, provider, provider_event_id, provider_message_id,
+       provider_event_type, provider_status, classification, occurred_at,
+       event_key, payload_fingerprint_sha256)
+      values (${ids.deliveryEvidence}, 'telnyx', ${`event-${ids.deliveryEvent}`},
+        ${deliveryMessageId}, 'message.delivered', 'delivered', 'delivered',
+        ${eventTime}, ${`resolution:${ids.deliveryEvidence}`}, ${"c".repeat(64)})`;
+    await tx`insert into sms_delivery_event_history
+      (id, delivery_event_id, practice_id, attempt_id, communication_id,
+       kind, result, classification, event_key)
+      values (${ids.deliveryHistory}, ${ids.deliveryEvidence}, ${ids.practiceA},
+        ${ids.sendAttempt}, ${ids.deliveryCommunication}, 'automatic',
+        'projected', 'delivered', ${`resolution:${ids.deliveryHistory}`})`;
+
+    await tx`insert into messaging_registrations
+      (id, practice_id, provider, entity_type, display_name, legal_name,
+       tax_id_encrypted, tax_id_last4, contact_first_name, contact_last_name,
+       contact_email, business_phone, street, city, state, postal_code,
+       website, privacy_policy_url, terms_url, compliance_attested_at,
+       compliance_attested_by, status, provider_brand_id, provider_campaign_id)
+      values (${ids.registrationA}, ${ids.practiceA}, 'telnyx',
+        'PRIVATE_PROFIT', 'Resolution Clinic', 'Resolution Clinic LLC',
+        'synthetic-encrypted-tax-id', '1234', 'Test', 'Operator',
+        'operator@example.test', '+15555550200', '1 Test Way', 'Testville',
+        'NY', '10001', 'https://example.test',
+        'https://example.test/privacy', 'https://example.test/terms', now(),
+        ${ids.userA}, 'active', 'brand-resolution-test',
+        'campaign-resolution-test')`;
+    await tx`insert into location_messaging
+      (id, practice_id, location_id, provider, sender_e164, number_source,
+       registration_status, provider_profile_ready, enabled)
+      values (${ids.locationMessagingA}, ${ids.practiceA}, ${ids.locationA},
+        'telnyx', ${a2pPhone}, 'purchased', 'active', false, false)`;
+    await tx`insert into messaging_registration_events
+      (id, practice_id, registration_id, location_id, event_type, operation,
+       status_before, status_after, provider, provider_brand_id,
+       provider_campaign_id, actor_type, actor_name, operation_id, reason_code)
+      values (${ids.registrationEvidence}, ${ids.practiceA}, ${ids.registrationA},
+        ${ids.locationA}, 'provider_state_observed',
+        'registration_reconciliation', 'suspended', 'active', 'telnyx',
+        'brand-resolution-test', 'campaign-resolution-test', 'system',
+        'OpenVPM system', ${ids.carrierOperation},
+        'carrier_registration_reconciled')`;
+    await expectRejected("cross-kind resolution is rejected", () =>
+      appSystem(
+        (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, operation_id, practice_id, resolution,
+       external_evidence_reference, reason_code,
+       resolved_by_identity, resolved_by_name)
+      values (${ids.baseEvent}, ${randomUUID()}, ${ids.practiceA},
+        'provider_attested_no_projection', 'provider-support:wrong-kind',
+        'provider_support_invalid_callback', 'db-test', 'DB Test')`,
+      ),
+    );
+    await expectRejected("cross-tenant parent attribution is rejected", () =>
+      appSystem(
+        (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, operation_id, practice_id, resolution,
+       inbound_communication_id, reason_code,
+       resolved_by_identity, resolved_by_name)
+      values (${ids.baseEvent}, ${randomUUID()}, ${ids.practiceB},
+        'authoritative_projection', ${ids.crossTenantCommunication},
+        'projection_repaired', 'db-test', 'DB Test')`,
+      ),
+    );
+    await expectRejected("cross-tenant evidence is rejected", () =>
+      appSystem(
+        (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, operation_id, practice_id, resolution,
+       inbound_communication_id, reason_code,
+       resolved_by_identity, resolved_by_name)
+      values (${ids.baseEvent}, ${randomUUID()}, ${ids.practiceA},
+        'authoritative_projection', ${ids.crossTenantCommunication},
+        'projection_repaired', 'db-test', 'DB Test')`,
+      ),
+    );
+    await expectRejected(
+      "pending provider events cannot receive a resolution",
+      () =>
+        appSystem(
+          (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, operation_id, resolution, external_evidence_reference,
+       reason_code, resolved_by_identity, resolved_by_name)
+      values (${ids.pendingEvent}, ${randomUUID()},
+        'provider_attested_no_projection', 'provider-support:pending',
+        'provider_support_invalid_callback', 'db-test', 'DB Test')`,
+        ),
+    );
+    await expectRejected(
+      "conflict-caused quarantine cannot be cleared by a base resolution",
+      () =>
+        appSystem(
+          (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, operation_id, practice_id, resolution,
+       inbound_communication_id, reason_code,
+       resolved_by_identity, resolved_by_name)
+      values (${ids.conflictCausedEvent}, ${randomUUID()}, ${ids.practiceA},
+        'authoritative_projection', ${ids.conflictCausedCommunication},
+        'projection_repaired', 'db-test', 'DB Test')`,
+        ),
+    );
+    await expectRejected(
+      "STOP cannot clear without suppression or a strictly newer grant",
+      () =>
+        appSystem(
+          (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, operation_id, practice_id, resolution,
+       inbound_communication_id, sms_consent_event_id, reason_code,
+       resolved_by_identity, resolved_by_name)
+      values (${ids.unsafeStopEvent}, ${randomUUID()}, ${ids.practiceA},
+        'authoritative_projection', ${ids.unsafeStopCommunication},
+        ${ids.unsafeStopConsent}, 'projection_repaired', 'db-test', 'DB Test')`,
+        ),
+    );
+
+    const baseInserted = await appSystem(
+      (tx) => tx`insert into sms_provider_event_resolutions
+    (id, event_id, operation_id, practice_id, resolution,
+     inbound_communication_id, reason_code, resolved_by_identity, resolved_by_name)
+    values (${ids.baseResolution}, ${ids.baseEvent}, ${ids.baseOperation},
+      ${ids.practiceA}, 'authoritative_projection', ${ids.baseCommunication},
+      'projection_repaired', 'db-test', 'DB Test') returning id`,
+    );
+    requireResult(
+      "valid base authoritative projection evidence is accepted",
+      baseInserted[0]?.id === ids.baseResolution,
+    );
+
+    const conflictInserted = await appSystem(
+      (tx) => tx`insert into sms_provider_event_resolutions
+    (id, event_id, conflict_id, operation_id, practice_id, resolution,
+     sms_consent_event_id, reason_code, resolved_by_identity, resolved_by_name)
+    values (${ids.conflictResolution}, ${ids.baseEvent}, ${ids.baseConflict},
+      ${ids.conflictOperation}, ${ids.practiceA}, 'conservative_opt_out',
+      ${ids.baseConflictConsent}, 'provider_identity_conflict_opt_out',
+      'db-test', 'DB Test') returning id`,
+    );
+    requireResult(
+      "valid conflict-scoped conservative opt-out is accepted",
+      conflictInserted[0]?.id === ids.conflictResolution,
+    );
+
+    await tx`insert into sms_provider_event_conflicts
+    (id, original_event_id, incoming_raw_body_fingerprint_sha256,
+     incoming_provider_event_type, incoming_provider_event_id,
+     incoming_provider_message_id)
+    values (${ids.lateConflict}, ${ids.baseEvent}, ${"d".repeat(64)},
+      'message.received', ${`conflict-${ids.lateConflict}`},
+      ${`message-${ids.lateConflict}`})`;
+    const [lateConflictStatus] = await tx<
+      Array<{ conflicts: number; resolutions: number }>
+    >`select
+      (select count(*)::int from sms_provider_event_conflicts
+        where original_event_id = ${ids.baseEvent}) conflicts,
+      (select count(*)::int from sms_provider_event_resolutions
+        where event_id = ${ids.baseEvent} and conflict_id is not null) resolutions`;
+    requireResult(
+      "a later conflict does not inherit stale resolution evidence",
+      lateConflictStatus?.conflicts === 2 &&
+        lateConflictStatus.resolutions === 1,
+    );
+    await expectRejected(
+      "a conflict cannot be resolved against another event",
+      () =>
+        appSystem(
+          (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, conflict_id, operation_id, practice_id, resolution,
+       sms_consent_event_id, reason_code, resolved_by_identity, resolved_by_name)
+      values (${ids.baseEvent}, ${ids.conflictCausedConflict}, ${randomUUID()},
+        ${ids.practiceA}, 'conservative_opt_out', ${ids.baseConflictConsent},
+        'provider_identity_conflict_opt_out', 'db-test', 'DB Test')`,
+        ),
+    );
+    await expectRejected(
+      "conflict and operation idempotency are immutable",
+      () =>
+        appSystem(
+          (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, conflict_id, operation_id, practice_id, resolution,
+       sms_consent_event_id, reason_code, resolved_by_identity, resolved_by_name)
+      values (${ids.baseEvent}, ${ids.baseConflict}, ${ids.conflictOperation},
+        ${ids.practiceA}, 'conservative_opt_out', ${ids.baseConflictConsent},
+        'provider_identity_conflict_opt_out', 'db-test', 'DB Test')`,
+        ),
+    );
+
+    const staleStopInserted = await appSystem(
+      (tx) => tx`insert into sms_provider_event_resolutions
+    (id, event_id, operation_id, practice_id, resolution,
+     inbound_communication_id, sms_consent_event_id, reason_code,
+     resolved_by_identity, resolved_by_name)
+    values (${ids.staleStopResolution}, ${ids.staleStopEvent},
+      ${ids.staleStopOperation}, ${ids.practiceA}, 'authoritative_projection',
+      ${ids.staleStopCommunication}, ${ids.staleStopConsent},
+      'projection_repaired', 'db-test', 'DB Test') returning id`,
+    );
+    requireResult(
+      "a projected stale STOP is accepted only with a strictly newer durable grant",
+      staleStopInserted[0]?.id === ids.staleStopResolution,
+    );
+
+    const deliveryInserted = await appSystem(
+      (tx) => tx`insert into sms_provider_event_resolutions
+    (id, event_id, operation_id, practice_id, resolution,
+     sms_delivery_event_id, reason_code, resolved_by_identity, resolved_by_name)
+    values (${ids.deliveryResolution}, ${ids.deliveryEvent},
+      ${ids.deliveryOperation}, ${ids.practiceA}, 'authoritative_projection',
+      ${ids.deliveryEvidence}, 'delivery_reconciled', 'db-test', 'DB Test')
+    returning id`,
+    );
+    requireResult(
+      "valid delivery projection history is accepted",
+      deliveryInserted[0]?.id === ids.deliveryResolution,
+    );
+
+    const carrierInserted = await appSystem(
+      (tx) => tx`insert into sms_provider_event_resolutions
+    (id, event_id, operation_id, practice_id, resolution,
+     messaging_registration_event_id, reason_code,
+     resolved_by_identity, resolved_by_name)
+    values (${ids.carrierResolution}, ${ids.a2pEvent}, ${ids.carrierOperation},
+      ${ids.practiceA}, 'carrier_state_reconciled', ${ids.registrationEvidence},
+      'carrier_state_readback_confirmed', 'db-test', 'DB Test') returning id`,
+    );
+    requireResult(
+      "current carrier readback can reconcile a historical A2P status safely",
+      carrierInserted[0]?.id === ids.carrierResolution,
+    );
+
+    let releaseAcceptedPersistence!: () => void;
+    const acceptedPersistenceMayCommit = new Promise<void>((resolve) => {
+      releaseAcceptedPersistence = resolve;
+    });
+    let practiceShareLockAcquired!: () => void;
+    const practiceShareLock = new Promise<void>((resolve) => {
+      practiceShareLockAcquired = resolve;
+    });
+    const acceptedPersistence = concurrentOwner.begin(
+      async (rawConcurrentTx) => {
+        const concurrentTx =
+          rawConcurrentTx as unknown as ResolutionTransaction;
+        await concurrentTx`select id from practices
+        where id = ${ids.racingPractice} for share`;
+        practiceShareLockAcquired();
+        await acceptedPersistenceMayCommit;
+        await concurrentTx`insert into sms_send_attempt_events
+        (id, practice_id, attempt_id, kind, outcome, provider_message_id, event_key)
+        values (${ids.racingSendAttemptEvent}, ${ids.racingPractice},
+          ${ids.racingSendAttempt}, 'provider_result', 'accepted',
+          ${racingGlobalDeliveryMessageId},
+          ${`provider-result:${ids.racingSendAttempt}`})`;
+      },
+    );
+    await practiceShareLock;
+
+    let resolutionSettled = false;
+    const racingResolution = appSystem(
+      (tx) => tx`insert into sms_provider_event_resolutions
+        (event_id, operation_id, resolution, external_evidence_reference,
+         reason_code, resolved_by_identity, resolved_by_name)
+        values (${ids.racingGlobalDeliveryEvent}, ${randomUUID()},
+          'provider_attested_no_projection', 'provider-support:race-check',
+          'provider_support_invalid_callback', 'db-test', 'DB Test')`,
+    ).then(
+      () => {
+        resolutionSettled = true;
+        return { rejected: false };
+      },
+      () => {
+        resolutionSettled = true;
+        return { rejected: true };
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const waitedForPractice = !resolutionSettled;
+    releaseAcceptedPersistence();
+    await acceptedPersistence;
+    const racingOutcome = await racingResolution;
+    requireResult(
+      "global no-projection waits for an in-flight accepted send practice lock",
+      waitedForPractice,
+    );
+    requireResult(
+      "global no-projection rechecks ownership after accepted-send persistence",
+      racingOutcome.rejected,
+    );
+
+    await expectRejected(
+      "unattributed delivery cannot claim an arbitrary practice",
+      () =>
+        appSystem(
+          (tx) => tx`insert into sms_provider_event_resolutions
+      (event_id, operation_id, practice_id, resolution,
+       external_evidence_reference, reason_code,
+       resolved_by_identity, resolved_by_name)
+      values (${ids.globalDeliveryEvent}, ${randomUUID()}, ${ids.practiceA},
+        'provider_attested_no_projection', 'provider-support:arbitrary',
+        'provider_support_invalid_callback', 'db-test', 'DB Test')`,
+        ),
+    );
+    const globalInserted = await appSystem(
+      (tx) => tx`insert into sms_provider_event_resolutions
+    (id, event_id, operation_id, resolution, external_evidence_reference,
+     reason_code, resolved_by_identity, resolved_by_name)
+    values (${ids.globalResolution}, ${ids.globalDeliveryEvent},
+      ${ids.globalOperation}, 'provider_attested_no_projection',
+      'provider-support:case-closed', 'provider_support_invalid_callback',
+      'db-test', 'DB Test') returning id, practice_id`,
+    );
+    requireResult(
+      "valid provider-attested global no-projection evidence is accepted",
+      globalInserted[0]?.id === ids.globalResolution &&
+        globalInserted[0]?.practice_id === null,
+    );
+
+    const hiddenFromTenant = await appTenant(
+      ids.practiceA,
+      (tenantTx) =>
+        tenantTx`select id from sms_provider_event_resolutions
+      where id = any(${resolutionIds}::uuid[])`,
+    );
+    requireResult(
+      "tenant context cannot read system-only resolution evidence",
+      hiddenFromTenant.length === 0,
+    );
+    await expectRejected("resolution evidence rejects owner mutation", () =>
+      tx.savepoint(
+        (savepoint) =>
+          savepoint`update sms_provider_event_resolutions set detail = detail
+        where id = ${ids.baseResolution}`,
+      ),
+    );
+    await expectRejected(
+      "resolution evidence rejects application deletion",
+      () =>
+        appSystem(async (tx) => {
+          await tx`select set_config('app.ledger_maintenance', 'on', true)`;
+          return tx`delete from sms_provider_event_resolutions
+        where id = ${ids.baseResolution}`;
+        }),
+    );
+
+    console.log("✓ SMS provider event resolution PostgreSQL contracts passed");
+    throw rollbackSentinel;
+  });
+} catch (error) {
+  if (error !== rollbackSentinel) throw error;
+} finally {
+  activeOwnerTransaction = null;
+  await owner.end();
+  try {
+    await concurrentOwner.begin(async (rawCleanup) => {
+      const cleanup = rawCleanup as unknown as ResolutionTransaction;
+      await cleanup`select set_config('app.ledger_maintenance', 'on', true)`;
+      await cleanup`delete from sms_send_attempt_events
+        where id = ${ids.racingSendAttemptEvent}`;
+      await cleanup`delete from sms_send_attempts
+        where id = ${ids.racingSendAttempt}`;
+      await cleanup`delete from practices where id = ${ids.racingPractice}`;
+    });
+  } finally {
+    await concurrentOwner.end();
+  }
+}


### PR DESCRIPTION
## Summary
- add an append-only, system-only SMS provider-event resolution ledger with database-enforced evidence contracts
- add the platform-admin recovery console for exact event and conflict remediation without exposing message bodies or phone numbers
- permit audited remediation during a recovery hold while keeping release, activation, and sending blocked until all evidence is complete
- close STOP, A2P, delivery, late-conflict, in-flight accepted-send, and contradictory operator-reconciliation races
- add live PostgreSQL trigger assertions and four provider-free concurrency drills to CI

## Release safety
- apply migration 0085 and RLS before the application deployment
- keep MESSAGING_PROVISIONING_ENABLED, MESSAGING_INBOUND_ENABLED, and MESSAGING_SENDING_ENABLED false
- this change performs no SMS send, number purchase, provider mutation, or carrier spend
- terminal provider events remain immutable; every resolution is append-only and later conflicts re-open all gates

## Validation
- full web suite: 3,833 passed, 6 expected integration skips
- focused post-format safety suite: 219 passed
- provider-resolution PostgreSQL contract: 21 live assertions passed with zero residual fixtures
- provider-free PostgreSQL concurrency drill: 4 passed
- web and database type-checks passed
- production Next.js build passed
- Drizzle generation reports no schema changes
- staged diff secret scan reports no leaks
