### PR TITLE
Shorten onboarding to the first clinic day

### DIFF
--- a/apps/web/app/(dashboard)/clients/new/page.tsx
+++ b/apps/web/app/(dashboard)/clients/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
@@ -34,17 +34,31 @@ function canManageClientFormRole(role?: string | null): boolean {
   );
 }
 
+function NewClientPageFallback() {
+  return (
+    <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      Checking client access...
+    </div>
+  );
+}
+
 export default function NewClientPage() {
+  return (
+    <Suspense fallback={<NewClientPageFallback />}>
+      <NewClientPageContent />
+    </Suspense>
+  );
+}
+
+function NewClientPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: session, status } = useSession();
+  const firstClinicDay = searchParams.get("setup") === "first-visit";
 
   if (status === "loading") {
-    return (
-      <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
-        <Loader2 className="h-4 w-4 animate-spin" />
-        Checking client access...
-      </div>
-    );
+    return <NewClientPageFallback />;
   }
 
   if (!canManageClientFormRole(session?.user?.role)) {
@@ -72,10 +86,10 @@ export default function NewClientPage() {
     );
   }
 
-  return <NewClientForm />;
+  return <NewClientForm firstClinicDay={firstClinicDay} />;
 }
 
-function NewClientForm() {
+function NewClientForm({ firstClinicDay }: { firstClinicDay: boolean }) {
   const router = useRouter();
   const utils = trpc.useUtils();
   const [form, setForm] = useState({
@@ -97,6 +111,13 @@ function NewClientForm() {
     onSuccess: async (client) => {
       await utils.clients.list.invalidate();
       toast.success("Client created");
+      if (firstClinicDay) {
+        const ownerName = `${client.firstName} ${client.lastName}`;
+        router.push(
+          `/patients/new?clientId=${encodeURIComponent(client.id)}&clientName=${encodeURIComponent(ownerName)}&setup=first-visit`,
+        );
+        return;
+      }
       router.push(`/clients/${client.id}`);
     },
     onError: (err) => {
@@ -177,7 +198,9 @@ function NewClientForm() {
 
       <h2 className="font-heading text-xl font-semibold">New Client</h2>
       <p className="mt-1 text-sm text-muted-foreground">
-        Add a new client to your practice
+        {firstClinicDay
+          ? "First clinic day, step 1 of 3: add one real owner. Their pet is next."
+          : "Add a new client to your practice"}
       </p>
 
       {error && (

--- a/apps/web/app/(dashboard)/patients/new/page.tsx
+++ b/apps/web/app/(dashboard)/patients/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { AlertCircle, ArrowLeft, Check, Loader2 } from "lucide-react";
@@ -77,7 +77,18 @@ export default function NewPatientPage() {
     );
   }
 
-  return <NewPatientForm />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading patient form...
+        </div>
+      }
+    >
+      <NewPatientForm />
+    </Suspense>
+  );
 }
 
 function canManagePatientFormRole(role?: string | null): boolean {
@@ -108,6 +119,7 @@ function NewPatientForm() {
   const [error, setError] = useState<string | null>(null);
   const preselectedClientId = searchParams.get("clientId") ?? "";
   const preselectedClientName = (searchParams.get("clientName") ?? "").trim();
+  const firstClinicDay = searchParams.get("setup") === "first-visit";
   const trimmedClientSearch = clientSearch.trim();
   const canSearchClients = isClientSearchInputValid(clientSearch);
 
@@ -147,6 +159,12 @@ function NewPatientForm() {
   const createPatient = trpc.patients.create.useMutation({
     onSuccess: (patient) => {
       toast.success("Patient created");
+      if (firstClinicDay) {
+        router.push(
+          `/schedule?setup=first-visit&patient=${encodeURIComponent(patient.name)}`
+        );
+        return;
+      }
       router.push(`/patients/${patient.id}`);
     },
     onError: (err) => {
@@ -227,7 +245,9 @@ function NewPatientForm() {
 
       <h2 className="font-heading text-xl font-semibold">New Patient</h2>
       <p className="mt-1 text-sm text-muted-foreground">
-        Add a new patient record
+        {firstClinicDay
+          ? "First clinic day, step 2 of 3: add this owner's pet. Booking is next."
+          : "Add a new patient record"}
       </p>
 
       {error && (

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useRef, useEffect, useId, useMemo } from "react";
+import { Suspense, useState, useRef, useEffect, useId, useMemo } from "react";
 import { useSession } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
   ChevronLeft,
@@ -1830,19 +1831,21 @@ function BookingForm({
   defaultDate,
   defaultTime,
   defaultLocationId,
+  defaultPatientSearch,
   timeZone,
 }: {
   onClose: () => void;
   defaultDate: Date;
   defaultTime?: string;
   defaultLocationId?: string;
+  defaultPatientSearch?: string;
   timeZone?: string | null;
 }) {
   const modalRef = useRef<HTMLDivElement>(null);
   const utils = trpc.useUtils();
 
   // Form state
-  const [patientSearch, setPatientSearch] = useState("");
+  const [patientSearch, setPatientSearch] = useState(defaultPatientSearch ?? "");
   const [selectedPatient, setSelectedPatient] = useState<{
     id: string;
     name: string;
@@ -2447,6 +2450,22 @@ function BookingForm({
 // --- Main Page ---
 
 export default function SchedulePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading schedule...
+        </div>
+      }
+    >
+      <SchedulePageContent />
+    </Suspense>
+  );
+}
+
+function SchedulePageContent() {
+  const searchParams = useSearchParams();
   const { data: session } = useSession();
   const userRole = session?.user?.role;
   const canCreateAppointments = canCreateAppointmentsRole(userRole);
@@ -2465,6 +2484,14 @@ export default function SchedulePage() {
     startOfCalendarDay(new Date())
   );
   const [bookingDefaultTime, setBookingDefaultTime] = useState<string | undefined>(undefined);
+  const setupBookingOpened = useRef(false);
+  const firstClinicDay = searchParams.get("setup") === "first-visit";
+  const requestedPatientSearch = searchParams.get("patient")?.trim() ?? "";
+  const setupPatientSearch = isAppointmentPatientSearchInputValid(
+    requestedPatientSearch
+  )
+    ? requestedPatientSearch
+    : "";
 
   const weekDays = useMemo(() => buildWeekDays(currentDate), [currentDate]);
   const monthDays = useMemo(() => buildMonthGrid(currentDate), [currentDate]);
@@ -2648,6 +2675,20 @@ export default function SchedulePage() {
     setShowBookingForm(true);
   };
 
+  useEffect(() => {
+    if (
+      !firstClinicDay ||
+      setupBookingOpened.current ||
+      !canUseScheduleInteractions
+    ) {
+      return;
+    }
+    setupBookingOpened.current = true;
+    setBookingDefaultDate(startOfCalendarDay(new Date()));
+    setBookingDefaultTime(undefined);
+    setShowBookingForm(true);
+  }, [canUseScheduleInteractions, firstClinicDay]);
+
   const goToday = () => setCurrentDate(startOfCalendarDay(new Date()));
   const goPrev = () =>
     setCurrentDate((d) =>
@@ -2701,6 +2742,20 @@ export default function SchedulePage() {
 
   return (
     <div>
+      {firstClinicDay ? (
+        <div className="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800">
+            First clinic day · Step 3 of 3
+          </p>
+          <p className="mt-1 text-sm font-semibold text-foreground">
+            Book the pet&apos;s first real appointment.
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Choose the pet, time, location, and visit type. Your current PIMS
+            can stay in place while the team validates this visit end to end.
+          </p>
+        </div>
+      ) : null}
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div>
@@ -2982,6 +3037,7 @@ export default function SchedulePage() {
                   ? scheduleLocations[0]!.id
                   : undefined
             }
+            defaultPatientSearch={setupPatientSearch || undefined}
             timeZone={verifiedCalendarSettings.timezone}
           />
         )}

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -44,6 +44,7 @@ import { AccentColorPicker } from "@/components/brand/accent-color-picker";
 import { MessagingTab } from "@/components/settings/messaging-tab";
 import { BookingTab } from "@/components/settings/booking-tab";
 import { ProviderHours } from "@/components/settings/provider-hours";
+import { MigrationHelpRequest } from "@/components/onboarding/migration-help-request";
 import { ServicesTab } from "@/components/settings/services-tab";
 import { useWelcome } from "@/components/welcome/welcome-provider";
 import { cn, isValidEmail } from "@/lib/utils";
@@ -4136,21 +4137,16 @@ function DataTab() {
           ))}
         </div>
         {migrationSource ? (
-          <div className="mb-4 max-w-2xl rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-            <p>
-              {
-                MIGRATION_SOURCES.find((s) => s.id === migrationSource)!
-                  .exportHint
-              }
-            </p>
-            {migrationSource === "shepherd" ? (
-              <a
-                href="mailto:support@openvpm.com?subject=Assisted%20Shepherd%20migration"
-                className="mt-2 inline-flex font-medium text-primary hover:underline"
-              >
-                Request a migration review before the full import
-              </a>
-            ) : null}
+          <div className="mb-4 max-w-2xl space-y-3">
+            <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              <p>
+                {
+                  MIGRATION_SOURCES.find((s) => s.id === migrationSource)!
+                    .exportHint
+                }
+              </p>
+            </div>
+            <MigrationHelpRequest source={migrationSource} />
           </div>
         ) : (
           <p className="mb-4 text-xs font-medium text-amber-700">

--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -10,65 +10,28 @@ import {
   useState,
 } from "react";
 import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { ArrowLeft, ArrowRight, Loader2, PawPrint } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
-import { useTour } from "@/components/tour/tour-provider";
 import { firstRunMode } from "@/lib/welcome/first-run";
 import {
   DEFAULT_ONBOARDING_INTENT,
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
 import type { JourneyState, StepHandle } from "./journey-types";
+import {
+  ONBOARDING_JOURNEY_STEPS,
+  onboardingJourneyResumeIndex,
+  type OnboardingJourneyStep,
+} from "@/lib/onboarding/journey-plan";
 import { ChoosePathStep } from "./steps/choose-path";
 import { PracticeBasicsStep } from "./steps/practice-basics";
-import { BrandingStep } from "./steps/branding";
-import { InviteTeamStep } from "./steps/invite-team";
 import { BringDataStep } from "./steps/bring-data";
-import { TryAgentStep } from "./steps/try-agent";
-import { SetUpTextingStep } from "./steps/set-up-texting";
-import { AddACardStep } from "./steps/add-a-card";
 import { AllSetStep } from "./steps/all-set";
-
-type StepId =
-  | "intent"
-  | "basics"
-  | "branding"
-  | "team"
-  | "data"
-  | "agent"
-  | "phone"
-  | "billing"
-  | "allSet";
-
-interface StepDef {
-  id: StepId;
-  title: string;
-}
-
-/**
- * The effective step list. Billing ("add a card") only appears on the hosted
- * service; self-host has nothing to charge. The closing guided-setup step
- * always comes last and offers the quick product tour.
- */
-function buildSteps(billingEnforced: boolean): StepDef[] {
-  return [
-    { id: "intent", title: "How do you want to start?" },
-    { id: "basics", title: "Tell us about your clinic." },
-    { id: "branding", title: "Make it feel like yours." },
-    { id: "team", title: "Bring your team in." },
-    { id: "data", title: "Bring your clinic records." },
-    { id: "agent", title: "Try your AI helper." },
-    { id: "phone", title: "Set up texting." },
-    ...(billingEnforced
-      ? [{ id: "billing" as const, title: "Add a card." }]
-      : []),
-    { id: "allSet", title: "Guided setup complete." },
-  ];
-}
 
 interface OnboardingJourneyContextValue {
   /** Open the "Make it yours" guided setup (resumes at the saved step). */
@@ -92,7 +55,7 @@ export function useOnboardingJourney() {
  * checklist can also invoke `openJourney()` explicitly. Mount once in the
  * dashboard layout. Each step runs its own server work on Continue; finishing
  * marks onboarding complete (and clears the sample data unless the user chose to
- * keep it), then optionally launches the quick product tour.
+ * keep it), then routes directly to the next real clinic action.
  */
 export function OnboardingJourneyProvider({
   children,
@@ -108,88 +71,27 @@ export function OnboardingJourneyProvider({
   const onboardingState = trpc.settings.getOnboardingState.useQuery(undefined, {
     enabled: isAdmin,
   });
-  const subscription = trpc.subscription.get.useQuery(undefined, {
-    enabled: isAdmin,
-  });
-
-  const billingEnforced = subscription.data?.billingEnforced ?? false;
-  const steps = useMemo(() => buildSteps(billingEnforced), [billingEnforced]);
+  const steps = ONBOARDING_JOURNEY_STEPS;
 
   const journeyStepId = onboardingState.data?.journeyStepId ?? null;
   const onboardingIntent = onboardingState.data?.onboardingIntent ?? null;
   const resumeIndex = useMemo(() => {
-    // Anyone who started before pathways existed gets the new choice once.
-    if (!onboardingIntent) return 0;
-    const i = steps.findIndex((s) => s.id === journeyStepId);
-    return i >= 0 ? i : 0;
-  }, [steps, journeyStepId, onboardingIntent]);
+    return onboardingJourneyResumeIndex({
+      onboardingIntent,
+      journeyStepId,
+      migrationHasCommittedChanges:
+        onboardingState.data?.migrationHasCommittedChanges === true,
+    });
+  }, [journeyStepId, onboardingIntent, onboardingState.data]);
 
   // null = closed; a number is the active step index.
   const [index, setIndex] = useState<number | null>(null);
   // Opens at most once per mount, so finishing/dismissing never reopens it.
   const opened = useRef(false);
-  // A manual CTA can be clicked before the subscription query settles. Queue
-  // that intent so the click is never lost and resolve it against stable steps.
-  const pendingManualOpen = useRef(false);
-  const pendingOpenRetryAttempted = useRef(false);
-
-  const retryPendingManualOpen = useCallback(() => {
-    if (pendingOpenRetryAttempted.current) return;
-    pendingOpenRetryAttempted.current = true;
-    toast.error("Guided setup is still loading. Retrying now.");
-    void subscription.refetch().then((result) => {
-      if (result.error && pendingManualOpen.current) {
-        pendingManualOpen.current = false;
-        pendingOpenRetryAttempted.current = false;
-        toast.error("Guided setup could not load. Please try again.");
-      }
-    });
-  }, [subscription.refetch]);
-
   const openJourney = useCallback(() => {
-    // `billingEnforced` changes the step positions. Never open against the
-    // temporary self-host step list while subscription context is loading.
     if (!isAdmin) return;
-    if (!subscription.data) {
-      pendingManualOpen.current = true;
-      if (subscription.error) {
-        retryPendingManualOpen();
-      }
-      return;
-    }
-    pendingManualOpen.current = false;
-    pendingOpenRetryAttempted.current = false;
     setIndex(resumeIndex);
-  }, [
-    isAdmin,
-    resumeIndex,
-    subscription.data,
-    subscription.error,
-    retryPendingManualOpen,
-  ]);
-
-  useEffect(() => {
-    if (!isAdmin) {
-      pendingManualOpen.current = false;
-      pendingOpenRetryAttempted.current = false;
-      return;
-    }
-    if (!pendingManualOpen.current || index !== null) return;
-    if (!subscription.data) {
-      if (subscription.error) retryPendingManualOpen();
-      return;
-    }
-    pendingManualOpen.current = false;
-    pendingOpenRetryAttempted.current = false;
-    setIndex(resumeIndex);
-  }, [
-    isAdmin,
-    index,
-    resumeIndex,
-    retryPendingManualOpen,
-    subscription.data,
-    subscription.error,
-  ]);
+  }, [isAdmin, resumeIndex]);
 
   // Returning from Stripe Checkout during setup: ?setup=resume reopens the
   // journey at the saved step (the card step persisted "allSet" before the
@@ -199,10 +101,7 @@ export function OnboardingJourneyProvider({
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     if (params.get("setup") !== "resume") return;
-    // Wait for both the saved cursor and the hosted/self-host step list. A
-    // numeric index resolved against the temporary list can otherwise shift
-    // from `allSet` back to `billing` once subscription data arrives.
-    if (!onboardingState.data || !subscription.data) return;
+    if (!onboardingState.data) return;
     opened.current = true;
     params.delete("setup");
     const rest = params.toString();
@@ -212,13 +111,7 @@ export function OnboardingJourneyProvider({
       window.location.pathname + (rest ? `?${rest}` : ""),
     );
     setIndex(resumeIndex);
-  }, [
-    isAdmin,
-    index,
-    onboardingState.data,
-    subscription.data,
-    resumeIndex,
-  ]);
+  }, [isAdmin, index, onboardingState.data, resumeIndex]);
 
   useEffect(() => {
     if (opened.current || index !== null || !isAdmin) return;
@@ -227,8 +120,8 @@ export function OnboardingJourneyProvider({
     // offer, activation checklist). NEXT_PUBLIC_FIRST_RUN_MODE=wizard
     // restores this auto-open exactly.
     if (firstRunMode() === "welcome") return;
-    // Wait until all gates are loaded so the step list + resume point are stable.
-    if (!onboardingStatus.data || !onboardingState.data || !subscription.data) {
+    // Wait until the setup state is loaded so the resume point is stable.
+    if (!onboardingStatus.data || !onboardingState.data) {
       return;
     }
     const notFinished = onboardingStatus.data.completedAt == null;
@@ -245,7 +138,6 @@ export function OnboardingJourneyProvider({
     index,
     onboardingStatus.data,
     onboardingState.data,
-    subscription.data,
     resumeIndex,
   ]);
 
@@ -290,7 +182,7 @@ function JourneyShell({
   initialMigrationSourceHasCommittedChanges,
   initialMigrationCompletedModes,
 }: {
-  steps: StepDef[];
+  steps: readonly OnboardingJourneyStep[];
   index: number;
   setIndex: (i: number | null) => void;
   initialIntent: OnboardingIntent;
@@ -302,16 +194,16 @@ function JourneyShell({
   >;
 }) {
   const utils = trpc.useUtils();
-  const { start: startTour } = useTour();
+  const router = useRouter();
   const completeOnboarding = trpc.settings.completeOnboarding.useMutation();
   const clearDemoData = trpc.settings.clearDemoData.useMutation();
   const setJourneyProgress = trpc.settings.setJourneyProgress.useMutation();
 
-  // Shared step state. Default to keeping sample data and offering the tour.
+  // Shared step state. Real imports replace sample data; otherwise the clinic
+  // can keep the sample records while it adds its first real client.
   const [state, setStateRaw] = useState<JourneyState>({
     onboardingIntent: initialIntent,
     keepSampleData: !initialMigrationHasCommittedChanges,
-    startTourAfter: true,
     hasPartialImport: false,
     hasImportedData: initialMigrationHasCommittedChanges,
     migrationSource: initialMigrationSource,
@@ -374,18 +266,19 @@ function JourneyShell({
       utils.settings.getOnboardingState.invalidate(),
     ]);
     setIndex(null);
-    // Chain the quick product tour if the user opted in on the last step.
-    if (state.startTourAfter) {
-      startTour();
-    }
+    router.push(
+      state.hasImportedData
+        ? "/schedule?setup=first-visit"
+        : "/clients/new?setup=first-visit",
+    );
   }, [
     completeOnboarding,
     clearDemoData,
     state.keepSampleData,
-    state.startTourAfter,
+    state.hasImportedData,
     utils,
     setIndex,
-    startTour,
+    router,
   ]);
 
   const handleContinue = useCallback(async () => {
@@ -543,12 +436,6 @@ function JourneyShell({
                 {step.id === "basics" ? (
                   <PracticeBasicsStep register={register} />
                 ) : null}
-                {step.id === "branding" ? (
-                  <BrandingStep register={register} />
-                ) : null}
-                {step.id === "team" ? (
-                  <InviteTeamStep register={register} />
-                ) : null}
                 {step.id === "data" ? (
                   <BringDataStep
                     register={register}
@@ -556,21 +443,8 @@ function JourneyShell({
                     setState={setState}
                   />
                 ) : null}
-                {step.id === "agent" ? (
-                  <TryAgentStep register={register} />
-                ) : null}
-                {step.id === "phone" ? (
-                  <SetUpTextingStep register={register} />
-                ) : null}
-                {step.id === "billing" ? (
-                  <AddACardStep register={register} />
-                ) : null}
                 {step.id === "allSet" ? (
-                  <AllSetStep
-                    register={register}
-                    state={state}
-                    setState={setState}
-                  />
+                  <AllSetStep register={register} state={state} />
                 ) : null}
               </div>
 
@@ -629,10 +503,8 @@ function JourneyShell({
                   {busy ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   ) : null}
-                  {isLast ? "Finish" : (continueLabel ?? "Continue")}
-                  {!isLast && !busy ? (
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  ) : null}
+                  {continueLabel ?? (isLast ? "Finish" : "Continue")}
+                  {!busy ? <ArrowRight className="ml-2 h-4 w-4" /> : null}
                 </Button>
               </div>
             </div>

--- a/apps/web/components/onboarding/journey-types.ts
+++ b/apps/web/components/onboarding/journey-types.ts
@@ -8,8 +8,6 @@ export interface JourneyState {
   onboardingIntent: OnboardingIntent;
   /** When true, the seeded sample data stays put instead of being cleared at finish. */
   keepSampleData: boolean;
-  /** When true, finishing the wizard launches the quick product tour. */
-  startTourAfter: boolean;
   /** A reviewed multi-file migration has committed at least one stage locally. */
   hasPartialImport: boolean;
   /** Sticky for this journey once reviewed real data has reached the practice. */

--- a/apps/web/components/onboarding/migration-help-request.tsx
+++ b/apps/web/components/onboarding/migration-help-request.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Check, Loader2, ShieldCheck } from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc";
+
+/**
+ * Requests a hands-on migration review without asking a clinic to email PHI or
+ * expose an export through a public link. The server marker is idempotent and
+ * also feeds the existing activation-recovery queue.
+ */
+export function MigrationHelpRequest({ source }: { source: string }) {
+  const utils = trpc.useUtils();
+  const state = trpc.settings.getOnboardingState.useQuery();
+  const request = trpc.settings.requestMigrationHelp.useMutation({
+    onSuccess: async (result) => {
+      utils.settings.getOnboardingState.setData(undefined, (previous) =>
+        previous
+          ? {
+              ...previous,
+              setupHelpRequestedAt:
+                previous.setupHelpRequestedAt ?? result.requestedAt,
+              setupHelpRequestKind: "migration",
+              setupHelpMigrationSource: result.source,
+              migrationHelpRequestedAt: result.requestedAt,
+            }
+          : previous,
+      );
+      await utils.settings.getOnboardingState.invalidate();
+      toast.success("Migration review requested");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const requestedAt = state.data?.migrationHelpRequestedAt ?? null;
+
+  return (
+    <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3">
+      <div className="flex items-start gap-2.5">
+        <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" />
+        <div className="min-w-0">
+          <p className="text-xs font-semibold text-emerald-900">
+            {requestedAt
+              ? "Migration review requested"
+              : "Want us to review the export first?"}
+          </p>
+          <p className="mt-1 text-xs leading-5 text-slate-600">
+            {requestedAt
+              ? "We will contact your clinic admin with a private transfer and review plan. Keep the files where they are until then."
+              : "Request a hands-on review before importing. Do not email patient files or use an Anyone-with-the-link folder. We will contact your clinic admin with a private transfer plan."}
+          </p>
+          {requestedAt ? (
+            <span className="mt-2 inline-flex items-center gap-1.5 text-xs font-medium text-emerald-800">
+              <Check className="h-3.5 w-3.5" />
+              Request saved
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => request.mutate({ source })}
+              disabled={request.isPending || state.isLoading}
+              className="mt-2 inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-800 underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {request.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              Request a private migration review
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/onboarding/steps/all-set.tsx
+++ b/apps/web/components/onboarding/steps/all-set.tsx
@@ -1,80 +1,58 @@
 "use client";
 
 import { useEffect } from "react";
-import { PartyPopper, Compass } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { CalendarPlus, UserPlus } from "lucide-react";
 import type { JourneyState, StepHandle } from "../journey-types";
 
 /**
- * Closing step: celebrate, then offer a quick product tour. The choice sets
- * `startTourAfter`; the overlay's finish() launches the tour when it's on.
- * Continue ("Finish") always advances.
+ * Closing step: turn setup momentum into the first real clinic action. The
+ * overlay completes guided setup and routes to the action named here.
  */
 export function AllSetStep({
   register,
   state,
-  setState,
 }: {
   register: (h: StepHandle) => void;
   state: JourneyState;
-  setState: (patch: Partial<JourneyState>) => void;
 }) {
+  const hasImportedData = state.hasImportedData;
   useEffect(() => {
-    register({ onContinue: async () => true });
-  }, [register]);
+    register({
+      continueLabel: hasImportedData
+        ? "Book the first appointment"
+        : "Add the first real client",
+      onContinue: async () => true,
+    });
+  }, [hasImportedData, register]);
+
+  const Icon = hasImportedData ? CalendarPlus : UserPlus;
 
   return (
     <div className="space-y-5">
       <div className="flex items-center gap-3">
         <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
-          <PartyPopper className="h-5 w-5" />
+          <Icon className="h-5 w-5" />
         </span>
         <p className="text-sm leading-6 text-slate-600">
-          You finished the guided setup. Before switching clinic workflows,
-          use the launch checklist on your dashboard to validate a real visit,
-          appointment requests, payments, and communications with your team.
-          Want a quick look around first?
+          {hasImportedData
+            ? "Your reviewed records are saved. Book one real appointment next, then run that visit from check-in through checkout before changing your clinic's live workflow."
+            : "Your clinic basics are saved. Add one real client and pet next. Your current PIMS can stay in place while you validate the complete visit with your team."}
         </p>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        <button
-          type="button"
-          onClick={() => setState({ startTourAfter: true })}
-          className={cn(
-            "rounded-lg border p-4 text-left transition-colors",
-            state.startTourAfter
-              ? "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500"
-              : "border-slate-200 hover:border-slate-300"
-          )}
-        >
-          <Compass className="h-5 w-5 text-emerald-700" />
-          <p className="mt-2 text-sm font-medium text-slate-900">
-            Take the quick tour
-          </p>
-          <p className="mt-1 text-xs text-slate-500">
-            A 60-second walk through the schedule, records, billing, and AI.
-          </p>
-        </button>
-
-        <button
-          type="button"
-          onClick={() => setState({ startTourAfter: false })}
-          className={cn(
-            "rounded-lg border p-4 text-left transition-colors",
-            !state.startTourAfter
-              ? "border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500"
-              : "border-slate-200 hover:border-slate-300"
-          )}
-        >
-          <PartyPopper className="h-5 w-5 text-emerald-700" />
-          <p className="mt-2 text-sm font-medium text-slate-900">
-            Jump right in
-          </p>
-          <p className="mt-1 text-xs text-slate-500">
-            Head straight to your dashboard. You can take the tour anytime.
-          </p>
-        </button>
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800">
+          What happens next
+        </p>
+        <p className="mt-1 text-sm font-semibold text-slate-950">
+          {hasImportedData
+            ? "Choose a pet and put the first visit on the schedule."
+            : "Create one owner, add their pet, and book the first visit."}
+        </p>
+        <p className="mt-1 text-xs leading-5 text-slate-600">
+          Branding, teammates, AI, texting, and billing remain in your dashboard
+          checklist. None of them blocks this first clinic test.
+        </p>
       </div>
     </div>
   );

--- a/apps/web/components/onboarding/steps/bring-data.tsx
+++ b/apps/web/components/onboarding/steps/bring-data.tsx
@@ -41,6 +41,7 @@ import { getOnboardingIntentOption } from "@/lib/onboarding/intent";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import type { StepProps } from "../journey-types";
+import { MigrationHelpRequest } from "../migration-help-request";
 
 type Choice = "import" | "api" | "keep";
 type CsvPreview = {
@@ -681,13 +682,8 @@ export function BringDataStep({ register, state, setState }: StepProps) {
             </label>
             <div className="rounded-md border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
               <p>{selectedMigrationSourceHint}</p>
-              <a
-                href={`mailto:support@openvpm.com?subject=${encodeURIComponent(`${selectedMigrationSourceName} full history migration review`)}`}
-                className="mt-2 inline-flex font-medium text-emerald-700 hover:underline"
-              >
-                Ask us to review your full-history export before import
-              </a>
             </div>
+            <MigrationHelpRequest source={migrationSource} />
 
             <div className="space-y-4">
               {MIGRATION_STEPS.slice(0, 2).map((step, index) => (

--- a/apps/web/lib/__tests__/client-patient-form-ui.test.ts
+++ b/apps/web/lib/__tests__/client-patient-form-ui.test.ts
@@ -111,7 +111,9 @@ describe("client and patient form UI states", () => {
     expect(newClient).toContain("if (!canManageClientFormRole(session?.user?.role))");
     expect(newClient).toContain("Checking client access...");
     expect(newClient).toContain("Client actions are read-only");
-    expect(newClient).toContain("return <NewClientForm />");
+    expect(newClient).toContain(
+      "return <NewClientForm firstClinicDay={firstClinicDay} />"
+    );
 
     expect(editClient).toContain("function canManageClientFormRole");
     expect(editClient).toContain("if (!canManageClientFormRole(session?.user?.role))");
@@ -123,13 +125,33 @@ describe("client and patient form UI states", () => {
     expect(newPatient).toContain("if (!canManagePatientFormRole(session?.user?.role))");
     expect(newPatient).toContain("Checking patient access...");
     expect(newPatient).toContain("Patient actions are read-only");
-    expect(newPatient).toContain("return <NewPatientForm />");
+    expect(newPatient).toContain("<NewPatientForm />");
 
     expect(editPatient).toContain("function canManagePatientFormRole");
     expect(editPatient).toContain("if (!canManagePatientFormRole(session?.user?.role))");
     expect(editPatient).toContain("Checking patient access...");
     expect(editPatient).toContain("Patient actions are read-only");
     expect(editPatient).toContain("return <EditPatientForm />");
+  });
+
+  it("keeps first-clinic-day momentum through owner, pet, and booking", () => {
+    const newClient = readFileSync(
+      "app/(dashboard)/clients/new/page.tsx",
+      "utf8"
+    );
+    const newPatient = readFileSync(
+      "app/(dashboard)/patients/new/page.tsx",
+      "utf8"
+    );
+
+    expect(newClient).toContain('searchParams.get("setup") === "first-visit"');
+    expect(newClient).toContain("First clinic day, step 1 of 3");
+    expect(newClient).toContain("&setup=first-visit`");
+    expect(newPatient).toContain('searchParams.get("setup") === "first-visit"');
+    expect(newPatient).toContain("First clinic day, step 2 of 3");
+    expect(newPatient).toContain(
+      "`/schedule?setup=first-visit&patient=${encodeURIComponent(patient.name)}`"
+    );
   });
 
   it("surfaces New Patient owner-search loading and error states", () => {

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -14,6 +14,14 @@ describe("dashboard onboarding UI states", () => {
     "components/onboarding/journey-overlay.tsx",
     "utf8",
   );
+  const journeyPlanSource = readFileSync(
+    "lib/onboarding/journey-plan.ts",
+    "utf8",
+  );
+  const migrationHelpSource = readFileSync(
+    "components/onboarding/migration-help-request.tsx",
+    "utf8",
+  );
   const settingsRouter = readFileSync("server/routers/settings.ts", "utf8");
 
   it("surfaces activation checklist query failures before hiding for missing data", () => {
@@ -143,22 +151,11 @@ describe("dashboard onboarding UI states", () => {
       "const openJourney = useCallback(() => {",
     );
     expect(journeyProviderSource).toContain("if (!isAdmin) return;");
-    expect(journeyProviderSource).toContain("pendingManualOpen.current = true");
-    expect(journeyProviderSource).toContain("!pendingManualOpen.current ||");
-    expect(journeyProviderSource).toContain(
-      "pendingManualOpen.current = false",
-    );
-    expect(journeyProviderSource).toContain(
-      "if (subscription.error) retryPendingManualOpen();",
-    );
-    expect(journeyProviderSource).toContain(
-      "if (result.error && pendingManualOpen.current)",
-    );
     expect(journeyProviderSource).toContain(
       "const isOpen = isAdmin && index !== null",
     );
     expect(journeyProviderSource).toContain("value={{ openJourney, isOpen }}");
-    expect(journeyProviderSource).toMatch(/<JourneyShell\s+steps=\{steps\}/);
+    expect(journeyProviderSource).toContain("steps={steps}");
     expect(journeyProviderSource).toContain(
       "disabled={busy || continueDisabled}",
     );
@@ -173,6 +170,15 @@ describe("dashboard onboarding UI states", () => {
     );
     expect(settingsRouter).toContain("clearDemoData: adminProcedure.mutation");
     expect(settingsRouter).toContain("setOnboardingIntent: adminProcedure");
+    expect(journeyPlanSource).toContain(
+      '{ id: "data", title: "Bring your clinic records." }',
+    );
+    expect(journeyProviderSource).toContain(
+      "router.push(\n      state.hasImportedData",
+    );
+    expect(journeyProviderSource).toContain('"/clients/new?setup=first-visit"');
+    expect(journeyProviderSource).not.toContain("<SetUpTextingStep");
+    expect(journeyProviderSource).not.toContain("<AddACardStep");
   });
 
   it("uses the selected pathway to put a tailored first win first", () => {
@@ -204,6 +210,14 @@ describe("dashboard onboarding UI states", () => {
     expect(activationSource).toContain("Resume guided setup");
     expect(activationSource).toContain("Start guided setup");
     expect(activationSource).toContain("onClick={openJourney}");
+    expect(migrationHelpSource).toContain(
+      "trpc.settings.requestMigrationHelp.useMutation",
+    );
+    expect(migrationHelpSource).toContain(
+      "Do not email patient files or use an Anyone-with-the-link folder.",
+    );
+    expect(settingsRouter).toContain("requestMigrationHelp: adminProcedure");
+    expect(settingsRouter).toContain('"Private migration review requested"');
   });
 
   it("auto-opens the wizard for unfinished, non-dismissed onboarding and resumes durably", () => {
@@ -236,9 +250,8 @@ describe("dashboard onboarding UI states", () => {
     expect(settingsRouter).toContain("asc(appointments.startTime)");
     expect(settingsRouter).toContain("asc(appointments.id)");
     // Resume from the durable cursor rather than always step 0.
-    expect(journeyProviderSource).toContain(
-      "steps.findIndex((s) => s.id === journeyStepId)",
-    );
+    expect(journeyProviderSource).toContain("onboardingJourneyResumeIndex({");
+    expect(journeyPlanSource).toContain("retiredStepIds.has");
     expect(journeyProviderSource).toContain("setIndex(resumeIndex)");
     // "I'll finish later" records dismissal WITHOUT completing onboarding.
     expect(journeyProviderSource).toContain(
@@ -254,7 +267,7 @@ describe("dashboard onboarding UI states", () => {
       "await persistCursor(steps[prev]!.id, false)",
     );
     expect(journeyProviderSource).toContain(
-      "if (!onboardingState.data || !subscription.data) return;",
+      "if (!onboardingState.data) return;",
     );
     expect(settingsRouter).toContain("setJourneyProgress: adminProcedure");
   });

--- a/apps/web/lib/__tests__/onboarding-import-ui.test.ts
+++ b/apps/web/lib/__tests__/onboarding-import-ui.test.ts
@@ -16,6 +16,14 @@ describe("onboarding import UI", () => {
     "components/onboarding/journey-overlay.tsx",
     "utf8",
   );
+  const journeyPlanSource = readFileSync(
+    "lib/onboarding/journey-plan.ts",
+    "utf8",
+  );
+  const migrationHelpSource = readFileSync(
+    "components/onboarding/migration-help-request.tsx",
+    "utf8",
+  );
 
   it("offers the complete four-stage clinic migration in safe order", () => {
     expect(MIGRATION_STEPS.map((step) => step.mode)).toEqual([
@@ -42,10 +50,11 @@ describe("onboarding import UI", () => {
     expect(source).toContain(
       "History attaches only to a safely matched real patient",
     );
-    expect(journeySource).toContain('title: "Bring your clinic records."');
-    expect(journeySource).not.toContain(
+    expect(journeyPlanSource).toContain('title: "Bring your clinic records."');
+    expect(journeyPlanSource).not.toContain(
       'title: "Add your real clients and pets."',
     );
+    expect(journeySource).toContain("<BringDataStep");
   });
 
   it("previews every supplied file before its exact reviewed commit", () => {
@@ -100,8 +109,10 @@ describe("onboarding import UI", () => {
     );
     expect(source).toContain("Already reviewed:");
     expect(source.match(/clearAllImportReview\(\)/g)).toHaveLength(4);
-    expect(source).toContain(
-      "Ask us to review your full-history export before import",
+    expect(source).toContain("<MigrationHelpRequest source={migrationSource}");
+    expect(migrationHelpSource).toContain("Request a private migration review");
+    expect(migrationHelpSource).toContain(
+      "Do not email patient files or use an Anyone-with-the-link folder.",
     );
   });
 

--- a/apps/web/lib/__tests__/onboarding-journey-plan.test.ts
+++ b/apps/web/lib/__tests__/onboarding-journey-plan.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  ONBOARDING_JOURNEY_STEPS,
+  onboardingJourneyResumeIndex,
+} from "@/lib/onboarding/journey-plan";
+
+describe("onboarding journey plan", () => {
+  it("keeps the guided path focused on the first real clinic action", () => {
+    expect(ONBOARDING_JOURNEY_STEPS.map((step) => step.id)).toEqual([
+      "intent",
+      "basics",
+      "data",
+      "allSet",
+    ]);
+  });
+
+  it("resumes a current step exactly", () => {
+    expect(
+      onboardingJourneyResumeIndex({
+        onboardingIntent: "alongside",
+        journeyStepId: "data",
+        migrationHasCommittedChanges: false,
+      }),
+    ).toBe(2);
+  });
+
+  it("moves retired chores to real data without restarting setup", () => {
+    expect(
+      onboardingJourneyResumeIndex({
+        onboardingIntent: "replace",
+        journeyStepId: "phone",
+        migrationHasCommittedChanges: false,
+      }),
+    ).toBe(2);
+  });
+
+  it("moves a legacy clinic with committed data to the first-day handoff", () => {
+    expect(
+      onboardingJourneyResumeIndex({
+        onboardingIntent: "replace",
+        journeyStepId: "billing",
+        migrationHasCommittedChanges: true,
+      }),
+    ).toBe(3);
+  });
+
+  it("still asks for a path when no intent was durably saved", () => {
+    expect(
+      onboardingJourneyResumeIndex({
+        onboardingIntent: null,
+        journeyStepId: "allSet",
+        migrationHasCommittedChanges: true,
+      }),
+    ).toBe(0);
+  });
+});

--- a/apps/web/lib/__tests__/onboarding-ui-states.test.ts
+++ b/apps/web/lib/__tests__/onboarding-ui-states.test.ts
@@ -39,6 +39,7 @@ describe("onboarding UI states", () => {
     "components/onboarding/journey-overlay.tsx",
     "utf8",
   );
+  const journeyPlan = readFileSync("lib/onboarding/journey-plan.ts", "utf8");
   const settingsRouter = readFileSync("server/routers/settings.ts", "utf8");
   const dataRouter = readFileSync("server/routers/data.ts", "utf8");
 
@@ -72,7 +73,7 @@ describe("onboarding UI states", () => {
   });
 
   it("starts with a persisted adoption pathway and recommends running alongside", () => {
-    expect(journeyOverlay).toContain(
+    expect(journeyPlan).toContain(
       '{ id: "intent", title: "How do you want to start?" }',
     );
     expect(journeyOverlay).toContain(

--- a/apps/web/lib/__tests__/request-only-booking-ui.test.ts
+++ b/apps/web/lib/__tests__/request-only-booking-ui.test.ts
@@ -141,8 +141,13 @@ describe("request-only booking UI", () => {
       "Keep validating real clinic workflows with your team before"
     );
     expect(activationChecklist).not.toContain("is ready to run");
-    expect(allSetStep).toContain("You finished the guided setup.");
-    expect(allSetStep).toContain("Before switching clinic workflows");
+    expect(allSetStep).toContain("Add the first real client");
+    expect(allSetStep).toContain(
+      "before changing your clinic's live workflow"
+    );
+    expect(allSetStep).toContain(
+      "None of them blocks this first clinic test."
+    );
     expect(allSetStep).not.toContain("Your workspace is ready");
   });
 });

--- a/apps/web/lib/__tests__/schedule-ui.test.ts
+++ b/apps/web/lib/__tests__/schedule-ui.test.ts
@@ -30,6 +30,23 @@ describe("schedule appointment form UX", () => {
     );
   });
 
+  it("opens a bounded booking handoff for the first clinic day", () => {
+    const source = readFileSync("app/(dashboard)/schedule/page.tsx", "utf8");
+
+    expect(source).toContain('searchParams.get("setup") === "first-visit"');
+    expect(source).toContain("<Suspense");
+    expect(source).toContain("<SchedulePageContent />");
+    expect(source).toContain("First clinic day · Step 3 of 3");
+    expect(source).toContain(
+      "isAppointmentPatientSearchInputValid(\n    requestedPatientSearch"
+    );
+    expect(source).toContain("setupBookingOpened.current = true");
+    expect(source).toContain("setShowBookingForm(true)");
+    expect(source).toContain(
+      "defaultPatientSearch={setupPatientSearch || undefined}"
+    );
+  });
+
   it("bounds New Appointment inputs before creating appointments", () => {
     const source = readFileSync("app/(dashboard)/schedule/page.tsx", "utf8");
 

--- a/apps/web/lib/onboarding/journey-plan.ts
+++ b/apps/web/lib/onboarding/journey-plan.ts
@@ -1,0 +1,53 @@
+export type OnboardingJourneyStepId = "intent" | "basics" | "data" | "allSet";
+
+export interface OnboardingJourneyStep {
+  id: OnboardingJourneyStepId;
+  title: string;
+}
+
+/**
+ * Guided setup should end at the first useful clinic action. Branding, team,
+ * AI, texting, and billing stay available from the dashboard checklist, but
+ * they do not stand between signup and a real client or appointment.
+ */
+export const ONBOARDING_JOURNEY_STEPS: readonly OnboardingJourneyStep[] = [
+  { id: "intent", title: "How do you want to start?" },
+  { id: "basics", title: "Tell us about your clinic." },
+  { id: "data", title: "Bring your clinic records." },
+  { id: "allSet", title: "Start your first clinic day." },
+];
+
+const retiredStepIds = new Set([
+  "branding",
+  "team",
+  "agent",
+  "phone",
+  "billing",
+]);
+
+/**
+ * Preserve progress from the former nine-step journey. A clinic paused on a
+ * retired setup chore resumes at real data (or the first-day handoff when a
+ * reviewed migration already committed) instead of being sent back to step 1.
+ */
+export function onboardingJourneyResumeIndex(input: {
+  onboardingIntent: string | null | undefined;
+  journeyStepId: string | null | undefined;
+  migrationHasCommittedChanges: boolean;
+}): number {
+  if (!input.onboardingIntent) return 0;
+
+  const currentIndex = ONBOARDING_JOURNEY_STEPS.findIndex(
+    (step) => step.id === input.journeyStepId,
+  );
+  if (currentIndex >= 0) return currentIndex;
+
+  if (input.journeyStepId && retiredStepIds.has(input.journeyStepId)) {
+    return ONBOARDING_JOURNEY_STEPS.findIndex(
+      (step) =>
+        step.id === (input.migrationHasCommittedChanges ? "allSet" : "data"),
+    );
+  }
+
+  return 0;
+}

--- a/apps/web/server/__tests__/settings-onboarding-help.test.ts
+++ b/apps/web/server/__tests__/settings-onboarding-help.test.ts
@@ -50,14 +50,15 @@ function createDb(opts: { practiceRows: unknown[]; updatedRows?: unknown[] }) {
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
+  const execute = vi.fn(async (_statement: unknown) => undefined);
   const db: Record<string, unknown> = {
     select,
     update,
-    execute: vi.fn(async () => undefined),
+    execute,
   };
   db.transaction = async (fn: (tx: unknown) => unknown) => fn(db);
 
-  return { db, select, updateSet };
+  return { db, execute, select, updateSet };
 }
 
 beforeEach(() => {
@@ -121,6 +122,87 @@ describe("settings.requestOnboardingHelp", () => {
       callerWithRole(db).requestOnboardingHelp(),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+});
+
+describe("settings.requestMigrationHelp", () => {
+  it("persists a private migration request and routes it into setup recovery", async () => {
+    const { db, execute, updateSet } = createDb({
+      practiceRows: [{ name: "Aspen Creek Animal Hospital", settings: {} }],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+
+    const result = await callerWithRole(db).requestMigrationHelp({
+      source: "shepherd",
+    });
+
+    expect(result).toEqual({
+      requestedAt: expect.any(String),
+      source: "shepherd",
+    });
+    expect(
+      execute.mock.calls.some(([statement]) =>
+        JSON.stringify(statement).includes("pg_advisory_xact_lock"),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(execute.mock.calls)).toContain("migration-help");
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: expect.anything() }),
+    );
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Private migration review requested",
+      expect.stringContaining("source=shepherd"),
+    );
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Private migration review requested",
+      expect.stringContaining("requestedBy=owner@example.com"),
+    );
+  });
+
+  it("returns the durable migration request without alerting twice", async () => {
+    const requestedAt = "2026-08-11T12:00:00.000Z";
+    const { db, updateSet } = createDb({
+      practiceRows: [
+        {
+          name: "Aspen Creek Animal Hospital",
+          settings: {
+            onboardingState: {
+              migrationHelpRequestedAt: requestedAt,
+              setupHelpMigrationSource: "shepherd",
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      callerWithRole(db).requestMigrationHelp({ source: "other" }),
+    ).resolves.toEqual({ requestedAt, source: "shepherd" });
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid source identifiers before database access", async () => {
+    const { db, select, updateSet } = createDb({ practiceRows: [] });
+
+    await expect(
+      callerWithRole(db).requestMigrationHelp({ source: "bad source" }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("keeps migration requests admin-only", async () => {
+    const { db, select } = createDb({ practiceRows: [] });
+
+    await expect(
+      callerWithRole(db, "front_desk").requestMigrationHelp({
+        source: "shepherd",
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(select).not.toHaveBeenCalled();
     expect(mocks.alertOps).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -256,6 +256,10 @@ const journeyStepIdInput = z
   .max(64, "Journey step must be at most 64 characters")
   .nullish();
 const onboardingIntentInput = z.enum(ONBOARDING_INTENTS);
+const migrationHelpSourceInput = z
+  .string()
+  .trim()
+  .refine(isValidMigrationSource, "Migration source is invalid");
 
 /**
  * At or above this many patients a practice counts as established, so the
@@ -511,6 +515,9 @@ interface PracticeSettings {
     setupHelpRequestedAt?: string;
     setupHelpRequestedByUserId?: string;
     setupHelpRequestedByEmail?: string;
+    setupHelpRequestKind?: "general" | "migration";
+    setupHelpMigrationSource?: string;
+    migrationHelpRequestedAt?: string;
   };
   accountDeletionRequest?: {
     status: "requested";
@@ -1761,6 +1768,70 @@ export const settingsRouter = createRouter({
 
     return { requestedAt };
   }),
+
+  /**
+   * Request a private, hands-on migration review without moving any clinic
+   * records through email. This also sets the generic setup-help marker so the
+   * request appears in the existing activation-recovery queue.
+   */
+  requestMigrationHelp: adminProcedure
+    .input(z.object({ source: migrationHelpSourceInput }))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${`migration-help:${ctx.practiceId}`}, 0))`,
+      );
+      const [practice] = await ctx.db
+        .select({ name: practices.name, settings: practices.settings })
+        .from(practices)
+        .where(activePracticeWhere(ctx.practiceId))
+        .limit(1);
+      if (!practice) {
+        throw practiceNotFound();
+      }
+
+      const settings = (practice.settings ?? {}) as PracticeSettings;
+      const state = settings.onboardingState;
+      if (state?.migrationHelpRequestedAt) {
+        return {
+          requestedAt: state.migrationHelpRequestedAt,
+          source: state.setupHelpMigrationSource ?? input.source,
+        };
+      }
+
+      const requestedAt = new Date().toISOString();
+      const [updated] = await ctx.db
+        .update(practices)
+        .set({
+          settings: onboardingStateMergePatch({
+            setupHelpRequestedAt: state?.setupHelpRequestedAt ?? requestedAt,
+            setupHelpRequestedByUserId:
+              state?.setupHelpRequestedByUserId ?? ctx.user.id,
+            setupHelpRequestedByEmail:
+              state?.setupHelpRequestedByEmail ?? ctx.user.email,
+            setupHelpRequestKind: "migration",
+            setupHelpMigrationSource: input.source,
+            migrationHelpRequestedAt: requestedAt,
+          }),
+        })
+        .where(activePracticeWhere(ctx.practiceId))
+        .returning({ id: practices.id });
+      if (!updated) {
+        throw practiceNotFound();
+      }
+
+      await alertOps(
+        "Private migration review requested",
+        [
+          `practice=${ctx.practiceId}`,
+          `practiceName=${practice.name}`,
+          `requestedBy=${ctx.user.email}`,
+          `source=${input.source}`,
+          `requestedAt=${requestedAt}`,
+        ].join(" "),
+      );
+
+      return { requestedAt, source: input.source };
+    }),
 
   /** Dismiss the dashboard "finish setup" card. */
   dismissSetup: adminProcedure.mutation(async ({ ctx }) => {


### PR DESCRIPTION
## What changed

- reduce guided setup from nine blocking chores to four decisions: path, clinic basics, real records, and the first clinic day
- preserve legacy journey cursors while moving retired branding, team, AI, texting, and billing work into the non-blocking dashboard checklist
- hand a new clinic directly from first real owner to pet to appointment, with bounded query inputs and build-safe Suspense boundaries
- replace migration-review mailto links with an admin-only, idempotent in-product request that stores no file, link, or patient data

## Why

Hosted clinics are entering setup but not consistently reaching a real client or appointment. The guided path should establish value before asking for optional configuration, while clinics requesting migration help need a private transfer plan instead of email or public-link instructions.

## Safety and impact

- no database migration or provider mutation
- migration help accepts only a bounded source identifier and uses a tenant-scoped transaction lock
- no export URL, file name, record content, or PHI is stored
- SMS, billing, and replica rollout flags are unchanged
- existing clinics on retired journey steps resume at records or the first-day handoff instead of restarting

## Validation

- `pnpm --filter @openpims/web type-check`
- `pnpm --filter @openpims/web test` — 3,844 passed; 6 expected integration skips
- `pnpm --filter @openpims/web build` — production build and all 45 static pages passed
- `git diff --check`
- focused Prettier check for new release files
