### PR TITLE
Harden encounter estimate conversion and medication charge handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,15 @@ jobs:
           REMINDER_POLICY_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run lib/messaging/__tests__/appointment-reminder-eligibility.integration.test.ts
 
+      # Prove the encounter-to-charge boundary with real row/advisory locks and
+      # database rollback. Fixtures are synthetic and the drill is restricted
+      # to the disposable local PostgreSQL service above.
+      - name: Execute billing estimate conversion concurrency drill
+        env:
+          BILLING_CONVERSION_DB_INTEGRATION: "1"
+          HOSTED_BILLING_ENABLED: "false"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/billing-estimate-conversion.integration.test.ts
+
       - run: pnpm --filter @openpims/db db:rls:test
 
       - run: pnpm --filter @openpims/db db:migration-runs:test

--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -80,7 +80,7 @@ function canManageBillingRole(role?: string | null): boolean {
 
 function formatBillingDateInput(
   value: Date | string,
-  timeZone?: string | null
+  timeZone?: string | null,
 ) {
   if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
     const [year, month, day] = value.split("-").map(Number) as [
@@ -90,7 +90,7 @@ function formatBillingDateInput(
     ];
     return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString(
       "en-US",
-      { timeZone: "UTC" }
+      { timeZone: "UTC" },
     );
   }
 
@@ -99,7 +99,7 @@ function formatBillingDateInput(
 
 function formatBillingInstantDate(
   value: Date | string,
-  timeZone?: string | null
+  timeZone?: string | null,
 ) {
   const options: Intl.DateTimeFormatOptions = {
     dateStyle: "short",
@@ -138,7 +138,11 @@ function getDisplayStatus(invoice: {
   ) {
     return { label: "settled", style: STATUS_STYLES.settled };
   }
-  if (paid + adjusted > 0 && paid + adjusted < total && invoice.status !== "paid") {
+  if (
+    paid + adjusted > 0 &&
+    paid + adjusted < total &&
+    invoice.status !== "paid"
+  ) {
     return { label: "partial", style: STATUS_STYLES.partial };
   }
   return {
@@ -159,6 +163,15 @@ export default function BillingPage() {
   const [pendingInvoiceVoidId, setPendingInvoiceVoidId] = useState<
     string | null
   >(null);
+  const [pendingEstimateConversion, setPendingEstimateConversion] = useState<{
+    id: string;
+    updatedAt: Date | string;
+    appointmentId: string | null;
+    total: string | null;
+    clientFirstName: string | null;
+    clientLastName: string | null;
+    patientName: string | null;
+  } | null>(null);
   const [invoiceVoidReason, setInvoiceVoidReason] = useState("");
   const limit = 25;
 
@@ -212,13 +225,37 @@ export default function BillingPage() {
     },
   });
 
+  const refreshEstimateConversionData = async (
+    invoiceId: string,
+    appointmentId: string | null,
+  ) => {
+    await Promise.all([
+      utils.billing.listInvoices.invalidate(),
+      utils.billing.getInvoice.invalidate({ id: invoiceId }),
+      utils.billing.listProducts.invalidate(),
+      utils.billing.listDispenseChargeQueue.invalidate(),
+      utils.inventory.list.invalidate(),
+      appointmentId
+        ? utils.encounters.getCloseout.invalidate({ appointmentId })
+        : Promise.resolve(),
+      appointmentId
+        ? utils.encounters.getVisitReconciliation.invalidate({ appointmentId })
+        : Promise.resolve(),
+    ]);
+  };
+
   const convertEstimate = trpc.billing.convertEstimateToInvoice.useMutation({
-    onSuccess: () => {
-      toast.success("Estimate converted to invoice");
-      utils.billing.listInvoices.invalidate();
+    onSuccess: async (_, variables) => {
+      const appointmentId = pendingEstimateConversion?.appointmentId ?? null;
+      setPendingEstimateConversion(null);
+      toast.success("Estimate converted to a draft invoice");
+      await refreshEstimateConversionData(variables.id, appointmentId);
     },
-    onError: (err) => {
+    onError: async (err, variables) => {
+      const appointmentId = pendingEstimateConversion?.appointmentId ?? null;
+      setPendingEstimateConversion(null);
       toast.error(err.message);
+      await refreshEstimateConversionData(variables.id, appointmentId);
     },
   });
 
@@ -237,15 +274,39 @@ export default function BillingPage() {
   const handleStatusChange = (
     e: React.MouseEvent,
     id: string,
-    status: "sent"
+    status: "sent",
   ) => {
     e.stopPropagation();
     updateStatus.mutate({ id, status });
   };
 
-  const handleConvertEstimate = (e: React.MouseEvent, id: string) => {
+  const handleConvertEstimate = (
+    e: React.MouseEvent,
+    estimate: {
+      id: string;
+      updatedAt: Date | string;
+      appointmentId: string | null;
+      total: string | null;
+      clientFirstName: string | null;
+      clientLastName: string | null;
+      patientName: string | null;
+    },
+  ) => {
     e.stopPropagation();
-    convertEstimate.mutate({ id });
+    setPendingEstimateConversion(estimate);
+  };
+
+  const closeEstimateConversionDialog = () => {
+    if (convertEstimate.isPending) return;
+    setPendingEstimateConversion(null);
+  };
+
+  const confirmEstimateConversion = () => {
+    if (!pendingEstimateConversion) return;
+    convertEstimate.mutate({
+      id: pendingEstimateConversion.id,
+      expectedUpdatedAt: new Date(pendingEstimateConversion.updatedAt),
+    });
   };
 
   const handleVoidInvoice = (e: React.MouseEvent, id: string) => {
@@ -284,9 +345,7 @@ export default function BillingPage() {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="font-heading text-xl font-semibold">Billing</h2>
-          <p className="text-sm text-muted-foreground">
-            Invoices and payments
-          </p>
+          <p className="text-sm text-muted-foreground">Invoices and payments</p>
         </div>
         {canManageBilling && (
           <Button asChild>
@@ -418,7 +477,7 @@ export default function BillingPage() {
                     isExpanded={expandedId === invoice.id}
                     onToggle={() =>
                       setExpandedId(
-                        expandedId === invoice.id ? null : invoice.id
+                        expandedId === invoice.id ? null : invoice.id,
                       )
                     }
                     onStatusChange={handleStatusChange}
@@ -493,6 +552,16 @@ export default function BillingPage() {
           }
         />
       )}
+
+      <ActionConfirmationDialog
+        open={pendingEstimateConversion !== null}
+        title="Convert estimate to a draft invoice?"
+        description={`The ${pendingEstimateConversion ? formatCurrency(pendingEstimateConversion.total) : "selected"} estimate for ${pendingEstimateConversion?.patientName?.trim() || [pendingEstimateConversion?.clientFirstName, pendingEstimateConversion?.clientLastName].filter(Boolean).join(" ") || "this client"} will become a draft invoice. Eligible product stock will be deducted. The client is not charged, and performed work is not automatically reconciled.`}
+        confirmLabel="Convert to draft invoice"
+        isPending={convertEstimate.isPending}
+        onCancel={closeEstimateConversionDialog}
+        onConfirm={confirmEstimateConversion}
+      />
 
       <ActionConfirmationDialog
         open={pendingInvoiceVoidId !== null}
@@ -681,7 +750,8 @@ function DispenseChargeQueuePanel({
                   {formatBillingInstantDate(item.createdAt, billingTimeZone)}
                   {item.appointmentId ? (
                     <>
-                      {" "}·{" "}
+                      {" "}
+                      ·{" "}
                       <Link
                         href={`/encounters/${item.appointmentId}#charge-capture`}
                         className="underline underline-offset-2"
@@ -783,7 +853,6 @@ function DispenseChargeQueuePanel({
         onCancel={closeWaiveDialog}
         onConfirm={confirmWaive}
       />
-
     </section>
   );
 }
@@ -805,8 +874,7 @@ function WellnessBillingPanel({
   });
   const dueMembershipsMissing =
     settingsReady && !dueQuery.isLoading && !dueQuery.error && !dueQuery.data;
-  const dueMembershipsUnavailable =
-    !!dueQuery.error || dueMembershipsMissing;
+  const dueMembershipsUnavailable = !!dueQuery.error || dueMembershipsMissing;
   const verifiedDueMemberships =
     dueQuery.isLoading || dueMembershipsUnavailable || !dueQuery.data
       ? null
@@ -815,7 +883,7 @@ function WellnessBillingPanel({
   const totalDue = verifiedDueMemberships
     ? verifiedDueMemberships.reduce(
         (sum, row) => sum + Number(row.price ?? 0),
-        0
+        0,
       )
     : 0;
 
@@ -867,12 +935,12 @@ function WellnessBillingPanel({
               {dueQuery.isLoading
                 ? "Checking due memberships..."
                 : dueQuery.error
-                ? dueQuery.error.message
-                : dueMembershipsMissing
-                ? "Unable to load due wellness memberships. Please retry."
-                : `${dueMemberships.length} scheduled invoice${
-                    dueMemberships.length === 1 ? "" : "s"
-                  } due, ${formatCurrency(totalDue)} before tax`}
+                  ? dueQuery.error.message
+                  : dueMembershipsMissing
+                    ? "Unable to load due wellness memberships. Please retry."
+                    : `${dueMemberships.length} scheduled invoice${
+                        dueMemberships.length === 1 ? "" : "s"
+                      } due, ${formatCurrency(totalDue)} before tax`}
             </p>
             {!dueMembershipsUnavailable && !dueQuery.isLoading && (
               <p className="mt-1 text-xs text-muted-foreground">
@@ -946,7 +1014,7 @@ function WellnessBillingPanel({
                   <td className="px-4 py-3 text-muted-foreground">
                     {formatBillingDateInput(
                       row.nextBillingDate,
-                      billingTimeZone
+                      billingTimeZone,
                     )}
                   </td>
                   <td className="px-4 py-3 text-right tabular-nums">
@@ -984,6 +1052,7 @@ function InvoiceRow({
     adjustedAmount?: string | null;
     dueDate: string | null;
     createdAt: Date | string | null;
+    updatedAt: Date | string;
     isEstimate: boolean;
     appointmentId: string | null;
     clientFirstName: string | null;
@@ -992,12 +1061,19 @@ function InvoiceRow({
   };
   isExpanded: boolean;
   onToggle: () => void;
-  onStatusChange: (
+  onStatusChange: (e: React.MouseEvent, id: string, status: "sent") => void;
+  onConvertEstimate: (
     e: React.MouseEvent,
-    id: string,
-    status: "sent"
+    estimate: {
+      id: string;
+      updatedAt: Date | string;
+      appointmentId: string | null;
+      total: string | null;
+      clientFirstName: string | null;
+      clientLastName: string | null;
+      patientName: string | null;
+    },
   ) => void;
-  onConvertEstimate: (e: React.MouseEvent, id: string) => void;
   onVoidInvoice: (e: React.MouseEvent, id: string) => void;
   practiceName: string;
   billingTimeZone?: string | null;
@@ -1007,7 +1083,7 @@ function InvoiceRow({
   const formatCurrency = useCurrencyFormatter();
   const detail = trpc.billing.getInvoice.useQuery(
     { id: invoice.id },
-    { enabled: isExpanded }
+    { enabled: isExpanded },
   );
 
   const displayStatus = getDisplayStatus(invoice);
@@ -1062,30 +1138,34 @@ function InvoiceRow({
         </td>
         <td className="px-4 py-3 text-right">
           <div className="flex items-center justify-end gap-1">
-            {canManageBilling && invoice.isEstimate && (
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={isMutating}
-                onClick={(e) => onConvertEstimate(e, invoice.id)}
-                title="Convert to Invoice"
-              >
-                <ArrowRightLeft className="h-3.5 w-3.5" />
-              </Button>
-            )}
+            {canManageBilling &&
+              invoice.isEstimate &&
+              (invoice.status === "draft" || invoice.status === "sent") && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="min-h-11 min-w-11"
+                  disabled={isMutating}
+                  onClick={(e) => onConvertEstimate(e, invoice)}
+                  aria-label="Review and convert estimate to draft invoice"
+                  title="Review and convert to draft invoice"
+                >
+                  <ArrowRightLeft className="h-3.5 w-3.5" />
+                </Button>
+              )}
             {canManageBilling &&
               !invoice.isEstimate &&
               invoice.status === "draft" && (
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={isMutating}
-                onClick={(e) => onStatusChange(e, invoice.id, "sent")}
-                title="Mark as Sent"
-              >
-                <Send className="h-3.5 w-3.5" />
-              </Button>
-            )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={isMutating}
+                  onClick={(e) => onStatusChange(e, invoice.id, "sent")}
+                  title="Mark as Sent"
+                >
+                  <Send className="h-3.5 w-3.5" />
+                </Button>
+              )}
             {canManageBilling &&
               !invoice.isEstimate &&
               (invoice.status === "sent" || invoice.status === "overdue") && (
@@ -1121,7 +1201,11 @@ function InvoiceRow({
       </tr>
       {isExpanded && (
         <tr className="border-b border-border last:border-0">
-          <td colSpan={9} className="bg-muted/20 px-8 py-4" data-tour="invoice-detail">
+          <td
+            colSpan={9}
+            className="bg-muted/20 px-8 py-4"
+            data-tour="invoice-detail"
+          >
             {detail.isLoading ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -1155,10 +1239,14 @@ function InvoiceRow({
                         onClick={async (e) => {
                           e.stopPropagation();
                           const d = detail.data!;
-                          const clientName = [d.clientFirstName, d.clientLastName]
+                          const clientName = [
+                            d.clientFirstName,
+                            d.clientLastName,
+                          ]
                             .filter(Boolean)
                             .join(" ");
-                          const { generateInvoicePdf } = await import("@/lib/pdf");
+                          const { generateInvoicePdf } =
+                            await import("@/lib/pdf");
                           generateInvoicePdf({
                             practiceName,
                             clientName,
@@ -1167,16 +1255,16 @@ function InvoiceRow({
                             invoiceDate: d.createdAt
                               ? formatBillingInstantDate(
                                   d.createdAt,
-                                  billingTimeZone
+                                  billingTimeZone,
                                 )
                               : formatBillingInstantDate(
                                   new Date(),
-                                  billingTimeZone
+                                  billingTimeZone,
                                 ),
                             dueDate: d.dueDate
                               ? formatBillingDateInput(
                                   d.dueDate,
-                                  billingTimeZone
+                                  billingTimeZone,
                                 )
                               : undefined,
                             status: "estimate",
@@ -1197,16 +1285,28 @@ function InvoiceRow({
                         <Download className="mr-1 h-3.5 w-3.5" />
                         Present to Client
                       </Button>
-                      {canManageBilling && (
-                        <Button
-                          size="sm"
-                          disabled={isMutating}
-                          onClick={(e) => onConvertEstimate(e, invoice.id)}
-                        >
-                          <CheckCircle className="mr-1 h-3.5 w-3.5" />
-                          Approve &amp; Convert
-                        </Button>
-                      )}
+                      {canManageBilling &&
+                        (invoice.status === "draft" ||
+                          invoice.status === "sent") && (
+                          <Button
+                            size="sm"
+                            disabled={isMutating}
+                            onClick={(e) =>
+                              onConvertEstimate(e, {
+                                ...invoice,
+                                updatedAt: detail.data!.updatedAt,
+                                appointmentId: detail.data!.appointmentId,
+                                total: detail.data!.total,
+                                clientFirstName: detail.data!.clientFirstName,
+                                clientLastName: detail.data!.clientLastName,
+                                patientName: detail.data!.patientName,
+                              })
+                            }
+                          >
+                            <CheckCircle className="mr-1 h-3.5 w-3.5" />
+                            Review &amp; Convert
+                          </Button>
+                        )}
                     </div>
                   </div>
                 )}
@@ -1215,8 +1315,7 @@ function InvoiceRow({
                   <span className="text-muted-foreground">
                     Client:{" "}
                     <span className="text-foreground font-medium">
-                      {detail.data.clientFirstName}{" "}
-                      {detail.data.clientLastName}
+                      {detail.data.clientFirstName} {detail.data.clientLastName}
                     </span>
                   </span>
                   {detail.data.clientEmail && (
@@ -1228,73 +1327,80 @@ function InvoiceRow({
                 {detail.data.items.length > 0 ? (
                   <div className="overflow-x-auto">
                     <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b border-border">
-                        <th className="py-2 text-left font-medium text-muted-foreground">
-                          Description
-                        </th>
-                        <th className="py-2 text-left font-medium text-muted-foreground">
-                          Type
-                        </th>
-                        <th className="py-2 text-right font-medium text-muted-foreground">
-                          Qty
-                        </th>
-                        <th className="py-2 text-right font-medium text-muted-foreground">
-                          Unit Price
-                        </th>
-                        <th className="py-2 text-right font-medium text-muted-foreground">
-                          Total
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {detail.data.items.map((item) => (
-                        <tr
-                          key={item.id}
-                          className="border-b border-border/50 last:border-0"
-                        >
-                          <td className="py-2">{item.description}</td>
-                          <td className="py-2 capitalize text-muted-foreground">
-                            {item.itemType} · {item.taxable ? "taxable" : "not taxable"}
+                      <thead>
+                        <tr className="border-b border-border">
+                          <th className="py-2 text-left font-medium text-muted-foreground">
+                            Description
+                          </th>
+                          <th className="py-2 text-left font-medium text-muted-foreground">
+                            Type
+                          </th>
+                          <th className="py-2 text-right font-medium text-muted-foreground">
+                            Qty
+                          </th>
+                          <th className="py-2 text-right font-medium text-muted-foreground">
+                            Unit Price
+                          </th>
+                          <th className="py-2 text-right font-medium text-muted-foreground">
+                            Total
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {detail.data.items.map((item) => (
+                          <tr
+                            key={item.id}
+                            className="border-b border-border/50 last:border-0"
+                          >
+                            <td className="py-2">{item.description}</td>
+                            <td className="py-2 capitalize text-muted-foreground">
+                              {item.itemType} ·{" "}
+                              {item.taxable ? "taxable" : "not taxable"}
+                            </td>
+                            <td className="py-2 text-right tabular-nums">
+                              {item.quantity}
+                            </td>
+                            <td className="py-2 text-right tabular-nums">
+                              {formatCurrency(item.unitPrice)}
+                            </td>
+                            <td className="py-2 text-right tabular-nums">
+                              {formatCurrency(item.total)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                      <tfoot>
+                        <tr className="border-t border-border">
+                          <td
+                            colSpan={4}
+                            className="py-2 text-right font-medium"
+                          >
+                            Subtotal
                           </td>
                           <td className="py-2 text-right tabular-nums">
-                            {item.quantity}
-                          </td>
-                          <td className="py-2 text-right tabular-nums">
-                            {formatCurrency(item.unitPrice)}
-                          </td>
-                          <td className="py-2 text-right tabular-nums">
-                            {formatCurrency(item.total)}
+                            {formatCurrency(detail.data.subtotal)}
                           </td>
                         </tr>
-                      ))}
-                    </tbody>
-                    <tfoot>
-                      <tr className="border-t border-border">
-                        <td colSpan={4} className="py-2 text-right font-medium">
-                          Subtotal
-                        </td>
-                        <td className="py-2 text-right tabular-nums">
-                          {formatCurrency(detail.data.subtotal)}
-                        </td>
-                      </tr>
-                      <tr>
-                        <td colSpan={4} className="py-1 text-right text-muted-foreground">
-                          Tax
-                        </td>
-                        <td className="py-1 text-right tabular-nums text-muted-foreground">
-                          {formatCurrency(detail.data.tax)}
-                        </td>
-                      </tr>
-                      <tr className="font-semibold">
-                        <td colSpan={4} className="py-2 text-right">
-                          Total
-                        </td>
-                        <td className="py-2 text-right tabular-nums">
-                          {formatCurrency(detail.data.total)}
-                        </td>
-                      </tr>
-                    </tfoot>
+                        <tr>
+                          <td
+                            colSpan={4}
+                            className="py-1 text-right text-muted-foreground"
+                          >
+                            Tax
+                          </td>
+                          <td className="py-1 text-right tabular-nums text-muted-foreground">
+                            {formatCurrency(detail.data.tax)}
+                          </td>
+                        </tr>
+                        <tr className="font-semibold">
+                          <td colSpan={4} className="py-2 text-right">
+                            Total
+                          </td>
+                          <td className="py-2 text-right tabular-nums">
+                            {formatCurrency(detail.data.total)}
+                          </td>
+                        </tr>
+                      </tfoot>
                     </table>
                   </div>
                 ) : (
@@ -1341,10 +1447,14 @@ function InvoiceRow({
                         onClick={async (e) => {
                           e.stopPropagation();
                           const d = detail.data!;
-                          const clientName = [d.clientFirstName, d.clientLastName]
+                          const clientName = [
+                            d.clientFirstName,
+                            d.clientLastName,
+                          ]
                             .filter(Boolean)
                             .join(" ");
-                          const { generateInvoicePdf } = await import("@/lib/pdf");
+                          const { generateInvoicePdf } =
+                            await import("@/lib/pdf");
                           generateInvoicePdf({
                             practiceName,
                             clientName,
@@ -1353,16 +1463,16 @@ function InvoiceRow({
                             invoiceDate: d.createdAt
                               ? formatBillingInstantDate(
                                   d.createdAt,
-                                  billingTimeZone
+                                  billingTimeZone,
                                 )
                               : formatBillingInstantDate(
                                   new Date(),
-                                  billingTimeZone
+                                  billingTimeZone,
                                 ),
                             dueDate: d.dueDate
                               ? formatBillingDateInput(
                                   d.dueDate,
-                                  billingTimeZone
+                                  billingTimeZone,
                                 )
                               : undefined,
                             status: d.status,
@@ -1386,8 +1496,8 @@ function InvoiceRow({
                       {canManageBilling &&
                         (invoice.status === "sent" ||
                           invoice.status === "overdue") && (
-                        <EmailInvoiceButton invoiceId={invoice.id} />
-                      )}
+                          <EmailInvoiceButton invoiceId={invoice.id} />
+                        )}
                     </div>
                   </div>
                 )}
@@ -1474,7 +1584,7 @@ function PaymentSection({
   const [paymentMethod, setPaymentMethod] = useState<string>("cash");
   const [paymentNotes, setPaymentNotes] = useState("");
   const [adjustmentType, setAdjustmentType] = useState<"credit" | "write_off">(
-    "credit"
+    "credit",
   );
   const [adjustmentAmount, setAdjustmentAmount] = useState("");
   const [adjustmentReason, setAdjustmentReason] = useState("");
@@ -1871,83 +1981,83 @@ function PaymentSection({
       ) : paymentsQuery.data && paymentsQuery.data.length > 0 ? (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border">
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Date
-              </th>
-              <th className="py-2 text-right font-medium text-muted-foreground">
-                Amount
-              </th>
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Method
-              </th>
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Received By
-              </th>
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Notes
-              </th>
-              {canRefund && <th className="py-2" />}
-            </tr>
-          </thead>
-          <tbody>
-            {paymentsQuery.data.map((payment) => (
-              <tr
-                key={payment.id}
-                className="border-b border-border/50 last:border-0"
-              >
-                <td className="py-2 text-muted-foreground">
-                  {payment.receivedAt
-                    ? formatBillingInstantDate(
-                        payment.receivedAt,
-                        billingTimeZone
-                      )
-                    : "\u2014"}
-                </td>
-                <td
-                  className={`py-2 text-right tabular-nums font-medium ${
-                    Number(payment.amount) < 0
-                      ? "text-destructive"
-                      : "text-green-600"
-                  }`}
-                >
-                  {formatCurrency(payment.amount)}
-                </td>
-                <td className="py-2 capitalize text-muted-foreground">
-                  {payment.method?.replace(/_/g, " ") ?? "\u2014"}
-                </td>
-                <td className="py-2 text-muted-foreground">
-                  {payment.receivedByName ?? "\u2014"}
-                </td>
-                <td className="py-2 text-muted-foreground">
-                  {payment.notes || "\u2014"}
-                </td>
-                {canRefund && (
-                  <td className="py-2 text-right">
-                    {Number(payment.amount) > 0 && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
-                        disabled={refundPayment.isPending}
-                        onClick={() => {
-                          setRefundReason("");
-                          setRefundDueDate(invoiceDueDate ?? "");
-                          setRefundTarget({
-                            paymentId: payment.id,
-                            amount: payment.amount,
-                          });
-                        }}
-                      >
-                        Refund
-                      </Button>
-                    )}
-                  </td>
-                )}
+            <thead>
+              <tr className="border-b border-border">
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Date
+                </th>
+                <th className="py-2 text-right font-medium text-muted-foreground">
+                  Amount
+                </th>
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Method
+                </th>
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Received By
+                </th>
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Notes
+                </th>
+                {canRefund && <th className="py-2" />}
               </tr>
-            ))}
-          </tbody>
+            </thead>
+            <tbody>
+              {paymentsQuery.data.map((payment) => (
+                <tr
+                  key={payment.id}
+                  className="border-b border-border/50 last:border-0"
+                >
+                  <td className="py-2 text-muted-foreground">
+                    {payment.receivedAt
+                      ? formatBillingInstantDate(
+                          payment.receivedAt,
+                          billingTimeZone,
+                        )
+                      : "\u2014"}
+                  </td>
+                  <td
+                    className={`py-2 text-right tabular-nums font-medium ${
+                      Number(payment.amount) < 0
+                        ? "text-destructive"
+                        : "text-green-600"
+                    }`}
+                  >
+                    {formatCurrency(payment.amount)}
+                  </td>
+                  <td className="py-2 capitalize text-muted-foreground">
+                    {payment.method?.replace(/_/g, " ") ?? "\u2014"}
+                  </td>
+                  <td className="py-2 text-muted-foreground">
+                    {payment.receivedByName ?? "\u2014"}
+                  </td>
+                  <td className="py-2 text-muted-foreground">
+                    {payment.notes || "\u2014"}
+                  </td>
+                  {canRefund && (
+                    <td className="py-2 text-right">
+                      {Number(payment.amount) > 0 && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
+                          disabled={refundPayment.isPending}
+                          onClick={() => {
+                            setRefundReason("");
+                            setRefundDueDate(invoiceDueDate ?? "");
+                            setRefundTarget({
+                              paymentId: payment.id,
+                              amount: payment.amount,
+                            });
+                          }}
+                        >
+                          Refund
+                        </Button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
           </table>
         </div>
       ) : (
@@ -1959,54 +2069,54 @@ function PaymentSection({
       ) : adjustmentsQuery.data && adjustmentsQuery.data.length > 0 ? (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border">
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Date
-              </th>
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Type
-              </th>
-              <th className="py-2 text-right font-medium text-muted-foreground">
-                Amount
-              </th>
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Created By
-              </th>
-              <th className="py-2 text-left font-medium text-muted-foreground">
-                Reason
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {adjustmentsQuery.data.map((adjustment) => (
-              <tr
-                key={adjustment.id}
-                className="border-b border-border/50 last:border-0"
-              >
-                <td className="py-2 text-muted-foreground">
-                  {adjustment.createdAt
-                    ? formatBillingInstantDate(
-                        adjustment.createdAt,
-                        billingTimeZone
-                      )
-                    : "\u2014"}
-                </td>
-                <td className="py-2 capitalize text-muted-foreground">
-                  {adjustment.type.replace(/_/g, " ")}
-                </td>
-                <td className="py-2 text-right tabular-nums font-medium text-teal-600">
-                  {formatCurrency(adjustment.amount)}
-                </td>
-                <td className="py-2 text-muted-foreground">
-                  {adjustment.createdByName ?? "\u2014"}
-                </td>
-                <td className="py-2 text-muted-foreground">
-                  {adjustment.reason || "\u2014"}
-                </td>
+            <thead>
+              <tr className="border-b border-border">
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Date
+                </th>
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Type
+                </th>
+                <th className="py-2 text-right font-medium text-muted-foreground">
+                  Amount
+                </th>
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Created By
+                </th>
+                <th className="py-2 text-left font-medium text-muted-foreground">
+                  Reason
+                </th>
               </tr>
-            ))}
-          </tbody>
+            </thead>
+            <tbody>
+              {adjustmentsQuery.data.map((adjustment) => (
+                <tr
+                  key={adjustment.id}
+                  className="border-b border-border/50 last:border-0"
+                >
+                  <td className="py-2 text-muted-foreground">
+                    {adjustment.createdAt
+                      ? formatBillingInstantDate(
+                          adjustment.createdAt,
+                          billingTimeZone,
+                        )
+                      : "\u2014"}
+                  </td>
+                  <td className="py-2 capitalize text-muted-foreground">
+                    {adjustment.type.replace(/_/g, " ")}
+                  </td>
+                  <td className="py-2 text-right tabular-nums font-medium text-teal-600">
+                    {formatCurrency(adjustment.amount)}
+                  </td>
+                  <td className="py-2 text-muted-foreground">
+                    {adjustment.createdByName ?? "\u2014"}
+                  </td>
+                  <td className="py-2 text-muted-foreground">
+                    {adjustment.reason || "\u2014"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
           </table>
         </div>
       ) : (

--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -58,6 +58,7 @@ import {
   isAppointmentPatientSearchInputValid,
 } from "@/lib/scheduling/appointment-policy";
 import { ServicePicker } from "@/components/billing/service-picker";
+import { ActionConfirmationDialog } from "@/components/common/action-confirmation-dialog";
 import { CapturePhotos } from "@/components/records/capture-photos";
 import { ConsentSign } from "@/components/records/consent-sign";
 import { EncounterVitalsCard } from "@/components/records/encounter-vitals-card";
@@ -811,10 +812,12 @@ export default function EncounterWorkspacePage() {
 
           <EncounterInvoices
             appointmentId={appointmentId}
+            patientName={appointment.patientName}
             invoicesQuery={invoicesQuery}
             visitInvoices={visitInvoices}
             canManage={
               canManageBilling(role) &&
+              appointment.status === "in_exam" &&
               closeoutQuery.data?.closeout?.status !== "completed"
             }
           />
@@ -2976,11 +2979,13 @@ function OperationalCloseoutForm({
 
 function EncounterInvoices({
   appointmentId,
+  patientName,
   invoicesQuery,
   visitInvoices,
   canManage,
 }: {
   appointmentId: string;
+  patientName: string | null;
   invoicesQuery: InvoiceQueryState;
   visitInvoices: Array<{
     id: string;
@@ -2989,85 +2994,189 @@ function EncounterInvoices({
     paidAmount: string;
     adjustedAmount: string;
     isEstimate: boolean;
+    updatedAt: Date | string;
   }>;
   canManage: boolean;
 }) {
+  const utils = trpc.useUtils();
   const fmt = useCurrencyFormatterWithConfig();
+  const [pendingEstimate, setPendingEstimate] = useState<{
+    id: string;
+    total: string;
+    updatedAt: Date | string;
+  } | null>(null);
+  const activeEstimates = visitInvoices.filter(
+    (invoice) => invoice.isEstimate && invoice.status !== "void",
+  );
+  const activeActualInvoices = visitInvoices.filter(
+    (invoice) => !invoice.isEstimate && invoice.status !== "void",
+  );
+  const eligibleEstimate =
+    activeEstimates.length === 1 &&
+    activeActualInvoices.length === 0 &&
+    (activeEstimates[0]?.status === "draft" ||
+      activeEstimates[0]?.status === "sent")
+      ? activeEstimates[0]
+      : null;
+  const convertEstimate = trpc.billing.convertEstimateToInvoice.useMutation({
+    onSuccess: async ({ id }) => {
+      setPendingEstimate(null);
+      toast.success("Estimate converted to a draft visit invoice");
+      await Promise.all([
+        utils.billing.listInvoices.invalidate({
+          appointmentId,
+          limit: 25,
+          offset: 0,
+        }),
+        utils.billing.getInvoice.invalidate({ id }),
+        utils.billing.listProducts.invalidate(),
+        utils.billing.listDispenseChargeQueue.invalidate(),
+        utils.inventory.list.invalidate(),
+        utils.encounters.getCloseout.invalidate({ appointmentId }),
+        utils.encounters.getVisitReconciliation.invalidate({ appointmentId }),
+      ]);
+    },
+    onError: async (error, variables) => {
+      setPendingEstimate(null);
+      toast.error(error.message);
+      await Promise.all([
+        utils.billing.listInvoices.invalidate({
+          appointmentId,
+          limit: 25,
+          offset: 0,
+        }),
+        utils.billing.getInvoice.invalidate({ id: variables.id }),
+        utils.billing.listProducts.invalidate(),
+        utils.billing.listDispenseChargeQueue.invalidate(),
+        utils.inventory.list.invalidate(),
+        utils.encounters.getCloseout.invalidate({ appointmentId }),
+        utils.encounters.getVisitReconciliation.invalidate({ appointmentId }),
+      ]);
+    },
+  });
+
+  function confirmEstimateConversion() {
+    if (!pendingEstimate) return;
+    convertEstimate.mutate({
+      id: pendingEstimate.id,
+      expectedUpdatedAt: new Date(pendingEstimate.updatedAt),
+    });
+  }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Invoice state</CardTitle>
-        <CardDescription>
-          Charges and payment status linked directly to this visit.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {invoicesQuery.isLoading ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Loading visit invoices...
-          </div>
-        ) : invoicesQuery.error || !invoicesQuery.data ? (
-          <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
-            Unable to load invoice state. Do not create duplicate charges until
-            this is resolved.
-          </div>
-        ) : visitInvoices.length === 0 ? (
-          <EmptyState
-            icon={Receipt}
-            title="No active invoice for this visit"
-            description={
-              canManage
-                ? "Add all known services and products in Charge capture to create a visit-linked draft."
-                : "An admin or front desk teammate can create this visit's charges."
-            }
-            className="p-8"
-          />
-        ) : (
-          <div className="flex flex-col gap-3">
-            {visitInvoices.map((invoice) => {
-              const paid = Number(invoice.paidAmount ?? 0);
-              const adjusted = Number(invoice.adjustedAmount ?? 0);
-              const balance = Math.max(
-                0,
-                Number(invoice.total ?? 0) - paid - adjusted,
-              );
-              return (
-                <div
-                  key={invoice.id}
-                  className="flex flex-col gap-3 rounded-md border border-border p-4 sm:flex-row sm:items-center sm:justify-between"
-                >
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <p className="font-medium">
-                        {invoice.isEstimate ? "Estimate" : "Invoice"}
-                      </p>
-                      <Badge
-                        variant={
-                          invoice.status === "paid" ? "success" : "outline"
-                        }
-                      >
-                        {invoice.status}
-                      </Badge>
-                    </div>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      Total {fmt(invoice.total)} · Balance {fmt(balance)}
-                    </p>
-                  </div>
-                  <Button size="sm" variant="outline" asChild>
-                    <Link href={`/billing?expand=${invoice.id}`}>
-                      Open invoice
-                    </Link>
-                  </Button>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Invoice state</CardTitle>
+          <CardDescription>
+            Charges and payment status linked directly to this visit.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {invoicesQuery.isLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading visit invoices...
+            </div>
+          ) : invoicesQuery.error || !invoicesQuery.data ? (
+            <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+              Unable to load invoice state. Do not create duplicate charges
+              until this is resolved.
+            </div>
+          ) : visitInvoices.length === 0 ? (
+            <EmptyState
+              icon={Receipt}
+              title="No active invoice for this visit"
+              description={
+                canManage
+                  ? "Add all known services and products in Charge capture to create a visit-linked draft."
+                  : "An admin or front desk teammate can create this visit's charges."
+              }
+              className="p-8"
+            />
+          ) : (
+            <div className="flex flex-col gap-3">
+              {activeEstimates.length > 1 &&
+              activeActualInvoices.length === 0 ? (
+                <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-950 dark:text-amber-100">
+                  Multiple active estimates are linked to this visit. Review and
+                  void the extras in Billing before converting one to the visit
+                  invoice.
                 </div>
-              );
-            })}
-          </div>
-        )}
-        <span className="sr-only">Appointment {appointmentId}</span>
-      </CardContent>
-    </Card>
+              ) : null}
+              {visitInvoices.map((invoice) => {
+                const paid = Number(invoice.paidAmount ?? 0);
+                const adjusted = Number(invoice.adjustedAmount ?? 0);
+                const balance = Math.max(
+                  0,
+                  Number(invoice.total ?? 0) - paid - adjusted,
+                );
+                return (
+                  <div
+                    key={invoice.id}
+                    className="flex flex-col gap-3 rounded-md border border-border p-4 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium">
+                          {invoice.isEstimate ? "Estimate" : "Invoice"}
+                        </p>
+                        <Badge
+                          variant={
+                            invoice.status === "paid" ? "success" : "outline"
+                          }
+                        >
+                          {invoice.status}
+                        </Badge>
+                      </div>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        Total {fmt(invoice.total)} · Balance {fmt(balance)}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {canManage && eligibleEstimate?.id === invoice.id ? (
+                        <Button
+                          size="sm"
+                          className="min-h-11"
+                          disabled={convertEstimate.isPending}
+                          onClick={() =>
+                            setPendingEstimate({
+                              id: invoice.id,
+                              total: invoice.total,
+                              updatedAt: invoice.updatedAt,
+                            })
+                          }
+                        >
+                          Review &amp; convert estimate
+                        </Button>
+                      ) : null}
+                      <Button size="sm" variant="outline" asChild>
+                        <Link href={`/billing?expand=${invoice.id}`}>
+                          Open {invoice.isEstimate ? "estimate" : "invoice"}
+                        </Link>
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          <span className="sr-only">Appointment {appointmentId}</span>
+        </CardContent>
+      </Card>
+
+      <ActionConfirmationDialog
+        open={pendingEstimate !== null}
+        title="Convert estimate to a draft visit invoice?"
+        description={`The ${pendingEstimate ? fmt(pendingEstimate.total) : "selected"} estimate for ${patientName?.trim() || "this patient"} will become a draft visit invoice. Eligible product stock will be deducted. The client is not charged, and performed work is not automatically reconciled.`}
+        confirmLabel="Convert to draft invoice"
+        isPending={convertEstimate.isPending}
+        onCancel={() => {
+          if (!convertEstimate.isPending) setPendingEstimate(null);
+        }}
+        onConfirm={confirmEstimateConversion}
+      />
+    </>
   );
 }
 
@@ -3528,7 +3637,7 @@ function ChargeCapture({
           }),
       )
       .map((prescription) => ({
-        id: `prescription:${prescription.id}`,
+        id: `dispense:${prescription.dispenseChargeId}`,
         itemId: prescription.productId!,
         itemType: "product" as const,
         name: prescription.dispenseChargeDescription!,

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -558,8 +558,9 @@ const sections: Section[] = [
       {
         name: "billing.convertEstimateToInvoice",
         method: "POST",
-        description: "Convert an approved estimate into a billable invoice.",
-        input: `{ id: string }`,
+        description:
+          "Revalidate an eligible estimate and convert it into a draft invoice.",
+        input: `{ id: string, expectedUpdatedAt: Date }`,
         response: `Invoice`,
       },
       {

--- a/apps/web/lib/__tests__/api-docs.test.ts
+++ b/apps/web/lib/__tests__/api-docs.test.ts
@@ -307,4 +307,19 @@ describe("API reference docs", () => {
 
     expect(assignSection).toContain("expectedAssignedTo: string | null");
   });
+
+  it("documents estimate conversion optimistic concurrency", () => {
+    const source = readFileSync("app/api-docs/page.tsx", "utf8");
+    const conversionSection = source.slice(
+      source.indexOf('name: "billing.convertEstimateToInvoice"'),
+      source.indexOf(
+        'name: "billing.recordPayment"',
+        source.indexOf('name: "billing.convertEstimateToInvoice"'),
+      ),
+    );
+
+    expect(conversionSection).toContain(
+      "{ id: string, expectedUpdatedAt: Date }",
+    );
+  });
 });

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -39,10 +39,10 @@ describe("billing invoice form UX", () => {
     expect(
       isBillingInvoiceSubtotalValid([
         { quantity: 100, unitPrice: "99999999.99" },
-      ])
+      ]),
     ).toBe(false);
     expect(source).toContain(
-      "maxLength={BILLING_INVOICE_LINE_DESCRIPTION_MAX_LENGTH}"
+      "maxLength={BILLING_INVOICE_LINE_DESCRIPTION_MAX_LENGTH}",
     );
     expect(source).toContain("min={BILLING_INVOICE_LINE_QUANTITY_MIN}");
     expect(source).toContain("max={BILLING_INVOICE_LINE_QUANTITY_MAX}");
@@ -60,13 +60,13 @@ describe("billing invoice form UX", () => {
 
   it("uses currency inputs for invoice unit prices", () => {
     expect(source).toMatch(
-      /type="number"[\s\S]*?step="0\.01"[\s\S]*?min=\{0\}[\s\S]*?max=\{BILLING_UNIT_PRICE_MAX\}[\s\S]*?placeholder="Unit Price"/
+      /type="number"[\s\S]*?step="0\.01"[\s\S]*?min=\{0\}[\s\S]*?max=\{BILLING_UNIT_PRICE_MAX\}[\s\S]*?placeholder="Unit Price"/,
     );
   });
 
   it("defaults invoice due dates from the practice timezone", () => {
     expect(source).toContain(
-      'import { formatDateInputForTimeZone } from "@/lib/date-input"'
+      'import { formatDateInputForTimeZone } from "@/lib/date-input"',
     );
     expect(source).toContain(
       "function defaultDueDate(timeZone?: string | null)",
@@ -91,7 +91,7 @@ describe("billing invoice form UX", () => {
     expect(source).toContain("setDueDateTouched(true)");
     expect(source).toContain("Loading practice date settings...");
     expect(source).toContain(
-      "Choose a due date manually. Practice settings could not load."
+      "Choose a due date manually. Practice settings could not load.",
     );
     expect(source).not.toContain("taxConfigQuery.data?.timezone");
     expect(source).not.toContain("formatDateInputLocal");
@@ -114,9 +114,9 @@ describe("billing invoice form UX", () => {
     expect(source).toContain("clientOptions.map((client)");
     expect(source).toContain("clientResults.error || clientResultsMissing");
     expect(source).toContain("Unable to search clients. Please retry.");
-    expect(source.indexOf("clientResults.error || clientResultsMissing")).toBeLessThan(
-      source.indexOf("No clients found")
-    );
+    expect(
+      source.indexOf("clientResults.error || clientResultsMissing"),
+    ).toBeLessThan(source.indexOf("No clients found"));
     expect(source).toContain("patientResults.error");
     expect(source).toContain("patientResults.isLoading");
     expect(source).toContain("const patientResultsMissing =");
@@ -134,7 +134,7 @@ describe("billing invoice form UX", () => {
     expect(source).toContain("services={serviceOptions}");
     expect(source).toContain("serviceOptions.find((s) => s.id === serviceId)");
     expect(source).toContain(
-      "serviceOptions.find((s) => s.id === selectedServiceId)"
+      "serviceOptions.find((s) => s.id === selectedServiceId)",
     );
     expect(source).toContain("servicesQuery.error || servicesMissing");
     expect(source).toContain("Unable to load billing services");
@@ -156,13 +156,13 @@ describe("billing invoice form UX", () => {
     expect(source).toContain("Loading practice tax settings...");
     expect(source).toContain("taxConfigQuery.error || taxConfigMissing");
     expect(source).toContain(
-      'taxConfigReady && taxConfig ? taxConfig.taxRatePercent : "0.00"'
+      'taxConfigReady && taxConfig ? taxConfig.taxRatePercent : "0.00"',
     );
     expect(source).toContain(
-      'taxConfigReady && taxConfig ? taxConfig.currency : "usd"'
+      'taxConfigReady && taxConfig ? taxConfig.currency : "usd"',
     );
     expect(source).toContain(
-      'taxConfigReady && taxConfig ? taxConfig.country : "US"'
+      'taxConfigReady && taxConfig ? taxConfig.country : "US"',
     );
     expect(source).not.toContain("taxConfigQuery.data?.taxRatePercent");
     expect(source).not.toContain("taxConfigQuery.data?.currency");
@@ -174,12 +174,10 @@ describe("billing invoice form UX", () => {
     expect(source).toContain("function canManageBillingRole");
     expect(source).toContain('role === "admin" || role === "front_desk"');
     expect(source).toContain("function NewInvoiceForm()");
-    expect(source).toContain(
-      "if (!canManageBillingRole(session?.user?.role))"
-    );
+    expect(source).toContain("if (!canManageBillingRole(session?.user?.role))");
     expect(source).toContain("Billing actions are read-only");
     expect(source).toContain(
-      "Only admins and front desk staff can create invoices or estimates."
+      "Only admins and front desk staff can create invoices or estimates.",
     );
   });
 });
@@ -192,7 +190,7 @@ describe("billing invoice payment actions", () => {
       'canManageBilling &&\n    (invoiceStatus === "sent" || invoiceStatus === "overdue") &&\n    remaining > 0',
     );
     expect(source).not.toContain(
-      'invoiceStatus !== "paid" && invoiceStatus !== "void" && remaining > 0'
+      'invoiceStatus !== "paid" && invoiceStatus !== "void" && remaining > 0',
     );
   });
 
@@ -207,38 +205,38 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("detail.data.appointmentId");
     expect(source).toContain("Back to visit");
     expect(source).toContain(
-      "`/encounters/${encodeURIComponent(detail.data.appointmentId)}#charge-capture`"
+      "`/encounters/${encodeURIComponent(detail.data.appointmentId)}#charge-capture`",
     );
   });
 
   it("stacks payment actions and forms at phone width", () => {
     expect(source).toContain(
-      'className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"'
+      'className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"',
     );
     expect(source).toContain(
-      'className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-3"'
+      'className="grid w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-3"',
     );
     expect(source.match(/grid grid-cols-1 gap-3 sm:grid-cols-3/g)).toHaveLength(
-      2
+      2,
     );
     expect(
-      source.match(
-        /flex flex-col-reverse gap-2 sm:flex-row sm:items-center/g
-      )
+      source.match(/flex flex-col-reverse gap-2 sm:flex-row sm:items-center/g),
     ).toHaveLength(2);
   });
 
   it("offers invoice email only while a balance-bearing invoice is sent or overdue", () => {
     expect(source).toContain(
-      '(invoice.status === "sent" ||\n                          invoice.status === "overdue")'
+      '(invoice.status === "sent" ||\n                          invoice.status === "overdue")',
     );
     expect(source).not.toContain(
-      'invoice.status === "overdue" ||\n                          invoice.status === "paid"'
+      'invoice.status === "overdue" ||\n                          invoice.status === "paid"',
     );
   });
 
   it("uses accessible in-app dialogs for irreversible billing actions", () => {
     expect(source).toContain("<ActionConfirmationDialog");
+    expect(source).toContain('title="Convert estimate to a draft invoice?"');
+    expect(source).toContain('confirmLabel="Convert to draft invoice"');
     expect(source).toContain('title="Void invoice?"');
     expect(source).toContain('label: "Reason for voiding"');
     expect(source).toContain('title="Refund payment?"');
@@ -247,11 +245,46 @@ describe("billing invoice payment actions", () => {
     expect(source).not.toContain("window.confirm");
   });
 
+  it("requires a fresh estimate snapshot and explicit confirmation before conversion", () => {
+    expect(source).toContain("pendingEstimateConversion");
+    expect(source).toContain("setPendingEstimateConversion(estimate)");
+    expect(source).toContain(
+      "expectedUpdatedAt: new Date(pendingEstimateConversion.updatedAt)",
+    );
+    expect(source).toContain(
+      'invoice.status === "draft" || invoice.status === "sent"',
+    );
+    expect(source).toContain("Review and convert to draft invoice");
+    expect(source).toContain(
+      'aria-label="Review and convert estimate to draft invoice"',
+    );
+    expect(source).toContain('className="min-h-11 min-w-11"');
+    expect(source).toContain(
+      "Eligible product stock will be deducted. The client is not charged, and performed work is not automatically reconciled.",
+    );
+    expect(source).toContain("pendingEstimateConversion?.patientName");
+    expect(source).toContain("updatedAt: detail.data!.updatedAt");
+    expect(source).toContain("appointmentId: detail.data!.appointmentId");
+    expect(source).toContain("setPendingEstimateConversion(null)");
+    expect(source).toContain("utils.billing.getInvoice.invalidate");
+    expect(source).toContain("utils.billing.listProducts.invalidate()");
+    expect(source).toContain("utils.inventory.list.invalidate()");
+    expect(source).toContain(
+      "utils.billing.listDispenseChargeQueue.invalidate()",
+    );
+    expect(source).toContain(
+      "utils.encounters.getVisitReconciliation.invalidate",
+    );
+    expect(source).not.toContain("convertEstimate.mutate({ id });");
+  });
+
   it("keeps one operation ID across payment and adjustment retries", () => {
-    expect(source).toContain("paymentOperationId.current ??= crypto.randomUUID()");
+    expect(source).toContain(
+      "paymentOperationId.current ??= crypto.randomUUID()",
+    );
     expect(source).toContain("operationId: paymentOperationId.current");
     expect(source).toContain(
-      "adjustmentOperationId.current ??= crypto.randomUUID()"
+      "adjustmentOperationId.current ??= crypto.randomUUID()",
     );
     expect(source).toContain("operationId: adjustmentOperationId.current");
   });
@@ -265,13 +298,11 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("!cardPaymentsEnabled");
     expect(source).toContain("Card payments are not configured");
     expect(source).toContain(
-      'import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect"'
+      'import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect"',
     );
     expect(source).toContain("if (!isSafeCheckoutRedirectUrl(url))");
     expect(source).not.toContain("cardPaymentStatus.data?.enabled");
-    expect(source).not.toContain(
-      "disabled={cardCheckout.isPending}"
-    );
+    expect(source).not.toContain("disabled={cardCheckout.isPending}");
   });
 
   it("hides write-only billing controls for non-billing roles", () => {
@@ -279,14 +310,14 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("function canManageBillingRole");
     expect(source).toContain('role === "admin" || role === "front_desk"');
     expect(source).toContain(
-      "const canManageBilling = canManageBillingRole(session?.user?.role)"
+      "const canManageBilling = canManageBillingRole(session?.user?.role)",
     );
     expect(source).toContain("{canManageBilling && (");
     expect(source).toContain("canManageBilling={canManageBilling}");
     expect(source).toContain("enabled: canManageBilling");
     expect(source).toContain("canManageBilling &&\n    (invoiceStatus");
     expect(source).toContain(
-      "canManageBilling &&\n    isBillingAmountWithinBalance(paymentAmount"
+      "canManageBilling &&\n    isBillingAmountWithinBalance(paymentAmount",
     );
     expect(source).toContain("<EmailInvoiceButton invoiceId={invoice.id} />");
   });
@@ -302,23 +333,23 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("const amountInputMax = Math.min");
     expect(source).toContain("const canRecordPayment =");
     expect(source).toContain(
-      "isBillingAmountWithinBalance(paymentAmount, invoiceBalanceDue)"
+      "isBillingAmountWithinBalance(paymentAmount, invoiceBalanceDue)",
     );
     expect(source).toContain(
-      "paymentNotes.trim().length <= BILLING_NOTES_MAX_LENGTH"
+      "paymentNotes.trim().length <= BILLING_NOTES_MAX_LENGTH",
     );
     expect(source).toContain("const canApplyAdjustment =");
     expect(source).toContain(
-      "isBillingAmountWithinBalance(adjustmentAmount, invoiceBalanceDue)"
+      "isBillingAmountWithinBalance(adjustmentAmount, invoiceBalanceDue)",
     );
     expect(source).toContain(
-      "adjustmentReason.trim().length <= BILLING_ADJUSTMENT_REASON_MAX_LENGTH"
+      "adjustmentReason.trim().length <= BILLING_ADJUSTMENT_REASON_MAX_LENGTH",
     );
     expect(source).toContain("min={BILLING_PAYMENT_AMOUNT_MIN}");
     expect(source).toContain("max={amountInputMax}");
     expect(source).toContain("maxLength={BILLING_NOTES_MAX_LENGTH}");
     expect(source).toContain(
-      "maxLength={BILLING_ADJUSTMENT_REASON_MAX_LENGTH}"
+      "maxLength={BILLING_ADJUSTMENT_REASON_MAX_LENGTH}",
     );
     expect(source).toContain("amount: paymentAmount.trim()");
     expect(source).toContain("notes: paymentNotes.trim() || undefined");
@@ -354,21 +385,19 @@ describe("billing invoice payment actions", () => {
       "formatBillingInstantDate(invoice.createdAt, billingTimeZone)",
     );
     expect(source).toMatch(/formatBillingDateInput\(\s*row\.nextBillingDate/);
-    expect(source).toMatch(
-      /formatBillingInstantDate\(\s*payment\.receivedAt/,
-    );
+    expect(source).toMatch(/formatBillingInstantDate\(\s*payment\.receivedAt/);
     expect(source).toMatch(
       /formatBillingInstantDate\(\s*adjustment\.createdAt/,
     );
     expect(source).toMatch(/formatBillingDateInput\(\s*d\.dueDate/);
     expect(source).not.toContain(
-      "new Date(invoice.dueDate).toLocaleDateString"
+      "new Date(invoice.dueDate).toLocaleDateString",
     );
     expect(source).not.toContain(
-      "new Date(payment.receivedAt).toLocaleDateString"
+      "new Date(payment.receivedAt).toLocaleDateString",
     );
     expect(source).not.toContain(
-      "new Date(adjustment.createdAt).toLocaleDateString"
+      "new Date(adjustment.createdAt).toLocaleDateString",
     );
     expect(source).not.toContain("billingConfig.data?.timezone");
   });
@@ -376,18 +405,18 @@ describe("billing invoice payment actions", () => {
   it("uses the loaded clinic name in both estimate and invoice PDFs", () => {
     const estimatePdfBlock = source.slice(
       source.indexOf("{/* Estimate Approval Card */}"),
-      source.indexOf('<div className="flex items-center gap-6 text-sm">')
+      source.indexOf('<div className="flex items-center gap-6 text-sm">'),
     );
     const invoicePdfBlock = source.slice(
       source.indexOf("{/* Balance Summary */}"),
-      source.indexOf("{/* Payment History & Record Payment */}")
+      source.indexOf("{/* Payment History & Record Payment */}"),
     );
 
     expect(source).toContain(
-      "data && verifiedBillingConfig && data.items.length > 0"
+      "data && verifiedBillingConfig && data.items.length > 0",
     );
     expect(source).toContain(
-      "practiceName={verifiedBillingConfig.practiceName}"
+      "practiceName={verifiedBillingConfig.practiceName}",
     );
     expect(estimatePdfBlock).toContain("practiceName,");
     expect(invoicePdfBlock).toContain("practiceName,");

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -215,6 +215,43 @@ describe("clinic encounter workspace", () => {
     );
   });
 
+  it("converts exactly one active estimate through an explicit visit review", () => {
+    expect(workspaceSource).toContain(
+      "trpc.billing.convertEstimateToInvoice.useMutation",
+    );
+    expect(workspaceSource).toContain("activeEstimates.length === 1");
+    expect(workspaceSource).toContain("activeActualInvoices.length === 0");
+    expect(workspaceSource).toContain('activeEstimates[0]?.status === "draft"');
+    expect(workspaceSource).toContain('activeEstimates[0]?.status === "sent"');
+    expect(workspaceSource).toContain(
+      "Multiple active estimates are linked to this visit.",
+    );
+    expect(workspaceSource).toContain("Review &amp; convert estimate");
+    expect(workspaceSource).toContain('className="min-h-11"');
+    expect(workspaceSource).toContain(
+      'title="Convert estimate to a draft visit invoice?"',
+    );
+    expect(workspaceSource).toContain(
+      "expectedUpdatedAt: new Date(pendingEstimate.updatedAt)",
+    );
+    expect(workspaceSource).toContain(
+      "Eligible product stock will be deducted. The client is not charged, and performed work is not automatically reconciled.",
+    );
+    expect(workspaceSource).toContain("patientName={appointment.patientName}");
+    expect(workspaceSource).toContain("setPendingEstimate(null)");
+    expect(workspaceSource).toContain(
+      "utils.billing.listDispenseChargeQueue.invalidate()",
+    );
+    expect(workspaceSource).toContain(
+      "utils.billing.listProducts.invalidate()",
+    );
+    expect(workspaceSource).toContain("utils.inventory.list.invalidate()");
+    expect(workspaceSource).toContain(
+      "utils.encounters.getVisitReconciliation.invalidate({ appointmentId })",
+    );
+    expect(workspaceSource).toContain('appointment.status === "in_exam" &&');
+  });
+
   it("requires the durable two-stage closeout instead of a direct checkout", () => {
     expect(workspaceSource).toContain("trpc.encounters.getCloseout.useQuery");
     expect(workspaceSource).toContain(
@@ -257,6 +294,9 @@ describe("clinic encounter workspace", () => {
     expect(workspaceSource).toContain("tab=prescriptions&new=1");
     expect(workspaceSource).toContain("sourceDispenseChargeId");
     expect(workspaceSource).toContain('dispenseChargeStatus === "pending"');
+    expect(workspaceSource).toContain(
+      "id: `dispense:${prescription.dispenseChargeId}`",
+    );
     expect(workspaceSource).toContain("inventory already dispensed");
     expect(workspaceSource).toContain("expectedUpdatedAt");
   });

--- a/apps/web/server/__tests__/billing-adjustments.test.ts
+++ b/apps/web/server/__tests__/billing-adjustments.test.ts
@@ -28,12 +28,10 @@ const baseInvoice = {
   paidAmount: "20.00",
   status: "sent",
   isEstimate: false,
+  updatedAt: new Date("2026-08-11T12:00:00.000Z"),
 };
 
-function callerWithDb(
-  db: Record<string, unknown>,
-  injectOperationId = true
-) {
+function callerWithDb(db: Record<string, unknown>, injectOperationId = true) {
   const session = {
     user: {
       id: USER_ID,
@@ -66,7 +64,7 @@ function thenableRows(result: unknown[]) {
     for: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
-      reject?: (e: unknown) => unknown
+      reject?: (e: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject),
   };
   return builder;
@@ -141,7 +139,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "credit",
         amount: "10.00",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -156,7 +154,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "credit",
         amount: "10.123",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -165,7 +163,7 @@ describe("billing invoice adjustments", () => {
         operationId: OPERATION_ID,
         type: "write_off",
         amount: "100000000",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -180,7 +178,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "write_off",
         amount: "10.00",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -196,7 +194,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "credit",
         amount: "10.00",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -212,7 +210,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "credit",
         amount: "10.00",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Mark the invoice as sent before applying an adjustment.",
@@ -231,7 +229,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "write_off",
         amount: "11.00",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -249,7 +247,7 @@ describe("billing invoice adjustments", () => {
         type: "write_off",
         amount: "80.00",
         reason: "Bad debt",
-      })
+      }),
     ).resolves.toMatchObject({ amount: "80.00", balanceDue: "0.00" });
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -265,7 +263,7 @@ describe("billing invoice adjustments", () => {
         createdBy: USER_ID,
         operationKey: `dashboard-adjustment:${PRACTICE_ID}:${OPERATION_ID}`,
         balanceAfter: "0.00",
-      })
+      }),
     );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
@@ -278,7 +276,7 @@ describe("billing invoice adjustments", () => {
         adjustedAmount: "80.00",
         total: "100.00",
         source: "dashboard",
-      }
+      },
     );
   });
 
@@ -291,11 +289,13 @@ describe("billing invoice adjustments", () => {
         [linkedInvoice],
         [{ status: "completed" }],
         [],
-        [{
-          id: CLOSEOUT_ID,
-          chargeDisposition: "accounts_receivable",
-          revision: 6,
-        }],
+        [
+          {
+            id: CLOSEOUT_ID,
+            chargeDisposition: "accounts_receivable",
+            revision: 6,
+          },
+        ],
       ],
       updateReturns: [[{ id: INVOICE_ID }], [{ id: CLOSEOUT_ID }]],
     });
@@ -311,7 +311,7 @@ describe("billing invoice adjustments", () => {
       expect.objectContaining({
         chargeDisposition: "paid",
         revision: 7,
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -324,7 +324,7 @@ describe("billing invoice adjustments", () => {
           priorRevision: 6,
           nextRevision: 7,
         }),
-      })
+      }),
     );
   });
 
@@ -350,7 +350,7 @@ describe("billing invoice adjustments", () => {
         type: "write_off",
         amount: "80.00",
         reason: "Bad debt",
-      })
+      }),
     ).resolves.toMatchObject({ ...replayAdjustment, balanceDue: "0.00" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -377,7 +377,7 @@ describe("billing invoice adjustments", () => {
         operationId: OPERATION_ID,
         type: "credit",
         amount: "30.00",
-      })
+      }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -395,7 +395,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "write_off",
         amount: "80.00",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message:
@@ -426,7 +426,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "credit",
         amount: "25.00",
-      })
+      }),
     ).resolves.toMatchObject({ amount: "25.00", balanceDue: "55.00" });
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -437,7 +437,7 @@ describe("billing invoice adjustments", () => {
         invoiceId: INVOICE_ID,
         type: "credit",
         amount: "25.00",
-      })
+      }),
     );
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
@@ -449,7 +449,7 @@ describe("billing invoice adjustments", () => {
     });
 
     await expect(
-      callerWithDb(db).listAdjustments({ invoiceId: INVOICE_ID })
+      callerWithDb(db).listAdjustments({ invoiceId: INVOICE_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(select).toHaveBeenCalledTimes(1);
@@ -466,10 +466,13 @@ describe("billing invoice adjustments", () => {
       callerWithDb(db).voidInvoice({
         id: INVOICE_ID,
         reason: "Duplicate invoice",
-      })
+      }),
     ).resolves.toMatchObject({ status: "void" });
 
-    expect(updateSet).toHaveBeenCalledWith({ status: "void" });
+    expect(updateSet).toHaveBeenCalledWith({
+      status: "void",
+      updatedAt: expect.any(Date),
+    });
   });
 
   it("does not void when invoice history changed concurrently", async () => {
@@ -483,13 +486,16 @@ describe("billing invoice adjustments", () => {
       callerWithDb(db).voidInvoice({
         id: INVOICE_ID,
         reason: "Duplicate invoice",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Invoice changed while voiding. Refresh and try again.",
     });
 
-    expect(updateSet).toHaveBeenCalledWith({ status: "void" });
+    expect(updateSet).toHaveBeenCalledWith({
+      status: "void",
+      updatedAt: expect.any(Date),
+    });
   });
 
   it("rejects voiding invoices with payment history", async () => {
@@ -502,7 +508,7 @@ describe("billing invoice adjustments", () => {
       callerWithDb(db).voidInvoice({
         id: INVOICE_ID,
         reason: "Duplicate invoice",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();

--- a/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
+++ b/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
@@ -1,0 +1,1124 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import {
+  appointments,
+  auditLog,
+  clients,
+  dispenseChargeQueue,
+  invoiceItems,
+  invoices,
+  locations,
+  patients,
+  practices,
+  prescriptionEvents,
+  prescriptions,
+  products,
+  services,
+  treatmentTemplateItems,
+  treatmentTemplates,
+  users,
+  visitCloseouts,
+  visitWorkItems,
+} from "@openpims/db";
+import { db } from "@openpims/db/client";
+import { withSystem } from "@/lib/tenant-db";
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/webhook-dispatcher", () => ({
+  dispatchWebhookEvent: vi.fn(async () => undefined),
+}));
+
+const { billingRouter } = await import("../routers/billing");
+const { encountersRouter } = await import("../routers/encounters");
+const { recordsRouter } = await import("../routers/records");
+const { templatesRouter } = await import("../routers/templates");
+
+const describeWithPostgres = process.env.BILLING_CONVERSION_DB_INTEGRATION
+  ? describe.sequential
+  : describe.skip;
+
+type Fixture = {
+  practiceId: string;
+  userId: string;
+  clientId: string;
+  patientId: string;
+  appointmentId: string;
+  locationId: string;
+  serviceId: string;
+};
+
+type ProductFixture = {
+  id: string;
+  stockQuantity: number;
+};
+
+type PrescriptionFixture = {
+  id: string;
+  eventId: string;
+  productId: string;
+};
+
+const fixtures = new Set<string>();
+
+function assertDisposableLocalDatabase(): void {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error(
+      "DATABASE_URL is required for the billing conversion drill",
+    );
+  }
+  const hostname = new URL(databaseUrl).hostname;
+  if (!["localhost", "127.0.0.1", "::1"].includes(hostname)) {
+    throw new Error(
+      "The billing conversion drill is restricted to disposable local PostgreSQL",
+    );
+  }
+}
+
+async function within<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} exceeded ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function callerContext(fixture: Fixture) {
+  return {
+    db,
+    session: {
+      user: {
+        id: fixture.userId,
+        email: `synthetic-${fixture.userId}@example.invalid`,
+        name: "Synthetic billing operator",
+        role: "admin" as const,
+        practiceId: fixture.practiceId,
+      },
+    },
+    ip: "192.0.2.1",
+  };
+}
+
+function billingCaller(fixture: Fixture) {
+  return billingRouter.createCaller(callerContext(fixture) as never);
+}
+
+function recordsCaller(fixture: Fixture) {
+  return recordsRouter.createCaller(callerContext(fixture) as never);
+}
+
+function encountersCaller(fixture: Fixture) {
+  return encountersRouter.createCaller(callerContext(fixture) as never);
+}
+
+function templatesCaller(fixture: Fixture) {
+  return templatesRouter.createCaller(callerContext(fixture) as never);
+}
+
+function rejectionDetails(reason: unknown): string {
+  const details: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = reason;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    if (current instanceof Error) details.push(current.message);
+    if (typeof current === "object") {
+      const record = current as Record<string, unknown>;
+      if (typeof record.code === "string") details.push(record.code);
+      current = record.cause;
+    } else {
+      details.push(String(current));
+      break;
+    }
+  }
+  return details.join(" | ");
+}
+
+function assertNoDeadlock(
+  results: readonly PromiseSettledResult<unknown>[],
+): void {
+  for (const result of results) {
+    if (result.status !== "rejected") continue;
+    const details = rejectionDetails(result.reason);
+    expect(details).not.toContain("40P01");
+    expect(details.toLowerCase()).not.toContain("deadlock detected");
+  }
+}
+
+function expectOneDomainRejection(
+  results: readonly PromiseSettledResult<unknown>[],
+  allowedMessages: readonly string[],
+): void {
+  assertNoDeadlock(results);
+  const rejected = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  expect(rejected).toHaveLength(1);
+  expect(rejected[0]!.reason).toMatchObject({ code: "CONFLICT" });
+  expect(allowedMessages).toContain(rejected[0]!.reason.message);
+}
+
+async function createFixture(): Promise<Fixture> {
+  const practiceId = randomUUID();
+  const userId = randomUUID();
+  const clientId = randomUUID();
+  const patientId = randomUUID();
+  const appointmentId = randomUUID();
+  const locationId = randomUUID();
+  const serviceId = randomUUID();
+  const now = new Date();
+
+  await withSystem(db, async (tx) => {
+    await tx.insert(practices).values({
+      id: practiceId,
+      name: `Synthetic billing drill ${practiceId}`,
+      taxRatePercent: "8.00",
+    });
+    await tx.insert(users).values({
+      id: userId,
+      practiceId,
+      email: `synthetic-${userId}@example.invalid`,
+      passwordHash: "synthetic-not-a-login",
+      name: "Synthetic billing operator",
+      role: "admin",
+      isVeterinarian: true,
+    });
+    await tx.insert(locations).values({
+      id: locationId,
+      practiceId,
+      name: "Synthetic billing location",
+      isPrimary: true,
+    });
+    await tx.insert(clients).values({
+      id: clientId,
+      practiceId,
+      firstName: "Synthetic",
+      lastName: "Client",
+    });
+    await tx.insert(patients).values({
+      id: patientId,
+      practiceId,
+      clientId,
+      name: "Synthetic Patient",
+      species: "canine",
+    });
+    await tx.insert(appointments).values({
+      id: appointmentId,
+      practiceId,
+      locationId,
+      startTime: new Date(now.getTime() - 30 * 60_000),
+      endTime: new Date(now.getTime() + 30 * 60_000),
+      patientId,
+      clientId,
+      doctorId: userId,
+      status: "in_exam",
+    });
+    await tx.insert(services).values({
+      id: serviceId,
+      practiceId,
+      name: "Synthetic exam service",
+      defaultPrice: "50.00",
+      taxable: false,
+    });
+  });
+
+  fixtures.add(practiceId);
+  return {
+    practiceId,
+    userId,
+    clientId,
+    patientId,
+    appointmentId,
+    locationId,
+    serviceId,
+  };
+}
+
+async function createProduct(
+  fixture: Fixture,
+  stockQuantity = 10,
+  id = randomUUID(),
+): Promise<ProductFixture> {
+  await withSystem(db, async (tx) => {
+    await tx.insert(products).values({
+      id,
+      practiceId: fixture.practiceId,
+      name: `Synthetic product ${id}`,
+      unitPrice: "15.00",
+      taxable: true,
+      stockQuantity,
+    });
+  });
+  return { id, stockQuantity };
+}
+
+async function createVisit(
+  fixture: Fixture,
+  id = randomUUID(),
+): Promise<string> {
+  await withSystem(db, async (tx) => {
+    await tx.insert(appointments).values({
+      id,
+      practiceId: fixture.practiceId,
+      locationId: fixture.locationId,
+      startTime: new Date("2026-08-11T17:00:00.000Z"),
+      endTime: new Date("2026-08-11T18:00:00.000Z"),
+      patientId: fixture.patientId,
+      clientId: fixture.clientId,
+      doctorId: fixture.userId,
+      status: "in_exam",
+    });
+  });
+  return id;
+}
+
+async function createEstimate(
+  fixture: Fixture,
+  input: {
+    id?: string;
+    itemId?: string;
+    itemType?: "service" | "product";
+    quantity?: number;
+    sourcePrescriptionId?: string;
+    sourceDispenseChargeId?: string;
+  } = {},
+): Promise<{ id: string; updatedAt: Date; itemId: string }> {
+  const id = input.id ?? randomUUID();
+  const itemId = input.itemId ?? fixture.serviceId;
+  const itemType = input.itemType ?? "service";
+  const quantity = input.quantity ?? 1;
+  const unitPrice = itemType === "product" ? "15.00" : "50.00";
+  const updatedAt = new Date();
+  const subtotal = (Number(unitPrice) * quantity).toFixed(2);
+
+  await withSystem(db, async (tx) => {
+    await tx.insert(invoices).values({
+      id,
+      practiceId: fixture.practiceId,
+      clientId: fixture.clientId,
+      patientId: fixture.patientId,
+      appointmentId: fixture.appointmentId,
+      status: "draft",
+      subtotal,
+      tax: "0.00",
+      total: subtotal,
+      paidAmount: "0.00",
+      isEstimate: true,
+      updatedAt,
+    });
+    await tx.insert(invoiceItems).values({
+      id: randomUUID(),
+      invoiceId: id,
+      description: `Synthetic ${itemType}`,
+      quantity,
+      unitPrice,
+      total: subtotal,
+      taxable: itemType === "product",
+      itemType,
+      itemId,
+      sourcePrescriptionId: input.sourcePrescriptionId ?? null,
+      sourceDispenseChargeId: input.sourceDispenseChargeId ?? null,
+    });
+  });
+
+  return { id, updatedAt, itemId };
+}
+
+async function createPrescription(
+  fixture: Fixture,
+  product: ProductFixture,
+  appointmentId: string | null = fixture.appointmentId,
+): Promise<PrescriptionFixture> {
+  const id = randomUUID();
+  const eventId = randomUUID();
+  await withSystem(db, async (tx) => {
+    await tx.insert(prescriptions).values({
+      id,
+      practiceId: fixture.practiceId,
+      patientId: fixture.patientId,
+      appointmentId,
+      medicationName: "Synthetic medication",
+      dosage: "Synthetic dose",
+      frequency: "Once daily",
+      quantity: 2,
+      productId: product.id,
+      refillsRemaining: 1,
+      prescribedBy: fixture.userId,
+      startDate: "2026-08-11",
+      status: "active",
+    });
+    await tx.insert(prescriptionEvents).values({
+      id: eventId,
+      practiceId: fixture.practiceId,
+      prescriptionId: id,
+      patientId: fixture.patientId,
+      productId: product.id,
+      eventType: "created",
+      quantity: 2,
+      statusBefore: null,
+      statusAfter: "active",
+      refillsBefore: null,
+      refillsAfter: 1,
+      actorId: fixture.userId,
+      actorName: "Synthetic billing operator",
+    });
+  });
+  return { id, eventId, productId: product.id };
+}
+
+async function createPendingDispense(
+  fixture: Fixture,
+  prescription: PrescriptionFixture,
+): Promise<string> {
+  const id = randomUUID();
+  await withSystem(db, async (tx) => {
+    await tx.insert(dispenseChargeQueue).values({
+      id,
+      practiceId: fixture.practiceId,
+      prescriptionEventId: prescription.eventId,
+      prescriptionId: prescription.id,
+      patientId: fixture.patientId,
+      clientId: fixture.clientId,
+      appointmentId: fixture.appointmentId,
+      productId: prescription.productId,
+      quantity: 2,
+      descriptionSnapshot: "Synthetic medication dispense",
+      unitPriceSnapshot: "15.00",
+      status: "pending",
+    });
+  });
+  return id;
+}
+
+async function createServiceTemplate(fixture: Fixture): Promise<string> {
+  const templateId = randomUUID();
+  await withSystem(db, async (tx) => {
+    await tx.insert(treatmentTemplates).values({
+      id: templateId,
+      practiceId: fixture.practiceId,
+      name: "Synthetic conversion version template",
+      isActive: true,
+    });
+    await tx.insert(treatmentTemplateItems).values({
+      id: randomUUID(),
+      templateId,
+      itemType: "service",
+      itemId: fixture.serviceId,
+      description: "Synthetic templated service",
+      defaultQuantity: 1,
+      defaultUnitPrice: "25.00",
+      sortOrder: 0,
+    });
+  });
+  return templateId;
+}
+
+async function cleanupFixture(practiceId: string): Promise<void> {
+  await withSystem(db, async (tx) => {
+    await tx.execute(
+      sql`select set_config('app.ledger_maintenance', 'on', true)`,
+    );
+    await tx
+      .delete(visitWorkItems)
+      .where(eq(visitWorkItems.practiceId, practiceId));
+    await tx
+      .delete(visitCloseouts)
+      .where(eq(visitCloseouts.practiceId, practiceId));
+    await tx
+      .delete(dispenseChargeQueue)
+      .where(eq(dispenseChargeQueue.practiceId, practiceId));
+    await tx
+      .delete(prescriptionEvents)
+      .where(eq(prescriptionEvents.practiceId, practiceId));
+    await tx
+      .delete(invoiceItems)
+      .where(
+        inArray(
+          invoiceItems.invoiceId,
+          tx
+            .select({ id: invoices.id })
+            .from(invoices)
+            .where(eq(invoices.practiceId, practiceId)),
+        ),
+      );
+    await tx
+      .delete(treatmentTemplateItems)
+      .where(
+        inArray(
+          treatmentTemplateItems.templateId,
+          tx
+            .select({ id: treatmentTemplates.id })
+            .from(treatmentTemplates)
+            .where(eq(treatmentTemplates.practiceId, practiceId)),
+        ),
+      );
+    await tx
+      .delete(treatmentTemplates)
+      .where(eq(treatmentTemplates.practiceId, practiceId));
+    await tx.delete(auditLog).where(eq(auditLog.practiceId, practiceId));
+    await tx.delete(invoices).where(eq(invoices.practiceId, practiceId));
+    await tx
+      .delete(prescriptions)
+      .where(eq(prescriptions.practiceId, practiceId));
+    await tx.delete(products).where(eq(products.practiceId, practiceId));
+    await tx.delete(services).where(eq(services.practiceId, practiceId));
+    await tx
+      .delete(appointments)
+      .where(eq(appointments.practiceId, practiceId));
+    await tx.delete(patients).where(eq(patients.practiceId, practiceId));
+    await tx.delete(clients).where(eq(clients.practiceId, practiceId));
+    await tx.delete(users).where(eq(users.practiceId, practiceId));
+    await tx.delete(locations).where(eq(locations.practiceId, practiceId));
+    await tx.delete(practices).where(eq(practices.id, practiceId));
+  });
+  fixtures.delete(practiceId);
+}
+
+async function invoiceState(practiceId: string) {
+  return withSystem(db, async (tx) => {
+    const rows = await tx
+      .select({
+        id: invoices.id,
+        isEstimate: invoices.isEstimate,
+        status: invoices.status,
+      })
+      .from(invoices)
+      .where(eq(invoices.practiceId, practiceId))
+      .orderBy(asc(invoices.id));
+    const audits = await tx
+      .select({ id: auditLog.id })
+      .from(auditLog)
+      .where(
+        and(
+          eq(auditLog.practiceId, practiceId),
+          eq(auditLog.action, "estimate_converted"),
+        ),
+      );
+    return { rows, conversionAuditCount: audits.length };
+  });
+}
+
+async function productStock(
+  productIds: string[],
+): Promise<Map<string, number>> {
+  const rows = await withSystem(db, (tx) =>
+    tx
+      .select({ id: products.id, stockQuantity: products.stockQuantity })
+      .from(products)
+      .where(inArray(products.id, productIds)),
+  );
+  return new Map(rows.map((row) => [row.id, row.stockQuantity]));
+}
+
+describeWithPostgres("billing estimate conversion PostgreSQL drill", () => {
+  beforeAll(() => {
+    assertDisposableLocalDatabase();
+  });
+
+  afterEach(async () => {
+    for (const practiceId of [...fixtures]) {
+      await cleanupFixture(practiceId);
+    }
+  });
+
+  it("serializes two estimates for one visit and deducts stock once", async () => {
+    const fixture = await createFixture();
+    const product = await createProduct(fixture, 10);
+    const first = await createEstimate(fixture, {
+      itemType: "product",
+      itemId: product.id,
+      quantity: 2,
+    });
+    const second = await createEstimate(fixture, {
+      itemType: "product",
+      itemId: product.id,
+      quantity: 2,
+    });
+
+    const results = await within(
+      Promise.allSettled([
+        billingCaller(fixture).convertEstimateToInvoice({
+          id: first.id,
+          expectedUpdatedAt: first.updatedAt,
+        }),
+        billingCaller(fixture).convertEstimateToInvoice({
+          id: second.id,
+          expectedUpdatedAt: second.updatedAt,
+        }),
+      ]),
+      "concurrent estimate conversion",
+    );
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    expectOneDomainRejection(results, [
+      "This visit already has an active invoice. Open it instead of converting another estimate.",
+    ]);
+    const state = await invoiceState(fixture.practiceId);
+    expect(state.rows.filter((row) => !row.isEstimate)).toHaveLength(1);
+    expect(state.rows.filter((row) => row.isEstimate)).toHaveLength(1);
+    expect(state.conversionAuditCount).toBe(1);
+    expect((await productStock([product.id])).get(product.id)).toBe(8);
+  });
+
+  it("serializes conversion against creation of an actual visit invoice", async () => {
+    const fixture = await createFixture();
+    const product = await createProduct(fixture, 10);
+    const estimate = await createEstimate(fixture, {
+      itemType: "product",
+      itemId: product.id,
+      quantity: 2,
+    });
+
+    const results = await within(
+      Promise.allSettled([
+        billingCaller(fixture).convertEstimateToInvoice({
+          id: estimate.id,
+          expectedUpdatedAt: estimate.updatedAt,
+        }),
+        billingCaller(fixture).createInvoice({
+          clientId: fixture.clientId,
+          patientId: fixture.patientId,
+          appointmentId: fixture.appointmentId,
+          isEstimate: false,
+          items: [
+            {
+              description: "Synthetic product",
+              quantity: 2,
+              unitPrice: "15.00",
+              itemType: "product",
+              itemId: product.id,
+            },
+          ],
+        }),
+      ]),
+      "conversion/create serialization",
+    );
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    expectOneDomainRejection(results, [
+      "This visit already has an active invoice. Open it instead of converting another estimate.",
+      "This visit already has an active invoice. Open it instead of creating a duplicate.",
+    ]);
+    const state = await invoiceState(fixture.practiceId);
+    expect(state.rows.filter((row) => !row.isEstimate)).toHaveLength(1);
+    expect((await productStock([product.id])).get(product.id)).toBe(8);
+  });
+
+  it("makes an estimate confirmation stale after a serialized template edit", async () => {
+    const fixture = await createFixture();
+    const estimate = await createEstimate(fixture);
+    const templateId = await createServiceTemplate(fixture);
+
+    await expect(
+      templatesCaller(fixture).applyToInvoice({
+        templateId,
+        invoiceId: estimate.id,
+      }),
+    ).resolves.toMatchObject({ id: estimate.id, isEstimate: true });
+    await expect(
+      billingCaller(fixture).convertEstimateToInvoice({
+        id: estimate.id,
+        expectedUpdatedAt: estimate.updatedAt,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("Estimate changed"),
+    });
+
+    const [current] = await withSystem(db, (tx) =>
+      tx
+        .select({
+          isEstimate: invoices.isEstimate,
+          updatedAt: invoices.updatedAt,
+        })
+        .from(invoices)
+        .where(eq(invoices.id, estimate.id)),
+    );
+    const currentItems = await withSystem(db, (tx) =>
+      tx
+        .select({ id: invoiceItems.id })
+        .from(invoiceItems)
+        .where(eq(invoiceItems.invoiceId, estimate.id)),
+    );
+    expect(current).toMatchObject({ isEstimate: true });
+    expect(current!.updatedAt.getTime()).toBeGreaterThan(
+      estimate.updatedAt.getTime(),
+    );
+    expect(currentItems).toHaveLength(2);
+  });
+
+  it("rolls back an earlier stock deduction when a later product is insufficient", async () => {
+    const fixture = await createFixture();
+    const firstProduct = await createProduct(
+      fixture,
+      10,
+      "10000000-0000-0000-0000-000000000001",
+    );
+    const secondProduct = await createProduct(
+      fixture,
+      0,
+      "20000000-0000-0000-0000-000000000002",
+    );
+    const estimateId = randomUUID();
+    const updatedAt = new Date();
+    await withSystem(db, async (tx) => {
+      await tx.insert(invoices).values({
+        id: estimateId,
+        practiceId: fixture.practiceId,
+        clientId: fixture.clientId,
+        patientId: fixture.patientId,
+        appointmentId: fixture.appointmentId,
+        status: "draft",
+        subtotal: "30.00",
+        tax: "0.00",
+        total: "30.00",
+        paidAmount: "0.00",
+        isEstimate: true,
+        updatedAt,
+      });
+      await tx.insert(invoiceItems).values([
+        {
+          id: "10000000-0000-0000-0000-000000000011",
+          invoiceId: estimateId,
+          description: "Synthetic available product",
+          quantity: 1,
+          unitPrice: "15.00",
+          total: "15.00",
+          taxable: true,
+          itemType: "product",
+          itemId: firstProduct.id,
+        },
+        {
+          id: "20000000-0000-0000-0000-000000000022",
+          invoiceId: estimateId,
+          description: "Synthetic unavailable product",
+          quantity: 1,
+          unitPrice: "15.00",
+          total: "15.00",
+          taxable: true,
+          itemType: "product",
+          itemId: secondProduct.id,
+        },
+      ]);
+    });
+
+    await expect(
+      billingCaller(fixture).convertEstimateToInvoice({
+        id: estimateId,
+        expectedUpdatedAt: updatedAt,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    const stocks = await productStock([firstProduct.id, secondProduct.id]);
+    expect(stocks.get(firstProduct.id)).toBe(10);
+    expect(stocks.get(secondProduct.id)).toBe(0);
+    const state = await invoiceState(fixture.practiceId);
+    expect(state.rows).toEqual([
+      { id: estimateId, isEstimate: true, status: "draft" },
+    ]);
+    expect(state.conversionAuditCount).toBe(0);
+  });
+
+  it("rejects a source-prescription estimate while its dispense remains pending", async () => {
+    const fixture = await createFixture();
+    const product = await createProduct(fixture, 10);
+    const prescription = await createPrescription(fixture, product);
+    const pendingId = await createPendingDispense(fixture, prescription);
+    const estimate = await createEstimate(fixture, {
+      itemType: "product",
+      itemId: product.id,
+      quantity: 2,
+      sourcePrescriptionId: prescription.id,
+    });
+
+    await expect(
+      billingCaller(fixture).convertEstimateToInvoice({
+        id: estimate.id,
+        expectedUpdatedAt: estimate.updatedAt,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    const [pending] = await withSystem(db, (tx) =>
+      tx
+        .select({ status: dispenseChargeQueue.status })
+        .from(dispenseChargeQueue)
+        .where(eq(dispenseChargeQueue.id, pendingId)),
+    );
+    expect(pending?.status).toBe("pending");
+    expect((await productStock([product.id])).get(product.id)).toBe(10);
+    const state = await invoiceState(fixture.practiceId);
+    expect(state.rows[0]?.isEstimate).toBe(true);
+    expect(state.conversionAuditCount).toBe(0);
+  });
+
+  it("serializes a same-visit medication estimate against its refill without deadlock", async () => {
+    const fixture = await createFixture();
+    const product = await createProduct(fixture, 10);
+    const prescription = await createPrescription(fixture, product);
+    const estimate = await createEstimate(fixture, {
+      itemType: "product",
+      itemId: product.id,
+      quantity: 2,
+    });
+
+    const results = await within(
+      Promise.allSettled([
+        billingCaller(fixture).convertEstimateToInvoice({
+          id: estimate.id,
+          expectedUpdatedAt: estimate.updatedAt,
+        }),
+        recordsCaller(fixture).recordPrescriptionRefill({
+          id: prescription.id,
+          operationId: randomUUID(),
+          appointmentId: fixture.appointmentId,
+          note: "Synthetic concurrency drill refill",
+        }),
+      ]),
+      "conversion/refill serialization",
+    );
+
+    assertNoDeadlock(results);
+    expect(results[1]).toEqual(
+      expect.objectContaining({ status: "fulfilled" }),
+    );
+    expect(results[0]).toEqual(expect.objectContaining({ status: "rejected" }));
+    if (results[0]?.status === "rejected") {
+      expect(results[0].reason).toMatchObject({
+        code: "PRECONDITION_FAILED",
+        message:
+          "Charge a visit-dispensed medication from its prescription entry so stock is not deducted twice.",
+      });
+    }
+    expect((await productStock([product.id])).get(product.id)).toBe(8);
+    const [prescriptionState] = await withSystem(db, (tx) =>
+      tx
+        .select({ refillsRemaining: prescriptions.refillsRemaining })
+        .from(prescriptions)
+        .where(eq(prescriptions.id, prescription.id)),
+    );
+    expect(prescriptionState?.refillsRemaining).toBe(0);
+    const queue = await withSystem(db, (tx) =>
+      tx
+        .select({ status: dispenseChargeQueue.status })
+        .from(dispenseChargeQueue)
+        .where(eq(dispenseChargeQueue.prescriptionId, prescription.id)),
+    );
+    expect(queue).toEqual([{ status: "pending" }]);
+  });
+
+  it("blocks visit financial handoff until an older prescription refill is charged", async () => {
+    const fixture = await createFixture();
+    const product = await createProduct(fixture, 10);
+    const prescription = await createPrescription(fixture, product, null);
+    const estimate = await createEstimate(fixture);
+
+    await billingCaller(fixture).convertEstimateToInvoice({
+      id: estimate.id,
+      expectedUpdatedAt: estimate.updatedAt,
+    });
+    await recordsCaller(fixture).recordPrescriptionRefill({
+      id: prescription.id,
+      operationId: randomUUID(),
+      appointmentId: fixture.appointmentId,
+      note: "Synthetic visit-linked refill billing drill",
+    });
+
+    const closeoutBeforeFinalization = await encountersCaller(
+      fixture,
+    ).getCloseout({
+      appointmentId: fixture.appointmentId,
+    });
+    expect(closeoutBeforeFinalization.activeMedications).toEqual([
+      expect.objectContaining({
+        id: prescription.id,
+        productId: product.id,
+        quantity: 2,
+      }),
+    ]);
+
+    const clinicalInput = {
+      appointmentId: fixture.appointmentId,
+      expectedRevision: 0,
+      diagnosisSummary: null,
+      dischargeInstructions: null,
+      warningSigns: null,
+      noInstructionsReason: "Synthetic handoff has no owner instructions.",
+      followUpDisposition: "none" as const,
+      followUpNotes: null,
+      followUpAppointmentId: null,
+      followUpDueDate: null,
+      followUpAssignedTo: null,
+      documentationExceptionReason:
+        "Synthetic drill does not require a SOAP note.",
+    };
+    await expect(
+      encountersCaller(fixture).finalizeClinical({
+        ...clinicalInput,
+        prescriptionDisposition: "not_needed",
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("linked prescriptions"),
+    });
+    const finalized = await encountersCaller(fixture).finalizeClinical({
+      ...clinicalInput,
+      prescriptionDisposition: "prescribed",
+    });
+    expect(finalized.medicationSnapshot).toEqual([
+      expect.objectContaining({
+        prescriptionId: prescription.id,
+        quantity: 2,
+      }),
+    ]);
+
+    await expect(
+      billingCaller(fixture).updateInvoiceStatus({
+        id: estimate.id,
+        status: "sent",
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("medication dispense"),
+    });
+
+    const closeout = await encountersCaller(fixture).getCloseout({
+      appointmentId: fixture.appointmentId,
+    });
+    const refillCharge = closeout.medications.find(
+      (medication) =>
+        medication.id === prescription.id &&
+        medication.dispenseChargeStatus === "pending",
+    );
+    expect(refillCharge).toMatchObject({
+      productId: product.id,
+      dispenseChargeStatus: "pending",
+      quantity: 2,
+    });
+    expect(refillCharge?.dispenseChargeId).toEqual(expect.any(String));
+
+    await billingCaller(fixture).createDispenseChargeInvoice({
+      id: refillCharge!.dispenseChargeId!,
+      acknowledgeLegacyReview: false,
+    });
+    expect((await productStock([product.id])).get(product.id)).toBe(8);
+    await expect(
+      billingCaller(fixture).updateInvoiceStatus({
+        id: estimate.id,
+        status: "sent",
+      }),
+    ).resolves.toMatchObject({ id: estimate.id, status: "sent" });
+
+    await expect(
+      encountersCaller(fixture).completeVisit({
+        appointmentId: fixture.appointmentId,
+        expectedRevision: finalized.revision,
+        chargeDisposition: "accounts_receivable",
+        invoiceDueDate: "2099-12-31",
+        handoffMethod: "print",
+      }),
+    ).resolves.toMatchObject({
+      appointment: { status: "checked_out" },
+      closeout: { status: "completed" },
+    });
+    const queue = await withSystem(db, (tx) =>
+      tx
+        .select({ status: dispenseChargeQueue.status })
+        .from(dispenseChargeQueue)
+        .where(eq(dispenseChargeQueue.id, refillCharge!.dispenseChargeId!)),
+    );
+    expect(queue).toEqual([{ status: "invoiced" }]);
+  });
+
+  it("serializes cross-invoice product swaps with the old and new stock rows prelocked", async () => {
+    const fixture = await createFixture();
+    const secondAppointmentId = await createVisit(fixture);
+    const firstProduct = await createProduct(
+      fixture,
+      10,
+      "10000000-0000-0000-0000-000000000101",
+    );
+    const secondProduct = await createProduct(
+      fixture,
+      10,
+      "20000000-0000-0000-0000-000000000202",
+    );
+    const firstInvoice = await billingCaller(fixture).createInvoice({
+      clientId: fixture.clientId,
+      patientId: fixture.patientId,
+      appointmentId: fixture.appointmentId,
+      isEstimate: false,
+      items: [
+        {
+          description: "Synthetic first product",
+          quantity: 1,
+          unitPrice: "15.00",
+          itemType: "product",
+          itemId: firstProduct.id,
+        },
+      ],
+    });
+    const secondInvoice = await billingCaller(fixture).createInvoice({
+      clientId: fixture.clientId,
+      patientId: fixture.patientId,
+      appointmentId: secondAppointmentId,
+      isEstimate: false,
+      items: [
+        {
+          description: "Synthetic second product",
+          quantity: 1,
+          unitPrice: "15.00",
+          itemType: "product",
+          itemId: secondProduct.id,
+        },
+      ],
+    });
+    const invoiceVersions = await withSystem(db, (tx) =>
+      tx
+        .select({ id: invoices.id, updatedAt: invoices.updatedAt })
+        .from(invoices)
+        .where(inArray(invoices.id, [firstInvoice.id, secondInvoice.id])),
+    );
+    expect(
+      new Map(invoiceVersions.map((invoice) => [invoice.id, invoice.updatedAt]))
+        .get(firstInvoice.id)
+        ?.getTime(),
+    ).toBe(firstInvoice.updatedAt.getTime());
+    expect(
+      new Map(invoiceVersions.map((invoice) => [invoice.id, invoice.updatedAt]))
+        .get(secondInvoice.id)
+        ?.getTime(),
+    ).toBe(secondInvoice.updatedAt.getTime());
+
+    const results = await within(
+      Promise.allSettled([
+        billingCaller(fixture).updateInvoiceItems({
+          id: firstInvoice.id,
+          expectedUpdatedAt: firstInvoice.updatedAt,
+          items: [
+            {
+              description: "Synthetic second product",
+              quantity: 1,
+              unitPrice: "15.00",
+              itemType: "product",
+              itemId: secondProduct.id,
+            },
+          ],
+        }),
+        billingCaller(fixture).updateInvoiceItems({
+          id: secondInvoice.id,
+          expectedUpdatedAt: secondInvoice.updatedAt,
+          items: [
+            {
+              description: "Synthetic first product",
+              quantity: 1,
+              unitPrice: "15.00",
+              itemType: "product",
+              itemId: firstProduct.id,
+            },
+          ],
+        }),
+      ]),
+      "cross-invoice product swap",
+    );
+
+    assertNoDeadlock(results);
+    expect(results).toEqual([
+      expect.objectContaining({ status: "fulfilled" }),
+      expect.objectContaining({ status: "fulfilled" }),
+    ]);
+    const stocks = await productStock([firstProduct.id, secondProduct.id]);
+    expect(stocks.get(firstProduct.id)).toBe(9);
+    expect(stocks.get(secondProduct.id)).toBe(9);
+  });
+
+  it("serializes a same-invoice product edit against void without a product-invoice deadlock", async () => {
+    const fixture = await createFixture();
+    const firstProduct = await createProduct(
+      fixture,
+      10,
+      "10000000-0000-0000-0000-000000000301",
+    );
+    const secondProduct = await createProduct(
+      fixture,
+      10,
+      "20000000-0000-0000-0000-000000000302",
+    );
+    const invoice = await billingCaller(fixture).createInvoice({
+      clientId: fixture.clientId,
+      patientId: fixture.patientId,
+      isEstimate: false,
+      items: [
+        {
+          description: "Synthetic first product",
+          quantity: 1,
+          unitPrice: "15.00",
+          itemType: "product",
+          itemId: firstProduct.id,
+        },
+      ],
+    });
+
+    const results = await within(
+      Promise.allSettled([
+        billingCaller(fixture).updateInvoiceItems({
+          id: invoice.id,
+          expectedUpdatedAt: invoice.updatedAt,
+          items: [
+            {
+              description: "Synthetic second product",
+              quantity: 1,
+              unitPrice: "15.00",
+              itemType: "product",
+              itemId: secondProduct.id,
+            },
+          ],
+        }),
+        billingCaller(fixture).voidInvoice({
+          id: invoice.id,
+          reason: "Synthetic concurrency drill void",
+        }),
+      ]),
+      "same-invoice edit/void serialization",
+    );
+
+    assertNoDeadlock(results);
+    expect(results[1]).toMatchObject({ status: "fulfilled" });
+    if (results[0]?.status === "rejected") {
+      expect(results[0].reason).toMatchObject({
+        code: "PRECONDITION_FAILED",
+        message:
+          "Only an unpaid draft invoice can have its line items changed.",
+      });
+    }
+    const [finalInvoice] = await withSystem(db, (tx) =>
+      tx
+        .select({ status: invoices.status })
+        .from(invoices)
+        .where(eq(invoices.id, invoice.id)),
+    );
+    expect(finalInvoice).toEqual({ status: "void" });
+    const stocks = await productStock([firstProduct.id, secondProduct.id]);
+    expect(stocks.get(firstProduct.id)).toBe(10);
+    expect(stocks.get(secondProduct.id)).toBe(10);
+  });
+});

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -38,8 +39,10 @@ function callerWithDb(db: Record<string, unknown>, role = "front_desk") {
 function thenableRows(result: unknown[]) {
   return {
     limit: vi.fn(async () => result),
-    then: (resolve: (value: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
-      Promise.resolve(result).then(resolve, reject),
+    then: (
+      resolve: (value: unknown[]) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => Promise.resolve(result).then(resolve, reject),
   };
 }
 
@@ -148,7 +151,10 @@ describe("billing invoice integrity", () => {
     });
 
     await expect(
-      callerWithDb(db, "viewer").convertEstimateToInvoice({ id: INVOICE_ID })
+      callerWithDb(db, "viewer").convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(select).not.toHaveBeenCalled();
@@ -169,7 +175,7 @@ describe("billing invoice integrity", () => {
           },
         ],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -182,7 +188,7 @@ describe("billing invoice integrity", () => {
           },
         ],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -197,7 +203,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: [{ ...productLine, description: " ".repeat(4) }],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -205,7 +211,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: [{ ...productLine, description: "d".repeat(501) }],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -214,7 +220,7 @@ describe("billing invoice integrity", () => {
         items: [productLine],
         dueDate: "2026-02-31",
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -222,7 +228,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: Array.from({ length: 201 }, () => productLine),
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -236,7 +242,7 @@ describe("billing invoice integrity", () => {
           },
         ],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -251,7 +257,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -268,7 +274,7 @@ describe("billing invoice integrity", () => {
         patientId: PATIENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -286,7 +292,7 @@ describe("billing invoice integrity", () => {
         appointmentId: APPOINTMENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Appointment not found for this client and patient.",
@@ -303,6 +309,8 @@ describe("billing invoice integrity", () => {
         [{ id: APPOINTMENT_ID }],
         [{ taxRatePercent: "0.00" }],
         [{ id: APPOINTMENT_ID, status: "in_exam" }],
+        [],
+        [],
         [],
         [{ id: PRODUCT_ID, deletedAt: null }],
       ],
@@ -324,7 +332,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     );
 
     const duplicate = createDb({
@@ -345,7 +353,7 @@ describe("billing invoice integrity", () => {
         appointmentId: APPOINTMENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message:
@@ -375,7 +383,7 @@ describe("billing invoice integrity", () => {
         appointmentId: APPOINTMENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Start the exam before capturing visit charges.",
@@ -388,11 +396,7 @@ describe("billing invoice integrity", () => {
 
   it("rejects product line references outside the practice", async () => {
     const { db, insertValues } = createDb({
-      selectResults: [
-        [{ id: CLIENT_ID }],
-        [{ taxRatePercent: "0.00" }],
-        [],
-      ],
+      selectResults: [[{ id: CLIENT_ID }], [{ taxRatePercent: "0.00" }], []],
     });
 
     await expect(
@@ -400,7 +404,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -438,7 +442,7 @@ describe("billing invoice integrity", () => {
         total: "30.00",
         dueDate: "2026-07-15",
         isEstimate: false,
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith([
       expect.objectContaining({
@@ -529,7 +533,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -554,7 +558,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
@@ -577,6 +581,7 @@ describe("billing invoice integrity", () => {
           },
         ],
         [{ itemType: "product", itemId: PRODUCT_ID, quantity: 1 }],
+        [],
         [{ id: PRODUCT_ID, deletedAt: null }],
       ],
       updateReturns: [
@@ -599,7 +604,7 @@ describe("billing invoice integrity", () => {
         id: INVOICE_ID,
         expectedUpdatedAt: UPDATED_AT,
         items: [{ ...productLine, quantity: 3 }],
-      })
+      }),
     ).resolves.toMatchObject({
       id: INVOICE_ID,
       subtotal: "45.00",
@@ -620,14 +625,14 @@ describe("billing invoice integrity", () => {
         subtotal: "45.00",
         tax: "4.50",
         total: "49.50",
-      })
+      }),
     );
     expect(updateSet).toHaveBeenNthCalledWith(
       4,
       expect.objectContaining({
         deletedAt: expect.any(Date),
         updatedAt: expect.any(Date),
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith([
       expect.objectContaining({
@@ -665,7 +670,7 @@ describe("billing invoice integrity", () => {
         id: INVOICE_ID,
         expectedUpdatedAt: UPDATED_AT,
         items: [productLine],
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("confirmed against performed work"),
@@ -721,7 +726,7 @@ describe("billing invoice integrity", () => {
             itemId: SERVICE_ID,
           },
         ],
-      })
+      }),
     ).resolves.toMatchObject({ id: INVOICE_ID, total: "80.00" });
 
     expect(lockCalls).toEqual([
@@ -782,7 +787,7 @@ describe("billing invoice integrity", () => {
               itemId: SERVICE_ID,
             },
           ],
-        })
+        }),
       ).rejects.toMatchObject({
         code: "NOT_FOUND",
         message: "One or more services were not found",
@@ -793,7 +798,7 @@ describe("billing invoice integrity", () => {
       ]);
       expect(updateSet).not.toHaveBeenCalled();
       expect(insertValues).not.toHaveBeenCalled();
-    }
+    },
   );
 
   it("rejects an archived product reference before inventory or invoice writes", async () => {
@@ -810,7 +815,7 @@ describe("billing invoice integrity", () => {
         clientId: CLIENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "One or more products were not found",
@@ -823,19 +828,9 @@ describe("billing invoice integrity", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("charges a visit prescription without deducting already-dispensed stock twice", async () => {
-    const { db, insertValues, updateSet } = createDb({
-      selectResults: [
-        [{ id: CLIENT_ID }],
-        [{ id: PATIENT_ID }],
-        [{ id: APPOINTMENT_ID }],
-        [{ taxRatePercent: "0.00" }],
-        [{ id: APPOINTMENT_ID, status: "in_exam" }],
-        [],
-        [{ id: PRODUCT_ID, deletedAt: null }],
-        [{ id: PRESCRIPTION_ID, productId: PRODUCT_ID, quantity: 2 }],
-        [],
-      ],
+  it("rejects legacy prescription-only charge links in new invoice input", async () => {
+    const { db, insertValues, updateSet, select } = createDb({
+      selectResults: [],
     });
 
     await expect(
@@ -850,17 +845,17 @@ describe("billing invoice integrity", () => {
           },
         ],
         isEstimate: false,
-      })
-    ).resolves.toMatchObject({ id: INVOICE_ID });
-
-    expect(updateSet).not.toHaveBeenCalled();
-    expect(insertValues).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        itemId: PRODUCT_ID,
-        sourcePrescriptionId: PRESCRIPTION_ID,
-        quantity: 2,
       }),
-    ]);
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining(
+        "Prescription-only charge links are read-only legacy data",
+      ),
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("charges a dispense-time snapshot without deducting stock and resolves visit work", async () => {
@@ -873,7 +868,6 @@ describe("billing invoice integrity", () => {
         [{ taxRatePercent: "0.00" }],
         [{ id: APPOINTMENT_ID, status: "in_exam" }],
         [],
-        [{ id: PRODUCT_ID, deletedAt: null }],
         [],
         [
           {
@@ -890,6 +884,7 @@ describe("billing invoice integrity", () => {
             invoiceId: null,
           },
         ],
+        [{ id: PRODUCT_ID, deletedAt: null }],
       ],
       updateReturns: [
         [
@@ -1126,6 +1121,7 @@ describe("billing invoice integrity", () => {
             status: "draft",
             subtotal: "50.00",
             paidAmount: "0.00",
+            updatedAt: UPDATED_AT,
           },
         ],
         [
@@ -1294,7 +1290,6 @@ describe("billing invoice integrity", () => {
         [{ taxRatePercent: "0.00" }],
         [{ id: APPOINTMENT_ID, status: "in_exam" }],
         [],
-        [{ id: PRODUCT_ID, deletedAt: null }],
         [{ id: PRESCRIPTION_ID, productId: PRODUCT_ID, quantity: 2 }],
       ],
     });
@@ -1306,7 +1301,7 @@ describe("billing invoice integrity", () => {
         appointmentId: APPOINTMENT_ID,
         items: [productLine],
         isEstimate: false,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -1340,7 +1335,7 @@ describe("billing invoice integrity", () => {
         id: INVOICE_ID,
         expectedUpdatedAt: UPDATED_AT,
         items: [productLine],
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Only an unpaid draft invoice can have its line items changed.",
@@ -1380,7 +1375,7 @@ describe("billing invoice integrity", () => {
             itemType: "service",
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -1423,117 +1418,592 @@ describe("billing invoice integrity", () => {
             itemType: "service",
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
-      message: "Invoice state changed while saving charges. Refresh and try again.",
+      message:
+        "Invoice state changed while saving charges. Refresh and try again.",
     });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("deducts product stock when converting an estimate to an invoice", async () => {
-    const { db, updateSet } = createDb({
+  it("revalidates and audits a standalone estimate before deducting product stock", async () => {
+    const { db, updateSet, insertValues, lockCalls, execute } = createDb({
       selectResults: [
+        [{ appointmentId: null }],
         [
           {
             id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: null,
+            appointmentId: null,
             total: "30.00",
             paidAmount: "0.00",
-            status: "draft",
+            status: "sent",
             isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
           },
         ],
-        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
+        [
+          {
+            description: "Medication",
+            quantity: 2,
+            unitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+            sourcePrescriptionId: null,
+            sourceDispenseChargeId: null,
+          },
+        ],
+        [{ id: PRODUCT_ID, taxable: true, stockQuantity: 10 }],
       ],
       updateReturns: [
-        [{ id: INVOICE_ID, isEstimate: false }],
         [{ id: PRODUCT_ID, stockQuantity: 8 }],
+        [{ id: INVOICE_ID, isEstimate: false, status: "draft" }],
       ],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID })
-    ).resolves.toMatchObject({ isEstimate: false });
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).resolves.toMatchObject({ isEstimate: false, status: "draft" });
 
-    expect(updateSet).toHaveBeenCalledWith({ isEstimate: false });
-    expect(updateSet).toHaveBeenCalledTimes(2);
+    // Two calls come from the protected-procedure tenant/recovery boundary;
+    // conversion adds the invoice advisory lock.
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(lockCalls.map((call) => call.mode)).toEqual([
+      "update",
+      "share",
+      "update",
+    ]);
+    expect(lockCalls.every((call) => call.inTransaction)).toBe(true);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isEstimate: false,
+        status: "draft",
+        updatedAt: expect.any(Date),
+      }),
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "estimate_converted",
+        entityType: "invoice",
+        entityId: INVOICE_ID,
+        changes: expect.objectContaining({
+          priorStatus: "sent",
+          nextStatus: "draft",
+          visitLinked: false,
+          itemCount: 1,
+          productLineCount: 1,
+        }),
+      }),
+    );
   });
 
-  it("rejects void estimate conversion before inventory changes", async () => {
-    const { db, updateSet } = createDb({
+  it("serializes a visit estimate behind invoice and appointment locks", async () => {
+    const { db, execute, lockCalls, updateSet, insertValues } = createDb({
       selectResults: [
+        [{ appointmentId: APPOINTMENT_ID }],
+        [
+          {
+            id: APPOINTMENT_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            status: "in_exam",
+          },
+        ],
         [
           {
             id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
+            total: "65.00",
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
+          },
+        ],
+        [],
+        [
+          {
+            description: "Wellness Exam",
+            quantity: 1,
+            unitPrice: "65.00",
+            itemType: "service",
+            itemId: SERVICE_ID,
+            sourcePrescriptionId: null,
+            sourceDispenseChargeId: null,
+          },
+        ],
+        [],
+        [{ id: SERVICE_ID, taxable: false }],
+      ],
+      updateReturns: [[{ id: INVOICE_ID, isEstimate: false, status: "draft" }]],
+    });
+
+    await expect(
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).resolves.toMatchObject({ isEstimate: false, status: "draft" });
+
+    // The visit path adds both invoice and appointment advisory locks after
+    // the two protected-procedure boundary calls.
+    expect(execute).toHaveBeenCalledTimes(4);
+    expect(lockCalls[0]).toMatchObject({
+      mode: "update",
+      inTransaction: true,
+      writesBeforeLock: 0,
+    });
+    expect(updateSet).toHaveBeenCalledTimes(1);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "estimate_converted",
+        changes: expect.objectContaining({ visitLinked: true }),
+      }),
+    );
+  });
+
+  it("requires an open exam before reading or changing visit estimate lines", async () => {
+    const { db, updateSet, insertValues, lockCalls } = createDb({
+      selectResults: [
+        [{ appointmentId: APPOINTMENT_ID }],
+        [
+          {
+            id: APPOINTMENT_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            status: "checked_in",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Start the exam before converting this visit estimate to an invoice.",
+    });
+
+    expect(lockCalls).toHaveLength(1);
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects a competing active visit invoice before inventory changes", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [{ appointmentId: APPOINTMENT_ID }],
+        [
+          {
+            id: APPOINTMENT_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            status: "in_exam",
+          },
+        ],
+        [
+          {
+            id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
+            total: "65.00",
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
+          },
+        ],
+        [{ id: "00000000-0000-0000-0000-000000000099" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message:
+        "This visit already has an active invoice. Open it instead of converting another estimate.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("blocks an estimate product that overlaps a dispensed visit medication", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [{ appointmentId: APPOINTMENT_ID }],
+        [
+          {
+            id: APPOINTMENT_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            status: "in_exam",
+          },
+        ],
+        [
+          {
+            id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
+            total: "30.00",
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
+          },
+        ],
+        [],
+        [
+          {
+            description: "Medication",
+            quantity: 2,
+            unitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+            sourcePrescriptionId: null,
+            sourceDispenseChargeId: null,
+          },
+        ],
+        [],
+        [{ id: DISPENSE_CHARGE_ID }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Charge this patient's already-dispensed medication from the medication billing queue so inventory is not deducted twice.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("blocks legacy prescription-sourced estimate medication before conversion", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [{ appointmentId: APPOINTMENT_ID }],
+        [
+          {
+            id: APPOINTMENT_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            status: "in_exam",
+          },
+        ],
+        [
+          {
+            id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
+            total: "30.00",
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
+          },
+        ],
+        [],
+        [
+          {
+            description: "Medication",
+            quantity: 2,
+            unitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+            sourcePrescriptionId: PRESCRIPTION_ID,
+            sourceDispenseChargeId: null,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This estimate contains a dispensed-medication line. Rebuild the medication charge from Charge capture or the medication billing queue before converting.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects void and stale estimate conversion before inventory changes", async () => {
+    const voidDb = createDb({
+      selectResults: [
+        [{ appointmentId: null }],
+        [
+          {
+            id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: null,
+            appointmentId: null,
             total: "30.00",
             paidAmount: "0.00",
             status: "void",
             isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
           },
         ],
       ],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID })
+      callerWithDb(voidDb.db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Cannot convert a void estimate.",
     });
+    expect(voidDb.updateSet).not.toHaveBeenCalled();
 
-    expect(updateSet).not.toHaveBeenCalled();
-  });
-
-  it("rejects stale estimate conversion before inventory changes", async () => {
-    const { db, updateSet } = createDb({
+    const staleDb = createDb({
       selectResults: [
+        [{ appointmentId: null }],
         [
           {
             id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: null,
+            appointmentId: null,
             total: "30.00",
             paidAmount: "0.00",
             status: "draft",
             isEstimate: true,
+            dueDate: null,
+            updatedAt: new Date(UPDATED_AT.getTime() + 1),
           },
         ],
-        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
+      ],
+    });
+    await expect(
+      callerWithDb(staleDb.db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Estimate changed. Refresh before converting it.",
+    });
+    expect(staleDb.updateSet).not.toHaveBeenCalled();
+  });
+
+  it("rolls back conversion when product stock is insufficient", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [{ appointmentId: null }],
+        [
+          {
+            id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: null,
+            appointmentId: null,
+            total: "30.00",
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
+          },
+        ],
+        [
+          {
+            description: "Medication",
+            quantity: 2,
+            unitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+            sourcePrescriptionId: null,
+            sourceDispenseChargeId: null,
+          },
+        ],
+        [{ id: PRODUCT_ID, taxable: true, stockQuantity: 1 }],
       ],
       updateReturns: [[]],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID })
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
-    expect(updateSet).toHaveBeenCalledWith({ isEstimate: false });
+    expect(updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ isEstimate: false }),
+    );
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("rejects conversion when product stock is insufficient", async () => {
-    const { db, updateSet } = createDb({
+  it("fails the conversion CAS without committing an audit after stock validation", async () => {
+    const { db, updateSet, insertValues } = createDb({
       selectResults: [
+        [{ appointmentId: null }],
         [
           {
             id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: null,
+            appointmentId: null,
             total: "30.00",
             paidAmount: "0.00",
             status: "draft",
             isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
           },
         ],
-        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
+        [
+          {
+            description: "Medication",
+            quantity: 2,
+            unitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+            sourcePrescriptionId: null,
+            sourceDispenseChargeId: null,
+          },
+        ],
+        [{ id: PRODUCT_ID, taxable: true, stockQuantity: 10 }],
       ],
-      updateReturns: [[{ id: INVOICE_ID, isEstimate: false }], []],
+      updateReturns: [[{ id: PRODUCT_ID, stockQuantity: 8 }], []],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID })
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Estimate changed while converting. Refresh and try again.",
+    });
 
-    expect(updateSet).toHaveBeenCalledWith({ isEstimate: false });
     expect(updateSet).toHaveBeenCalledTimes(2);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("keeps conversion validation, stock movement, CAS, and audit in one ordered transaction", () => {
+    const source = readFileSync("server/routers/billing.ts", "utf8");
+    const block = source.slice(
+      source.indexOf("convertEstimateToInvoice:"),
+      source.indexOf("\n});", source.indexOf("convertEstimateToInvoice:")),
+    );
+    const transaction = block.indexOf("return ctx.db.transaction");
+    const invoiceLock = block.indexOf(
+      "pg_advisory_xact_lock(hashtextextended(${input.id}, 0))",
+    );
+    const appointmentLock = block.indexOf(
+      "pg_advisory_xact_lock(hashtextextended(${identity.appointmentId}, 0))",
+    );
+    const itemRead = block.indexOf("const items = await tx");
+    const prescriptionValidation = block.indexOf(
+      "await assertPrescriptionChargeSources",
+    );
+    const dispenseValidation = block.indexOf(
+      "await assertDispenseChargeSources",
+    );
+    const productLock = block.indexOf("await assertLineItemReferences");
+    const stockDeduction = block.indexOf("await deductProductStock");
+    const conversionWrite = block.indexOf(".update(invoices)", stockDeduction);
+    const auditWrite = block.indexOf('action: "estimate_converted"');
+
+    expect(transaction).toBeGreaterThan(-1);
+    expect(invoiceLock).toBeGreaterThan(transaction);
+    expect(appointmentLock).toBeGreaterThan(invoiceLock);
+    expect(itemRead).toBeGreaterThan(appointmentLock);
+    expect(prescriptionValidation).toBeGreaterThan(itemRead);
+    expect(dispenseValidation).toBeGreaterThan(prescriptionValidation);
+    expect(productLock).toBeGreaterThan(dispenseValidation);
+    expect(stockDeduction).toBeGreaterThan(productLock);
+    expect(conversionWrite).toBeGreaterThan(stockDeduction);
+    expect(auditWrite).toBeGreaterThan(conversionWrite);
+    expect(block).toContain("invoiceUpdatedAtMatches(input.expectedUpdatedAt)");
+    expect(block).toContain("noActivePaymentsForInvoice()");
+    expect(block).toContain("noActiveAdjustmentsForInvoice()");
+  });
+
+  it("prelocks the sorted union of prior and replacement product rows", () => {
+    const source = readFileSync("server/routers/billing.ts", "utf8");
+    const helper = source.slice(
+      source.indexOf("async function assertLineItemReferences"),
+      source.indexOf("function invoiceLineTaxable"),
+    );
+    expect(helper).toContain(
+      "const previousProductQuantities = quantitiesFor(",
+    );
+    expect(helper).toContain(
+      "...new Set([...productIds, ...previousProductQuantities.keys()])",
+    );
+    expect(helper).toContain("inArray(products.id, productIdsToLock)");
+    expect(helper.indexOf(".orderBy(products.id)")).toBeLessThan(
+      helper.indexOf('.for("update")'),
+    );
+  });
+
+  it("prelocks void inventory before mutating the invoice or restoring stock", () => {
+    const source = readFileSync("server/routers/billing.ts", "utf8");
+    const block = source.slice(
+      source.indexOf("voidInvoice:"),
+      source.indexOf("convertEstimateToInvoice:"),
+    );
+    const invoiceAdvisory = block.indexOf("pg_advisory_xact_lock");
+    const stockRead = block.indexOf("const stockItems");
+    const productLocks = block.indexOf("await assertLineItemReferences");
+    const invoiceWrite = block.indexOf(".update(invoices)");
+    const stockRestore = block.indexOf("await restoreProductStock");
+
+    expect(invoiceAdvisory).toBeGreaterThan(-1);
+    expect(stockRead).toBeGreaterThan(invoiceAdvisory);
+    expect(productLocks).toBeGreaterThan(stockRead);
+    expect(invoiceWrite).toBeGreaterThan(productLocks);
+    expect(stockRestore).toBeGreaterThan(invoiceWrite);
+    const stockReadHelper = source.slice(
+      source.indexOf("async function invoiceProductItemsForStock"),
+      source.indexOf("async function restoreProductStock"),
+    );
+    expect(stockReadHelper).toContain(
+      ".orderBy(invoiceItems.itemId, invoiceItems.id)",
+    );
   });
 
   it("rejects voiding through the generic status endpoint", async () => {
@@ -1543,7 +2013,7 @@ describe("billing invoice integrity", () => {
       callerWithDb(db).updateInvoiceStatus({
         id: INVOICE_ID,
         status: "void",
-      } as never)
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -1574,11 +2044,11 @@ describe("billing invoice integrity", () => {
       callerWithDb(db).updateInvoiceStatus({
         id: INVOICE_ID,
         status: "sent",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
-        "Resolve every performed vaccination, lab, procedure, and prescription before sending or collecting this visit invoice.",
+        "Resolve every performed vaccination, lab, procedure, prescription, and medication dispense before sending or collecting this visit invoice.",
     });
     expect(execute).toHaveBeenCalledTimes(8);
     expect(updateSet).not.toHaveBeenCalled();
@@ -1607,7 +2077,7 @@ describe("billing invoice integrity", () => {
       callerWithDb(db).updateInvoiceStatus({
         id: INVOICE_ID,
         status: "sent",
-      })
+      }),
     ).resolves.toMatchObject({ status: "sent" });
     expect(updateSet).toHaveBeenCalledWith({ status: "sent" });
   });
@@ -1622,12 +2092,14 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "sent",
             isEstimate: false,
+            updatedAt: UPDATED_AT,
           },
         ],
         [],
         [],
         [],
         [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
+        [{ id: PRODUCT_ID, deletedAt: null, taxable: true }],
       ],
       updateReturns: [
         [{ id: INVOICE_ID, status: "void", isEstimate: false }],
@@ -1639,10 +2111,13 @@ describe("billing invoice integrity", () => {
       callerWithDb(db).voidInvoice({
         id: INVOICE_ID,
         reason: "Duplicate invoice",
-      })
+      }),
     ).resolves.toMatchObject({ status: "void" });
 
-    expect(updateSet).toHaveBeenNthCalledWith(1, { status: "void" });
+    expect(updateSet).toHaveBeenNthCalledWith(1, {
+      status: "void",
+      updatedAt: expect.any(Date),
+    });
     expect(updateSet).toHaveBeenNthCalledWith(2, {
       stockQuantity: expect.anything(),
     });
@@ -1660,6 +2135,7 @@ describe("billing invoice integrity", () => {
             status: "sent",
             isEstimate: false,
             appointmentId: APPOINTMENT_ID,
+            updatedAt: UPDATED_AT,
           },
         ],
         [{ id: APPOINTMENT_ID }],
@@ -1684,7 +2160,7 @@ describe("billing invoice integrity", () => {
         invoiceItemId: null,
         resolvedBy: null,
         resolvedAt: null,
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1697,7 +2173,7 @@ describe("billing invoice integrity", () => {
           nextStatus: "void",
           reopenedVisitWorkItemIds: [workItemId],
         }),
-      })
+      }),
     );
   });
 
@@ -1712,6 +2188,7 @@ describe("billing invoice integrity", () => {
             status: "sent",
             isEstimate: false,
             appointmentId: APPOINTMENT_ID,
+            updatedAt: UPDATED_AT,
           },
         ],
         [{ id: APPOINTMENT_ID }],
@@ -1723,7 +2200,7 @@ describe("billing invoice integrity", () => {
       callerWithDb(db).voidInvoice({
         id: INVOICE_ID,
         reason: "Duplicate invoice",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -1754,7 +2231,7 @@ describe("billing invoice integrity", () => {
       callerWithDb(db).voidInvoice({
         id: INVOICE_ID,
         reason: "Duplicate invoice",
-      })
+      }),
     ).resolves.toMatchObject({ status: "void" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -1770,8 +2247,12 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "sent",
             isEstimate: false,
+            updatedAt: UPDATED_AT,
           },
         ],
+        [],
+        [],
+        [],
         [],
       ],
       updateReturns: [[]],
@@ -1781,10 +2262,13 @@ describe("billing invoice integrity", () => {
       callerWithDb(db).voidInvoice({
         id: INVOICE_ID,
         reason: "Duplicate invoice",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
-    expect(updateSet).toHaveBeenCalledWith({ status: "void" });
+    expect(updateSet).toHaveBeenCalledWith({
+      status: "void",
+      updatedAt: expect.any(Date),
+    });
   });
 });

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -56,7 +56,7 @@ function createDb(opts: {
     builder.for = vi.fn(async () => result);
     builder.then = (
       resolve: (value: unknown[]) => unknown,
-      reject?: (error: unknown) => unknown
+      reject?: (error: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject);
     return builder;
   });
@@ -177,7 +177,7 @@ describe("encounter closeout database locking", () => {
   it("locks only the appointment row when its optional type is left joined", () => {
     const source = readFileSync(
       new URL("../routers/encounters.ts", import.meta.url),
-      "utf8"
+      "utf8",
     );
 
     expect(source).toContain('.for("update", { of: appointments })');
@@ -186,14 +186,14 @@ describe("encounter closeout database locking", () => {
   it("preserves visit-work resolver attribution after staff deactivation", () => {
     const source = readFileSync(
       new URL("../routers/encounters.ts", import.meta.url),
-      "utf8"
+      "utf8",
     );
 
     expect(source).toMatch(
-      /leftJoin\(\s*users,\s*and\(\s*eq\(visitWorkItems\.resolvedBy, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\)\s*,?\s*\)\s*,?\s*\)/s
+      /leftJoin\(\s*users,\s*and\(\s*eq\(visitWorkItems\.resolvedBy, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\)\s*,?\s*\)\s*,?\s*\)/s,
     );
     expect(source).not.toMatch(
-      /eq\(visitWorkItems\.resolvedBy, users\.id\)[\s\S]{0,120}?isNull\(users\.deletedAt\)/s
+      /eq\(visitWorkItems\.resolvedBy, users\.id\)[\s\S]{0,120}?isNull\(users\.deletedAt\)/s,
     );
   });
 });
@@ -213,9 +213,11 @@ describe("encounter prescription lifecycle semantics", () => {
     expect(finalizeMedicationQuery).toContain("prescriptions.endDate");
     expect(finalizeMedicationQuery).toContain("appointment.practiceTimezone");
     expect(routerSource).toContain("medications: medicationHistory");
+    expect(routerSource).toContain("const chargeCaptureMedications = [");
     expect(routerSource).toContain(
-      'medication.effectiveStatus === "active"',
+      "eq(dispenseChargeQueue.appointmentId, input.appointmentId)",
     );
+    expect(routerSource).toContain('medication.effectiveStatus === "active"');
 
     const pageSource = readFileSync(
       new URL(
@@ -267,7 +269,7 @@ describe("encounter closeout safety", () => {
     });
     expect(error).toMatchObject({
       code: "PRECONDITION_FAILED",
-      message: expect.stringContaining("Resolve every performed vaccination"),
+      message: expect.stringContaining("medication dispense"),
     });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -300,7 +302,7 @@ describe("encounter closeout safety", () => {
         chargeDisposition: "no_charge",
         noChargeReason: "Complimentary postoperative recheck",
         handoffMethod: "verbal",
-      })
+      }),
     ).resolves.toEqual({ closeout: completed, appointment: checkedOut });
 
     expect(updateSet).toHaveBeenNthCalledWith(
@@ -309,7 +311,7 @@ describe("encounter closeout safety", () => {
         status: "completed",
         chargeDisposition: "no_charge",
         revision: 3,
-      })
+      }),
     );
     expect(updateSet).toHaveBeenNthCalledWith(2, { status: "checked_out" });
   });
@@ -335,7 +337,7 @@ describe("encounter closeout safety", () => {
         chargeDisposition: "no_charge",
         noChargeReason: "Complimentary recheck",
         handoffMethod: "print",
-      })
+      }),
     ).resolves.toEqual({ closeout: completed, appointment: checkedOut });
     expect(updateSet).not.toHaveBeenCalled();
   });
@@ -352,7 +354,7 @@ describe("encounter closeout safety", () => {
         chargeDisposition: "no_charge",
         noChargeReason: "Complimentary recheck",
         handoffMethod: "verbal",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Finalize the clinical handoff before completing the visit.",
@@ -382,7 +384,7 @@ describe("encounter closeout safety", () => {
         chargeDisposition: "no_charge",
         noChargeReason: "Complimentary recheck",
         handoffMethod: "verbal",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -418,7 +420,7 @@ describe("encounter closeout safety", () => {
         chargeDisposition: "paid",
         noChargeReason: null,
         handoffMethod: "print",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "The visit invoice is not fully paid.",
@@ -463,7 +465,7 @@ describe("encounter closeout safety", () => {
         chargeDisposition,
         noChargeReason: null,
         handoffMethod: "print",
-      })
+      }),
     ).resolves.toEqual({ closeout: completed, appointment: checkedOut });
     expect(updateSet).toHaveBeenNthCalledWith(
       1,
@@ -471,7 +473,7 @@ describe("encounter closeout safety", () => {
         status: "completed",
         chargeDisposition,
         invoiceId: INVOICE_ID,
-      })
+      }),
     );
   });
 
@@ -614,8 +616,7 @@ describe("encounter closeout safety", () => {
       }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
-      message:
-        "Invoice changed while preparing pay later. Refresh and retry.",
+      message: "Invoice changed while preparing pay later. Refresh and retry.",
     });
     expect(updateSet).toHaveBeenCalledTimes(1);
   });
@@ -629,7 +630,7 @@ describe("encounter closeout safety", () => {
       callerWithDb(db, "veterinarian").finalizeClinical({
         ...clinicalInput,
         documentationExceptionReason: null,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Finalize the SOAP draft or document why SOAP is not required.",
@@ -695,7 +696,7 @@ describe("encounter closeout safety", () => {
     });
 
     await expect(
-      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput)
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput),
     ).resolves.toEqual(finalized);
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -705,7 +706,7 @@ describe("encounter closeout safety", () => {
         clinicalFinalizerName: "Clinic User",
         medicationSnapshot: [],
         revision: 1,
-      })
+      }),
     );
   });
 
@@ -740,10 +741,10 @@ describe("encounter closeout safety", () => {
       callerWithDb(db, "veterinarian").finalizeClinical({
         ...clinicalInput,
         prescriptionDisposition: "prescribed",
-      })
+      }),
     ).resolves.toEqual(finalized);
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ medicationSnapshot: [medication] })
+      expect.objectContaining({ medicationSnapshot: [medication] }),
     );
   });
 
@@ -769,7 +770,7 @@ describe("encounter closeout safety", () => {
     });
 
     await expect(
-      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput)
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -786,7 +787,7 @@ describe("encounter closeout safety", () => {
       ],
     });
     await expect(
-      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput)
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Start the exam before preparing the clinical closeout.",
@@ -797,7 +798,7 @@ describe("encounter closeout safety", () => {
   it("keeps front desk users from authoring clinical content", async () => {
     const { db, select } = createDb({});
     await expect(
-      callerWithDb(db, "front_desk").finalizeClinical(clinicalInput)
+      callerWithDb(db, "front_desk").finalizeClinical(clinicalInput),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(select).not.toHaveBeenCalled();
   });
@@ -822,18 +823,18 @@ describe("encounter closeout safety", () => {
         appointmentId: APPOINTMENT_ID,
         expectedRevision: 2,
         reason: "Correct the dosage wording",
-      })
+      }),
     ).resolves.toEqual(reopened);
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         revision: 3,
         amendmentDraft: expect.objectContaining({
-            baseRevision: 2,
-            reason: "Correct the dosage wording",
-            reopenedBy: USER_ID,
-            dischargeInstructions: "Give with food.",
-          }),
-      })
+          baseRevision: 2,
+          reason: "Correct the dosage wording",
+          reopenedBy: USER_ID,
+          dischargeInstructions: "Give with food.",
+        }),
+      }),
     );
     const values = updateSet.mock.calls[0]![0] as Record<string, unknown>;
     expect(values).not.toHaveProperty("status");
@@ -870,7 +871,7 @@ describe("encounter closeout safety", () => {
         ...clinicalInput,
         expectedRevision: 3,
         dischargeInstructions: "Give one tablet with food.",
-      })
+      }),
     ).resolves.toEqual(saved);
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -916,7 +917,7 @@ describe("encounter closeout safety", () => {
         appointmentId: APPOINTMENT_ID,
         expectedRevision: 3,
         reason: "Correct the dosage wording",
-      })
+      }),
     ).resolves.toEqual(completedWithDraft);
     const openValues = openDb.updateSet.mock.calls[0]![0] as Record<
       string,
@@ -949,7 +950,7 @@ describe("encounter closeout safety", () => {
         ...clinicalInput,
         expectedRevision: 4,
         dischargeInstructions: "Give one tablet with food.",
-      })
+      }),
     ).resolves.toEqual(promoted);
 
     expect(promoteDb.updateSet).toHaveBeenCalledWith(
@@ -966,7 +967,7 @@ describe("encounter closeout safety", () => {
           }),
         ],
         revision: 5,
-      })
+      }),
     );
     const promoteValues = promoteDb.updateSet.mock.calls[0]![0] as Record<
       string,
@@ -979,8 +980,7 @@ describe("encounter closeout safety", () => {
 
   it("preserves operational resolution when an amendment leaves the needed follow-up unchanged", async () => {
     const checkedOut = { ...openAppointment, status: "checked_out" };
-    const resolutionAppointmentId =
-      "00000000-0000-0000-0000-000000000008";
+    const resolutionAppointmentId = "00000000-0000-0000-0000-000000000008";
     const resolvedAt = new Date("2026-08-09T17:00:00.000Z");
     const resolutionScheduledAt = new Date("2099-01-02T17:00:00.000Z");
     const completedWithDraft = {
@@ -1037,7 +1037,7 @@ describe("encounter closeout safety", () => {
         followUpDisposition: "needed",
         followUpDueDate: "2099-01-01",
         followUpAssignedTo: ASSIGNEE_ID,
-      })
+      }),
     ).resolves.toEqual(finalized);
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1054,7 +1054,7 @@ describe("encounter closeout safety", () => {
             followUpResolvedBy: USER_ID,
           }),
         ],
-      })
+      }),
     );
   });
 
@@ -1086,7 +1086,7 @@ describe("encounter closeout safety", () => {
         followUpDisposition: "needed",
         followUpDueDate: "2099-01-01",
         followUpAssignedTo: ASSIGNEE_ID,
-      })
+      }),
     ).resolves.toEqual(finalized);
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1096,7 +1096,7 @@ describe("encounter closeout safety", () => {
         followUpAssigneeName: "Alex Coordinator",
         followUpAppointmentId: null,
         followUpScheduledAt: null,
-      })
+      }),
     );
   });
 
@@ -1112,7 +1112,7 @@ describe("encounter closeout safety", () => {
     const { db } = createDb({ selectResults: [[pending]] });
 
     await expect(
-      callerWithDb(db, "front_desk").listPendingFollowUps()
+      callerWithDb(db, "front_desk").listPendingFollowUps(),
     ).resolves.toEqual([pending]);
   });
 
@@ -1163,7 +1163,7 @@ describe("encounter closeout safety", () => {
         resolution: "scheduled",
         resolutionAppointmentId: scheduledAppointment.id,
         notes: null,
-      })
+      }),
     ).resolves.toEqual(resolved);
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1173,7 +1173,7 @@ describe("encounter closeout safety", () => {
         followUpResolvedBy: USER_ID,
         followUpResolverName: "Clinic User",
         revision: 5,
-      })
+      }),
     );
     const values = updateSet.mock.calls[0]![0] as Record<string, unknown>;
     expect(values).not.toHaveProperty("followUpDisposition");
@@ -1186,7 +1186,7 @@ describe("encounter closeout safety", () => {
       selectResults: [[openAppointment], [{ id: PATIENT_ID }]],
     });
     await expect(
-      callerWithDb(db, "technician").finalizeClinical(clinicalInput)
+      callerWithDb(db, "technician").finalizeClinical(clinicalInput),
     ).rejects.toMatchObject({
       code: "FORBIDDEN",
       message:
@@ -1241,7 +1241,7 @@ describe("encounter closeout safety", () => {
   it("fails closed for a missing or cross-tenant appointment", async () => {
     const { db, updateSet, insertValues } = createDb({ selectResults: [[]] });
     await expect(
-      callerWithDb(db).saveDraft(clinicalInput)
+      callerWithDb(db).saveDraft(clinicalInput),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
     expect(updateSet).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();

--- a/apps/web/server/__tests__/records-prescription-lifecycle.test.ts
+++ b/apps/web/server/__tests__/records-prescription-lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -116,6 +117,27 @@ afterEach(() => {
 });
 
 describe("prescription lifecycle mutations", () => {
+  it("locks a visit-linked refill in appointment then prescription order", () => {
+    const source = readFileSync("server/routers/records.ts", "utf8");
+    const block = source.slice(
+      source.indexOf("recordPrescriptionRefill:"),
+      source.indexOf(
+        "cancelPrescription:",
+        source.indexOf("recordPrescriptionRefill:"),
+      ),
+    );
+    const routeRead = block.indexOf("const [prescriptionIdentity]");
+    const appointmentLock = block.indexOf("lockOpenAppointmentForClinicalWork");
+    const prescriptionLock = block.indexOf("lockPrescriptionForLifecycle");
+    const productWrite = block.indexOf("deductDispensedProductStock");
+
+    expect(routeRead).toBeGreaterThan(-1);
+    expect(appointmentLock).toBeGreaterThan(routeRead);
+    expect(prescriptionLock).toBeGreaterThan(appointmentLock);
+    expect(productWrite).toBeGreaterThan(prescriptionLock);
+    expect(block).toContain("prescription.patientId !== routedPatientId");
+  });
+
   it("deducts stock, decrements refills, and appends one attributed event", async () => {
     const updated = activePrescription({ refillsRemaining: 1 });
     const event = {

--- a/apps/web/server/__tests__/templates-safety.test.ts
+++ b/apps/web/server/__tests__/templates-safety.test.ts
@@ -48,7 +48,7 @@ function createDb(opts?: {
     for: ReturnType<typeof vi.fn>;
     then: (
       resolve: (value: unknown[]) => unknown,
-      reject?: (error: unknown) => unknown
+      reject?: (error: unknown) => unknown,
     ) => Promise<unknown>;
   };
   const select = vi.fn(() => {
@@ -59,7 +59,7 @@ function createDb(opts?: {
       for: lockFor,
       then: (
         resolve: (value: unknown[]) => unknown,
-        reject?: (error: unknown) => unknown
+        reject?: (error: unknown) => unknown,
       ) => Promise.resolve(result).then(resolve, reject),
     };
     afterWhereForCurrentSelect = afterWhere;
@@ -79,7 +79,9 @@ function createDb(opts?: {
 
   const updateResults = [...(opts?.updateResults ?? [])];
   const updateReturning = vi.fn(async () =>
-    updateResults.length > 0 ? updateResults.shift() : (opts?.updatedRows ?? [])
+    updateResults.length > 0
+      ? updateResults.shift()
+      : (opts?.updatedRows ?? []),
   );
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
@@ -126,7 +128,7 @@ describe("treatment template safety", () => {
             sortOrder: 0,
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -137,7 +139,7 @@ describe("treatment template safety", () => {
         defaultQuantity: 1,
         defaultUnitPrice: "100000000",
         sortOrder: 0,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -158,7 +160,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).create({
         name: "Dental package",
         items: [unlinkedProduct],
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: expect.stringContaining("active inventory product"),
@@ -168,7 +170,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).addItem({
         templateId: TEMPLATE_ID,
         ...unlinkedProduct,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: expect.stringContaining("active inventory product"),
@@ -185,7 +187,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).create({
         name: " ".repeat(4),
         items: [],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -193,7 +195,7 @@ describe("treatment template safety", () => {
         name: "Dental package",
         description: "d".repeat(2001),
         items: [],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -201,7 +203,7 @@ describe("treatment template safety", () => {
         name: "Dental package",
         category: "c".repeat(129),
         items: [],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -214,7 +216,7 @@ describe("treatment template safety", () => {
           defaultUnitPrice: "75.00",
           sortOrder: 0,
         })),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -225,7 +227,7 @@ describe("treatment template safety", () => {
         defaultQuantity: 2,
         defaultUnitPrice: "99999999.99",
         sortOrder: 0,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -236,14 +238,14 @@ describe("treatment template safety", () => {
         defaultQuantity: 1,
         defaultUnitPrice: "75.00",
         sortOrder: 10001,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).update({
         id: TEMPLATE_ID,
         name: " ".repeat(4),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -251,32 +253,29 @@ describe("treatment template safety", () => {
     expect(updateSet).not.toHaveBeenCalled();
   });
 
-  it(
-    "requires referenced product items to belong to the practice before creating a template",
-    async () => {
-      const { db, insertValues } = createDb({
-        selectResults: [[{ id: PRACTICE_ID }], []],
-      });
+  it("requires referenced product items to belong to the practice before creating a template", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [[{ id: PRACTICE_ID }], []],
+    });
 
-      await expect(
-        callerWithDb(db).create({
-          name: "Dental package",
-          items: [
-            {
-              itemType: "product",
-              itemId: PRODUCT_ID,
-              description: "Dental chews",
-              defaultQuantity: 1,
-              defaultUnitPrice: "12.00",
-              sortOrder: 0,
-            },
-          ],
-        })
-      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    await expect(
+      callerWithDb(db).create({
+        name: "Dental package",
+        items: [
+          {
+            itemType: "product",
+            itemId: PRODUCT_ID,
+            description: "Dental chews",
+            defaultQuantity: 1,
+            defaultUnitPrice: "12.00",
+            sortOrder: 0,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
-      expect(insertValues).not.toHaveBeenCalled();
-    }
-  );
+    expect(insertValues).not.toHaveBeenCalled();
+  });
 
   it("lists active tenant inventory products for template setup", async () => {
     const productOptions = [
@@ -291,7 +290,9 @@ describe("treatment template safety", () => {
       selectResults: [[{ id: PRACTICE_ID }], productOptions],
     });
 
-    await expect(callerWithDb(db).listProducts()).resolves.toEqual(productOptions);
+    await expect(callerWithDb(db).listProducts()).resolves.toEqual(
+      productOptions,
+    );
     expect(select).toHaveBeenCalledTimes(2);
   });
 
@@ -299,20 +300,22 @@ describe("treatment template safety", () => {
     const { db, select } = createDb();
 
     await expect(
-      callerWithDb(db, "veterinarian").listProducts()
+      callerWithDb(db, "veterinarian").listProducts(),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(select).not.toHaveBeenCalled();
 
     const source = readFileSync("server/routers/templates.ts", "utf8");
     const listProductsBlock = source.slice(
       source.indexOf("listProducts:"),
-      source.indexOf("getById:")
+      source.indexOf("getById:"),
     );
     expect(listProductsBlock).toContain('requireRole("admin")');
     expect(listProductsBlock).toContain(
-      "eq(products.practiceId, ctx.practiceId)"
+      "eq(products.practiceId, ctx.practiceId)",
     );
-    expect(listProductsBlock).toContain("activePracticePredicate(ctx.practiceId)");
+    expect(listProductsBlock).toContain(
+      "activePracticePredicate(ctx.practiceId)",
+    );
     expect(listProductsBlock).toContain("isNull(products.deletedAt)");
   });
 
@@ -375,7 +378,7 @@ describe("treatment template safety", () => {
     const source = readFileSync("server/routers/templates.ts", "utf8");
     const detailBlock = source.slice(
       source.indexOf("getById:"),
-      source.indexOf("create: protectedProcedure")
+      source.indexOf("create: protectedProcedure"),
     );
     expect(detailBlock).toContain("inArray(products.id, linkedProductIds)");
     expect(detailBlock).toContain("eq(products.practiceId, ctx.practiceId)");
@@ -403,13 +406,13 @@ describe("treatment template safety", () => {
             sortOrder: 0,
           },
         ],
-      })
+      }),
     ).resolves.toMatchObject({ id: TEMPLATE_ID });
 
     expect(transaction).toHaveBeenCalled();
     expect(lockFor).toHaveBeenCalledWith("share");
     expect(lockFor.mock.invocationCallOrder[0]).toBeLessThan(
-      insertValues.mock.invocationCallOrder[0]!
+      insertValues.mock.invocationCallOrder[0]!,
     );
     expect(insertValues).toHaveBeenNthCalledWith(
       1,
@@ -418,7 +421,7 @@ describe("treatment template safety", () => {
         name: "Dental package",
         description: "Common oral-health estimate",
         category: "Dentistry",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenNthCalledWith(2, [
       expect.objectContaining({
@@ -450,13 +453,13 @@ describe("treatment template safety", () => {
         defaultQuantity: 1,
         defaultUnitPrice: " 75.00 ",
         sortOrder: 1,
-      })
+      }),
     ).resolves.toMatchObject({ id: ITEM_ID });
 
     expect(transaction).toHaveBeenCalled();
     expect(lockFor).toHaveBeenCalledWith("share");
     expect(lockFor.mock.invocationCallOrder[0]).toBeLessThan(
-      insertValues.mock.invocationCallOrder[0]!
+      insertValues.mock.invocationCallOrder[0]!,
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -465,7 +468,7 @@ describe("treatment template safety", () => {
         itemId: SERVICE_ID,
         description: "Exam",
         defaultUnitPrice: "75.00",
-      })
+      }),
     );
   });
 
@@ -483,7 +486,7 @@ describe("treatment template safety", () => {
         defaultQuantity: 1,
         defaultUnitPrice: "75.00",
         sortOrder: 0,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -495,7 +498,7 @@ describe("treatment template safety", () => {
     });
 
     await expect(
-      callerWithDb(db).removeItem({ id: ITEM_ID })
+      callerWithDb(db).removeItem({ id: ITEM_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -511,7 +514,7 @@ describe("treatment template safety", () => {
     });
 
     await expect(
-      callerWithDb(db).removeItem({ id: ITEM_ID })
+      callerWithDb(db).removeItem({ id: ITEM_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: expect.any(Date) });
@@ -557,7 +560,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).resolves.toMatchObject({
       id: INVOICE_ID,
       total: "165.00",
@@ -574,9 +577,11 @@ describe("treatment template safety", () => {
       subtotal: "150.00",
       tax: "15.00",
       total: "165.00",
+      updatedAt: expect.anything(),
     });
-    expect(lockFor).toHaveBeenCalledTimes(1);
-    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor).toHaveBeenCalledTimes(2);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "share");
     expect(execute).toHaveBeenCalled();
   });
 
@@ -609,7 +614,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: expect.stringContaining("active inventory product"),
@@ -693,7 +698,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).resolves.toMatchObject({ id: INVOICE_ID, total: "185.00" });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -702,11 +707,12 @@ describe("treatment template safety", () => {
         expect.objectContaining({ itemId: SECOND_SERVICE_ID }),
         expect.objectContaining({ itemId: PRODUCT_ID }),
         expect.objectContaining({ itemId: SECOND_PRODUCT_ID }),
-      ])
+      ]),
     );
-    expect(lockFor).toHaveBeenCalledTimes(2);
-    expect(lockFor).toHaveBeenNthCalledWith(1, "share");
+    expect(lockFor).toHaveBeenCalledTimes(3);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
     expect(lockFor).toHaveBeenNthCalledWith(2, "share");
+    expect(lockFor).toHaveBeenNthCalledWith(3, "share");
     // Four request setup/read queries + two catalog batches + totals + tax.
     expect(select).toHaveBeenCalledTimes(8);
   });
@@ -747,7 +753,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).resolves.toMatchObject({
       id: INVOICE_ID,
       total: "36.00",
@@ -768,6 +774,7 @@ describe("treatment template safety", () => {
       subtotal: "36.00",
       tax: "0.00",
       total: "36.00",
+      updatedAt: expect.anything(),
     });
     expect(lockFor).toHaveBeenCalledWith("update");
   });
@@ -807,7 +814,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).resolves.toMatchObject({ id: INVOICE_ID });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
@@ -815,6 +822,7 @@ describe("treatment template safety", () => {
       subtotal: "36.00",
       tax: "0.00",
       total: "36.00",
+      updatedAt: expect.anything(),
     });
   });
 
@@ -849,7 +857,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -878,10 +886,10 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
-    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transaction).toHaveBeenCalledTimes(2);
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
   });
@@ -906,10 +914,10 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
-    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transaction).toHaveBeenCalledTimes(2);
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
   });
@@ -944,7 +952,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -981,7 +989,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Service not found",
@@ -989,8 +997,9 @@ describe("treatment template safety", () => {
 
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
-    expect(lockFor).toHaveBeenCalledTimes(1);
-    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor).toHaveBeenCalledTimes(2);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "share");
   });
 
   it("rejects product references that are not active in the tenant", async () => {
@@ -1023,7 +1032,7 @@ describe("treatment template safety", () => {
       callerWithDb(db).applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Product not found",
@@ -1031,15 +1040,16 @@ describe("treatment template safety", () => {
 
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
-    expect(lockFor).toHaveBeenCalledTimes(1);
-    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor).toHaveBeenCalledTimes(2);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "share");
   });
 
   it("keeps batched catalog locks active, tenant-scoped, and deterministic", () => {
     const source = readFileSync("server/routers/templates.ts", "utf8");
     const block = source.slice(
       source.indexOf("async function lockActiveTemplateCatalogItems"),
-      source.indexOf("async function deductTemplateProductStock")
+      source.indexOf("async function deductTemplateProductStock"),
     );
 
     expect(block).toContain("inArray(services.id, serviceIds)");
@@ -1055,6 +1065,10 @@ describe("treatment template safety", () => {
     const applyBlock = source.slice(source.indexOf("applyToInvoice:"));
     expect(applyBlock).toContain("pg_advisory_xact_lock");
     expect(applyBlock).toContain("hashtextextended(${input.invoiceId}, 0)");
+    expect(applyBlock.indexOf("pg_advisory_xact_lock")).toBeLessThan(
+      applyBlock.indexOf('.for("update")'),
+    );
+    expect(applyBlock).toContain("updatedAt: nextInvoiceUpdatedAtSql()");
   });
 
   it("rejects template reads and writes when the practice is missing or deleted", async () => {
@@ -1079,14 +1093,14 @@ describe("treatment template safety", () => {
     });
 
     await expect(
-      caller.create({ name: "Dental package", items: [] })
+      caller.create({ name: "Dental package", items: [] }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
     });
 
     await expect(
-      caller.update({ id: TEMPLATE_ID, name: "Dental package" })
+      caller.update({ id: TEMPLATE_ID, name: "Dental package" }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -1105,7 +1119,7 @@ describe("treatment template safety", () => {
         defaultQuantity: 1,
         defaultUnitPrice: "75.00",
         sortOrder: 0,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -1120,7 +1134,7 @@ describe("treatment template safety", () => {
       caller.applyToInvoice({
         templateId: TEMPLATE_ID,
         invoiceId: INVOICE_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",

--- a/apps/web/server/__tests__/visit-work-reconciliation.test.ts
+++ b/apps/web/server/__tests__/visit-work-reconciliation.test.ts
@@ -143,6 +143,12 @@ describe("visit work reconciliation", () => {
     expect(integritySource).toMatch(
       /select \$\{labResults\.id\} as id[\s\S]*order by \$\{labResults\.id\}[\s\S]*\) as lab_source/,
     );
+    expect(integritySource).toContain(
+      "${dispenseChargeQueue.appointmentId} = ${appointmentId}",
+    );
+    expect(integritySource).toContain(
+      "${dispenseChargeQueue.status} = 'pending'",
+    );
   });
 
   it("does not create unresolved ledger work for a historical closed visit", async () => {
@@ -158,7 +164,7 @@ describe("visit work reconciliation", () => {
     await expect(
       callerWithDb(db).getVisitReconciliation({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).resolves.toMatchObject({ unresolvedCount: 0, items: [] });
     // The tenant-context statement still runs, but no source upserts do.
     expect(execute).toHaveBeenCalledTimes(1);
@@ -167,32 +173,32 @@ describe("visit work reconciliation", () => {
   it("serializes vaccination correction and work materialization on the source row", () => {
     const integrity = readFileSync(
       new URL("../visit-billing-integrity.ts", import.meta.url),
-      "utf8"
+      "utf8",
     );
     const records = readFileSync(
       new URL("../routers/records.ts", import.meta.url),
-      "utf8"
+      "utf8",
     );
 
     const syncTransaction = integrity.indexOf("await ctx.db.transaction");
     const syncSourceLock = integrity.indexOf(
       "select ${vaccinationRecords.id}",
-      syncTransaction
+      syncTransaction,
     );
     const syncInsert = integrity.indexOf(
       "insert into ${visitWorkItems}",
-      syncSourceLock
+      syncSourceLock,
     );
     const freshCorrectionCheck = integrity.indexOf(
       "from ${clinicalRecordCorrections} as vaccination_correction",
-      syncInsert
+      syncInsert,
     );
     expect(syncTransaction).toBeGreaterThanOrEqual(0);
     expect(syncSourceLock).toBeGreaterThan(syncTransaction);
     expect(syncInsert).toBeGreaterThan(syncSourceLock);
     expect(freshCorrectionCheck).toBeGreaterThan(syncInsert);
     expect(integrity.slice(syncSourceLock, syncInsert)).toContain(
-      "order by ${vaccinationRecords.id}"
+      "order by ${vaccinationRecords.id}",
     );
     expect(integrity.slice(syncSourceLock, syncInsert)).toContain("for update");
 
@@ -200,13 +206,13 @@ describe("visit work reconciliation", () => {
     const correctionEnd = records.indexOf("createVaccination", correctionStart);
     const correctionMutation = records.slice(correctionStart, correctionEnd);
     const correctionSourceLock = correctionMutation.indexOf(
-      '.for("update", { of: vaccinationRecords })'
+      '.for("update", { of: vaccinationRecords })',
     );
     const correctionInsert = correctionMutation.indexOf(
-      ".insert(clinicalRecordCorrections)"
+      ".insert(clinicalRecordCorrections)",
     );
     const correctionWorkUpdate = correctionMutation.indexOf(
-      ".update(visitWorkItems)"
+      ".update(visitWorkItems)",
     );
     expect(correctionSourceLock).toBeGreaterThanOrEqual(0);
     expect(correctionInsert).toBeGreaterThan(correctionSourceLock);
@@ -411,12 +417,7 @@ describe("visit work reconciliation", () => {
     };
     const reopened = { ...unresolvedWork };
     const { db, updateSet, insertValues } = createDb({
-      selectResults: [
-        [openAppointment],
-        [{ id: PATIENT_ID }],
-        [],
-        [charged],
-      ],
+      selectResults: [[openAppointment], [{ id: PATIENT_ID }], [], [charged]],
       updateResults: [[reopened]],
     });
 
@@ -475,7 +476,7 @@ describe("visit work reconciliation", () => {
         appointmentId: APPOINTMENT_ID,
         workItemId: WORK_ITEM_ID,
         reason: "Review the reconciliation again",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -502,7 +503,7 @@ describe("visit work reconciliation", () => {
         appointmentId: APPOINTMENT_ID,
         workItemId: WORK_ITEM_ID,
         reason: "Linked the wrong invoice line",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -121,6 +121,7 @@ type InvoiceForPayment = {
   isEstimate: boolean;
   appointmentId?: string | null;
   dueDate?: string | null;
+  updatedAt?: Date;
 };
 
 type InvoiceAdjustmentType = "credit" | "write_off";
@@ -128,7 +129,7 @@ type InvoiceStatus = "draft" | "sent" | "paid" | "overdue" | "void";
 
 async function assertInvoiceItemsNotReconciled(
   ctx: BillingContext,
-  invoiceId: string
+  invoiceId: string,
 ) {
   const rows = await ctx.db.execute(sql`
     select ${visitWorkItems.id}
@@ -160,8 +161,13 @@ const allowedInvoiceStatusTransitions: Record<
   void: [],
 };
 
-function canTransitionInvoiceStatus(current: InvoiceStatus, next: InvoiceStatus) {
-  return current === next || allowedInvoiceStatusTransitions[current].includes(next);
+function canTransitionInvoiceStatus(
+  current: InvoiceStatus,
+  next: InvoiceStatus,
+) {
+  return (
+    current === next || allowedInvoiceStatusTransitions[current].includes(next)
+  );
 }
 
 function invoiceCheckoutReturnUrl({
@@ -195,9 +201,12 @@ const invoiceStatusSchema = z.enum([
   "void",
 ]);
 
-const currencyAmountSchema = z.string().trim().refine((value) => {
-  return BILLING_CURRENCY_AMOUNT_PATTERN.test(value);
-}, "Amount must be a valid currency amount.");
+const currencyAmountSchema = z
+  .string()
+  .trim()
+  .refine((value) => {
+    return BILLING_CURRENCY_AMOUNT_PATTERN.test(value);
+  }, "Amount must be a valid currency amount.");
 
 const paymentAmountSchema = currencyAmountSchema.refine((value) => {
   return moneyToCents(value) > 0;
@@ -207,22 +216,22 @@ const nonNegativeMoneySchema = currencyAmountSchema;
 
 const optionalServiceTextInput = (label: string, max: number) =>
   optionalClinicalTextInput(label, max).transform(
-    (value) => value || undefined
+    (value) => value || undefined,
   );
 
 const servicePriceInput = nonNegativeMoneySchema.transform((value) =>
-  centsToMoney(moneyToCents(value))
+  centsToMoney(moneyToCents(value)),
 );
 
 const serviceInput = z.object({
   name: clinicalTextInput("Service name", BILLING_SERVICE_NAME_MAX_LENGTH),
   code: optionalServiceTextInput(
     "Service code",
-    BILLING_SERVICE_CODE_MAX_LENGTH
+    BILLING_SERVICE_CODE_MAX_LENGTH,
   ),
   category: optionalServiceTextInput(
     "Service category",
-    BILLING_SERVICE_CATEGORY_MAX_LENGTH
+    BILLING_SERVICE_CATEGORY_MAX_LENGTH,
   ),
   defaultPrice: servicePriceInput,
   taxable: z.boolean().default(true),
@@ -246,10 +255,10 @@ function serviceSnapshotConditions(expected: ServiceSnapshot) {
 
 async function lockServiceCatalog(
   database: ServiceCatalogDb,
-  practiceId: string
+  practiceId: string,
 ) {
   await database.execute(
-    sql`select pg_advisory_xact_lock(hashtext(${`service-catalog:${practiceId}`}::text))`
+    sql`select pg_advisory_xact_lock(hashtext(${`service-catalog:${practiceId}`}::text))`,
   );
 }
 
@@ -257,7 +266,7 @@ async function assertServiceIdentityAvailable(
   database: ServiceCatalogDb,
   practiceId: string,
   input: ServiceSnapshot,
-  excludeId?: string
+  excludeId?: string,
 ) {
   const [collision] = await database
     .select({ id: services.id })
@@ -271,9 +280,9 @@ async function assertServiceIdentityAvailable(
           sql`lower(${services.name}) = lower(${input.name})`,
           input.code
             ? sql`lower(${services.code}) = lower(${input.code})`
-            : undefined
-        )
-      )
+            : undefined,
+        ),
+      ),
     )
     .limit(1);
 
@@ -288,17 +297,17 @@ async function assertServiceIdentityAvailable(
 
 const billingNotesInput = optionalClinicalTextInput(
   "Notes",
-  BILLING_NOTES_MAX_LENGTH
+  BILLING_NOTES_MAX_LENGTH,
 );
 const invoiceSearchInput = optionalClinicalTextInput(
   "Search",
-  BILLING_INVOICE_SEARCH_MAX_LENGTH
+  BILLING_INVOICE_SEARCH_MAX_LENGTH,
 );
 const invoiceLineInput = z
   .object({
     description: clinicalTextInput(
       "Line item description",
-      BILLING_INVOICE_LINE_DESCRIPTION_MAX_LENGTH
+      BILLING_INVOICE_LINE_DESCRIPTION_MAX_LENGTH,
     ),
     quantity: z
       .number()
@@ -337,6 +346,14 @@ const invoiceLineInput = z
         message: "Choose one medication dispense source for this line.",
       });
     }
+    if (item.sourcePrescriptionId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["sourcePrescriptionId"],
+        message:
+          "Prescription-only charge links are read-only legacy data. Add this medication from Charge capture or the medication billing queue.",
+      });
+    }
   });
 
 const createInvoiceInput = z
@@ -348,7 +365,7 @@ const createInvoiceInput = z
       .array(invoiceLineInput)
       .max(
         BILLING_INVOICE_MAX_ITEMS,
-        `Invoices can include at most ${BILLING_INVOICE_MAX_ITEMS} items.`
+        `Invoices can include at most ${BILLING_INVOICE_MAX_ITEMS} items.`,
       ),
     dueDate: clinicalDateInput("Due date").optional(),
     isEstimate: z.boolean().optional().default(false),
@@ -356,7 +373,7 @@ const createInvoiceInput = z
   .superRefine((input, ctx) => {
     const subtotalCents = input.items.reduce(
       (sum, item) => sum + moneyToCents(item.unitPrice) * item.quantity,
-      0
+      0,
     );
     if (subtotalCents > BILLING_MAX_MONEY_CENTS) {
       ctx.addIssue({
@@ -376,13 +393,13 @@ const updateInvoiceItemsInput = z
       .min(1, "An invoice must include at least one line item.")
       .max(
         BILLING_INVOICE_MAX_ITEMS,
-        `Invoices can include at most ${BILLING_INVOICE_MAX_ITEMS} items.`
+        `Invoices can include at most ${BILLING_INVOICE_MAX_ITEMS} items.`,
       ),
   })
   .superRefine((input, ctx) => {
     const subtotalCents = input.items.reduce(
       (sum, item) => sum + moneyToCents(item.unitPrice) * item.quantity,
-      0
+      0,
     );
     if (subtotalCents > BILLING_MAX_MONEY_CENTS) {
       ctx.addIssue({
@@ -421,7 +438,9 @@ async function assertActivePractice(ctx: BillingContext) {
 }
 
 async function assertBillingProviderActionsAllowed(ctx: BillingContext) {
-  if (await lockPracticeForExternalSideEffects(ctx.db as Database, ctx.practiceId)) {
+  if (
+    await lockPracticeForExternalSideEffects(ctx.db as Database, ctx.practiceId)
+  ) {
     return;
   }
   throw new TRPCError({
@@ -432,7 +451,7 @@ async function assertBillingProviderActionsAllowed(ctx: BillingContext) {
 
 async function throwServiceMutationMiss(
   ctx: BillingContext,
-  serviceId: string
+  serviceId: string,
 ): Promise<never> {
   const [current] = await ctx.db
     .select({ id: services.id })
@@ -441,8 +460,8 @@ async function throwServiceMutationMiss(
       and(
         eq(services.id, serviceId),
         eq(services.practiceId, ctx.practiceId),
-        isNull(services.deletedAt)
-      )
+        isNull(services.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -458,7 +477,7 @@ async function throwServiceMutationMiss(
 
 async function throwArchivedServiceMutationMiss(
   ctx: BillingContext,
-  serviceId: string
+  serviceId: string,
 ): Promise<never> {
   const [current] = await ctx.db
     .select({ id: services.id })
@@ -467,8 +486,8 @@ async function throwArchivedServiceMutationMiss(
       and(
         eq(services.id, serviceId),
         eq(services.practiceId, ctx.practiceId),
-        isNotNull(services.deletedAt)
-      )
+        isNotNull(services.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -484,8 +503,8 @@ async function throwArchivedServiceMutationMiss(
 
 async function getInvoiceForPractice(
   ctx: BillingContext,
-  invoiceId: string
-): Promise<InvoiceForPayment> {
+  invoiceId: string,
+): Promise<InvoiceForPayment & { updatedAt: Date }> {
   const [invoice] = await ctx.db
     .select({
       id: invoices.id,
@@ -495,14 +514,15 @@ async function getInvoiceForPractice(
       isEstimate: invoices.isEstimate,
       appointmentId: invoices.appointmentId,
       dueDate: invoices.dueDate,
+      updatedAt: invoices.updatedAt,
     })
     .from(invoices)
     .where(
       and(
         eq(invoices.id, invoiceId),
         eq(invoices.practiceId, ctx.practiceId),
-        isNull(invoices.deletedAt)
-      )
+        isNull(invoices.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -544,7 +564,8 @@ function assertCanAdjustInvoice(invoice: InvoiceForPayment) {
   if (invoice.isEstimate) {
     throw new TRPCError({
       code: "BAD_REQUEST",
-      message: "Convert the estimate to an invoice before applying an adjustment.",
+      message:
+        "Convert the estimate to an invoice before applying an adjustment.",
     });
   }
   if (invoice.status === "void") {
@@ -642,6 +663,22 @@ function noActiveAdjustmentsForInvoice(): SQL {
   )`;
 }
 
+function invoiceUpdatedAtMatches(expectedUpdatedAt: Date): SQL {
+  // postgres.js decodes timestamptz into a JavaScript Date and therefore drops
+  // PostgreSQL's sub-millisecond precision. Compare the durable value at the
+  // precision the client can faithfully round-trip instead of rejecting an
+  // unchanged row created with clock_timestamp().
+  const start = expectedUpdatedAt.toISOString();
+  const end = new Date(expectedUpdatedAt.getTime() + 1).toISOString();
+  return sql`${invoices.updatedAt} >= ${start}::timestamptz and ${invoices.updatedAt} < ${end}::timestamptz`;
+}
+
+function nextInvoiceUpdatedAt(currentUpdatedAt: Date): Date {
+  // Ensure two serialized mutations never reuse the same client-visible
+  // version millisecond, even when they execute in one clock tick.
+  return new Date(Math.max(Date.now(), currentUpdatedAt.getTime() + 1));
+}
+
 function invoiceAdjustmentTotalMatches(expectedCents: number): SQL {
   return sql`coalesce((
     select sum(${invoiceAdjustments.amount})
@@ -651,7 +688,10 @@ function invoiceAdjustmentTotalMatches(expectedCents: number): SQL {
   ), 0) = ${centsToMoney(expectedCents)}::numeric`;
 }
 
-async function listInvoiceAdjustmentRows(ctx: BillingContext, invoiceId: string) {
+async function listInvoiceAdjustmentRows(
+  ctx: BillingContext,
+  invoiceId: string,
+) {
   return ctx.db
     .select({
       amount: invoiceAdjustments.amount,
@@ -662,14 +702,14 @@ async function listInvoiceAdjustmentRows(ctx: BillingContext, invoiceId: string)
       and(
         eq(invoiceAdjustments.invoiceId, invoiceId),
         adjustmentPracticeScope(ctx),
-        isNull(invoiceAdjustments.deletedAt)
-      )
+        isNull(invoiceAdjustments.deletedAt),
+      ),
     );
 }
 
 async function getInvoiceAdjustmentTotalCents(
   ctx: BillingContext,
-  invoiceId: string
+  invoiceId: string,
 ): Promise<number> {
   const rows = await listInvoiceAdjustmentRows(ctx, invoiceId);
   return rows.reduce((sum, row) => sum + moneyToCents(row.amount), 0);
@@ -704,7 +744,7 @@ function serializePaymentAccountStatus(row: PaymentAccountRow | null) {
     payoutsEnabled: row.payoutsEnabled,
     detailsSubmitted: row.detailsSubmitted,
     requirementsCurrentlyDue: normalizeRequirements(
-      row.requirementsCurrentlyDue
+      row.requirementsCurrentlyDue,
     ),
     requirementsDisabledReason: row.requirementsDisabledReason,
     lastSyncedAt: row.lastSyncedAt,
@@ -712,7 +752,7 @@ function serializePaymentAccountStatus(row: PaymentAccountRow | null) {
 }
 
 async function getStripeConnectPaymentAccount(
-  ctx: BillingContext
+  ctx: BillingContext,
 ): Promise<PaymentAccountRow | null> {
   const [account] = await ctx.db
     .select()
@@ -721,8 +761,8 @@ async function getStripeConnectPaymentAccount(
       and(
         eq(practicePaymentAccounts.practiceId, ctx.practiceId),
         eq(practicePaymentAccounts.provider, STRIPE_CONNECT_PROVIDER),
-        isNull(practicePaymentAccounts.deletedAt)
-      )
+        isNull(practicePaymentAccounts.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -731,7 +771,7 @@ async function getStripeConnectPaymentAccount(
 
 async function upsertStripeConnectPaymentAccount(
   ctx: BillingContext,
-  account: { id: string } & Parameters<typeof stripeConnectAccountState>[0]
+  account: { id: string } & Parameters<typeof stripeConnectAccountState>[0],
 ) {
   const state = stripeConnectAccountState(account);
   const [row] = await ctx.db
@@ -789,7 +829,7 @@ function adjustmentLabel(type: InvoiceAdjustmentType): string {
 
 async function assertClientBelongsToPractice(
   ctx: BillingContext,
-  clientId: string
+  clientId: string,
 ) {
   const [client] = await ctx.db
     .select({ id: clients.id })
@@ -798,8 +838,8 @@ async function assertClientBelongsToPractice(
       and(
         eq(clients.id, clientId),
         eq(clients.practiceId, ctx.practiceId),
-        isNull(clients.deletedAt)
-      )
+        isNull(clients.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -811,7 +851,7 @@ async function assertClientBelongsToPractice(
 async function assertPatientBelongsToClient(
   ctx: BillingContext,
   patientId: string,
-  clientId: string
+  clientId: string,
 ) {
   const [patient] = await ctx.db
     .select({ id: patients.id })
@@ -821,8 +861,8 @@ async function assertPatientBelongsToClient(
         eq(patients.id, patientId),
         eq(patients.clientId, clientId),
         eq(patients.practiceId, ctx.practiceId),
-        isNull(patients.deletedAt)
-      )
+        isNull(patients.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -838,7 +878,7 @@ async function assertAppointmentBelongsToClientPatient(
   ctx: BillingContext,
   appointmentId: string,
   clientId: string,
-  patientId?: string
+  patientId?: string,
 ) {
   const conditions = [
     eq(appointments.id, appointmentId),
@@ -871,7 +911,7 @@ async function lockAppointmentForVisitBilling(
   appointmentId: string,
   clientId: string,
   patientId: string | undefined,
-  isEstimate: boolean
+  isEstimate: boolean,
 ) {
   const conditions = [
     eq(appointments.id, appointmentId),
@@ -914,7 +954,7 @@ async function lockAppointmentForVisitBilling(
 
 async function assertInvoiceNotCompletedCloseout(
   ctx: BillingContext,
-  invoiceId: string
+  invoiceId: string,
 ) {
   const [closeout] = await ctx.db
     .select({ id: visitCloseouts.id })
@@ -924,8 +964,8 @@ async function assertInvoiceNotCompletedCloseout(
         eq(visitCloseouts.invoiceId, invoiceId),
         eq(visitCloseouts.practiceId, ctx.practiceId),
         eq(visitCloseouts.status, "completed"),
-        isNull(visitCloseouts.deletedAt)
-      )
+        isNull(visitCloseouts.deletedAt),
+      ),
     )
     .limit(1);
   if (closeout) {
@@ -939,7 +979,7 @@ async function assertInvoiceNotCompletedCloseout(
 
 async function lockAppointmentForInvoiceMutation(
   ctx: BillingContext,
-  appointmentId: string | null | undefined
+  appointmentId: string | null | undefined,
 ) {
   if (!appointmentId) return;
   const [appointment] = await ctx.db
@@ -949,8 +989,8 @@ async function lockAppointmentForInvoiceMutation(
       and(
         eq(appointments.id, appointmentId),
         eq(appointments.practiceId, ctx.practiceId),
-        isNull(appointments.deletedAt)
-      )
+        isNull(appointments.deletedAt),
+      ),
     )
     .for("update");
   if (!appointment) {
@@ -967,18 +1007,18 @@ async function assertLineItemReferences(
   options: {
     previousItems?: readonly DispensableItem[];
     lockProductsForStock?: boolean;
-  } = {}
+  } = {},
 ) {
   const quantitiesFor = (
     source: readonly DispensableItem[],
-    itemType: DispensableItem["itemType"]
+    itemType: DispensableItem["itemType"],
   ) => {
     const quantities = new Map<string, number>();
     for (const item of source) {
       if (item.itemType !== itemType || !item.itemId) continue;
       quantities.set(
         item.itemId,
-        (quantities.get(item.itemId) ?? 0) + item.quantity
+        (quantities.get(item.itemId) ?? 0) + item.quantity,
       );
     }
     return quantities;
@@ -986,8 +1026,15 @@ async function assertLineItemReferences(
 
   const serviceQuantities = quantitiesFor(items, "service");
   const productQuantities = quantitiesFor(items, "product");
+  const previousProductQuantities = quantitiesFor(
+    options.previousItems ?? [],
+    "product",
+  );
   const serviceIds = [...serviceQuantities.keys()].sort();
   const productIds = [...productQuantities.keys()].sort();
+  const productIdsToLock = [
+    ...new Set([...productIds, ...previousProductQuantities.keys()]),
+  ].sort();
 
   // Lock in a stable service-then-product order. The lock and lifecycle check
   // must stay in the invoice transaction so a catalog row cannot be archived
@@ -1005,8 +1052,8 @@ async function assertLineItemReferences(
           .where(
             and(
               inArray(services.id, serviceIds),
-              eq(services.practiceId, ctx.practiceId)
-            )
+              eq(services.practiceId, ctx.practiceId),
+            ),
           )
           .orderBy(services.id)
           .for("share");
@@ -1016,7 +1063,7 @@ async function assertLineItemReferences(
     deletedAt: Date | null;
     taxable: boolean;
   }> = [];
-  if (productIds.length > 0) {
+  if (productIdsToLock.length > 0) {
     const productQuery = ctx.db
       .select({
         id: products.id,
@@ -1026,9 +1073,9 @@ async function assertLineItemReferences(
       .from(products)
       .where(
         and(
-          inArray(products.id, productIds),
-          eq(products.practiceId, ctx.practiceId)
-        )
+          inArray(products.id, productIdsToLock),
+          eq(products.practiceId, ctx.practiceId),
+        ),
       )
       .orderBy(products.id);
     productRows = options.lockProductsForStock
@@ -1044,14 +1091,14 @@ async function assertLineItemReferences(
   }
   const previousServiceQuantities = quantitiesFor(
     options.previousItems ?? [],
-    "service"
+    "service",
   );
   if (
     serviceRows.some(
       (row) =>
         row.deletedAt != null &&
         (serviceQuantities.get(row.id) ?? 0) >
-          (previousServiceQuantities.get(row.id) ?? 0)
+          (previousServiceQuantities.get(row.id) ?? 0),
     )
   ) {
     throw new TRPCError({
@@ -1060,8 +1107,10 @@ async function assertLineItemReferences(
     });
   }
   if (
-    productRows.length !== productIds.length ||
-    productRows.some((row) => row.deletedAt != null)
+    productRows.length !== productIdsToLock.length ||
+    productRows.some(
+      (row) => productQuantities.has(row.id) && row.deletedAt != null,
+    )
   ) {
     throw new TRPCError({
       code: "NOT_FOUND",
@@ -1131,7 +1180,7 @@ function invoiceLineTaxTotals(
 }
 
 function stockOwnedItems(
-  items: readonly InvoiceLineInput[]
+  items: readonly InvoiceLineInput[],
 ): DispensableItem[] {
   return items
     .filter(
@@ -1151,7 +1200,7 @@ async function assertPrescriptionChargeSources(
     appointmentId?: string | null;
     patientId?: string | null;
     currentInvoiceId?: string;
-  }
+  },
 ) {
   const sourcedItems = items.filter((item) => item.sourcePrescriptionId);
   const sourceIds = sourcedItems.map((item) => item.sourcePrescriptionId!);
@@ -1184,14 +1233,14 @@ async function assertPrescriptionChargeSources(
         eq(prescriptions.patientId, options.patientId),
         eq(prescriptions.practiceId, ctx.practiceId),
         isNull(prescriptions.deletedAt),
-        isNotNull(prescriptions.productId)
-      )
+        isNotNull(prescriptions.productId),
+      ),
     )
     .orderBy(prescriptions.id)
     .for("share");
   const byId = new Map(linkedPrescriptions.map((rx) => [rx.id, rx]));
   const visitProductIds = new Set(
-    linkedPrescriptions.map((rx) => rx.productId).filter(Boolean)
+    linkedPrescriptions.map((rx) => rx.productId).filter(Boolean),
   );
 
   for (const item of items) {
@@ -1211,11 +1260,13 @@ async function assertPrescriptionChargeSources(
     if (
       !prescription ||
       prescription.productId !== item.itemId ||
-      (prescription.quantity !== null && prescription.quantity !== item.quantity)
+      (prescription.quantity !== null &&
+        prescription.quantity !== item.quantity)
     ) {
       throw new TRPCError({
         code: "PRECONDITION_FAILED",
-        message: "Prescription charge no longer matches the visit dispensation.",
+        message:
+          "Prescription charge no longer matches the visit dispensation.",
       });
     }
   }
@@ -1543,7 +1594,7 @@ async function lockDispenseChargeWorkflow(
 
 async function deductProductStock(
   ctx: BillingContext,
-  items: readonly DispensableItem[]
+  items: readonly DispensableItem[],
 ) {
   const deductions = computeStockDeductions([...items]);
   for (const deduction of deductions) {
@@ -1557,8 +1608,8 @@ async function deductProductStock(
           eq(products.id, deduction.productId),
           eq(products.practiceId, ctx.practiceId),
           isNull(products.deletedAt),
-          sql`${products.stockQuantity} >= ${deduction.quantity}`
-        )
+          sql`${products.stockQuantity} >= ${deduction.quantity}`,
+        ),
       )
       .returning({ id: products.id, stockQuantity: products.stockQuantity });
 
@@ -1573,7 +1624,7 @@ async function deductProductStock(
 
 async function invoiceProductItemsForStock(
   ctx: BillingContext,
-  invoiceId: string
+  invoiceId: string,
 ): Promise<DispensableItem[]> {
   return ctx.db
     .select({
@@ -1588,14 +1639,15 @@ async function invoiceProductItemsForStock(
         invoiceItemPracticeScope(ctx),
         isNull(invoiceItems.sourcePrescriptionId),
         isNull(invoiceItems.sourceDispenseChargeId),
-        isNull(invoiceItems.deletedAt)
-      )
-    );
+        isNull(invoiceItems.deletedAt),
+      ),
+    )
+    .orderBy(invoiceItems.itemId, invoiceItems.id);
 }
 
 async function restoreProductStock(
   ctx: BillingContext,
-  items: readonly DispensableItem[]
+  items: readonly DispensableItem[],
 ) {
   const restorations = computeStockDeductions([...items]);
   for (const restoration of restorations) {
@@ -1609,15 +1661,16 @@ async function restoreProductStock(
           eq(products.id, restoration.productId),
           eq(products.practiceId, ctx.practiceId),
           isNull(products.deletedAt),
-          sql`${products.stockQuantity} + ${restoration.quantity} <= ${POSTGRES_INTEGER_MAX}`
-        )
+          sql`${products.stockQuantity} + ${restoration.quantity} <= ${POSTGRES_INTEGER_MAX}`,
+        ),
       )
       .returning({ id: products.id, stockQuantity: products.stockQuantity });
 
     if (!product) {
       throw new TRPCError({
         code: "BAD_REQUEST",
-        message: "Unable to restore stock for one or more product invoice lines.",
+        message:
+          "Unable to restore stock for one or more product invoice lines.",
       });
     }
   }
@@ -1965,7 +2018,8 @@ export const billingRouter = createRouter({
         if (!sourceProduct) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: "The dispensed product is no longer available for billing.",
+            message:
+              "The dispensed product is no longer available for billing.",
           });
         }
         const newLine = {
@@ -1985,6 +2039,7 @@ export const billingRouter = createRouter({
                 status: invoices.status,
                 subtotal: invoices.subtotal,
                 paidAmount: invoices.paidAmount,
+                updatedAt: invoices.updatedAt,
               })
               .from(invoices)
               .where(
@@ -2046,7 +2101,7 @@ export const billingRouter = createRouter({
               subtotal: centsToMoney(totals.subtotalCents),
               tax: centsToMoney(totals.taxCents),
               total: centsToMoney(totals.totalCents),
-              updatedAt: new Date(),
+              updatedAt: nextInvoiceUpdatedAt(existingVisitInvoice.updatedAt),
             })
             .where(
               and(
@@ -2084,6 +2139,7 @@ export const billingRouter = createRouter({
               paidAmount: "0.00",
               dueDate: null,
               isEstimate: false,
+              updatedAt: new Date(),
             })
             .returning({ id: invoices.id });
           invoiceId = invoice!.id;
@@ -2360,7 +2416,7 @@ export const billingRouter = createRouter({
         appointmentId: z.string().uuid().optional(),
         limit: z.number().int().min(1).max(100).default(25),
         offset: listOffsetInput,
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const conditions: ReturnType<typeof eq>[] = [
@@ -2414,8 +2470,8 @@ export const billingRouter = createRouter({
             and(
               eq(invoices.clientId, clients.id),
               eq(clients.practiceId, ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .leftJoin(
             patients,
@@ -2423,8 +2479,8 @@ export const billingRouter = createRouter({
               eq(invoices.patientId, patients.id),
               eq(patients.clientId, invoices.clientId),
               eq(patients.practiceId, ctx.practiceId),
-              isNull(patients.deletedAt)
-            )
+              isNull(patients.deletedAt),
+            ),
           )
           .where(and(...conditions))
           .orderBy(desc(invoices.createdAt))
@@ -2469,8 +2525,8 @@ export const billingRouter = createRouter({
           and(
             eq(invoices.clientId, clients.id),
             eq(clients.practiceId, ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .leftJoin(
           patients,
@@ -2478,20 +2534,23 @@ export const billingRouter = createRouter({
             eq(invoices.patientId, patients.id),
             eq(patients.clientId, invoices.clientId),
             eq(patients.practiceId, ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .where(
           and(
             eq(invoices.id, input.id),
             eq(invoices.practiceId, ctx.practiceId),
-            isNull(invoices.deletedAt)
-          )
+            isNull(invoices.deletedAt),
+          ),
         )
         .limit(1);
 
       if (!invoice) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invoice not found",
+        });
       }
 
       const [items, adjustmentRows] = await Promise.all([
@@ -2502,14 +2561,14 @@ export const billingRouter = createRouter({
             and(
               eq(invoiceItems.invoiceId, input.id),
               invoiceItemPracticeScope(ctx),
-              isNull(invoiceItems.deletedAt)
-            )
+              isNull(invoiceItems.deletedAt),
+            ),
           ),
         listInvoiceAdjustmentRows(ctx, input.id),
       ]);
       const adjustedCents = adjustmentRows.reduce(
         (sum, row) => sum + moneyToCents(row.amount),
-        0
+        0,
       );
 
       return {
@@ -2526,7 +2585,7 @@ export const billingRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         status: z.enum(["draft", "sent", "paid", "overdue"]),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const existing = await getInvoiceForPractice(ctx, input.id);
@@ -2567,10 +2626,13 @@ export const billingRouter = createRouter({
       if (input.status === "sent" && existing.appointmentId) {
         return ctx.db.transaction(async (tx) => {
           const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
-          await lockAppointmentForInvoiceMutation(txCtx, existing.appointmentId);
+          await lockAppointmentForInvoiceMutation(
+            txCtx,
+            existing.appointmentId,
+          );
           await assertVisitInvoiceReadyForFinancialAction(
             txCtx,
-            existing.appointmentId
+            existing.appointmentId,
           );
           const [invoice] = await tx
             .update(invoices)
@@ -2611,7 +2673,10 @@ export const billingRouter = createRouter({
       .select()
       .from(services)
       .where(
-        and(eq(services.practiceId, ctx.practiceId), isNull(services.deletedAt))
+        and(
+          eq(services.practiceId, ctx.practiceId),
+          isNull(services.deletedAt),
+        ),
       )
       .orderBy(services.name);
   }),
@@ -2624,8 +2689,8 @@ export const billingRouter = createRouter({
       .where(
         and(
           eq(services.practiceId, ctx.practiceId),
-          isNotNull(services.deletedAt)
-        )
+          isNotNull(services.deletedAt),
+        ),
       )
       .orderBy(services.name);
   }),
@@ -2664,7 +2729,7 @@ export const billingRouter = createRouter({
       serviceInput.extend({
         id: z.string().uuid(),
         expected: serviceInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -2674,7 +2739,7 @@ export const billingRouter = createRouter({
           tx,
           ctx.practiceId,
           input,
-          input.id
+          input.id,
         );
         const [result] = await tx
           .update(services)
@@ -2690,8 +2755,8 @@ export const billingRouter = createRouter({
               eq(services.id, input.id),
               eq(services.practiceId, ctx.practiceId),
               isNull(services.deletedAt),
-              ...serviceSnapshotConditions(input.expected)
-            )
+              ...serviceSnapshotConditions(input.expected),
+            ),
           )
           .returning();
         return result;
@@ -2707,7 +2772,7 @@ export const billingRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         expected: serviceInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -2719,8 +2784,8 @@ export const billingRouter = createRouter({
             eq(services.id, input.id),
             eq(services.practiceId, ctx.practiceId),
             isNull(services.deletedAt),
-            ...serviceSnapshotConditions(input.expected)
-          )
+            ...serviceSnapshotConditions(input.expected),
+          ),
         )
         .returning({ id: services.id });
       if (!archived) {
@@ -2734,7 +2799,7 @@ export const billingRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         expected: serviceInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -2744,7 +2809,7 @@ export const billingRouter = createRouter({
           tx,
           ctx.practiceId,
           input.expected,
-          input.id
+          input.id,
         );
         const [result] = await tx
           .update(services)
@@ -2754,8 +2819,8 @@ export const billingRouter = createRouter({
               eq(services.id, input.id),
               eq(services.practiceId, ctx.practiceId),
               isNotNull(services.deletedAt),
-              ...serviceSnapshotConditions(input.expected)
-            )
+              ...serviceSnapshotConditions(input.expected),
+            ),
           )
           .returning({ id: services.id });
         return result;
@@ -2780,8 +2845,8 @@ export const billingRouter = createRouter({
           and(
             eq(patients.clientId, input.clientId),
             eq(patients.practiceId, ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .orderBy(patients.name);
     }),
@@ -2792,14 +2857,18 @@ export const billingRouter = createRouter({
     .mutation(async ({ ctx, input }) => {
       await assertClientBelongsToPractice(ctx, input.clientId);
       if (input.patientId) {
-        await assertPatientBelongsToClient(ctx, input.patientId, input.clientId);
+        await assertPatientBelongsToClient(
+          ctx,
+          input.patientId,
+          input.clientId,
+        );
       }
       if (input.appointmentId) {
         await assertAppointmentBelongsToClientPatient(
           ctx,
           input.appointmentId,
           input.clientId,
-          input.patientId
+          input.patientId,
         );
       }
       // Tax rate is configured per practice (region-aware), not hardcoded.
@@ -2818,14 +2887,14 @@ export const billingRouter = createRouter({
           // Serialize charge capture for one visit so two front-desk tabs
           // cannot both pass the duplicate check and create competing bills.
           await tx.execute(
-            sql`select pg_advisory_xact_lock(hashtextextended(${input.appointmentId}, 0))`
+            sql`select pg_advisory_xact_lock(hashtextextended(${input.appointmentId}, 0))`,
           );
           await lockAppointmentForVisitBilling(
             txCtx,
             input.appointmentId,
             input.clientId,
             input.patientId,
-            input.isEstimate ?? false
+            input.isEstimate ?? false,
           );
           const [existingVisitInvoice] = await tx
             .select({ id: invoices.id })
@@ -2836,8 +2905,8 @@ export const billingRouter = createRouter({
                 eq(invoices.appointmentId, input.appointmentId),
                 eq(invoices.isEstimate, input.isEstimate ?? false),
                 ne(invoices.status, "void"),
-                isNull(invoices.deletedAt)
-              )
+                isNull(invoices.deletedAt),
+              ),
             )
             .limit(1);
           if (existingVisitInvoice) {
@@ -2848,11 +2917,6 @@ export const billingRouter = createRouter({
             });
           }
         }
-        const taxabilityByReference = await assertLineItemReferences(
-          txCtx,
-          input.items,
-          { lockProductsForStock: !(input.isEstimate ?? false) },
-        );
         await assertPrescriptionChargeSources(txCtx, input.items, {
           appointmentId: input.appointmentId,
           patientId: input.patientId,
@@ -2863,6 +2927,11 @@ export const billingRouter = createRouter({
           appointmentId: input.appointmentId,
           isEstimate: input.isEstimate ?? false,
         });
+        const taxabilityByReference = await assertLineItemReferences(
+          txCtx,
+          input.items,
+          { lockProductsForStock: !(input.isEstimate ?? false) },
+        );
         if (!(input.isEstimate ?? false)) {
           await deductProductStock(txCtx, stockOwnedItems(input.items));
         }
@@ -2887,6 +2956,7 @@ export const billingRouter = createRouter({
             paidAmount: "0.00",
             dueDate: input.dueDate ?? null,
             isEstimate: input.isEstimate ?? false,
+            updatedAt: new Date(),
           })
           .returning();
 
@@ -2902,9 +2972,7 @@ export const billingRouter = createRouter({
               description: item.description,
               quantity: item.quantity,
               unitPrice: item.unitPrice,
-              total: centsToMoney(
-                item.quantity * moneyToCents(item.unitPrice),
-              ),
+              total: centsToMoney(item.quantity * moneyToCents(item.unitPrice)),
               taxable: invoiceLineTaxable(item, taxabilityByReference),
               itemType: item.itemType as "service" | "product",
               itemId: item.itemId ?? null,
@@ -2945,7 +3013,7 @@ export const billingRouter = createRouter({
       return ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${input.id}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${input.id}, 0))`,
         );
 
         const [existing] = await tx
@@ -2964,13 +3032,16 @@ export const billingRouter = createRouter({
             and(
               eq(invoices.id, input.id),
               eq(invoices.practiceId, ctx.practiceId),
-              isNull(invoices.deletedAt)
-            )
+              isNull(invoices.deletedAt),
+            ),
           )
           .limit(1);
 
         if (!existing) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Invoice not found",
+          });
         }
         if (existing.isEstimate) {
           throw new TRPCError({
@@ -2979,13 +3050,19 @@ export const billingRouter = createRouter({
               "Convert or replace the estimate before editing visit invoice charges.",
           });
         }
-        if (existing.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
+        if (
+          existing.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()
+        ) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Invoice changed in another session. Refresh before saving charges.",
+            message:
+              "Invoice changed in another session. Refresh before saving charges.",
           });
         }
-        if (existing.status !== "draft" || moneyToCents(existing.paidAmount) > 0) {
+        if (
+          existing.status !== "draft" ||
+          moneyToCents(existing.paidAmount) > 0
+        ) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message:
@@ -3005,8 +3082,8 @@ export const billingRouter = createRouter({
               and(
                 eq(appointments.id, existing.appointmentId),
                 eq(appointments.practiceId, ctx.practiceId),
-                isNull(appointments.deletedAt)
-              )
+                isNull(appointments.deletedAt),
+              ),
             )
             .limit(1);
           if (!appointment?.clientId) {
@@ -3020,14 +3097,12 @@ export const billingRouter = createRouter({
             existing.appointmentId,
             appointment.clientId,
             appointment.patientId ?? undefined,
-            false
+            false,
           );
         }
-        const previousItems = await invoiceProductItemsForStock(txCtx, input.id);
-        const taxabilityByReference = await assertLineItemReferences(
+        const previousItems = await invoiceProductItemsForStock(
           txCtx,
-          input.items,
-          { previousItems, lockProductsForStock: true },
+          input.id,
         );
         await assertPrescriptionChargeSources(txCtx, input.items, {
           appointmentId: existing.appointmentId,
@@ -3041,6 +3116,11 @@ export const billingRouter = createRouter({
           currentInvoiceId: existing.id,
           isEstimate: existing.isEstimate,
         });
+        const taxabilityByReference = await assertLineItemReferences(
+          txCtx,
+          input.items,
+          { previousItems, lockProductsForStock: true },
+        );
         await restoreProductStock(txCtx, previousItems);
         await deductProductStock(txCtx, stockOwnedItems(input.items));
 
@@ -3056,7 +3136,7 @@ export const billingRouter = createRouter({
             subtotal: centsToMoney(totals.subtotalCents),
             tax: centsToMoney(totals.taxCents),
             total: centsToMoney(totals.totalCents),
-            updatedAt: new Date(),
+            updatedAt: nextInvoiceUpdatedAt(existing.updatedAt),
           })
           .where(
             and(
@@ -3066,10 +3146,10 @@ export const billingRouter = createRouter({
               eq(invoices.status, "draft"),
               eq(invoices.isEstimate, existing.isEstimate),
               eq(invoices.paidAmount, existing.paidAmount ?? "0.00"),
-              eq(invoices.updatedAt, input.expectedUpdatedAt),
+              invoiceUpdatedAtMatches(input.expectedUpdatedAt),
               noActivePaymentsForInvoice(),
-              noActiveAdjustmentsForInvoice()
-            )
+              noActiveAdjustmentsForInvoice(),
+            ),
           )
           .returning();
 
@@ -3089,8 +3169,8 @@ export const billingRouter = createRouter({
             and(
               eq(invoiceItems.invoiceId, input.id),
               invoiceItemPracticeScope(txCtx),
-              isNull(invoiceItems.deletedAt)
-            )
+              isNull(invoiceItems.deletedAt),
+            ),
           );
 
         await reopenInvoiceDispenseCharges(txCtx, input.id);
@@ -3135,7 +3215,7 @@ export const billingRouter = createRouter({
       z.object({
         search: invoiceSearchInput,
         limit: z.number().int().min(1).max(100).default(50),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const conditions: SQL[] = [
@@ -3163,16 +3243,23 @@ export const billingRouter = createRouter({
         invoiceId: z.string().uuid(),
         operationId: z.string().uuid(),
         amount: paymentAmountSchema,
-        method: z.enum(["cash", "credit_card", "debit_card", "check", "online", "other"]),
+        method: z.enum([
+          "cash",
+          "credit_card",
+          "debit_card",
+          "check",
+          "online",
+          "other",
+        ]),
         notes: billingNotesInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const operationKey = `dashboard-payment:${ctx.practiceId}:${input.operationId}`;
       const result = await ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
         );
 
         const [existingPayment] = await tx
@@ -3191,29 +3278,34 @@ export const billingRouter = createRouter({
           .where(
             and(
               eq(payments.externalId, operationKey),
-              eq(invoices.practiceId, ctx.practiceId)
-            )
+              eq(invoices.practiceId, ctx.practiceId),
+            ),
           )
           .limit(1);
         if (existingPayment) {
           if (
             existingPayment.invoiceId !== input.invoiceId ||
-            moneyToCents(existingPayment.amount) !== moneyToCents(input.amount) ||
+            moneyToCents(existingPayment.amount) !==
+              moneyToCents(input.amount) ||
             existingPayment.method !== input.method ||
             (existingPayment.notes ?? null) !== (input.notes ?? null)
           ) {
             throw new TRPCError({
               code: "CONFLICT",
-              message: "This payment operation ID was already used for different details.",
+              message:
+                "This payment operation ID was already used for different details.",
             });
           }
           return { payment: existingPayment, replayed: true as const };
         }
 
-        const invoiceIdentity = await getInvoiceForPractice(txCtx, input.invoiceId);
+        const invoiceIdentity = await getInvoiceForPractice(
+          txCtx,
+          input.invoiceId,
+        );
         await lockAppointmentForInvoiceMutation(
           txCtx,
-          invoiceIdentity.appointmentId
+          invoiceIdentity.appointmentId,
         );
         const invoice = invoiceIdentity.appointmentId
           ? await getInvoiceForPractice(txCtx, input.invoiceId)
@@ -3221,13 +3313,13 @@ export const billingRouter = createRouter({
         assertCanRecordPayment(invoice);
         await assertVisitInvoiceReadyForFinancialAction(
           txCtx,
-          invoice.appointmentId
+          invoice.appointmentId,
         );
         const totalCents = moneyToCents(invoice.total);
         const paidBeforeCents = moneyToCents(invoice.paidAmount);
         const adjustedCents = await getInvoiceAdjustmentTotalCents(
           txCtx,
-          input.invoiceId
+          input.invoiceId,
         );
         const amountCents = moneyToCents(input.amount);
         const balanceCents = invoiceBalanceCents(invoice, adjustedCents);
@@ -3258,8 +3350,8 @@ export const billingRouter = createRouter({
               eq(invoices.isEstimate, false),
               eq(invoices.status, invoice.status),
               eq(invoices.paidAmount, invoice.paidAmount ?? "0"),
-              invoiceAdjustmentTotalMatches(adjustedCents)
-            )
+              invoiceAdjustmentTotalMatches(adjustedCents),
+            ),
           )
           .returning({ id: invoices.id });
 
@@ -3351,15 +3443,15 @@ export const billingRouter = createRouter({
           users,
           and(
             eq(payments.receivedBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
-          )
+            eq(users.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
             eq(payments.invoiceId, input.invoiceId),
             paymentPracticeScope(ctx),
-            isNull(payments.deletedAt)
-          )
+            isNull(payments.deletedAt),
+          ),
         )
         .orderBy(desc(payments.receivedAt));
     }),
@@ -3382,10 +3474,10 @@ export const billingRouter = createRouter({
         amount: paymentAmountSchema.optional(),
         reason: clinicalTextInput(
           "Refund reason",
-          BILLING_ADJUSTMENT_REASON_MAX_LENGTH
+          BILLING_ADJUSTMENT_REASON_MAX_LENGTH,
         ).min(5, "Explain why the payment is being refunded."),
         dueDate: clinicalDateInput("Due date").optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertBillingProviderActionsAllowed(ctx);
@@ -3402,13 +3494,16 @@ export const billingRouter = createRouter({
           and(
             eq(payments.id, input.paymentId),
             paymentPracticeScope(ctx),
-            isNull(payments.deletedAt)
-          )
+            isNull(payments.deletedAt),
+          ),
         )
         .limit(1);
 
       if (!payment) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Payment not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Payment not found",
+        });
       }
 
       const originalCents = moneyToCents(payment.amount);
@@ -3430,16 +3525,19 @@ export const billingRouter = createRouter({
       }
 
       const refundExternalId = `refund:payment:${payment.id}`;
-      const invoiceIdentity = await getInvoiceForPractice(ctx, payment.invoiceId);
+      const invoiceIdentity = await getInvoiceForPractice(
+        ctx,
+        payment.invoiceId,
+      );
 
       const result = await ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
         await lockAppointmentForInvoiceMutation(
           txCtx,
-          invoiceIdentity.appointmentId
+          invoiceIdentity.appointmentId,
         );
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${refundExternalId}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${refundExternalId}, 0))`,
         );
 
         const [existingRefund] = await tx
@@ -3448,8 +3546,8 @@ export const billingRouter = createRouter({
           .where(
             and(
               eq(payments.externalId, refundExternalId),
-              isNull(payments.deletedAt)
-            )
+              isNull(payments.deletedAt),
+            ),
           )
           .limit(1);
         if (existingRefund) {
@@ -3464,7 +3562,7 @@ export const billingRouter = createRouter({
           : invoiceIdentity;
         const adjustedCents = await getInvoiceAdjustmentTotalCents(
           txCtx,
-          payment.invoiceId
+          payment.invoiceId,
         );
         const paidBeforeCents = moneyToCents(invoice.paidAmount);
         if (amountCents > paidBeforeCents) {
@@ -3491,15 +3589,19 @@ export const billingRouter = createRouter({
                   eq(visitCloseouts.appointmentId, invoice.appointmentId),
                   eq(visitCloseouts.invoiceId, invoice.id),
                   eq(visitCloseouts.status, "completed"),
-                  isNull(visitCloseouts.deletedAt)
-                )
+                  isNull(visitCloseouts.deletedAt),
+                ),
               )
               .limit(1)
               .for("update")
           : [];
         const reopensCompletedPaidCloseout =
           reopensInvoice && closeout?.chargeDisposition === "paid";
-        if (reopensCompletedPaidCloseout && !invoice.dueDate && !input.dueDate) {
+        if (
+          reopensCompletedPaidCloseout &&
+          !invoice.dueDate &&
+          !input.dueDate
+        ) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message:
@@ -3542,16 +3644,15 @@ export const billingRouter = createRouter({
               eq(invoices.isEstimate, false),
               eq(invoices.status, invoice.status),
               eq(invoices.paidAmount, invoice.paidAmount ?? "0"),
-              invoiceAdjustmentTotalMatches(adjustedCents)
-            )
+              invoiceAdjustmentTotalMatches(adjustedCents),
+            ),
           )
           .returning({ id: invoices.id });
 
         if (!updatedInvoice) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message:
-              "Invoice changed while refunding. Refresh and try again.",
+            message: "Invoice changed while refunding. Refresh and try again.",
           });
         }
 
@@ -3570,8 +3671,8 @@ export const billingRouter = createRouter({
                 eq(visitCloseouts.status, "completed"),
                 eq(visitCloseouts.chargeDisposition, "paid"),
                 eq(visitCloseouts.revision, closeout.revision),
-                isNull(visitCloseouts.deletedAt)
-              )
+                isNull(visitCloseouts.deletedAt),
+              ),
             )
             .returning({ id: visitCloseouts.id });
           if (!updatedCloseout) {
@@ -3605,11 +3706,11 @@ export const billingRouter = createRouter({
             priorChargeDisposition: closeout?.chargeDisposition ?? null,
             nextChargeDisposition: reopensCompletedPaidCloseout
               ? "accounts_receivable"
-              : closeout?.chargeDisposition ?? null,
+              : (closeout?.chargeDisposition ?? null),
             priorCloseoutRevision: closeout?.revision ?? null,
             nextCloseoutRevision: reopensCompletedPaidCloseout
               ? closeout.revision + 1
-              : closeout?.revision ?? null,
+              : (closeout?.revision ?? null),
           },
         });
 
@@ -3737,8 +3838,8 @@ export const billingRouter = createRouter({
           and(
             eq(invoices.clientId, clients.id),
             eq(clients.practiceId, ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .leftJoin(
           patients,
@@ -3746,28 +3847,31 @@ export const billingRouter = createRouter({
             eq(invoices.patientId, patients.id),
             eq(patients.clientId, invoices.clientId),
             eq(patients.practiceId, ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .leftJoin(
           practices,
           and(
             eq(invoices.practiceId, practices.id),
             eq(practices.id, ctx.practiceId),
-            isNull(practices.deletedAt)
-          )
+            isNull(practices.deletedAt),
+          ),
         )
         .where(
           and(
             eq(invoices.id, input.invoiceId),
             eq(invoices.practiceId, ctx.practiceId),
-            isNull(invoices.deletedAt)
-          )
+            isNull(invoices.deletedAt),
+          ),
         )
         .limit(1);
 
       if (!invoice) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invoice not found",
+        });
       }
 
       assertCanRecordPayment(invoice);
@@ -3780,14 +3884,14 @@ export const billingRouter = createRouter({
           assertCanRecordPayment(currentInvoice);
           await assertVisitInvoiceReadyForFinancialAction(
             txCtx,
-            currentInvoice.appointmentId
+            currentInvoice.appointmentId,
           );
         });
       }
 
       const adjustedCents = await getInvoiceAdjustmentTotalCents(
         ctx,
-        input.invoiceId
+        input.invoiceId,
       );
       const balanceCents = invoiceBalanceCents(invoice, adjustedCents);
 
@@ -3800,7 +3904,7 @@ export const billingRouter = createRouter({
 
       const connectedAccount = billingEnforced()
         ? assertActiveStripeConnectAccount(
-            await getStripeConnectPaymentAccount(ctx)
+            await getStripeConnectPaymentAccount(ctx),
           )
         : null;
       const clientName = [invoice.clientFirstName, invoice.clientLastName]
@@ -3895,15 +3999,15 @@ export const billingRouter = createRouter({
           users,
           and(
             eq(invoiceAdjustments.createdBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
-          )
+            eq(users.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
             eq(invoiceAdjustments.invoiceId, input.invoiceId),
             adjustmentPracticeScope(ctx),
-            isNull(invoiceAdjustments.deletedAt)
-          )
+            isNull(invoiceAdjustments.deletedAt),
+          ),
         )
         .orderBy(desc(invoiceAdjustments.createdAt));
     }),
@@ -3921,14 +4025,14 @@ export const billingRouter = createRouter({
           .trim()
           .max(BILLING_ADJUSTMENT_REASON_MAX_LENGTH)
           .optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const operationKey = `dashboard-adjustment:${ctx.practiceId}:${input.operationId}`;
       const result = await ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
         );
 
         const [existingAdjustment] = await tx
@@ -3948,15 +4052,16 @@ export const billingRouter = createRouter({
           .where(
             and(
               eq(invoiceAdjustments.operationKey, operationKey),
-              eq(invoices.practiceId, ctx.practiceId)
-            )
+              eq(invoices.practiceId, ctx.practiceId),
+            ),
           )
           .limit(1);
         if (existingAdjustment) {
           if (
             existingAdjustment.invoiceId !== input.invoiceId ||
             existingAdjustment.type !== input.type ||
-            moneyToCents(existingAdjustment.amount) !== moneyToCents(input.amount) ||
+            moneyToCents(existingAdjustment.amount) !==
+              moneyToCents(input.amount) ||
             (existingAdjustment.reason ?? null) !== (input.reason ?? null)
           ) {
             throw new TRPCError({
@@ -3971,10 +4076,13 @@ export const billingRouter = createRouter({
           };
         }
 
-        const invoiceIdentity = await getInvoiceForPractice(txCtx, input.invoiceId);
+        const invoiceIdentity = await getInvoiceForPractice(
+          txCtx,
+          input.invoiceId,
+        );
         await lockAppointmentForInvoiceMutation(
           txCtx,
-          invoiceIdentity.appointmentId
+          invoiceIdentity.appointmentId,
         );
         const invoice = invoiceIdentity.appointmentId
           ? await getInvoiceForPractice(txCtx, input.invoiceId)
@@ -3982,11 +4090,11 @@ export const billingRouter = createRouter({
         assertCanAdjustInvoice(invoice);
         await assertVisitInvoiceReadyForFinancialAction(
           txCtx,
-          invoice.appointmentId
+          invoice.appointmentId,
         );
         const adjustedBeforeCents = await getInvoiceAdjustmentTotalCents(
           txCtx,
-          input.invoiceId
+          input.invoiceId,
         );
         const amountCents = moneyToCents(input.amount);
         const balanceCents = invoiceBalanceCents(invoice, adjustedBeforeCents);
@@ -4018,8 +4126,8 @@ export const billingRouter = createRouter({
               eq(invoices.isEstimate, invoice.isEstimate),
               eq(invoices.status, invoice.status),
               eq(invoices.paidAmount, invoice.paidAmount ?? "0"),
-              invoiceAdjustmentTotalMatches(adjustedBeforeCents)
-            )
+              invoiceAdjustmentTotalMatches(adjustedBeforeCents),
+            ),
           )
           .returning({ id: invoices.id });
 
@@ -4103,24 +4211,30 @@ export const billingRouter = createRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const invoice = await getInvoiceForPractice(ctx, input.id);
-      if (invoice.status === "paid") {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Cannot void a paid invoice.",
-        });
-      }
-      if (invoice.status === "void") {
-        return invoice;
-      }
-
       const voided = await ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        // Match direct edits and estimate conversion: one invoice advisory
+        // boundary, then appointment/source locks, then sorted product locks,
+        // and only then the invoice row update. This avoids invoice↔product
+        // cycles with concurrent edits and product↔product cycles across voids.
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${input.id}, 0))`,
+        );
+        const invoice = await getInvoiceForPractice(txCtx, input.id);
+        if (invoice.status === "paid") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Cannot void a paid invoice.",
+          });
+        }
+        if (invoice.status === "void") {
+          return invoice;
+        }
         await lockAppointmentForInvoiceMutation(txCtx, invoice.appointmentId);
         await assertInvoiceNotCompletedCloseout(txCtx, input.id);
         const adjustedCents = await getInvoiceAdjustmentTotalCents(
           txCtx,
-          input.id
+          input.id,
         );
         if (moneyToCents(invoice.paidAmount) > 0 || adjustedCents > 0) {
           throw new TRPCError({
@@ -4136,13 +4250,25 @@ export const billingRouter = createRouter({
               eq(visitWorkItems.practiceId, ctx.practiceId),
               eq(visitWorkItems.invoiceId, input.id),
               eq(visitWorkItems.status, "charged"),
-              isNull(visitWorkItems.deletedAt)
-            )
+              isNull(visitWorkItems.deletedAt),
+            ),
           )
           .for("update");
+        const stockItems = invoice.isEstimate
+          ? []
+          : await invoiceProductItemsForStock(txCtx, input.id);
+        if (stockItems.length > 0) {
+          await assertLineItemReferences(txCtx, [], {
+            previousItems: stockItems,
+            lockProductsForStock: true,
+          });
+        }
         const [updated] = await tx
           .update(invoices)
-          .set({ status: "void" })
+          .set({
+            status: "void",
+            updatedAt: nextInvoiceUpdatedAt(invoice.updatedAt),
+          })
           .where(
             and(
               eq(invoices.id, input.id),
@@ -4152,8 +4278,8 @@ export const billingRouter = createRouter({
               eq(invoices.isEstimate, invoice.isEstimate),
               eq(invoices.paidAmount, invoice.paidAmount ?? "0"),
               noActivePaymentsForInvoice(),
-              noActiveAdjustmentsForInvoice()
-            )
+              noActiveAdjustmentsForInvoice(),
+            ),
           )
           .returning();
 
@@ -4164,9 +4290,8 @@ export const billingRouter = createRouter({
           });
         }
 
-        if (!invoice.isEstimate) {
-          const items = await invoiceProductItemsForStock(txCtx, input.id);
-          await restoreProductStock(txCtx, items);
+        if (stockItems.length > 0) {
+          await restoreProductStock(txCtx, stockItems);
         }
         await reopenInvoiceDispenseCharges(txCtx, input.id);
         if (linkedWork.length > 0) {
@@ -4187,12 +4312,12 @@ export const billingRouter = createRouter({
                 eq(visitWorkItems.practiceId, ctx.practiceId),
                 inArray(
                   visitWorkItems.id,
-                  linkedWork.map((work) => work.id)
+                  linkedWork.map((work) => work.id),
                 ),
                 eq(visitWorkItems.status, "charged"),
                 eq(visitWorkItems.invoiceId, input.id),
-                isNull(visitWorkItems.deletedAt)
-              )
+                isNull(visitWorkItems.deletedAt),
+              ),
             );
         }
         await tx.insert(auditLog).values({
@@ -4221,17 +4346,221 @@ export const billingRouter = createRouter({
 
   convertEstimateToInvoice: protectedProcedure
     .use(requireRole("admin", "front_desk"))
-    .input(z.object({ id: z.string().uuid() }))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        expectedUpdatedAt: z.date(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
-      const existing = await getInvoiceForPractice(ctx, input.id);
-      assertCanConvertEstimate(existing);
-
-      const items = await invoiceProductItemsForStock(ctx, input.id);
+      // This first lookup only chooses the visit lock. Every mutable fact is
+      // re-read after the invoice/visit advisory locks inside the transaction.
+      const [identity] = await ctx.db
+        .select({ appointmentId: invoices.appointmentId })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.id, input.id),
+            eq(invoices.practiceId, ctx.practiceId),
+            isNull(invoices.deletedAt),
+          ),
+        )
+        .limit(1);
+      if (!identity) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invoice not found",
+        });
+      }
 
       return ctx.db.transaction(async (tx) => {
+        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${input.id}, 0))`,
+        );
+
+        let appointment:
+          | {
+              id: string;
+              clientId: string | null;
+              patientId: string | null;
+              status: (typeof appointments.$inferSelect)["status"];
+            }
+          | undefined;
+        if (identity.appointmentId) {
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${identity.appointmentId}, 0))`,
+          );
+          [appointment] = await tx
+            .select({
+              id: appointments.id,
+              clientId: appointments.clientId,
+              patientId: appointments.patientId,
+              status: appointments.status,
+            })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, identity.appointmentId),
+                eq(appointments.practiceId, ctx.practiceId),
+                isNull(appointments.deletedAt),
+              ),
+            )
+            .for("update");
+          if (!appointment) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "The linked appointment is no longer available.",
+            });
+          }
+          if (appointment.status !== "in_exam") {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                "Start the exam before converting this visit estimate to an invoice.",
+            });
+          }
+        }
+
+        const [existing] = await tx
+          .select({
+            id: invoices.id,
+            clientId: invoices.clientId,
+            patientId: invoices.patientId,
+            appointmentId: invoices.appointmentId,
+            total: invoices.total,
+            paidAmount: invoices.paidAmount,
+            status: invoices.status,
+            isEstimate: invoices.isEstimate,
+            dueDate: invoices.dueDate,
+            updatedAt: invoices.updatedAt,
+          })
+          .from(invoices)
+          .where(
+            and(
+              eq(invoices.id, input.id),
+              eq(invoices.practiceId, ctx.practiceId),
+              isNull(invoices.deletedAt),
+            ),
+          )
+          .for("update");
+        if (!existing) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Invoice not found",
+          });
+        }
+        assertCanConvertEstimate(existing);
+        if (
+          existing.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Estimate changed. Refresh before converting it.",
+          });
+        }
+        if (existing.appointmentId !== identity.appointmentId) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Estimate visit changed. Refresh before converting it.",
+          });
+        }
+        if (
+          appointment &&
+          (appointment.clientId !== existing.clientId ||
+            appointment.patientId !== existing.patientId)
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "The estimate no longer matches the visit client and patient.",
+          });
+        }
+
+        if (existing.appointmentId) {
+          const [activeInvoice] = await tx
+            .select({ id: invoices.id })
+            .from(invoices)
+            .where(
+              and(
+                eq(invoices.practiceId, ctx.practiceId),
+                eq(invoices.appointmentId, existing.appointmentId),
+                ne(invoices.id, input.id),
+                eq(invoices.isEstimate, false),
+                ne(invoices.status, "void"),
+                isNull(invoices.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (activeInvoice) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "This visit already has an active invoice. Open it instead of converting another estimate.",
+            });
+          }
+        }
+
+        const items = await tx
+          .select({
+            description: invoiceItems.description,
+            quantity: invoiceItems.quantity,
+            unitPrice: invoiceItems.unitPrice,
+            itemType: invoiceItems.itemType,
+            itemId: invoiceItems.itemId,
+            sourcePrescriptionId: invoiceItems.sourcePrescriptionId,
+            sourceDispenseChargeId: invoiceItems.sourceDispenseChargeId,
+          })
+          .from(invoiceItems)
+          .where(
+            and(
+              eq(invoiceItems.invoiceId, input.id),
+              invoiceItemPracticeScope(txCtx),
+              isNull(invoiceItems.deletedAt),
+            ),
+          )
+          .orderBy(invoiceItems.id)
+          .for("share");
+        if (items.length === 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Add at least one line item before converting this estimate.",
+          });
+        }
+
+        if (
+          items.some(
+            (item) => item.sourcePrescriptionId || item.sourceDispenseChargeId,
+          )
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "This estimate contains a dispensed-medication line. Rebuild the medication charge from Charge capture or the medication billing queue before converting.",
+          });
+        }
+        await assertPrescriptionChargeSources(txCtx, items, {
+          appointmentId: existing.appointmentId,
+          patientId: existing.patientId,
+          currentInvoiceId: input.id,
+        });
+        await assertDispenseChargeSources(txCtx, items, {
+          clientId: existing.clientId,
+          patientId: existing.patientId,
+          appointmentId: existing.appointmentId,
+          currentInvoiceId: input.id,
+          isEstimate: false,
+        });
+        await assertLineItemReferences(txCtx, items, {
+          lockProductsForStock: true,
+        });
+        await deductProductStock(txCtx, stockOwnedItems(items));
+
+        const convertedAt = nextInvoiceUpdatedAt(existing.updatedAt);
         const [invoice] = await tx
           .update(invoices)
-          .set({ isEstimate: false })
+          .set({ isEstimate: false, status: "draft", updatedAt: convertedAt })
           .where(
             and(
               eq(invoices.id, input.id),
@@ -4239,22 +4568,40 @@ export const billingRouter = createRouter({
               eq(invoices.isEstimate, true),
               eq(invoices.status, existing.status),
               eq(invoices.paidAmount, existing.paidAmount ?? "0"),
-              isNull(invoices.deletedAt)
-            )
+              invoiceUpdatedAtMatches(input.expectedUpdatedAt),
+              noActivePaymentsForInvoice(),
+              noActiveAdjustmentsForInvoice(),
+              isNull(invoices.deletedAt),
+            ),
           )
           .returning();
 
         if (!invoice) {
           throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Estimate changed while converting. Refresh and try again.",
+            code: "CONFLICT",
+            message:
+              "Estimate changed while converting. Refresh and try again.",
           });
         }
 
-        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
-        await deductProductStock(txCtx, items);
+        await tx.insert(auditLog).values({
+          practiceId: ctx.practiceId,
+          userId: ctx.user.id,
+          action: "estimate_converted",
+          entityType: "invoice",
+          entityId: input.id,
+          changes: {
+            priorStatus: existing.status,
+            nextStatus: "draft",
+            visitLinked: Boolean(existing.appointmentId),
+            itemCount: items.length,
+            productLineCount: items.filter(
+              (item) => item.itemType === "product",
+            ).length,
+          },
+        });
 
-        return invoice;
+        return invoice!;
       });
     }),
 });

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -84,21 +84,27 @@ const optionalText = (label: string, max: number) =>
 const clinicalDraftInput = z.object({
   appointmentId: z.string().uuid(),
   expectedRevision: z.number().int().min(0),
-  diagnosisSummary: optionalText("Diagnosis summary", CLOSEOUT_DIAGNOSIS_MAX_LENGTH),
+  diagnosisSummary: optionalText(
+    "Diagnosis summary",
+    CLOSEOUT_DIAGNOSIS_MAX_LENGTH,
+  ),
   dischargeInstructions: optionalText(
     "Discharge instructions",
-    CLOSEOUT_INSTRUCTIONS_MAX_LENGTH
+    CLOSEOUT_INSTRUCTIONS_MAX_LENGTH,
   ),
-  warningSigns: optionalText("Warning signs", CLOSEOUT_WARNING_SIGNS_MAX_LENGTH),
+  warningSigns: optionalText(
+    "Warning signs",
+    CLOSEOUT_WARNING_SIGNS_MAX_LENGTH,
+  ),
   noInstructionsReason: optionalText(
     "No-instructions reason",
-    CLOSEOUT_REASON_MAX_LENGTH
+    CLOSEOUT_REASON_MAX_LENGTH,
   ),
   prescriptionDisposition: z.enum(["prescribed", "not_needed"]).nullable(),
   followUpDisposition: z.enum(["none", "needed", "scheduled"]).nullable(),
   followUpNotes: optionalText(
     "Follow-up notes",
-    CLOSEOUT_FOLLOW_UP_NOTES_MAX_LENGTH
+    CLOSEOUT_FOLLOW_UP_NOTES_MAX_LENGTH,
   ),
   followUpAppointmentId: z.string().uuid().nullable(),
   followUpDueDate: clinicalDateInput("Follow-up due date")
@@ -113,7 +119,7 @@ const clinicalDraftInput = z.object({
     .transform((value) => value ?? null),
   documentationExceptionReason: optionalText(
     "Documentation exception",
-    CLOSEOUT_REASON_MAX_LENGTH
+    CLOSEOUT_REASON_MAX_LENGTH,
   ),
 });
 
@@ -189,7 +195,10 @@ const completeVisitInput = z
     appointmentId: z.string().uuid(),
     expectedRevision: z.number().int().min(1),
     chargeDisposition: z.enum(["paid", "accounts_receivable", "no_charge"]),
-    noChargeReason: optionalText("No-charge reason", CLOSEOUT_REASON_MAX_LENGTH),
+    noChargeReason: optionalText(
+      "No-charge reason",
+      CLOSEOUT_REASON_MAX_LENGTH,
+    ),
     invoiceDueDate: clinicalDateInput("Invoice due date").nullish(),
     handoffMethod: z.enum(["print", "verbal", "declined"]),
   })
@@ -251,7 +260,10 @@ const resolveNeededFollowUpInput = z
       .nullable()
       .optional()
       .transform((value) => value ?? null),
-    notes: optionalText("Follow-up resolution notes", CLOSEOUT_REASON_MAX_LENGTH),
+    notes: optionalText(
+      "Follow-up resolution notes",
+      CLOSEOUT_REASON_MAX_LENGTH,
+    ),
   })
   .superRefine((input, ctx) => {
     if (input.resolution === "scheduled" && !input.resolutionAppointmentId) {
@@ -261,10 +273,7 @@ const resolveNeededFollowUpInput = z
         message: "Choose the scheduled follow-up appointment.",
       });
     }
-    if (
-      input.resolution !== "scheduled" &&
-      input.resolutionAppointmentId
-    ) {
+    if (input.resolution !== "scheduled" && input.resolutionAppointmentId) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["resolutionAppointmentId"],
@@ -350,10 +359,7 @@ async function isVeterinarianProvider(
   return Boolean(provider);
 }
 
-async function lockAppointment(
-  ctx: EncounterContext,
-  appointmentId: string
-) {
+async function lockAppointment(ctx: EncounterContext, appointmentId: string) {
   const [appointment] = await ctx.db
     .select({
       id: appointments.id,
@@ -370,30 +376,33 @@ async function lockAppointment(
       and(
         eq(appointments.practiceId, practices.id),
         eq(practices.id, ctx.practiceId),
-        isNull(practices.deletedAt)
-      )
+        isNull(practices.deletedAt),
+      ),
     )
     .leftJoin(
       appointmentTypes,
       and(
         eq(appointments.typeId, appointmentTypes.id),
         eq(appointmentTypes.practiceId, ctx.practiceId),
-        isNull(appointmentTypes.deletedAt)
-      )
+        isNull(appointmentTypes.deletedAt),
+      ),
     )
     .where(
       and(
         eq(appointments.id, appointmentId),
         eq(appointments.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(appointments.deletedAt)
-      )
+        isNull(appointments.deletedAt),
+      ),
     )
     .limit(1)
     .for("update", { of: appointments });
 
   if (!appointment) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Appointment not found",
+    });
   }
   if (!appointment.patientId || !appointment.clientId) {
     throw new TRPCError({
@@ -410,8 +419,8 @@ async function lockAppointment(
         eq(patients.id, appointment.patientId),
         eq(patients.clientId, appointment.clientId),
         eq(patients.practiceId, ctx.practiceId),
-        isNull(patients.deletedAt)
-      )
+        isNull(patients.deletedAt),
+      ),
     )
     .limit(1);
   if (!patient) {
@@ -420,7 +429,11 @@ async function lockAppointment(
       message: "The appointment patient and client no longer match.",
     });
   }
-  return { ...appointment, patientId: appointment.patientId, clientId: appointment.clientId };
+  return {
+    ...appointment,
+    patientId: appointment.patientId,
+    clientId: appointment.clientId,
+  };
 }
 
 async function getCloseoutRow(ctx: EncounterContext, appointmentId: string) {
@@ -431,8 +444,8 @@ async function getCloseoutRow(ctx: EncounterContext, appointmentId: string) {
       and(
         eq(visitCloseouts.appointmentId, appointmentId),
         eq(visitCloseouts.practiceId, ctx.practiceId),
-        isNull(visitCloseouts.deletedAt)
-      )
+        isNull(visitCloseouts.deletedAt),
+      ),
     )
     .limit(1);
   return closeout ?? null;
@@ -449,7 +462,7 @@ function assertOpenForClinical(status: string) {
 
 function sameClinicalPayload(
   row: typeof visitCloseouts.$inferSelect,
-  input: z.infer<typeof clinicalDraftInput>
+  input: z.infer<typeof clinicalDraftInput>,
 ) {
   return (
     row.diagnosisSummary === input.diagnosisSummary &&
@@ -484,7 +497,7 @@ function clinicalDraftValues(input: z.infer<typeof clinicalDraftInput>) {
 
 function assertAmendmentAppointmentState(
   appointmentStatus: string,
-  closeoutStatus: (typeof visitCloseouts.$inferSelect)["status"]
+  closeoutStatus: (typeof visitCloseouts.$inferSelect)["status"],
 ) {
   const isOpenFinalizedVisit =
     closeoutStatus === "clinical_finalized" && appointmentStatus === "in_exam";
@@ -504,7 +517,7 @@ async function appointmentInvoiceRows(
   appointmentId: string,
   patientId: string,
   clientId: string,
-  lock = false
+  lock = false,
 ) {
   const query = ctx.db
     .select({
@@ -523,8 +536,8 @@ async function appointmentInvoiceRows(
         eq(invoices.practiceId, ctx.practiceId),
         eq(invoices.isEstimate, false),
         ne(invoices.status, "void"),
-        isNull(invoices.deletedAt)
-      )
+        isNull(invoices.deletedAt),
+      ),
     )
     .orderBy(desc(invoices.createdAt));
   return lock ? query.for("update") : query;
@@ -532,17 +545,14 @@ async function appointmentInvoiceRows(
 
 async function invoiceReadiness(
   ctx: EncounterContext,
-  row: Awaited<ReturnType<typeof appointmentInvoiceRows>>[number]
+  row: Awaited<ReturnType<typeof appointmentInvoiceRows>>[number],
 ) {
   const [[itemsSummary], [adjustmentsSummary]] = await Promise.all([
     ctx.db
       .select({ itemCount: sql<number>`count(*)::int` })
       .from(invoiceItems)
       .where(
-        and(
-          eq(invoiceItems.invoiceId, row.id),
-          isNull(invoiceItems.deletedAt)
-        )
+        and(eq(invoiceItems.invoiceId, row.id), isNull(invoiceItems.deletedAt)),
       ),
     ctx.db
       .select({
@@ -552,8 +562,8 @@ async function invoiceReadiness(
       .where(
         and(
           eq(invoiceAdjustments.invoiceId, row.id),
-          isNull(invoiceAdjustments.deletedAt)
-        )
+          isNull(invoiceAdjustments.deletedAt),
+        ),
       ),
   ]);
   const adjustedAmount = adjustmentsSummary?.adjustedAmount ?? "0";
@@ -569,7 +579,7 @@ async function invoiceReadiness(
 async function lockInitialDispenseCharge(
   ctx: EncounterContext,
   prescriptionId: string,
-  appointmentId: string
+  appointmentId: string,
 ) {
   const [charge] = await ctx.db
     .select({
@@ -585,15 +595,15 @@ async function lockInitialDispenseCharge(
       and(
         eq(dispenseChargeQueue.prescriptionEventId, prescriptionEvents.id),
         eq(prescriptionEvents.practiceId, ctx.practiceId),
-        eq(prescriptionEvents.eventType, "created")
-      )
+        eq(prescriptionEvents.eventType, "created"),
+      ),
     )
     .where(
       and(
         eq(dispenseChargeQueue.practiceId, ctx.practiceId),
         eq(dispenseChargeQueue.prescriptionId, prescriptionId),
-        eq(dispenseChargeQueue.appointmentId, appointmentId)
-      )
+        eq(dispenseChargeQueue.appointmentId, appointmentId),
+      ),
     )
     .limit(1)
     .for("update");
@@ -613,8 +623,7 @@ export const encountersRouter = createRouter({
         assigneeName: visitCloseouts.followUpAssigneeName,
         followUpNotes: visitCloseouts.followUpNotes,
         resolution: visitCloseouts.followUpResolution,
-        resolutionAppointmentId:
-          visitCloseouts.followUpResolutionAppointmentId,
+        resolutionAppointmentId: visitCloseouts.followUpResolutionAppointmentId,
         resolutionScheduledAt: visitCloseouts.followUpResolutionScheduledAt,
         resolutionNotes: visitCloseouts.followUpResolutionNotes,
         resolvedAt: visitCloseouts.followUpResolvedAt,
@@ -633,16 +642,16 @@ export const encountersRouter = createRouter({
         and(
           eq(visitCloseouts.appointmentId, appointments.id),
           eq(appointments.practiceId, ctx.practiceId),
-          isNull(appointments.deletedAt)
-        )
+          isNull(appointments.deletedAt),
+        ),
       )
       .innerJoin(
         patients,
         and(
           eq(appointments.patientId, patients.id),
           eq(patients.practiceId, ctx.practiceId),
-          isNull(patients.deletedAt)
-        )
+          isNull(patients.deletedAt),
+        ),
       )
       .innerJoin(
         clients,
@@ -650,8 +659,8 @@ export const encountersRouter = createRouter({
           eq(appointments.clientId, clients.id),
           eq(patients.clientId, clients.id),
           eq(clients.practiceId, ctx.practiceId),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       )
       .where(
         and(
@@ -660,10 +669,13 @@ export const encountersRouter = createRouter({
           inArray(visitCloseouts.status, ["clinical_finalized", "completed"]),
           isNull(visitCloseouts.followUpResolvedAt),
           activePracticePredicate(ctx.practiceId),
-          isNull(visitCloseouts.deletedAt)
-        )
+          isNull(visitCloseouts.deletedAt),
+        ),
       )
-      .orderBy(asc(visitCloseouts.followUpDueDate), asc(visitCloseouts.createdAt))
+      .orderBy(
+        asc(visitCloseouts.followUpDueDate),
+        asc(visitCloseouts.createdAt),
+      ),
   ),
 
   getCloseout: protectedProcedure
@@ -684,20 +696,23 @@ export const encountersRouter = createRouter({
           and(
             eq(appointments.practiceId, practices.id),
             eq(practices.id, ctx.practiceId),
-            isNull(practices.deletedAt)
-          )
+            isNull(practices.deletedAt),
+          ),
         )
         .where(
           and(
             eq(appointments.id, input.appointmentId),
             eq(appointments.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(appointments.deletedAt)
-          )
+            isNull(appointments.deletedAt),
+          ),
         )
         .limit(1);
       if (!appointment) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Appointment not found",
+        });
       }
       const [
         closeout,
@@ -705,6 +720,7 @@ export const encountersRouter = createRouter({
         soapDraftRows,
         missingSoapReplacementRows,
         medications,
+        visitDispenses,
         followUpAppointments,
         followUpAssignees,
       ] = await Promise.all([
@@ -823,51 +839,94 @@ export const encountersRouter = createRouter({
             ),
           )
           .orderBy(desc(prescriptions.createdAt)),
-          appointment.patientId && appointment.clientId
-            ? ctx.db
-                .select({
-                  id: appointments.id,
-                  startTime: appointments.startTime,
-                  status: appointments.status,
-                })
-                .from(appointments)
-                .where(
-                  and(
-                    eq(appointments.patientId, appointment.patientId),
-                    eq(appointments.clientId, appointment.clientId),
-                    eq(appointments.practiceId, ctx.practiceId),
-                    gt(appointments.startTime, new Date()),
-                    inArray(appointments.status, ["scheduled", "confirmed"]),
-                    isNull(appointments.deletedAt)
-                  )
-                )
-                .orderBy(appointments.startTime)
-                .limit(25)
-            : Promise.resolve([]),
-          ctx.db
-            .select({
-              id: users.id,
-              name: users.name,
-              email: users.email,
-              role: users.role,
-            })
-            .from(users)
-            .where(
-              and(
-                eq(users.practiceId, ctx.practiceId),
-                inArray(users.role, [
-                  "admin",
-                  "veterinarian",
-                  "technician",
-                  "front_desk",
-                ]),
-                activePracticePredicate(ctx.practiceId),
-                isNull(users.deletedAt)
+        ctx.db
+          .select({
+            id: prescriptions.id,
+            medicationName: prescriptions.medicationName,
+            dosage: prescriptions.dosage,
+            frequency: prescriptions.frequency,
+            instructions: prescriptions.instructions,
+            quantity: dispenseChargeQueue.quantity,
+            productId: dispenseChargeQueue.productId,
+            productName: products.name,
+            productTaxable: products.taxable,
+            productUnitPrice: dispenseChargeQueue.unitPriceSnapshot,
+            dispenseChargeId: dispenseChargeQueue.id,
+            dispenseChargeStatus: dispenseChargeQueue.status,
+            dispenseChargeDescription: dispenseChargeQueue.descriptionSnapshot,
+            status: prescriptions.status,
+            endDate: prescriptions.endDate,
+          })
+          .from(dispenseChargeQueue)
+          .innerJoin(
+            prescriptions,
+            and(
+              eq(dispenseChargeQueue.prescriptionId, prescriptions.id),
+              eq(prescriptions.practiceId, ctx.practiceId),
+            ),
+          )
+          .leftJoin(
+            products,
+            and(
+              eq(dispenseChargeQueue.productId, products.id),
+              eq(products.practiceId, ctx.practiceId),
+            ),
+          )
+          .where(
+            and(
+              eq(dispenseChargeQueue.practiceId, ctx.practiceId),
+              eq(dispenseChargeQueue.appointmentId, input.appointmentId),
+            ),
+          )
+          .orderBy(
+            desc(dispenseChargeQueue.createdAt),
+            desc(dispenseChargeQueue.id),
+          ),
+        appointment.patientId && appointment.clientId
+          ? ctx.db
+              .select({
+                id: appointments.id,
+                startTime: appointments.startTime,
+                status: appointments.status,
+              })
+              .from(appointments)
+              .where(
+                and(
+                  eq(appointments.patientId, appointment.patientId),
+                  eq(appointments.clientId, appointment.clientId),
+                  eq(appointments.practiceId, ctx.practiceId),
+                  gt(appointments.startTime, new Date()),
+                  inArray(appointments.status, ["scheduled", "confirmed"]),
+                  isNull(appointments.deletedAt),
+                ),
               )
-            )
-            .orderBy(asc(users.name), asc(users.email))
-            .limit(100),
-        ]);
+              .orderBy(appointments.startTime)
+              .limit(25)
+          : Promise.resolve([]),
+        ctx.db
+          .select({
+            id: users.id,
+            name: users.name,
+            email: users.email,
+            role: users.role,
+          })
+          .from(users)
+          .where(
+            and(
+              eq(users.practiceId, ctx.practiceId),
+              inArray(users.role, [
+                "admin",
+                "veterinarian",
+                "technician",
+                "front_desk",
+              ]),
+              activePracticePredicate(ctx.practiceId),
+              isNull(users.deletedAt),
+            ),
+          )
+          .orderBy(asc(users.name), asc(users.email))
+          .limit(100),
+      ]);
 
       const rawInvoices =
         appointment.patientId && appointment.clientId
@@ -875,17 +934,30 @@ export const encountersRouter = createRouter({
               ctx,
               input.appointmentId,
               appointment.patientId,
-              appointment.clientId
+              appointment.clientId,
             )
           : [];
       const invoiceSummaries = await Promise.all(
-        rawInvoices.map((invoice) => invoiceReadiness(ctx, invoice))
+        rawInvoices.map((invoice) => invoiceReadiness(ctx, invoice)),
       );
       const practiceToday = formatDateInputForTimeZone(
         new Date(),
         appointment.practiceTimezone,
       );
-      const medicationHistory = medications.map((medication) => ({
+      const visitDispenseIdsAlreadyIncluded = new Set(
+        medications
+          .map((medication) => medication.dispenseChargeId)
+          .filter((id): id is string => Boolean(id)),
+      );
+      const chargeCaptureMedications = [
+        ...medications,
+        ...visitDispenses.filter(
+          (medication) =>
+            !medication.dispenseChargeId ||
+            !visitDispenseIdsAlreadyIncluded.has(medication.dispenseChargeId),
+        ),
+      ];
+      const medicationHistory = chargeCaptureMedications.map((medication) => ({
         ...medication,
         effectiveStatus: effectivePrescriptionStatus({
           status: medication.status,
@@ -893,6 +965,17 @@ export const encountersRouter = createRouter({
           today: practiceToday,
         }),
       }));
+      const activeMedications = [
+        ...medicationHistory
+          .filter((medication) => medication.effectiveStatus === "active")
+          .reduce((byPrescription, medication) => {
+            if (!byPrescription.has(medication.id)) {
+              byPrescription.set(medication.id, medication);
+            }
+            return byPrescription;
+          }, new Map<string, (typeof medicationHistory)[number]>())
+          .values(),
+      ];
 
       return {
         closeout,
@@ -912,9 +995,7 @@ export const encountersRouter = createRouter({
             ? (missingSoapReplacementRows[0] ?? null)
             : null,
         medications: medicationHistory,
-        activeMedications: medicationHistory.filter(
-          (medication) => medication.effectiveStatus === "active",
-        ),
+        activeMedications,
         followUpAppointments,
         followUpAssignees,
         invoices: invoiceSummaries,
@@ -932,8 +1013,8 @@ export const encountersRouter = createRouter({
             eq(appointments.id, input.appointmentId),
             eq(appointments.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(appointments.deletedAt)
-          )
+            isNull(appointments.deletedAt),
+          ),
         )
         .limit(1);
       if (!appointment) {
@@ -999,8 +1080,8 @@ export const encountersRouter = createRouter({
               eq(visitWorkItems.vaccinationRecordId, vaccinationRecords.id),
               eq(vaccinationRecords.practiceId, ctx.practiceId),
               eq(vaccinationRecords.appointmentId, input.appointmentId),
-              isNull(vaccinationRecords.deletedAt)
-            )
+              isNull(vaccinationRecords.deletedAt),
+            ),
           )
           .leftJoin(
             labResults,
@@ -1008,8 +1089,8 @@ export const encountersRouter = createRouter({
               eq(visitWorkItems.labResultId, labResults.id),
               eq(labResults.practiceId, ctx.practiceId),
               eq(labResults.appointmentId, input.appointmentId),
-              isNull(labResults.deletedAt)
-            )
+              isNull(labResults.deletedAt),
+            ),
           )
           .leftJoin(
             procedures,
@@ -1017,8 +1098,8 @@ export const encountersRouter = createRouter({
               eq(visitWorkItems.procedureId, procedures.id),
               eq(procedures.practiceId, ctx.practiceId),
               eq(procedures.appointmentId, input.appointmentId),
-              isNull(procedures.deletedAt)
-            )
+              isNull(procedures.deletedAt),
+            ),
           )
           .leftJoin(
             prescriptions,
@@ -1026,42 +1107,42 @@ export const encountersRouter = createRouter({
               eq(visitWorkItems.prescriptionId, prescriptions.id),
               eq(prescriptions.practiceId, ctx.practiceId),
               eq(prescriptions.appointmentId, input.appointmentId),
-              isNull(prescriptions.deletedAt)
-            )
+              isNull(prescriptions.deletedAt),
+            ),
           )
           .leftJoin(
             products,
             and(
               eq(prescriptions.productId, products.id),
               eq(products.practiceId, ctx.practiceId),
-              isNull(products.deletedAt)
-            )
+              isNull(products.deletedAt),
+            ),
           )
           .leftJoin(
             invoiceItems,
-            eq(visitWorkItems.invoiceItemId, invoiceItems.id)
+            eq(visitWorkItems.invoiceItemId, invoiceItems.id),
           )
           .leftJoin(
             invoices,
             and(
               eq(visitWorkItems.invoiceId, invoices.id),
               eq(invoices.practiceId, ctx.practiceId),
-              eq(invoices.appointmentId, input.appointmentId)
-            )
+              eq(invoices.appointmentId, input.appointmentId),
+            ),
           )
           .leftJoin(
             users,
             and(
               eq(visitWorkItems.resolvedBy, users.id),
-              eq(users.practiceId, ctx.practiceId)
-            )
+              eq(users.practiceId, ctx.practiceId),
+            ),
           )
           .where(
             and(
               eq(visitWorkItems.practiceId, ctx.practiceId),
               eq(visitWorkItems.appointmentId, input.appointmentId),
-              isNull(visitWorkItems.deletedAt)
-            )
+              isNull(visitWorkItems.deletedAt),
+            ),
           )
           .orderBy(asc(visitWorkItems.createdAt), asc(visitWorkItems.id)),
         ctx.db
@@ -1075,8 +1156,8 @@ export const encountersRouter = createRouter({
             and(
               eq(services.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(services.deletedAt)
-            )
+              isNull(services.deletedAt),
+            ),
           )
           .orderBy(asc(services.name), asc(services.id))
           .limit(500),
@@ -1099,15 +1180,15 @@ export const encountersRouter = createRouter({
               eq(invoices.appointmentId, input.appointmentId),
               eq(invoices.isEstimate, false),
               ne(invoices.status, "void"),
-              isNull(invoices.deletedAt)
-            )
+              isNull(invoices.deletedAt),
+            ),
           )
           .leftJoin(
             visitWorkItems,
             and(
               eq(invoiceItems.id, visitWorkItems.invoiceItemId),
-              isNull(visitWorkItems.deletedAt)
-            )
+              isNull(visitWorkItems.deletedAt),
+            ),
           )
           .where(and(isNull(invoiceItems.deletedAt), isNull(visitWorkItems.id)))
           .orderBy(asc(invoiceItems.createdAt), asc(invoiceItems.id)),
@@ -1130,7 +1211,7 @@ export const encountersRouter = createRouter({
               item.invoiceStatus !== "void"),
           suggestedService:
             servicesByName.get(
-              item.sourceLabel.trim().toLocaleLowerCase("en-US")
+              item.sourceLabel.trim().toLocaleLowerCase("en-US"),
             ) ?? null,
         })),
         invoiceItemOptions,
@@ -1141,7 +1222,7 @@ export const encountersRouter = createRouter({
               (item.invoiceItemDeletedAt !== null ||
                 item.invoiceDeletedAt !== null ||
                 !item.invoiceStatus ||
-                item.invoiceStatus === "void"))
+                item.invoiceStatus === "void")),
         ).length,
       };
     }),
@@ -1180,8 +1261,8 @@ export const encountersRouter = createRouter({
               eq(visitWorkItems.id, input.workItemId),
               eq(visitWorkItems.practiceId, ctx.practiceId),
               eq(visitWorkItems.appointmentId, input.appointmentId),
-              isNull(visitWorkItems.deletedAt)
-            )
+              isNull(visitWorkItems.deletedAt),
+            ),
           )
           .limit(1)
           .for("update");
@@ -1214,7 +1295,7 @@ export const encountersRouter = createRouter({
           ? await lockInitialDispenseCharge(
               txCtx,
               workItem.prescriptionId,
-              input.appointmentId
+              input.appointmentId,
             )
           : null;
 
@@ -1254,14 +1335,14 @@ export const encountersRouter = createRouter({
                 eq(invoices.appointmentId, input.appointmentId),
                 eq(invoices.isEstimate, false),
                 ne(invoices.status, "void"),
-                isNull(invoices.deletedAt)
-              )
+                isNull(invoices.deletedAt),
+              ),
             )
             .where(
               and(
                 eq(invoiceItems.id, input.resolution.invoiceItemId),
-                isNull(invoiceItems.deletedAt)
-              )
+                isNull(invoiceItems.deletedAt),
+              ),
             )
             .limit(1);
           if (!charge) {
@@ -1374,8 +1455,8 @@ export const encountersRouter = createRouter({
               and(
                 eq(dispenseChargeQueue.id, dispenseCharge.id),
                 eq(dispenseChargeQueue.practiceId, ctx.practiceId),
-                eq(dispenseChargeQueue.status, "pending")
-              )
+                eq(dispenseChargeQueue.status, "pending"),
+              ),
             )
             .returning({ id: dispenseChargeQueue.id });
           if (!waived) {
@@ -1395,8 +1476,8 @@ export const encountersRouter = createRouter({
               eq(visitWorkItems.practiceId, ctx.practiceId),
               eq(visitWorkItems.appointmentId, input.appointmentId),
               eq(visitWorkItems.status, "unresolved"),
-              isNull(visitWorkItems.deletedAt)
-            )
+              isNull(visitWorkItems.deletedAt),
+            ),
           )
           .returning();
         if (!resolved) {
@@ -1432,8 +1513,8 @@ export const encountersRouter = createRouter({
               eq(visitWorkItems.id, input.workItemId),
               eq(visitWorkItems.practiceId, ctx.practiceId),
               eq(visitWorkItems.appointmentId, input.appointmentId),
-              isNull(visitWorkItems.deletedAt)
-            )
+              isNull(visitWorkItems.deletedAt),
+            ),
           )
           .limit(1)
           .for("update");
@@ -1453,9 +1534,9 @@ export const encountersRouter = createRouter({
                 eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
                 eq(
                   clinicalRecordCorrections.vaccinationRecordId,
-                  workItem.vaccinationRecordId
-                )
-              )
+                  workItem.vaccinationRecordId,
+                ),
+              ),
             )
             .limit(1);
           if (correction) {
@@ -1474,7 +1555,7 @@ export const encountersRouter = createRouter({
             ? await lockInitialDispenseCharge(
                 txCtx,
                 workItem.prescriptionId,
-                input.appointmentId
+                input.appointmentId,
               )
             : null;
         if (dispenseCharge && ctx.user.role !== "admin") {
@@ -1527,8 +1608,8 @@ export const encountersRouter = createRouter({
               and(
                 eq(dispenseChargeQueue.id, dispenseCharge.id),
                 eq(dispenseChargeQueue.practiceId, ctx.practiceId),
-                eq(dispenseChargeQueue.status, "waived")
-              )
+                eq(dispenseChargeQueue.status, "waived"),
+              ),
             )
             .returning({ id: dispenseChargeQueue.id });
           if (!reopenedCharge) {
@@ -1562,8 +1643,8 @@ export const encountersRouter = createRouter({
                 where ${clinicalRecordCorrections.practiceId} = ${ctx.practiceId}
                   and ${clinicalRecordCorrections.vaccinationRecordId} = ${visitWorkItems.vaccinationRecordId}
               )`,
-              isNull(visitWorkItems.deletedAt)
-            )
+              isNull(visitWorkItems.deletedAt),
+            ),
           )
           .returning();
         if (!reopened) {
@@ -1576,9 +1657,9 @@ export const encountersRouter = createRouter({
                   eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
                   eq(
                     clinicalRecordCorrections.vaccinationRecordId,
-                    workItem.vaccinationRecordId
-                  )
-                )
+                    workItem.vaccinationRecordId,
+                  ),
+                ),
               )
               .limit(1);
             if (correction) {
@@ -1595,7 +1676,7 @@ export const encountersRouter = createRouter({
           });
         }
         return reopened;
-      })
+      }),
     ),
 
   saveDraft: protectedProcedure
@@ -1612,7 +1693,8 @@ export const encountersRouter = createRouter({
           if (existing.revision !== input.expectedRevision) {
             throw new TRPCError({
               code: "CONFLICT",
-              message: "Closeout changed in another session. Refresh before saving.",
+              message:
+                "Closeout changed in another session. Refresh before saving.",
             });
           }
           const [saved] = await tx
@@ -1631,8 +1713,8 @@ export const encountersRouter = createRouter({
                 eq(visitCloseouts.status, existing.status),
                 eq(visitCloseouts.revision, existing.revision),
                 sql`${visitCloseouts.amendmentDraft} is not null`,
-                isNull(visitCloseouts.deletedAt)
-              )
+                isNull(visitCloseouts.deletedAt),
+              ),
             )
             .returning();
           if (!saved) {
@@ -1656,7 +1738,8 @@ export const encountersRouter = createRouter({
         if (revision !== input.expectedRevision) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Closeout changed in another session. Refresh before saving.",
+            message:
+              "Closeout changed in another session. Refresh before saving.",
           });
         }
         const values = {
@@ -1673,12 +1756,15 @@ export const encountersRouter = createRouter({
                 eq(visitCloseouts.practiceId, ctx.practiceId),
                 eq(visitCloseouts.status, "draft"),
                 eq(visitCloseouts.revision, revision),
-                isNull(visitCloseouts.deletedAt)
-              )
+                isNull(visitCloseouts.deletedAt),
+              ),
             )
             .returning();
           if (!saved) {
-            throw new TRPCError({ code: "CONFLICT", message: "Closeout changed; refresh and retry." });
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Closeout changed; refresh and retry.",
+            });
           }
           return saved;
         }
@@ -1691,7 +1777,7 @@ export const encountersRouter = createRouter({
           })
           .returning();
         return saved!;
-      })
+      }),
     ),
 
   finalizeClinical: protectedProcedure
@@ -1729,7 +1815,8 @@ export const encountersRouter = createRouter({
         if (revision !== input.expectedRevision) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Closeout changed in another session. Refresh before finalizing.",
+            message:
+              "Closeout changed in another session. Refresh before finalizing.",
           });
         }
 
@@ -1794,7 +1881,16 @@ export const encountersRouter = createRouter({
           .from(prescriptions)
           .where(
             and(
-              eq(prescriptions.appointmentId, input.appointmentId),
+              or(
+                eq(prescriptions.appointmentId, input.appointmentId),
+                sql`exists (
+                  select 1
+                  from ${dispenseChargeQueue}
+                  where ${dispenseChargeQueue.practiceId} = ${ctx.practiceId}
+                    and ${dispenseChargeQueue.appointmentId} = ${input.appointmentId}
+                    and ${dispenseChargeQueue.prescriptionId} = ${prescriptions.id}
+                )`,
+              ),
               eq(prescriptions.patientId, appointment.patientId),
               eq(prescriptions.practiceId, ctx.practiceId),
               eq(prescriptions.status, "active"),
@@ -1808,8 +1904,8 @@ export const encountersRouter = createRouter({
                   ),
                 ),
               ),
-              isNull(prescriptions.deletedAt)
-            )
+              isNull(prescriptions.deletedAt),
+            ),
           )
           .orderBy(prescriptions.createdAt);
         if (
@@ -1818,7 +1914,8 @@ export const encountersRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: "Create and link the visit prescription before finalizing.",
+            message:
+              "Create and link the visit prescription before finalizing.",
           });
         }
         if (
@@ -1849,21 +1946,22 @@ export const encountersRouter = createRouter({
                 eq(appointments.practiceId, ctx.practiceId),
                 gt(appointments.startTime, new Date()),
                 inArray(appointments.status, ["scheduled", "confirmed"]),
-                isNull(appointments.deletedAt)
-              )
+                isNull(appointments.deletedAt),
+              ),
             )
             .limit(1);
           if (!followUp) {
             throw new TRPCError({
               code: "PRECONDITION_FAILED",
-              message: "The selected follow-up appointment is no longer available.",
+              message:
+                "The selected follow-up appointment is no longer available.",
             });
           }
           followUpScheduledAt = followUp.startTime;
         } else if (input.followUpDisposition === "needed") {
           const today = formatDateInputForTimeZone(
             new Date(),
-            appointment.practiceTimezone
+            appointment.practiceTimezone,
           );
           if (!input.followUpDueDate || input.followUpDueDate < today) {
             throw new TRPCError({
@@ -1885,8 +1983,8 @@ export const encountersRouter = createRouter({
                   "front_desk",
                 ]),
                 activePracticePredicate(ctx.practiceId),
-                isNull(users.deletedAt)
-              )
+                isNull(users.deletedAt),
+              ),
             )
             .limit(1);
           if (!assignee) {
@@ -1901,11 +1999,11 @@ export const encountersRouter = createRouter({
         const now = new Date();
         const preserveFollowUpResolution = Boolean(
           amendmentDraft &&
-            existing &&
-            input.followUpDisposition === "needed" &&
-            existing.followUpDisposition === "needed" &&
-            existing.followUpDueDate === input.followUpDueDate &&
-            existing.followUpAssignedTo === input.followUpAssignedTo
+          existing &&
+          input.followUpDisposition === "needed" &&
+          existing.followUpDisposition === "needed" &&
+          existing.followUpDueDate === input.followUpDueDate &&
+          existing.followUpAssignedTo === input.followUpAssignedTo,
         );
         const values = {
           ...clinicalDraftValues(input),
@@ -1924,25 +2022,25 @@ export const encountersRouter = createRouter({
               : null,
           followUpAssigneeName,
           followUpResolution: preserveFollowUpResolution
-            ? existing?.followUpResolution ?? null
+            ? (existing?.followUpResolution ?? null)
             : null,
           followUpResolutionAppointmentId: preserveFollowUpResolution
-            ? existing?.followUpResolutionAppointmentId ?? null
+            ? (existing?.followUpResolutionAppointmentId ?? null)
             : null,
           followUpResolutionScheduledAt: preserveFollowUpResolution
-            ? existing?.followUpResolutionScheduledAt ?? null
+            ? (existing?.followUpResolutionScheduledAt ?? null)
             : null,
           followUpResolutionNotes: preserveFollowUpResolution
-            ? existing?.followUpResolutionNotes ?? null
+            ? (existing?.followUpResolutionNotes ?? null)
             : null,
           followUpResolvedAt: preserveFollowUpResolution
-            ? existing?.followUpResolvedAt ?? null
+            ? (existing?.followUpResolvedAt ?? null)
             : null,
           followUpResolvedBy: preserveFollowUpResolution
-            ? existing?.followUpResolvedBy ?? null
+            ? (existing?.followUpResolvedBy ?? null)
             : null,
           followUpResolverName: preserveFollowUpResolution
-            ? existing?.followUpResolverName ?? null
+            ? (existing?.followUpResolverName ?? null)
             : null,
           medicationSnapshot,
           status:
@@ -2007,10 +2105,7 @@ export const encountersRouter = createRouter({
             .update(visitCloseouts)
             .set({
               ...values,
-              amendmentHistory: [
-                ...existing.amendmentHistory,
-                priorVersion,
-              ],
+              amendmentHistory: [...existing.amendmentHistory, priorVersion],
               amendmentDraft: null,
             })
             .where(
@@ -2020,8 +2115,8 @@ export const encountersRouter = createRouter({
                 eq(visitCloseouts.status, existing.status),
                 eq(visitCloseouts.revision, revision),
                 sql`${visitCloseouts.amendmentDraft} is not null`,
-                isNull(visitCloseouts.deletedAt)
-              )
+                isNull(visitCloseouts.deletedAt),
+              ),
             )
             .returning();
           if (!finalized) {
@@ -2042,12 +2137,15 @@ export const encountersRouter = createRouter({
                 eq(visitCloseouts.practiceId, ctx.practiceId),
                 eq(visitCloseouts.status, "draft"),
                 eq(visitCloseouts.revision, revision),
-                isNull(visitCloseouts.deletedAt)
-              )
+                isNull(visitCloseouts.deletedAt),
+              ),
             )
             .returning();
           if (!finalized) {
-            throw new TRPCError({ code: "CONFLICT", message: "Closeout changed; refresh and retry." });
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Closeout changed; refresh and retry.",
+            });
           }
           return finalized;
         }
@@ -2060,7 +2158,7 @@ export const encountersRouter = createRouter({
           })
           .returning();
         return finalized!;
-      })
+      }),
     ),
 
   reopenClinical: protectedProcedure
@@ -2100,7 +2198,8 @@ export const encountersRouter = createRouter({
         if (closeout.revision !== input.expectedRevision) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Closeout changed in another session. Refresh before amending.",
+            message:
+              "Closeout changed in another session. Refresh before amending.",
           });
         }
         if (
@@ -2112,7 +2211,8 @@ export const encountersRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: "The finalized handoff is incomplete and cannot be amended safely.",
+            message:
+              "The finalized handoff is incomplete and cannot be amended safely.",
           });
         }
 
@@ -2147,8 +2247,8 @@ export const encountersRouter = createRouter({
               eq(visitCloseouts.status, closeout.status),
               eq(visitCloseouts.revision, closeout.revision),
               sql`${visitCloseouts.amendmentDraft} is null`,
-              isNull(visitCloseouts.deletedAt)
-            )
+              isNull(visitCloseouts.deletedAt),
+            ),
           )
           .returning();
         if (!reopened) {
@@ -2158,7 +2258,7 @@ export const encountersRouter = createRouter({
           });
         }
         return reopened;
-      })
+      }),
     ),
 
   resolveNeededFollowUp: protectedProcedure
@@ -2217,14 +2317,15 @@ export const encountersRouter = createRouter({
                 eq(appointments.practiceId, ctx.practiceId),
                 gt(appointments.startTime, new Date()),
                 inArray(appointments.status, ["scheduled", "confirmed"]),
-                isNull(appointments.deletedAt)
-              )
+                isNull(appointments.deletedAt),
+              ),
             )
             .limit(1);
           if (!followUp) {
             throw new TRPCError({
               code: "PRECONDITION_FAILED",
-              message: "The selected follow-up appointment is no longer available.",
+              message:
+                "The selected follow-up appointment is no longer available.",
             });
           }
           resolutionScheduledAt = followUp.startTime;
@@ -2254,8 +2355,8 @@ export const encountersRouter = createRouter({
               eq(visitCloseouts.followUpDisposition, "needed"),
               eq(visitCloseouts.revision, closeout.revision),
               isNull(visitCloseouts.followUpResolvedAt),
-              isNull(visitCloseouts.deletedAt)
-            )
+              isNull(visitCloseouts.deletedAt),
+            ),
           )
           .returning();
         if (!resolved) {
@@ -2265,7 +2366,7 @@ export const encountersRouter = createRouter({
           });
         }
         return resolved;
-      })
+      }),
     ),
 
   completeVisit: protectedProcedure
@@ -2288,10 +2389,13 @@ export const encountersRouter = createRouter({
           }
           throw new TRPCError({
             code: "CONFLICT",
-            message: "This visit is already checked out. Refresh to view its saved closeout.",
+            message:
+              "This visit is already checked out. Refresh to view its saved closeout.",
           });
         }
-        if (!canTransitionAppointmentStatus(appointment.status, "checked_out")) {
+        if (
+          !canTransitionAppointmentStatus(appointment.status, "checked_out")
+        ) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message: "This appointment is not ready for checkout.",
@@ -2300,7 +2404,8 @@ export const encountersRouter = createRouter({
         if (!closeout || closeout.status !== "clinical_finalized") {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: "Finalize the clinical handoff before completing the visit.",
+            message:
+              "Finalize the clinical handoff before completing the visit.",
           });
         }
         if (closeout.amendmentDraft) {
@@ -2313,7 +2418,8 @@ export const encountersRouter = createRouter({
         if (closeout.revision !== input.expectedRevision) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Closeout changed in another session. Refresh before completing the visit.",
+            message:
+              "Closeout changed in another session. Refresh before completing the visit.",
           });
         }
 
@@ -2325,12 +2431,13 @@ export const encountersRouter = createRouter({
           input.appointmentId,
           appointment.patientId,
           appointment.clientId,
-          true
+          true,
         );
         if (invoiceRows.length > 1) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: "This visit has multiple active invoices. Resolve them before checkout.",
+            message:
+              "This visit has multiple active invoices. Resolve them before checkout.",
           });
         }
         const invoice = invoiceRows[0]
@@ -2341,7 +2448,8 @@ export const encountersRouter = createRouter({
           if (invoice) {
             throw new TRPCError({
               code: "PRECONDITION_FAILED",
-              message: "Void or resolve the active visit invoice before marking no charge.",
+              message:
+                "Void or resolve the active visit invoice before marking no charge.",
             });
           }
         } else {
@@ -2367,14 +2475,15 @@ export const encountersRouter = createRouter({
           ) {
             throw new TRPCError({
               code: "PRECONDITION_FAILED",
-              message: "Pay-later visits need an unpaid invoice with saved charges.",
+              message:
+                "Pay-later visits need an unpaid invoice with saved charges.",
             });
           }
           if (input.chargeDisposition === "accounts_receivable") {
             const invoiceDueDate = input.invoiceDueDate!;
             const practiceToday = formatDateInputForTimeZone(
               new Date(),
-              appointment.practiceTimezone
+              appointment.practiceTimezone,
             );
             if (invoiceDueDate < practiceToday) {
               throw new TRPCError({
@@ -2398,8 +2507,8 @@ export const encountersRouter = createRouter({
                     ? eq(invoices.dueDate, invoice.dueDate)
                     : isNull(invoices.dueDate),
                   eq(invoices.isEstimate, false),
-                  isNull(invoices.deletedAt)
-                )
+                  isNull(invoices.deletedAt),
+                ),
               )
               .returning({ id: invoices.id });
             if (!presentedInvoice) {
@@ -2437,12 +2546,15 @@ export const encountersRouter = createRouter({
               eq(visitCloseouts.practiceId, ctx.practiceId),
               eq(visitCloseouts.status, "clinical_finalized"),
               eq(visitCloseouts.revision, closeout.revision),
-              isNull(visitCloseouts.deletedAt)
-            )
+              isNull(visitCloseouts.deletedAt),
+            ),
           )
           .returning();
         if (!completed) {
-          throw new TRPCError({ code: "CONFLICT", message: "Closeout changed; refresh and retry." });
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Closeout changed; refresh and retry.",
+          });
         }
         const [checkedOut] = await tx
           .update(appointments)
@@ -2452,8 +2564,8 @@ export const encountersRouter = createRouter({
               eq(appointments.id, input.appointmentId),
               eq(appointments.practiceId, ctx.practiceId),
               eq(appointments.status, appointment.status),
-              isNull(appointments.deletedAt)
-            )
+              isNull(appointments.deletedAt),
+            ),
           )
           .returning();
         if (!checkedOut) {
@@ -2463,6 +2575,6 @@ export const encountersRouter = createRouter({
           });
         }
         return { closeout: completed, appointment: checkedOut };
-      })
+      }),
     ),
 });

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -151,7 +151,12 @@ type ProblemStatus = (typeof PROBLEM_STATUSES)[number];
 
 const labStatusValues = ["pending", "completed", "reviewed"] as const;
 type LabStatus = (typeof labStatusValues)[number];
-const labResultFlagValues = ["unknown", "normal", "abnormal", "critical"] as const;
+const labResultFlagValues = [
+  "unknown",
+  "normal",
+  "abnormal",
+  "critical",
+] as const;
 const labFollowUpStatusValues = ["not_required", "open", "completed"] as const;
 
 const labStatusTransitions: Record<LabStatus, readonly LabStatus[]> = {
@@ -245,11 +250,11 @@ const createVaccinationInput = z.object({
   vaccineName: clinicalTextInput("Vaccine name", VACCINATION_NAME_MAX_LENGTH),
   lotNumber: optionalClinicalTextInput(
     "Lot number",
-    VACCINATION_LOT_NUMBER_MAX_LENGTH
+    VACCINATION_LOT_NUMBER_MAX_LENGTH,
   ),
   manufacturer: optionalClinicalTextInput(
     "Manufacturer",
-    VACCINATION_MANUFACTURER_MAX_LENGTH
+    VACCINATION_MANUFACTURER_MAX_LENGTH,
   ),
   nextDueDate: clinicalDateInput("Next due date").optional(),
 });
@@ -258,7 +263,7 @@ const createProblemInput = z.object({
   patientId: z.string().uuid(),
   description: clinicalTextInput(
     "Problem description",
-    PROBLEM_DESCRIPTION_MAX_LENGTH
+    PROBLEM_DESCRIPTION_MAX_LENGTH,
   ),
   status: z.enum(PROBLEM_STATUSES).default("active"),
   onsetDate: clinicalDateInput("Onset date").optional(),
@@ -271,12 +276,12 @@ const createPrescriptionInput = z
     operationId: z.string().uuid(),
     medicationName: clinicalTextInput(
       "Medication name",
-      PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH
+      PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH,
     ),
     dosage: clinicalTextInput("Dosage", PRESCRIPTION_DOSAGE_MAX_LENGTH),
     frequency: clinicalTextInput(
       "Frequency",
-      PRESCRIPTION_FREQUENCY_MAX_LENGTH
+      PRESCRIPTION_FREQUENCY_MAX_LENGTH,
     ),
     quantity: z
       .number()
@@ -295,7 +300,7 @@ const createPrescriptionInput = z
     endDate: clinicalDateInput("End date").optional(),
     instructions: optionalClinicalTextInput(
       "Prescription instructions",
-      PRESCRIPTION_INSTRUCTIONS_MAX_LENGTH
+      PRESCRIPTION_INSTRUCTIONS_MAX_LENGTH,
     ),
     acknowledgeSafetyWarnings: z.boolean().default(false),
   })
@@ -319,7 +324,7 @@ const createLabResultInput = z
     testName: clinicalTextInput("Test name", LAB_TEST_NAME_MAX_LENGTH),
     resultValue: optionalClinicalTextInput(
       "Result value",
-      LAB_RESULT_VALUE_MAX_LENGTH
+      LAB_RESULT_VALUE_MAX_LENGTH,
     ),
     unit: optionalClinicalTextInput("Unit", LAB_UNIT_MAX_LENGTH),
     referenceRangeLow: labReferenceInput("Reference range low").optional(),
@@ -333,7 +338,7 @@ const createLabResultInput = z
     if (
       !isOrderedLabReferenceRange(
         input.referenceRangeLow,
-        input.referenceRangeHigh
+        input.referenceRangeHigh,
       )
     ) {
       ctx.addIssue({
@@ -346,7 +351,8 @@ const createLabResultInput = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["resultValue"],
-        message: "A result value is required before a lab result can be completed.",
+        message:
+          "A result value is required before a lab result can be completed.",
       });
     }
     if (input.replacesLabResultId && !input.resultValue?.trim()) {
@@ -368,7 +374,8 @@ const createLabResultInput = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["status"],
-        message: "Pending lab results cannot carry partial values. Complete the result when values are available.",
+        message:
+          "Pending lab results cannot carry partial values. Complete the result when values are available.",
       });
     }
   });
@@ -480,7 +487,8 @@ async function getLabOperationReplay(
   ) {
     throw new TRPCError({
       code: "CONFLICT",
-      message: "This lab operation id was already used for different clinical evidence.",
+      message:
+        "This lab operation id was already used for different clinical evidence.",
     });
   }
   return getLabStatusForUpdate(ctx, event.labResultId);
@@ -502,7 +510,7 @@ function labMutationResultForRole(
 
 async function assertPatientBelongsToPractice(
   ctx: RecordsContext,
-  patientId: string
+  patientId: string,
 ) {
   const [patient] = await ctx.db
     .select({ id: patients.id })
@@ -512,8 +520,8 @@ async function assertPatientBelongsToPractice(
         eq(patients.id, patientId),
         eq(patients.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(patients.deletedAt)
-      )
+        isNull(patients.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -527,7 +535,7 @@ async function assertPatientBelongsToPractice(
 async function assertAppointmentBelongsToPatient(
   ctx: RecordsContext,
   appointmentId: string,
-  patientId: string
+  patientId: string,
 ) {
   const [appointment] = await ctx.db
     .select({ id: appointments.id })
@@ -538,8 +546,8 @@ async function assertAppointmentBelongsToPatient(
         eq(appointments.patientId, patientId),
         eq(appointments.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(appointments.deletedAt)
-      )
+        isNull(appointments.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -557,7 +565,7 @@ async function lockOpenAppointmentForClinicalWork(
   ctx: RecordsContext,
   appointmentId: string,
   patientId: string,
-  workLabel: string
+  workLabel: string,
 ) {
   const visit = await lockOpenVisitForClinicalAppend(ctx.db as Database, {
     practiceId: ctx.practiceId,
@@ -565,7 +573,10 @@ async function lockOpenAppointmentForClinicalWork(
     patientId,
   });
   if (!visit.ok && visit.reason === "appointment_not_found") {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Appointment not found",
+    });
   }
   if (!visit.ok && visit.reason === "visit_not_open") {
     throw new TRPCError({
@@ -592,7 +603,7 @@ type VisitWorkSource =
 async function registerVisitWorkItem(
   ctx: RecordsContext,
   appointmentId: string,
-  source: VisitWorkSource
+  source: VisitWorkSource,
 ) {
   if ("vaccinationRecordId" in source) {
     await ctx.db.execute(sql`
@@ -633,7 +644,7 @@ async function registerVisitWorkItem(
  */
 async function findActiveVisitId(
   ctx: RecordsContext,
-  patientId: string
+  patientId: string,
 ): Promise<string | null> {
   const [visit] = await ctx.db
     .select({ id: appointments.id })
@@ -643,8 +654,8 @@ async function findActiveVisitId(
         eq(appointments.practiceId, ctx.practiceId),
         eq(appointments.patientId, patientId),
         inArray(appointments.status, ["checked_in", "in_exam"]),
-        isNull(appointments.deletedAt)
-      )
+        isNull(appointments.deletedAt),
+      ),
     )
     .orderBy(desc(appointments.startTime))
     .limit(1);
@@ -654,7 +665,7 @@ async function findActiveVisitId(
 async function assessPrescriptionSafety(
   ctx: RecordsContext,
   patientId: string,
-  medicationName: string
+  medicationName: string,
 ) {
   const [allergies, activePrescriptions, interactions] = await Promise.all([
     ctx.db
@@ -681,8 +692,8 @@ async function assessPrescriptionSafety(
             where allergy_correction.practice_id = ${ctx.practiceId}
               and allergy_correction.patient_allergy_id = ${patientAllergies.id}
           )`,
-          isNull(patientAllergies.deletedAt)
-        )
+          isNull(patientAllergies.deletedAt),
+        ),
       ),
     ctx.db
       .select({
@@ -696,14 +707,11 @@ async function assessPrescriptionSafety(
           eq(prescriptions.status, "active"),
           or(
             isNull(prescriptions.endDate),
-            gte(
-              prescriptions.endDate,
-              practiceTodayExpression(ctx.practiceId),
-            )
+            gte(prescriptions.endDate, practiceTodayExpression(ctx.practiceId)),
           ),
           activePracticePredicate(ctx.practiceId),
-          isNull(prescriptions.deletedAt)
-        )
+          isNull(prescriptions.deletedAt),
+        ),
       ),
     ctx.db
       .select({
@@ -726,7 +734,7 @@ async function assessPrescriptionSafety(
 
 async function assertDispensedProductBelongsToPractice(
   ctx: RecordsContext,
-  productId: string
+  productId: string,
 ) {
   const [product] = await ctx.db
     .select({
@@ -741,8 +749,8 @@ async function assertDispensedProductBelongsToPractice(
         eq(products.id, productId),
         eq(products.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(products.deletedAt)
-      )
+        isNull(products.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -800,7 +808,7 @@ async function createDispenseChargeWork(
 async function deductDispensedProductStock(
   ctx: RecordsContext,
   productId: string,
-  quantity: number
+  quantity: number,
 ) {
   const [product] = await ctx.db
     .update(products)
@@ -813,8 +821,8 @@ async function deductDispensedProductStock(
         eq(products.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
         isNull(products.deletedAt),
-        sql`${products.stockQuantity} >= ${quantity}`
-      )
+        sql`${products.stockQuantity} >= ${quantity}`,
+      ),
     )
     .returning({ id: products.id, stockQuantity: products.stockQuantity });
 
@@ -839,7 +847,7 @@ type LockedPrescription = {
 
 async function lockPrescriptionForLifecycle(
   ctx: RecordsContext,
-  prescriptionId: string
+  prescriptionId: string,
 ): Promise<LockedPrescription> {
   const [prescription] = await ctx.db
     .select({
@@ -858,14 +866,17 @@ async function lockPrescriptionForLifecycle(
         eq(prescriptions.id, prescriptionId),
         eq(prescriptions.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(prescriptions.deletedAt)
-      )
+        isNull(prescriptions.deletedAt),
+      ),
     )
     .limit(1)
     .for("update");
 
   if (!prescription) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Prescription not found" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Prescription not found",
+    });
   }
   return prescription;
 }
@@ -878,7 +889,7 @@ async function lifecycleOperationReplay(
     eventTypes: PrescriptionEventType[];
     reason: string | null;
     appointmentId?: string | null;
-  }
+  },
 ) {
   const [event] = await ctx.db
     .select()
@@ -886,15 +897,16 @@ async function lifecycleOperationReplay(
     .where(
       and(
         eq(prescriptionEvents.practiceId, ctx.practiceId),
-        eq(prescriptionEvents.operationId, input.operationId)
-      )
+        eq(prescriptionEvents.operationId, input.operationId),
+      ),
     )
     .limit(1);
   if (!event) return null;
   if (event.prescriptionId !== input.prescriptionId) {
     throw new TRPCError({
       code: "CONFLICT",
-      message: "This prescription operation ID was already used for another change.",
+      message:
+        "This prescription operation ID was already used for another change.",
     });
   }
 
@@ -905,12 +917,15 @@ async function lifecycleOperationReplay(
       and(
         eq(prescriptions.id, input.prescriptionId),
         eq(prescriptions.practiceId, ctx.practiceId),
-        isNull(prescriptions.deletedAt)
-      )
+        isNull(prescriptions.deletedAt),
+      ),
     )
     .limit(1);
   if (!prescription) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Prescription not found" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Prescription not found",
+    });
   }
   const expectedEventType =
     input.eventTypes.length === 2
@@ -955,7 +970,7 @@ const prescriptionLifecycleReasonInput = z
   .trim()
   .min(
     PRESCRIPTION_LIFECYCLE_REASON_MIN_LENGTH,
-    "Explain the prescription lifecycle change."
+    "Explain the prescription lifecycle change.",
   )
   .max(PRESCRIPTION_LIFECYCLE_REASON_MAX_LENGTH);
 
@@ -966,14 +981,14 @@ async function transitionPrescription(
     operationId: string;
     reason: string;
     targetStatus: "completed" | "cancelled";
-  }
+  },
 ) {
   const eventType = input.targetStatus;
   return (ctx.db as Database).transaction(async (tx) => {
     const txCtx = { db: tx, practiceId: ctx.practiceId };
     const operationKey = `prescription-lifecycle:${ctx.practiceId}:${input.operationId}`;
     await tx.execute(
-      sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+      sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
     );
     const replay = await lifecycleOperationReplay(txCtx, {
       prescriptionId: input.id,
@@ -1005,8 +1020,8 @@ async function transitionPrescription(
           eq(prescriptions.id, prescription.id),
           eq(prescriptions.practiceId, ctx.practiceId),
           eq(prescriptions.status, "active"),
-          isNull(prescriptions.deletedAt)
-        )
+          isNull(prescriptions.deletedAt),
+        ),
       )
       .returning();
     if (!updated) {
@@ -1041,7 +1056,7 @@ async function transitionPrescription(
 
 async function getProblemStatusForUpdate(
   ctx: RecordsContext,
-  id: string
+  id: string,
 ): Promise<{ status: ProblemStatus; resolvedDate: string | null }> {
   const [problem] = await ctx.db
     .select({
@@ -1054,8 +1069,8 @@ async function getProblemStatusForUpdate(
         eq(problemList.id, id),
         eq(problemList.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(problemList.deletedAt)
-      )
+        isNull(problemList.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -1066,10 +1081,7 @@ async function getProblemStatusForUpdate(
   return problem;
 }
 
-async function getLabStatusForUpdate(
-  ctx: RecordsContext,
-  id: string
-) {
+async function getLabStatusForUpdate(ctx: RecordsContext, id: string) {
   const [result] = await ctx.db
     .select(getTableColumns(labResults))
     .from(labResults)
@@ -1165,8 +1177,7 @@ export const recordsRouter = createRouter({
           correctedAt: clinicalRecordCorrections.createdAt,
           correctedBy: clinicalRecordCorrections.correctedBy,
           correctedByName: clinicalRecordCorrections.correctedByName,
-          replacementSoapNoteId:
-            replacementFromSource.replacementSoapNoteId,
+          replacementSoapNoteId: replacementFromSource.replacementSoapNoteId,
           replacementCreatedAt: replacementFromSource.createdAt,
           replacementActorName: replacementFromSource.actorName,
           replacesSoapNoteId: sourceFromReplacement.sourceSoapNoteId,
@@ -1176,8 +1187,8 @@ export const recordsRouter = createRouter({
           clinicalRecordCorrections,
           and(
             eq(clinicalRecordCorrections.soapNoteId, soapNotes.id),
-            eq(clinicalRecordCorrections.practiceId, ctx.practiceId)
-          )
+            eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           replacementFromSource,
@@ -1198,8 +1209,8 @@ export const recordsRouter = createRouter({
             eq(soapNotes.patientId, input.patientId),
             eq(soapNotes.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(soapNotes.deletedAt)
-          )
+            isNull(soapNotes.deletedAt),
+          ),
         )
         .orderBy(desc(soapNotes.createdAt));
 
@@ -1247,7 +1258,7 @@ export const recordsRouter = createRouter({
           .trim()
           .min(CLINICAL_CORRECTION_REASON_MIN_LENGTH)
           .max(CLINICAL_CORRECTION_REASON_MAX_LENGTH),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) =>
       ctx.db.transaction(async (tx) => {
@@ -1334,8 +1345,8 @@ export const recordsRouter = createRouter({
           .where(
             and(
               eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
-              eq(clinicalRecordCorrections.soapNoteId, source.id)
-            )
+              eq(clinicalRecordCorrections.soapNoteId, source.id),
+            ),
           )
           .limit(1);
         if (existing) {
@@ -1353,7 +1364,7 @@ export const recordsRouter = createRouter({
           code: "CONFLICT",
           message: "Clinical correction changed; refresh and retry.",
         });
-      })
+      }),
     ),
 
   replaceSoapNote: protectedProcedure
@@ -1602,26 +1613,26 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(vaccinationRecords.administeredBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
-          )
+            eq(users.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           clinicalRecordCorrections,
           and(
             eq(
               clinicalRecordCorrections.vaccinationRecordId,
-              vaccinationRecords.id
+              vaccinationRecords.id,
             ),
-            eq(clinicalRecordCorrections.practiceId, ctx.practiceId)
-          )
+            eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
             eq(vaccinationRecords.patientId, input.patientId),
             eq(vaccinationRecords.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(vaccinationRecords.deletedAt)
-          )
+            isNull(vaccinationRecords.deletedAt),
+          ),
         )
         .orderBy(desc(vaccinationRecords.administeredAt));
     }),
@@ -1637,7 +1648,7 @@ export const recordsRouter = createRouter({
           .trim()
           .min(CLINICAL_CORRECTION_REASON_MIN_LENGTH)
           .max(CLINICAL_CORRECTION_REASON_MAX_LENGTH),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) =>
       ctx.db.transaction(async (tx) => {
@@ -1654,8 +1665,8 @@ export const recordsRouter = createRouter({
               eq(vaccinationRecords.patientId, input.patientId),
               eq(vaccinationRecords.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(vaccinationRecords.deletedAt)
-            )
+              isNull(vaccinationRecords.deletedAt),
+            ),
           )
           .limit(1)
           .for("update", { of: vaccinationRecords });
@@ -1702,8 +1713,8 @@ export const recordsRouter = createRouter({
                 eq(visitWorkItems.status, "unresolved"),
                 isNull(visitWorkItems.invoiceId),
                 isNull(visitWorkItems.invoiceItemId),
-                isNull(visitWorkItems.deletedAt)
-              )
+                isNull(visitWorkItems.deletedAt),
+              ),
             );
           return created;
         }
@@ -1714,8 +1725,8 @@ export const recordsRouter = createRouter({
           .where(
             and(
               eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
-              eq(clinicalRecordCorrections.vaccinationRecordId, source.id)
-            )
+              eq(clinicalRecordCorrections.vaccinationRecordId, source.id),
+            ),
           )
           .limit(1);
         if (existing) return existing;
@@ -1724,7 +1735,7 @@ export const recordsRouter = createRouter({
           code: "CONFLICT",
           message: "Clinical correction changed; refresh and retry.",
         });
-      })
+      }),
     ),
 
   createVaccination: protectedProcedure
@@ -1739,7 +1750,7 @@ export const recordsRouter = createRouter({
             txCtx,
             input.appointmentId,
             input.patientId,
-            "vaccination"
+            "vaccination",
           );
         }
         const [created] = await tx
@@ -1779,8 +1790,8 @@ export const recordsRouter = createRouter({
             eq(problemList.patientId, input.patientId),
             eq(problemList.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(problemList.deletedAt)
-          )
+            isNull(problemList.deletedAt),
+          ),
         )
         .orderBy(desc(problemList.createdAt));
     }),
@@ -1812,7 +1823,7 @@ export const recordsRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         status: z.enum(PROBLEM_STATUSES),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const existing = await getProblemStatusForUpdate(ctx, input.id);
@@ -1835,8 +1846,8 @@ export const recordsRouter = createRouter({
             eq(problemList.status, existing.status),
             activePracticePredicate(ctx.practiceId),
             sql`${problemList.resolvedDate} is not distinct from ${existing.resolvedDate}`,
-            isNull(problemList.deletedAt)
-          )
+            isNull(problemList.deletedAt),
+          ),
         )
         .returning();
       if (!problem) {
@@ -1879,24 +1890,24 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(prescriptions.prescribedBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
-          )
+            eq(users.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           products,
           and(
             eq(prescriptions.productId, products.id),
             eq(products.practiceId, ctx.practiceId),
-            isNull(products.deletedAt)
-          )
+            isNull(products.deletedAt),
+          ),
         )
         .where(
           and(
             eq(prescriptions.patientId, input.patientId),
             eq(prescriptions.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(prescriptions.deletedAt)
-          )
+            isNull(prescriptions.deletedAt),
+          ),
         )
         .orderBy(desc(prescriptions.createdAt));
     }),
@@ -1926,17 +1937,20 @@ export const recordsRouter = createRouter({
           dispenseChargeQueue,
           and(
             eq(dispenseChargeQueue.prescriptionEventId, prescriptionEvents.id),
-            eq(dispenseChargeQueue.practiceId, ctx.practiceId)
-          )
+            eq(dispenseChargeQueue.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
             eq(prescriptionEvents.practiceId, ctx.practiceId),
             eq(prescriptionEvents.prescriptionId, input.prescriptionId),
-            activePracticePredicate(ctx.practiceId)
-          )
+            activePracticePredicate(ctx.practiceId),
+          ),
         )
-        .orderBy(desc(prescriptionEvents.createdAt), desc(prescriptionEvents.id));
+        .orderBy(
+          desc(prescriptionEvents.createdAt),
+          desc(prescriptionEvents.id),
+        );
     }),
 
   checkPrescriptionSafety: protectedProcedure
@@ -1946,16 +1960,16 @@ export const recordsRouter = createRouter({
         patientId: z.string().uuid(),
         medicationName: clinicalTextInput(
           "Medication name",
-          PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH
+          PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH,
         ),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
       return assessPrescriptionSafety(
         ctx,
         input.patientId,
-        input.medicationName
+        input.medicationName,
       );
     }),
 
@@ -1967,7 +1981,7 @@ export const recordsRouter = createRouter({
         const txCtx: RecordsContext = { db: tx, practiceId: ctx.practiceId };
         const operationKey = `dashboard-prescription:${ctx.practiceId}:${input.operationId}`;
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
         );
 
         const [existing] = await tx
@@ -1994,8 +2008,8 @@ export const recordsRouter = createRouter({
           .where(
             and(
               eq(prescriptions.practiceId, ctx.practiceId),
-              eq(prescriptions.operationId, input.operationId)
-            )
+              eq(prescriptions.operationId, input.operationId),
+            ),
           )
           .limit(1);
         if (existing) {
@@ -2015,7 +2029,8 @@ export const recordsRouter = createRouter({
           if (
             !createdEvent ||
             existing.patientId !== input.patientId ||
-            (existing.appointmentId ?? null) !== (input.appointmentId ?? null) ||
+            (existing.appointmentId ?? null) !==
+              (input.appointmentId ?? null) ||
             existing.medicationName !== input.medicationName ||
             existing.dosage !== input.dosage ||
             existing.frequency !== input.frequency ||
@@ -2045,18 +2060,18 @@ export const recordsRouter = createRouter({
           await assertAppointmentBelongsToPatient(
             txCtx,
             input.appointmentId,
-            input.patientId
+            input.patientId,
           );
         }
         const safety = await assessPrescriptionSafety(
           txCtx,
           input.patientId,
-          input.medicationName
+          input.medicationName,
         );
         if (input.productId) {
           const product = await assertDispensedProductBelongsToPractice(
             txCtx,
-            input.productId
+            input.productId,
           );
           if (!input.quantity || input.quantity <= 0) {
             throw new TRPCError({
@@ -2087,7 +2102,7 @@ export const recordsRouter = createRouter({
             txCtx,
             input.appointmentId,
             input.patientId,
-            "prescriptions"
+            "prescriptions",
           );
         }
 
@@ -2095,7 +2110,7 @@ export const recordsRouter = createRouter({
           await deductDispensedProductStock(
             txCtx,
             input.productId,
-            input.quantity
+            input.quantity,
           );
         }
 
@@ -2181,14 +2196,14 @@ export const recordsRouter = createRouter({
           .trim()
           .max(PRESCRIPTION_LIFECYCLE_REASON_MAX_LENGTH)
           .optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db.transaction(async (tx) => {
         const txCtx = { db: tx, practiceId: ctx.practiceId };
         const operationKey = `prescription-lifecycle:${ctx.practiceId}:${input.operationId}`;
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
         );
         const replay = await lifecycleOperationReplay(txCtx, {
           prescriptionId: input.id,
@@ -2199,19 +2214,51 @@ export const recordsRouter = createRouter({
         });
         if (replay) return replay;
 
-        const prescription = await lockPrescriptionForLifecycle(txCtx, input.id);
+        let routedPatientId: string | null = null;
         if (input.appointmentId) {
+          const [prescriptionIdentity] = await tx
+            .select({ patientId: prescriptions.patientId })
+            .from(prescriptions)
+            .where(
+              and(
+                eq(prescriptions.id, input.id),
+                eq(prescriptions.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(prescriptions.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!prescriptionIdentity) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Prescription not found",
+            });
+          }
+          routedPatientId = prescriptionIdentity.patientId;
           await assertAppointmentBelongsToPatient(
             txCtx,
             input.appointmentId,
-            prescription.patientId,
+            routedPatientId,
           );
           await lockOpenAppointmentForClinicalWork(
             txCtx,
             input.appointmentId,
-            prescription.patientId,
+            routedPatientId,
             "prescriptions",
           );
+        }
+        // Visit-linked billing takes appointment -> prescription -> product.
+        // Keep refill dispensing in the same canonical order to avoid a cycle
+        // with estimate conversion or invoice charge validation.
+        const prescription = await lockPrescriptionForLifecycle(
+          txCtx,
+          input.id,
+        );
+        if (routedPatientId && prescription.patientId !== routedPatientId) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Prescription patient changed. Refresh and try again.",
+          });
         }
         const today = await practiceDateInput(txCtx);
         const effectiveStatus = effectivePrescriptionStatus({
@@ -2245,12 +2292,12 @@ export const recordsRouter = createRouter({
         if (prescription.productId && prescription.quantity) {
           await assertDispensedProductBelongsToPractice(
             txCtx,
-            prescription.productId
+            prescription.productId,
           );
           await deductDispensedProductStock(
             txCtx,
             prescription.productId,
-            prescription.quantity
+            prescription.quantity,
           );
         }
         const [updated] = await tx
@@ -2265,14 +2312,15 @@ export const recordsRouter = createRouter({
               eq(prescriptions.practiceId, ctx.practiceId),
               eq(prescriptions.status, "active"),
               eq(prescriptions.refillsRemaining, prescription.refillsRemaining),
-              isNull(prescriptions.deletedAt)
-            )
+              isNull(prescriptions.deletedAt),
+            ),
           )
           .returning();
         if (!updated) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Prescription changed while dispensing. Refresh and try again.",
+            message:
+              "Prescription changed while dispensing. Refresh and try again.",
           });
         }
         const [event] = await tx
@@ -2309,7 +2357,11 @@ export const recordsRouter = createRouter({
             medicationName: prescription.medicationName,
           });
         }
-        return { prescription: updated, event: event!, replayed: false as const };
+        return {
+          prescription: updated,
+          event: event!,
+          replayed: false as const,
+        };
       });
       if (!result.replayed) {
         const webhookEvent =
@@ -2335,12 +2387,12 @@ export const recordsRouter = createRouter({
         id: z.string().uuid(),
         operationId: z.string().uuid(),
         reason: prescriptionLifecycleReasonInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await transitionPrescription(
         { db: ctx.db, practiceId: ctx.practiceId, user: ctx.user },
-        { ...input, targetStatus: "completed" }
+        { ...input, targetStatus: "completed" },
       );
       if (!result.replayed) {
         await dispatchWebhookEvent(ctx.practiceId, "prescription.completed", {
@@ -2359,12 +2411,12 @@ export const recordsRouter = createRouter({
         id: z.string().uuid(),
         operationId: z.string().uuid(),
         reason: prescriptionLifecycleReasonInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await transitionPrescription(
         { db: ctx.db, practiceId: ctx.practiceId, user: ctx.user },
-        { ...input, targetStatus: "cancelled" }
+        { ...input, targetStatus: "cancelled" },
       );
       if (!result.replayed) {
         await dispatchWebhookEvent(ctx.practiceId, "prescription.cancelled", {
@@ -2463,22 +2515,22 @@ export const recordsRouter = createRouter({
           orderedBy,
           and(
             eq(labResults.orderedBy, orderedBy.id),
-            eq(orderedBy.practiceId, ctx.practiceId)
-          )
+            eq(orderedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           reviewedBy,
           and(
             eq(labResults.reviewedBy, reviewedBy.id),
-            eq(reviewedBy.practiceId, ctx.practiceId)
-          )
+            eq(reviewedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           followUpAssignee,
           and(
             eq(labResults.followUpAssignedTo, followUpAssignee.id),
-            eq(followUpAssignee.practiceId, ctx.practiceId)
-          )
+            eq(followUpAssignee.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           clinicalRecordCorrections,
@@ -2492,8 +2544,8 @@ export const recordsRouter = createRouter({
             eq(labResults.patientId, input.patientId),
             eq(labResults.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(labResults.deletedAt)
-          )
+            isNull(labResults.deletedAt),
+          ),
         )
         .orderBy(desc(labResults.createdAt));
       return rows;
@@ -2555,10 +2607,17 @@ export const recordsRouter = createRouter({
       z.object({
         resultId: z.string().uuid().optional(),
         filter: z
-          .enum(["action_required", "awaiting_results", "awaiting_review", "critical", "follow_up", "all"])
+          .enum([
+            "action_required",
+            "awaiting_results",
+            "awaiting_review",
+            "critical",
+            "follow_up",
+            "all",
+          ])
           .default("action_required"),
         limit: z.number().int().min(1).max(100).default(50),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const orderedBy = alias(users, "inbox_lab_ordered_by");
@@ -2583,7 +2642,10 @@ export const recordsRouter = createRouter({
         );
       } else if (!input.resultId && input.filter === "action_required") {
         conditions.push(
-          or(ne(labResults.status, "reviewed"), eq(labResults.followUpStatus, "open"))!
+          or(
+            ne(labResults.status, "reviewed"),
+            eq(labResults.followUpStatus, "open"),
+          )!,
         );
       } else if (!input.resultId && input.filter === "awaiting_results") {
         conditions.push(eq(labResults.status, "pending"));
@@ -2641,43 +2703,43 @@ export const recordsRouter = createRouter({
           patients,
           and(
             eq(labResults.patientId, patients.id),
-            eq(patients.practiceId, ctx.practiceId)
-          )
+            eq(patients.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           appointments,
           and(
             eq(labResults.appointmentId, appointments.id),
-            eq(appointments.practiceId, ctx.practiceId)
-          )
+            eq(appointments.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           clinician,
           and(
             eq(appointments.doctorId, clinician.id),
-            eq(clinician.practiceId, ctx.practiceId)
-          )
+            eq(clinician.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           orderedBy,
           and(
             eq(labResults.orderedBy, orderedBy.id),
-            eq(orderedBy.practiceId, ctx.practiceId)
-          )
+            eq(orderedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           reviewedBy,
           and(
             eq(labResults.reviewedBy, reviewedBy.id),
-            eq(reviewedBy.practiceId, ctx.practiceId)
-          )
+            eq(reviewedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           assignee,
           and(
             eq(labResults.followUpAssignedTo, assignee.id),
-            eq(assignee.practiceId, ctx.practiceId)
-          )
+            eq(assignee.practiceId, ctx.practiceId),
+          ),
         )
         .where(and(...conditions))
         .orderBy(
@@ -2690,8 +2752,10 @@ export const recordsRouter = createRouter({
             else 'infinity'::timestamptz end`),
           asc(sql`case ${labResults.status}
             when 'completed' then 0 when 'pending' then 1 else 2 end`),
-          asc(sql`coalesce(${labResults.completedAt}, ${labResults.createdAt})`),
-          asc(labResults.id)
+          asc(
+            sql`coalesce(${labResults.completedAt}, ${labResults.createdAt})`,
+          ),
+          asc(labResults.id),
         )
         .limit(input.resultId ? 2 : input.limit + 1);
       const visibleRows = frontDeskMode
@@ -2733,8 +2797,8 @@ export const recordsRouter = createRouter({
             eq(users.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             ne(users.role, "viewer"),
-            isNull(users.deletedAt)
-          )
+            isNull(users.deletedAt),
+          ),
         )
         .orderBy(asc(users.name));
     }),
@@ -2938,7 +3002,8 @@ export const recordsRouter = createRouter({
           if (existingReplay[0].creationPayloadHash !== creationPayloadHash) {
             throw new TRPCError({
               code: "CONFLICT",
-              message: "This lab creation id was already used for different result data.",
+              message:
+                "This lab creation id was already used for different result data.",
             });
           }
           if (input.replacesLabResultId) {
@@ -3129,7 +3194,10 @@ export const recordsRouter = createRouter({
           followUpStatus: created.followUpStatus,
           actorId: ctx.user.id,
           actorName: ctx.user.name,
-          note: created.status === "completed" ? "Result values available at entry." : null,
+          note:
+            created.status === "completed"
+              ? "Result values available at entry."
+              : null,
           operationId,
           operationPayloadHash: creationPayloadHash,
         });
@@ -3172,11 +3240,14 @@ export const recordsRouter = createRouter({
         id: z.string().uuid(),
         status: z.literal("reviewed"),
         operationId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       if (input.status === "reviewed" && ctx.user.role === "technician") {
-        throw new TRPCError({ code: "FORBIDDEN", message: "A veterinarian or administrator must review lab results." });
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "A veterinarian or administrator must review lab results.",
+        });
       }
       const payloadHash = labOperationHash({
         kind: "review",
@@ -3196,7 +3267,10 @@ export const recordsRouter = createRouter({
         const existing = await getLabStatusForUpdate(txCtx, input.id);
         assertLabStatusTransition(existing.status, input.status);
         if (!existing.resultValue?.trim()) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "A lab result cannot be reviewed without recorded values." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "A lab result cannot be reviewed without recorded values.",
+          });
         }
         if (
           existing.resultFlag === "critical" &&
@@ -3204,7 +3278,8 @@ export const recordsRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Assign owned follow-up for this critical result before recording clinical review.",
+            message:
+              "Assign owned follow-up for this critical result before recording clinical review.",
           });
         }
         const occurredAt = new Date();
@@ -3230,7 +3305,8 @@ export const recordsRouter = createRouter({
         if (!updated) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Lab result changed while updating. Refresh and try again.",
+            message:
+              "Lab result changed while updating. Refresh and try again.",
           });
         }
         await tx.insert(labResultEvents).values({
@@ -3266,22 +3342,35 @@ export const recordsRouter = createRouter({
       z
         .object({
           id: z.string().uuid(),
-          resultValue: clinicalTextInput("Result value", LAB_RESULT_VALUE_MAX_LENGTH),
+          resultValue: clinicalTextInput(
+            "Result value",
+            LAB_RESULT_VALUE_MAX_LENGTH,
+          ),
           unit: optionalClinicalTextInput("Unit", LAB_UNIT_MAX_LENGTH),
-          referenceRangeLow: labReferenceInput("Reference range low").optional(),
-          referenceRangeHigh: labReferenceInput("Reference range high").optional(),
+          referenceRangeLow: labReferenceInput(
+            "Reference range low",
+          ).optional(),
+          referenceRangeHigh: labReferenceInput(
+            "Reference range high",
+          ).optional(),
           resultFlag: z.enum(labResultFlagValues).default("unknown"),
           operationId: z.string().uuid(),
         })
         .superRefine((input, refineCtx) => {
-          if (!isOrderedLabReferenceRange(input.referenceRangeLow, input.referenceRangeHigh)) {
+          if (
+            !isOrderedLabReferenceRange(
+              input.referenceRangeLow,
+              input.referenceRangeHigh,
+            )
+          ) {
             refineCtx.addIssue({
               code: z.ZodIssueCode.custom,
               path: ["referenceRangeHigh"],
-              message: "Reference range high must be greater than or equal to low.",
+              message:
+                "Reference range high must be greater than or equal to low.",
             });
           }
-        })
+        }),
     )
     .mutation(async ({ ctx, input }) => {
       const payloadHash = labOperationHash({
@@ -3305,7 +3394,11 @@ export const recordsRouter = createRouter({
         if (replay) return replay;
         const existing = await getLabStatusForUpdate(txCtx, input.id);
         if (existing.status !== "pending") {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending lab results can be completed with new values." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Only pending lab results can be completed with new values.",
+          });
         }
         if (
           input.resultFlag === "critical" &&
@@ -3314,7 +3407,8 @@ export const recordsRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Set a due date on the open follow-up before recording this result as critical.",
+            message:
+              "Set a due date on the open follow-up before recording this result as critical.",
           });
         }
         const occurredAt = new Date();
@@ -3342,7 +3436,11 @@ export const recordsRouter = createRouter({
           )
           .returning();
         if (!updated) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Lab result changed while completing. Refresh and try again." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Lab result changed while completing. Refresh and try again.",
+          });
         }
         await tx.insert(labResultEvents).values({
           practiceId: ctx.practiceId,
@@ -3379,7 +3477,7 @@ export const recordsRouter = createRouter({
         dueAt: z.string().datetime().optional(),
         note: z.string().trim().max(1000).optional(),
         operationId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const dueAt = input.dueAt ? new Date(input.dueAt).toISOString() : null;
@@ -3405,7 +3503,8 @@ export const recordsRouter = createRouter({
         if (existing.status === "pending") {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Enter and complete the lab values before assigning follow-up.",
+            message:
+              "Enter and complete the lab values before assigning follow-up.",
           });
         }
         const [assignee] = await tx
@@ -3416,12 +3515,15 @@ export const recordsRouter = createRouter({
               eq(users.id, input.assigneeId),
               eq(users.practiceId, ctx.practiceId),
               ne(users.role, "viewer"),
-              isNull(users.deletedAt)
-            )
+              isNull(users.deletedAt),
+            ),
           )
           .limit(1);
         if (!assignee) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Choose an active clinic teammate." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Choose an active clinic teammate.",
+          });
         }
         if (existing.resultFlag === "critical" && !dueAt) {
           throw new TRPCError({
@@ -3432,7 +3534,8 @@ export const recordsRouter = createRouter({
         if (assignee.role === "front_desk" && !note) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Front desk follow-up requires actionable instructions from the clinical team.",
+            message:
+              "Front desk follow-up requires actionable instructions from the clinical team.",
           });
         }
         const occurredAt = new Date();
@@ -3462,14 +3565,21 @@ export const recordsRouter = createRouter({
           )
           .returning();
         if (!updated) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Lab result changed while assigning follow-up. Refresh and try again." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Lab result changed while assigning follow-up. Refresh and try again.",
+          });
         }
         await tx.insert(labResultEvents).values({
           practiceId: ctx.practiceId,
           labResultId: updated.id,
           patientId: updated.patientId,
           appointmentId: updated.appointmentId,
-          eventType: existing.followUpStatus === "not_required" ? "follow_up_assigned" : "follow_up_reassigned",
+          eventType:
+            existing.followUpStatus === "not_required"
+              ? "follow_up_assigned"
+              : "follow_up_reassigned",
           createdAt: occurredAt,
           statusBefore: updated.status,
           statusAfter: updated.status,
@@ -3520,11 +3630,18 @@ export const recordsRouter = createRouter({
         if (existing.status === "pending") {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Lab follow-up cannot be completed before result values are available.",
+            message:
+              "Lab follow-up cannot be completed before result values are available.",
           });
         }
-        if (existing.followUpStatus !== "open" || !existing.followUpAssignedTo) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "This lab result has no open follow-up." });
+        if (
+          existing.followUpStatus !== "open" ||
+          !existing.followUpAssignedTo
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "This lab result has no open follow-up.",
+          });
         }
         if (
           ctx.user.role === "front_desk" &&
@@ -3532,7 +3649,8 @@ export const recordsRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "FORBIDDEN",
-            message: "Front desk staff can complete only lab follow-up assigned to them.",
+            message:
+              "Front desk staff can complete only lab follow-up assigned to them.",
           });
         }
         const occurredAt = new Date();
@@ -3558,7 +3676,11 @@ export const recordsRouter = createRouter({
           )
           .returning();
         if (!updated) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Lab follow-up changed while completing. Refresh and try again." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Lab follow-up changed while completing. Refresh and try again.",
+          });
         }
         await tx.insert(labResultEvents).values({
           practiceId: ctx.practiceId,
@@ -3608,16 +3730,16 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(procedures.performedBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
-          )
+            eq(users.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
             eq(procedures.patientId, input.patientId),
             eq(procedures.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(procedures.deletedAt)
-          )
+            isNull(procedures.deletedAt),
+          ),
         )
         .orderBy(desc(procedures.createdAt));
     }),
@@ -3631,20 +3753,20 @@ export const recordsRouter = createRouter({
         name: clinicalTextInput("Procedure name", PROCEDURE_NAME_MAX_LENGTH),
         description: optionalClinicalTextInput(
           "Procedure description",
-          PROCEDURE_DESCRIPTION_MAX_LENGTH
+          PROCEDURE_DESCRIPTION_MAX_LENGTH,
         ),
         anesthesiaUsed: optionalClinicalTextInput(
           "Anesthesia used",
-          PROCEDURE_ANESTHESIA_MAX_LENGTH
+          PROCEDURE_ANESTHESIA_MAX_LENGTH,
         ),
         durationMinutes: positiveIntegerColumnInput
           .max(PROCEDURE_DURATION_MAX_MINUTES)
           .optional(),
         notes: optionalClinicalTextInput(
           "Procedure notes",
-          PROCEDURE_NOTES_MAX_LENGTH
+          PROCEDURE_NOTES_MAX_LENGTH,
         ),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const procedure = await ctx.db.transaction(async (tx) => {
@@ -3655,7 +3777,7 @@ export const recordsRouter = createRouter({
             txCtx,
             input.appointmentId,
             input.patientId,
-            "procedures"
+            "procedures",
           );
         }
         const [created] = await tx
@@ -3694,7 +3816,7 @@ export const recordsRouter = createRouter({
       z.object({
         patientId: z.string().uuid(),
         appointmentId: z.string().uuid().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
@@ -3703,7 +3825,7 @@ export const recordsRouter = createRouter({
             await assertAppointmentBelongsToPatient(
               ctx,
               input.appointmentId,
-              input.patientId
+              input.patientId,
             )
           ).id
         : await findActiveVisitId(ctx, input.patientId);
@@ -3755,8 +3877,8 @@ export const recordsRouter = createRouter({
             like(files.mimeType, "image/%"),
             eq(files.storageStatus, "available"),
             activePracticePredicate(ctx.practiceId),
-            isNull(files.deletedAt)
-          )
+            isNull(files.deletedAt),
+          ),
         )
         .orderBy(desc(files.createdAt))
         .limit(50);
@@ -3773,7 +3895,7 @@ export const recordsRouter = createRouter({
       z.object({
         patientId: z.string().uuid(),
         appointmentId: z.string().uuid().optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
@@ -3781,7 +3903,7 @@ export const recordsRouter = createRouter({
         await assertAppointmentBelongsToPatient(
           ctx,
           input.appointmentId,
-          input.patientId
+          input.patientId,
         );
       }
       return ctx.db
@@ -3805,8 +3927,8 @@ export const recordsRouter = createRouter({
             eq(consentRequests.fileId, files.id),
             eq(consentRequests.practiceId, ctx.practiceId),
             eq(consentRequests.status, "signed"),
-            isNull(consentRequests.deletedAt)
-          )
+            isNull(consentRequests.deletedAt),
+          ),
         )
         .where(
           and(
@@ -3820,11 +3942,11 @@ export const recordsRouter = createRouter({
             or(
               isNull(files.category),
               ne(files.category, CONSENT_FILE_CATEGORY),
-              eq(consentRequests.status, "signed")
+              eq(consentRequests.status, "signed"),
             ),
             activePracticePredicate(ctx.practiceId),
-            isNull(files.deletedAt)
-          )
+            isNull(files.deletedAt),
+          ),
         )
         .orderBy(desc(files.createdAt))
         .limit(200);
@@ -3853,8 +3975,8 @@ export const recordsRouter = createRouter({
             eq(consentForms.practiceId, ctx.practiceId),
             eq(consentForms.isActive, true),
             activePracticePredicate(ctx.practiceId),
-            isNull(consentForms.deletedAt)
-          )
+            isNull(consentForms.deletedAt),
+          ),
         )
         .orderBy(consentForms.sortOrder)
         .limit(100);
@@ -3871,7 +3993,7 @@ export const recordsRouter = createRouter({
           title: form.title,
           body: form.body,
           sortOrder: form.sortOrder,
-        }))
+        })),
       )
       .onConflictDoNothing();
     return listForms();
@@ -3891,9 +4013,19 @@ export const recordsRouter = createRouter({
         patientId: z.string().uuid(),
         appointmentId: z.string().uuid().optional(),
         formId: z.string().uuid(),
-        title: z.string().trim().min(1).max(CONSENT_TITLE_MAX_LENGTH).optional(),
-        bodyText: z.string().trim().min(1).max(CONSENT_BODY_MAX_LENGTH).optional(),
-      })
+        title: z
+          .string()
+          .trim()
+          .min(1)
+          .max(CONSENT_TITLE_MAX_LENGTH)
+          .optional(),
+        bodyText: z
+          .string()
+          .trim()
+          .min(1)
+          .max(CONSENT_BODY_MAX_LENGTH)
+          .optional(),
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
@@ -3909,8 +4041,8 @@ export const recordsRouter = createRouter({
             eq(consentForms.id, input.formId),
             eq(consentForms.practiceId, ctx.practiceId),
             eq(consentForms.isActive, true),
-            isNull(consentForms.deletedAt)
-          )
+            isNull(consentForms.deletedAt),
+          ),
         )
         .limit(1);
       if (!form) {
@@ -3936,7 +4068,7 @@ export const recordsRouter = createRouter({
             await assertAppointmentBelongsToPatient(
               ctx,
               input.appointmentId,
-              input.patientId
+              input.patientId,
             )
           ).id
         : await findActiveVisitId(ctx, input.patientId);
@@ -3991,8 +4123,8 @@ export const recordsRouter = createRouter({
             eq(files.patientId, input.patientId),
             eq(files.category, CONSENT_FILE_CATEGORY),
             eq(files.storageStatus, "available"),
-            isNull(files.deletedAt)
-          )
+            isNull(files.deletedAt),
+          ),
         )
         .where(
           and(
@@ -4000,8 +4132,8 @@ export const recordsRouter = createRouter({
             eq(consentRequests.patientId, input.patientId),
             eq(consentRequests.status, "signed"),
             activePracticePredicate(ctx.practiceId),
-            isNull(consentRequests.deletedAt)
-          )
+            isNull(consentRequests.deletedAt),
+          ),
         )
         .orderBy(desc(consentRequests.createdAt))
         .limit(50);

--- a/apps/web/server/routers/templates.ts
+++ b/apps/web/server/routers/templates.ts
@@ -49,19 +49,29 @@ type TemplateInvoiceItem = {
   quantity: number;
 };
 
-const moneyInput = z.string().trim().refine((value) => {
-  return TREATMENT_TEMPLATE_UNIT_PRICE_PATTERN.test(value);
-}, "Amount must be a valid currency amount.");
+const moneyInput = z
+  .string()
+  .trim()
+  .refine((value) => {
+    return TREATMENT_TEMPLATE_UNIT_PRICE_PATTERN.test(value);
+  }, "Amount must be a valid currency amount.");
 
 const PRODUCT_LINK_REQUIRED_MESSAGE =
   "Every product template item must be linked to an active inventory product.";
+
+function nextInvoiceUpdatedAtSql() {
+  return sql`greatest(
+    date_trunc('milliseconds', clock_timestamp()) + interval '1 millisecond',
+    date_trunc('milliseconds', ${invoices.updatedAt}) + interval '1 millisecond'
+  )`;
+}
 
 const templateItemBaseInput = z.object({
   itemType: z.enum(["service", "product"]),
   itemId: z.string().uuid().optional(),
   description: clinicalTextInput(
     "Template item description",
-    TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH
+    TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH,
   ),
   defaultQuantity: z
     .number()
@@ -80,7 +90,7 @@ const templateItemBaseInput = z.object({
 
 function refineTemplateItemTotal(
   item: z.infer<typeof templateItemBaseInput>,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
 ) {
   if (item.itemType === "product" && !item.itemId) {
     ctx.addIssue({
@@ -101,7 +111,7 @@ function refineTemplateItemTotal(
 }
 
 const templateItemInput = templateItemBaseInput.superRefine(
-  refineTemplateItemTotal
+  refineTemplateItemTotal,
 );
 
 const addTemplateItemInput = templateItemBaseInput
@@ -112,11 +122,11 @@ const templateMutableInput = {
   name: clinicalTextInput("Template name", TREATMENT_TEMPLATE_NAME_MAX_LENGTH),
   description: optionalClinicalTextInput(
     "Template description",
-    TREATMENT_TEMPLATE_DESCRIPTION_MAX_LENGTH
+    TREATMENT_TEMPLATE_DESCRIPTION_MAX_LENGTH,
   ),
   category: optionalClinicalTextInput(
     "Template category",
-    TREATMENT_TEMPLATE_CATEGORY_MAX_LENGTH
+    TREATMENT_TEMPLATE_CATEGORY_MAX_LENGTH,
   ),
 };
 
@@ -126,7 +136,7 @@ const createTemplateInput = z.object({
     .array(templateItemInput)
     .max(
       TREATMENT_TEMPLATE_MAX_ITEMS,
-      `Templates can include at most ${TREATMENT_TEMPLATE_MAX_ITEMS} items.`
+      `Templates can include at most ${TREATMENT_TEMPLATE_MAX_ITEMS} items.`,
     ),
 });
 
@@ -162,7 +172,7 @@ async function assertActivePractice(ctx: TemplatesContext) {
 async function lockActiveTemplateCatalogItems(
   ctx: TemplatesContext,
   items: Array<{ itemType: "service" | "product"; itemId?: string }>,
-  options: { lockProductsForStock?: boolean } = {}
+  options: { lockProductsForStock?: boolean } = {},
 ) {
   if (items.some((item) => item.itemType === "product" && !item.itemId)) {
     throw new TRPCError({
@@ -175,14 +185,14 @@ async function lockActiveTemplateCatalogItems(
     ...new Set(
       items
         .filter((item) => item.itemType === "service" && item.itemId)
-        .map((item) => item.itemId!)
+        .map((item) => item.itemId!),
     ),
   ];
   const productIds = [
     ...new Set(
       items
         .filter((item) => item.itemType === "product" && item.itemId)
-        .map((item) => item.itemId!)
+        .map((item) => item.itemId!),
     ),
   ];
 
@@ -201,8 +211,8 @@ async function lockActiveTemplateCatalogItems(
               inArray(services.id, serviceIds),
               eq(services.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(services.deletedAt)
-            )
+              isNull(services.deletedAt),
+            ),
           )
           .orderBy(asc(services.id))
           .for("share");
@@ -222,8 +232,8 @@ async function lockActiveTemplateCatalogItems(
               inArray(products.id, productIds),
               eq(products.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(products.deletedAt)
-            )
+              isNull(products.deletedAt),
+            ),
           )
           .orderBy(asc(products.id))
           .for(options.lockProductsForStock ? "update" : "share");
@@ -289,7 +299,7 @@ function templateInvoiceTaxTotals(
 
 async function deductTemplateProductStock(
   ctx: TemplatesContext,
-  items: readonly TemplateInvoiceItem[]
+  items: readonly TemplateInvoiceItem[],
 ) {
   const deductions = computeStockDeductions([...items]);
   for (const deduction of deductions) {
@@ -304,8 +314,8 @@ async function deductTemplateProductStock(
           eq(products.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
           isNull(products.deletedAt),
-          sql`${products.stockQuantity} >= ${deduction.quantity}`
-        )
+          sql`${products.stockQuantity} >= ${deduction.quantity}`,
+        ),
       )
       .returning({ id: products.id, stockQuantity: products.stockQuantity });
 
@@ -327,8 +337,8 @@ export const templatesRouter = createRouter({
       .where(
         and(
           eq(treatmentTemplates.practiceId, ctx.practiceId),
-          isNull(treatmentTemplates.deletedAt)
-        )
+          isNull(treatmentTemplates.deletedAt),
+        ),
       )
       .orderBy(asc(treatmentTemplates.name));
   }),
@@ -349,8 +359,8 @@ export const templatesRouter = createRouter({
           and(
             eq(products.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(products.deletedAt)
-          )
+            isNull(products.deletedAt),
+          ),
         )
         .orderBy(asc(products.name), asc(products.id));
     }),
@@ -367,8 +377,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.id, input.id),
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplates.deletedAt)
-          )
+            isNull(treatmentTemplates.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -385,8 +395,8 @@ export const templatesRouter = createRouter({
         .where(
           and(
             eq(treatmentTemplateItems.templateId, input.id),
-            isNull(treatmentTemplateItems.deletedAt)
-          )
+            isNull(treatmentTemplateItems.deletedAt),
+          ),
         )
         .orderBy(asc(treatmentTemplateItems.sortOrder));
 
@@ -394,7 +404,7 @@ export const templatesRouter = createRouter({
         ...new Set(
           items
             .filter((item) => item.itemType === "product" && item.itemId)
-            .map((item) => item.itemId!)
+            .map((item) => item.itemId!),
         ),
       ];
       const activeLinkedProducts =
@@ -408,11 +418,11 @@ export const templatesRouter = createRouter({
                   inArray(products.id, linkedProductIds),
                   eq(products.practiceId, ctx.practiceId),
                   activePracticePredicate(ctx.practiceId),
-                  isNull(products.deletedAt)
-                )
+                  isNull(products.deletedAt),
+                ),
               );
       const activeLinkedProductIds = new Set(
-        activeLinkedProducts.map((product) => product.id)
+        activeLinkedProducts.map((product) => product.id),
       );
 
       return {
@@ -421,9 +431,7 @@ export const templatesRouter = createRouter({
           ...item,
           hasActiveProductLink:
             item.itemType === "product"
-              ? Boolean(
-                  item.itemId && activeLinkedProductIds.has(item.itemId)
-                )
+              ? Boolean(item.itemId && activeLinkedProductIds.has(item.itemId))
               : null,
         })),
       };
@@ -441,7 +449,7 @@ export const templatesRouter = createRouter({
         // before the template persists its reference.
         await lockActiveTemplateCatalogItems(
           { db: tx, practiceId: ctx.practiceId },
-          input.items
+          input.items,
         );
 
         const [template] = await tx
@@ -464,7 +472,7 @@ export const templatesRouter = createRouter({
               defaultQuantity: item.defaultQuantity,
               defaultUnitPrice: item.defaultUnitPrice,
               sortOrder: item.sortOrder,
-            }))
+            })),
           );
         }
 
@@ -481,7 +489,7 @@ export const templatesRouter = createRouter({
         description: templateMutableInput.description,
         category: templateMutableInput.category,
         isActive: z.boolean().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -494,8 +502,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.id, id),
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplates.deletedAt)
-          )
+            isNull(treatmentTemplates.deletedAt),
+          ),
         )
         .returning();
 
@@ -522,8 +530,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.id, input.id),
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplates.deletedAt)
-          )
+            isNull(treatmentTemplates.deletedAt),
+          ),
         )
         .returning();
 
@@ -554,8 +562,8 @@ export const templatesRouter = createRouter({
               eq(treatmentTemplates.id, input.templateId),
               eq(treatmentTemplates.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(treatmentTemplates.deletedAt)
-            )
+              isNull(treatmentTemplates.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -568,7 +576,7 @@ export const templatesRouter = createRouter({
 
         await lockActiveTemplateCatalogItems(
           { db: tx, practiceId: ctx.practiceId },
-          [input]
+          [input],
         );
 
         const [item] = await tx
@@ -602,7 +610,7 @@ export const templatesRouter = createRouter({
         .from(treatmentTemplateItems)
         .innerJoin(
           treatmentTemplates,
-          eq(treatmentTemplateItems.templateId, treatmentTemplates.id)
+          eq(treatmentTemplateItems.templateId, treatmentTemplates.id),
         )
         .where(
           and(
@@ -610,8 +618,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             isNull(treatmentTemplates.deletedAt),
-            isNull(treatmentTemplateItems.deletedAt)
-          )
+            isNull(treatmentTemplateItems.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -629,8 +637,8 @@ export const templatesRouter = createRouter({
           and(
             eq(treatmentTemplateItems.id, input.id),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplateItems.deletedAt)
-          )
+            isNull(treatmentTemplateItems.deletedAt),
+          ),
         )
         .returning();
 
@@ -650,7 +658,7 @@ export const templatesRouter = createRouter({
       z.object({
         templateId: z.string().uuid(),
         invoiceId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -664,8 +672,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             isNull(treatmentTemplates.deletedAt),
-            eq(treatmentTemplates.isActive, true)
-          )
+            eq(treatmentTemplates.isActive, true),
+          ),
         )
         .limit(1);
 
@@ -676,50 +684,53 @@ export const templatesRouter = createRouter({
         });
       }
 
-      // Verify invoice belongs to this practice
-      const [invoice] = await ctx.db
-        .select({
-          id: invoices.id,
-          status: invoices.status,
-          paidAmount: invoices.paidAmount,
-          isEstimate: invoices.isEstimate,
-        })
-        .from(invoices)
-        .where(
-          and(
-            eq(invoices.id, input.invoiceId),
-            eq(invoices.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(invoices.deletedAt)
-          )
-        )
-        .limit(1);
-
-      if (!invoice) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Invoice not found",
-        });
-      }
-      if (invoice.status !== "draft") {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Apply treatment templates before sending the invoice.",
-        });
-      }
-      if (moneyToCents(invoice.paidAmount) > 0) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Cannot apply treatment templates to invoices with payments.",
-        });
-      }
-
       return ctx.db.transaction(async (tx) => {
         // Share the invoice serialization key used by direct charge edits so
         // concurrent template applications cannot calculate competing totals.
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${input.invoiceId}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${input.invoiceId}, 0))`,
         );
+
+        // Re-read after the serialization boundary. Template application is
+        // an invoice mutation and must advance the same client-visible version
+        // used by estimate confirmation and direct charge edits.
+        const [invoice] = await tx
+          .select({
+            id: invoices.id,
+            status: invoices.status,
+            paidAmount: invoices.paidAmount,
+            isEstimate: invoices.isEstimate,
+          })
+          .from(invoices)
+          .where(
+            and(
+              eq(invoices.id, input.invoiceId),
+              eq(invoices.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(invoices.deletedAt),
+            ),
+          )
+          .for("update");
+
+        if (!invoice) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Invoice not found",
+          });
+        }
+        if (invoice.status !== "draft") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Apply treatment templates before sending the invoice.",
+          });
+        }
+        if (moneyToCents(invoice.paidAmount) > 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Cannot apply treatment templates to invoices with payments.",
+          });
+        }
 
         // Fetch template items
         const items = await tx
@@ -728,8 +739,8 @@ export const templatesRouter = createRouter({
           .where(
             and(
               eq(treatmentTemplateItems.templateId, input.templateId),
-              isNull(treatmentTemplateItems.deletedAt)
-            )
+              isNull(treatmentTemplateItems.deletedAt),
+            ),
           )
           .orderBy(asc(treatmentTemplateItems.sortOrder));
 
@@ -750,7 +761,7 @@ export const templatesRouter = createRouter({
             itemType: item.itemType,
             itemId: item.itemId ?? undefined,
           })),
-          { lockProductsForStock: !invoice.isEstimate }
+          { lockProductsForStock: !invoice.isEstimate },
         );
 
         const invoiceItemRows = items.map((item) => {
@@ -777,7 +788,7 @@ export const templatesRouter = createRouter({
         if (!invoice.isEstimate) {
           await deductTemplateProductStock(
             { db: tx, practiceId: ctx.practiceId },
-            invoiceItemRows
+            invoiceItemRows,
           );
         }
 
@@ -795,8 +806,8 @@ export const templatesRouter = createRouter({
           .where(
             and(
               eq(invoiceItems.invoiceId, input.invoiceId),
-              isNull(invoiceItems.deletedAt)
-            )
+              isNull(invoiceItems.deletedAt),
+            ),
           );
 
         // Tax rate is configured per practice (region-aware), not hardcoded.
@@ -830,6 +841,7 @@ export const templatesRouter = createRouter({
             subtotal: centsToMoney(totals.subtotalCents),
             tax: centsToMoney(totals.taxCents),
             total: centsToMoney(totals.totalCents),
+            updatedAt: nextInvoiceUpdatedAtSql(),
           })
           .where(
             and(
@@ -839,8 +851,8 @@ export const templatesRouter = createRouter({
               eq(invoices.status, invoice.status),
               eq(invoices.paidAmount, invoice.paidAmount ?? "0"),
               eq(invoices.isEstimate, invoice.isEstimate),
-              isNull(invoices.deletedAt)
-            )
+              isNull(invoices.deletedAt),
+            ),
           )
           .returning();
 

--- a/apps/web/server/visit-billing-integrity.ts
+++ b/apps/web/server/visit-billing-integrity.ts
@@ -10,6 +10,7 @@ import {
   prescriptions,
   procedures,
   vaccinationRecords,
+  dispenseChargeQueue,
   visitCloseouts,
   visitWorkItems,
 } from "@openpims/db";
@@ -30,12 +31,16 @@ export async function markCompletedVisitCloseoutPaid(
   input: {
     appointmentId: string | null | undefined;
     invoiceId: string;
-    source: "dashboard_payment" | "dashboard_adjustment" | "stripe" | "stripe_connect";
+    source:
+      | "dashboard_payment"
+      | "dashboard_adjustment"
+      | "stripe"
+      | "stripe_connect";
     userId?: string | null;
     paymentId?: string | null;
     adjustmentId?: string | null;
     paymentExternalId?: string | null;
-  }
+  },
 ) {
   if (!input.appointmentId) return null;
 
@@ -52,8 +57,8 @@ export async function markCompletedVisitCloseoutPaid(
         eq(visitCloseouts.appointmentId, input.appointmentId),
         eq(visitCloseouts.invoiceId, input.invoiceId),
         eq(visitCloseouts.status, "completed"),
-        isNull(visitCloseouts.deletedAt)
-      )
+        isNull(visitCloseouts.deletedAt),
+      ),
     )
     .limit(1)
     .for("update");
@@ -77,14 +82,15 @@ export async function markCompletedVisitCloseoutPaid(
         eq(visitCloseouts.status, "completed"),
         eq(visitCloseouts.chargeDisposition, "accounts_receivable"),
         eq(visitCloseouts.revision, closeout.revision),
-        isNull(visitCloseouts.deletedAt)
-      )
+        isNull(visitCloseouts.deletedAt),
+      ),
     )
     .returning({ id: visitCloseouts.id });
   if (!updatedCloseout) {
     throw new TRPCError({
       code: "CONFLICT",
-      message: "Visit closeout changed while settling payment. Retry the operation.",
+      message:
+        "Visit closeout changed while settling payment. Retry the operation.",
     });
   }
 
@@ -107,7 +113,11 @@ export async function markCompletedVisitCloseoutPaid(
     },
   });
 
-  return { closeoutId: closeout.id, priorRevision: closeout.revision, nextRevision };
+  return {
+    closeoutId: closeout.id,
+    priorRevision: closeout.revision,
+    nextRevision,
+  };
 }
 
 /**
@@ -115,7 +125,10 @@ export async function markCompletedVisitCloseoutPaid(
  * Callers intentionally invoke this only for an open visit; historical closed
  * visits must not acquire new unresolved work after the fact.
  */
-export async function syncVisitWorkItems(ctx: VisitBillingContext, appointmentId: string) {
+export async function syncVisitWorkItems(
+  ctx: VisitBillingContext,
+  appointmentId: string,
+) {
   await ctx.db.transaction(async (tx) => {
     // Correction and materialization serialize on the same source row. This
     // lock statement intentionally precedes the INSERT so READ COMMITTED takes
@@ -203,34 +216,43 @@ export async function syncVisitWorkItems(ctx: VisitBillingContext, appointmentId
 export async function assertNoUnresolvedVisitWork(
   ctx: VisitBillingContext,
   appointmentId: string,
-  message = "Resolve every performed vaccination, lab, procedure, and prescription as charged, no charge, or void/corrected before checkout."
+  message = "Resolve every performed vaccination, lab, procedure, prescription, and medication dispense as charged, no charge, waived, or void/corrected before checkout.",
 ) {
   const rows = await ctx.db.execute(sql`
-    select ${visitWorkItems.id}
-    from ${visitWorkItems}
-    left join ${invoiceItems}
-      on ${invoiceItems.id} = ${visitWorkItems.invoiceItemId}
-    left join ${invoices}
-      on ${invoices.id} = ${visitWorkItems.invoiceId}
-      and ${invoices.practiceId} = ${ctx.practiceId}
-      and ${invoices.appointmentId} = ${appointmentId}
-    where ${visitWorkItems.practiceId} = ${ctx.practiceId}
-      and ${visitWorkItems.appointmentId} = ${appointmentId}
-      and (
-        ${visitWorkItems.status} = 'unresolved'
-        or (
-          ${visitWorkItems.status} = 'charged'
-          and (
-            ${invoiceItems.id} is null
-            or ${invoiceItems.deletedAt} is not null
-            or ${invoices.id} is null
-            or ${invoices.deletedAt} is not null
-            or ${invoices.status} = 'void'
+    select unresolved.id
+    from (
+      select ${visitWorkItems.id} as id, ${visitWorkItems.createdAt} as created_at
+      from ${visitWorkItems}
+      left join ${invoiceItems}
+        on ${invoiceItems.id} = ${visitWorkItems.invoiceItemId}
+      left join ${invoices}
+        on ${invoices.id} = ${visitWorkItems.invoiceId}
+        and ${invoices.practiceId} = ${ctx.practiceId}
+        and ${invoices.appointmentId} = ${appointmentId}
+      where ${visitWorkItems.practiceId} = ${ctx.practiceId}
+        and ${visitWorkItems.appointmentId} = ${appointmentId}
+        and (
+          ${visitWorkItems.status} = 'unresolved'
+          or (
+            ${visitWorkItems.status} = 'charged'
+            and (
+              ${invoiceItems.id} is null
+              or ${invoiceItems.deletedAt} is not null
+              or ${invoices.id} is null
+              or ${invoices.deletedAt} is not null
+              or ${invoices.status} = 'void'
+            )
           )
         )
-      )
-      and ${visitWorkItems.deletedAt} is null
-    order by ${visitWorkItems.createdAt}, ${visitWorkItems.id}
+        and ${visitWorkItems.deletedAt} is null
+      union all
+      select ${dispenseChargeQueue.id} as id, ${dispenseChargeQueue.createdAt} as created_at
+      from ${dispenseChargeQueue}
+      where ${dispenseChargeQueue.practiceId} = ${ctx.practiceId}
+        and ${dispenseChargeQueue.appointmentId} = ${appointmentId}
+        and ${dispenseChargeQueue.status} = 'pending'
+    ) unresolved
+    order by unresolved.created_at, unresolved.id
     limit 1
   `);
   if (rowsFromExecute<{ id: string }>(rows).length > 0) {
@@ -244,7 +266,7 @@ export async function assertNoUnresolvedVisitWork(
  */
 export async function assertVisitInvoiceReadyForFinancialAction(
   ctx: VisitBillingContext,
-  appointmentId: string | null | undefined
+  appointmentId: string | null | undefined,
 ) {
   if (!appointmentId) return;
 
@@ -255,15 +277,19 @@ export async function assertVisitInvoiceReadyForFinancialAction(
       and(
         eq(visitCloseouts.practiceId, ctx.practiceId),
         eq(visitCloseouts.appointmentId, appointmentId),
-        isNull(visitCloseouts.deletedAt)
-      )
+        isNull(visitCloseouts.deletedAt),
+      ),
     )
     .limit(1);
 
-  if (closeout?.status !== "clinical_finalized" && closeout?.status !== "completed") {
+  if (
+    closeout?.status !== "clinical_finalized" &&
+    closeout?.status !== "completed"
+  ) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
-      message: "Finalize the clinical handoff before sending or collecting this visit invoice.",
+      message:
+        "Finalize the clinical handoff before sending or collecting this visit invoice.",
     });
   }
 
@@ -273,7 +299,7 @@ export async function assertVisitInvoiceReadyForFinancialAction(
   await assertNoUnresolvedVisitWork(
     ctx,
     appointmentId,
-    "Resolve every performed vaccination, lab, procedure, and prescription before sending or collecting this visit invoice."
+    "Resolve every performed vaccination, lab, procedure, prescription, and medication dispense before sending or collecting this visit invoice.",
   );
 }
 
@@ -284,7 +310,7 @@ export async function assertVisitInvoiceReadyForFinancialAction(
  */
 export async function assertVisitReconciliationMutable(
   ctx: VisitBillingContext,
-  appointmentId: string
+  appointmentId: string,
 ) {
   const [invoice] = await ctx.db
     .select({ status: invoices.status })
@@ -295,8 +321,8 @@ export async function assertVisitReconciliationMutable(
         eq(invoices.appointmentId, appointmentId),
         eq(invoices.isEstimate, false),
         ne(invoices.status, "void"),
-        isNull(invoices.deletedAt)
-      )
+        isNull(invoices.deletedAt),
+      ),
     )
     .limit(1);
 


### PR DESCRIPTION
## What changed

- Adds an explicit, confirmed estimate-to-visit-invoice flow in Billing and the encounter workspace.
- Serializes conversion behind invoice and appointment locks, revalidates the client-visible invoice version, blocks competing actual invoices, validates catalog and medication sources, updates inventory atomically, normalizes the result to a reviewable draft, and records a PHI-free audit event.
- Makes visit-linked refill dispenses visible in both Charge capture and the signed clinical medication handoff, while blocking send, payment, portal checkout, and visit completion until every dispense is invoiced or explicitly waived.
- Rejects legacy prescription-only charge links for new writes and preserves the exact dispense identity through billing reconciliation.
- Canonicalizes prescription, product, template, edit, and void lock ordering to avoid inventory/invoice deadlocks and prevents template mutations from reusing a stale estimate version.
- Adds a disposable real-PostgreSQL concurrency and rollback drill to CI.

## Why

The prior estimate conversion path could bypass the safer visit-invoice invariants, including medication dispense reconciliation and some inventory lock ordering. Older prescriptions refilled during a visit could also remain outside the signed clinical handoff even though their charge existed. Those gaps could create duplicate or stranded medication charges, stale confirmation conversions, incomplete checkout evidence, and deadlock victims during concurrent clinic work.

## Clinic impact

Staff now review an estimate before promoting it into the active visit invoice. Performed medication work must be reconciled once, remains traceable to its exact dispense, and is included in the clinical handoff. Concurrent edits fail with clear refresh/review instructions instead of silently mutating stale work.

## Validation

- `pnpm --filter @openpims/web test` — 3,887 passed; 15 expected integration skips
- Disposable PostgreSQL billing drill — 9/9 passed, including deadlock checks, stock rollback, competing invoice serialization, stale-template rejection, refill/clinical handoff, and edit/void races
- `pnpm --filter @openpims/web type-check`
- `pnpm --filter @openpims/db type-check`
- `pnpm --filter @openpims/db db:generate` — no schema changes
- `pnpm --filter @openpims/web build`
- Prettier and `git diff --check`

No provider calls, SMS sends, payment charges, production mutations, or schema migrations are part of this change.