### PR TITLE
Add durable onboarding step conversion funnel

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -97,6 +97,8 @@ export default function AdminPage() {
   );
   const { data: funnel, error: funnelError } =
     trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false });
+  const { data: onboardingFunnel, error: onboardingFunnelError } =
+    trpc.admin.onboardingStepFunnel.useQuery({ days: 30 }, { retry: false });
   const { data: recoveryQueue, error: recoveryError } =
     trpc.admin.activationRecovery.useQuery(undefined, { retry: false });
   const { data: journey, error: journeyError } =
@@ -1391,6 +1393,152 @@ export default function AdminPage() {
         ) : (
           <p className="mt-3 text-sm text-muted-foreground">
             {funnelError ? "Could not load the funnel." : "Loading funnel..."}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-6 rounded-lg border border-border bg-card p-5">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <TrendingUp className="h-4 w-4" />
+          <span className="text-sm">
+            Guided setup cohorts (30 days)
+            {onboardingFunnel
+              ? ` · ${onboardingFunnel.totals.signups} registered`
+              : ""}
+          </span>
+        </div>
+        {onboardingFunnel ? (
+          <>
+            <div className="mt-3 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <div>
+                <p className="text-sm text-muted-foreground">Path completed</p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {onboardingFunnel.totals.intentCompleted}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(onboardingFunnel.totals.intentCompletionRate)}
+                  </span>
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {onboardingFunnel.totals.stalledBeforeIntent} stalled before
+                  choosing a path
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Clinic basics completed
+                </p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {onboardingFunnel.totals.basicsCompleted}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(onboardingFunnel.totals.basicsCompletionRate)}
+                  </span>
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {onboardingFunnel.totals.stalledAtBasics} stalled at clinic
+                  basics
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Data step completed
+                </p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {onboardingFunnel.totals.dataCompleted}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(onboardingFunnel.totals.dataCompletionRate)}
+                  </span>
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {onboardingFunnel.totals.stalledAtData} stalled at data
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  First-day handoff completed
+                </p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {onboardingFunnel.totals.allSetCompleted}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(onboardingFunnel.totals.allSetCompletionRate)}
+                  </span>
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {onboardingFunnel.totals.stalledAtAllSet} stalled at the
+                  first-day handoff
+                </p>
+              </div>
+            </div>
+            <p className="mt-3 text-xs text-muted-foreground">
+              Step rates are sequential: each percentage uses the prior step as
+              its denominator. A clinic is stalled only after{" "}
+              {onboardingFunnel.stallDays} full days without the next durable
+              transition. New timestamps are server-owned and first-write-wins;
+              historical cursor-only progress remains explicitly inferred.
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Complete exact step chains:{" "}
+              {onboardingFunnel.dataQuality.fullyInstrumentedPractices} ·
+              Partial/invalid exact chains:{" "}
+              {onboardingFunnel.dataQuality.partiallyInstrumentedPractices} ·
+              Historical inferred:{" "}
+              {onboardingFunnel.dataQuality.historicalInferredPractices} · No
+              step evidence:{" "}
+              {onboardingFunnel.dataQuality.noStepEvidencePractices}
+            </p>
+            {onboardingFunnel.weeks.length > 0 ? (
+              <div className="mt-4 overflow-x-auto">
+                <table className="w-full min-w-[36rem] text-xs">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="py-2 pr-3 font-medium">
+                        Registration week
+                      </th>
+                      <th className="px-3 py-2 text-right font-medium">
+                        Signups
+                      </th>
+                      <th className="px-3 py-2 text-right font-medium">Path</th>
+                      <th className="px-3 py-2 text-right font-medium">
+                        Basics
+                      </th>
+                      <th className="px-3 py-2 text-right font-medium">Data</th>
+                      <th className="py-2 pl-3 text-right font-medium">
+                        First-day handoff
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {onboardingFunnel.weeks.map((week) => (
+                      <tr key={week.weekStart}>
+                        <td className="py-2 pr-3 font-medium">
+                          {week.weekStart}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums">
+                          {week.signups}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums">
+                          {week.intentCompleted}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums">
+                          {week.basicsCompleted}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums">
+                          {week.dataCompleted}
+                        </td>
+                        <td className="py-2 pl-3 text-right tabular-nums">
+                          {week.allSetCompleted}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <p className="mt-3 text-sm text-muted-foreground">
+            {onboardingFunnelError
+              ? "Could not load guided setup cohorts."
+              : "Loading guided setup cohorts..."}
           </p>
         )}
       </div>

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActivationFunnel } from "@/lib/admin/activation-funnel";
 import type { JourneyFunnel } from "@/lib/admin/journey-funnel";
+import type { OnboardingStepFunnel } from "@/lib/admin/onboarding-step-funnel";
 
 const mocks = vi.hoisted(() => ({
   db: {},
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   sendEmail: vi.fn(async () => ({ success: true, id: "email_123" })),
   computeActivationFunnel: vi.fn(),
   computeJourneyFunnel: vi.fn(),
+  computeOnboardingStepFunnel: vi.fn(),
   loadClinicPilotQueue: vi.fn(async () => []),
 }));
 
@@ -39,6 +41,10 @@ vi.mock("@/lib/admin/activation-funnel", () => ({
 
 vi.mock("@/lib/admin/journey-funnel", () => ({
   computeJourneyFunnel: mocks.computeJourneyFunnel,
+}));
+
+vi.mock("@/lib/admin/onboarding-step-funnel", () => ({
+  computeOnboardingStepFunnel: mocks.computeOnboardingStepFunnel,
 }));
 
 vi.mock("@/lib/admin/clinic-pilots", () => ({
@@ -144,6 +150,35 @@ function journey(days: number): JourneyFunnel {
   };
 }
 
+function onboarding(days: number): OnboardingStepFunnel {
+  return {
+    days,
+    stallDays: 7,
+    weeks: [],
+    totals: {
+      signups: 5,
+      intentCompleted: 4,
+      basicsCompleted: 3,
+      dataCompleted: 2,
+      allSetCompleted: 1,
+      stalledBeforeIntent: 1,
+      stalledAtBasics: 1,
+      stalledAtData: 1,
+      stalledAtAllSet: 1,
+      intentCompletionRate: 0.8,
+      basicsCompletionRate: 0.75,
+      dataCompletionRate: 2 / 3,
+      allSetCompletionRate: 0.5,
+    },
+    dataQuality: {
+      fullyInstrumentedPractices: 2,
+      partiallyInstrumentedPractices: 1,
+      historicalInferredPractices: 1,
+      noStepEvidencePractices: 1,
+    },
+  };
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.clearAllMocks();
@@ -199,6 +234,9 @@ describe("activation digest cron", () => {
     mocks.computeJourneyFunnel.mockImplementation(
       async (_db: unknown, days: number) => journey(days),
     );
+    mocks.computeOnboardingStepFunnel.mockImplementation(
+      async (_db: unknown, days: number) => onboarding(days),
+    );
     mocks.loadClinicPilotQueue.mockResolvedValueOnce([
       {
         practiceName: "North <Clinic>",
@@ -229,6 +267,11 @@ describe("activation digest cron", () => {
     expect(mocks.computeActivationFunnel).toHaveBeenCalledWith(mocks.db, 30);
     expect(mocks.computeJourneyFunnel).toHaveBeenCalledWith(mocks.db, 7);
     expect(mocks.computeJourneyFunnel).toHaveBeenCalledWith(mocks.db, 30);
+    expect(mocks.computeOnboardingStepFunnel).toHaveBeenCalledWith(mocks.db, 7);
+    expect(mocks.computeOnboardingStepFunnel).toHaveBeenCalledWith(
+      mocks.db,
+      30,
+    );
     expect(mocks.loadClinicPilotQueue).toHaveBeenCalledWith(mocks.db);
     expect(mocks.sendEmail).toHaveBeenCalledTimes(2);
     expect(mocks.sendEmail).toHaveBeenCalledWith(
@@ -269,6 +312,18 @@ describe("activation digest cron", () => {
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
+        html: expect.stringContaining("Guided setup · past 30 days"),
+      }),
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining(
+          "Stalled after 7 days: before path 1 · basics 1 · data 1",
+        ),
+      }),
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
         html: expect.stringContaining("Supported clinic cohort"),
       }),
     );
@@ -298,6 +353,9 @@ describe("activation digest cron", () => {
     );
     mocks.computeJourneyFunnel.mockImplementation(
       async (_db: unknown, days: number) => journey(days),
+    );
+    mocks.computeOnboardingStepFunnel.mockImplementation(
+      async (_db: unknown, days: number) => onboarding(days),
     );
     mocks.sendEmail.mockResolvedValueOnce({
       success: false,

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -13,6 +13,10 @@ import {
   computeJourneyFunnel,
   type JourneyFunnel,
 } from "@/lib/admin/journey-funnel";
+import {
+  computeOnboardingStepFunnel,
+  type OnboardingStepFunnel,
+} from "@/lib/admin/onboarding-step-funnel";
 import { loadClinicPilotQueue } from "@/lib/admin/clinic-pilots";
 
 export const dynamic = "force-dynamic";
@@ -39,16 +43,34 @@ export async function GET(request: Request) {
       return NextResponse.json({ recipients: 0, sent: 0, failed: 0 });
     }
 
-    const [week, month, journeyWeek, journeyMonth, pilots] = await Promise.all([
+    const [
+      week,
+      month,
+      journeyWeek,
+      journeyMonth,
+      onboardingWeek,
+      onboardingMonth,
+      pilots,
+    ] = await Promise.all([
       computeActivationFunnel(db, 7),
       computeActivationFunnel(db, 30),
       computeJourneyFunnel(db, 7),
       computeJourneyFunnel(db, 30),
+      computeOnboardingStepFunnel(db, 7),
+      computeOnboardingStepFunnel(db, 30),
       loadClinicPilotQueue(db),
     ]);
 
     const subject = `OpenVPM trial funnel: ${week.totals.signups} signups, ${week.totals.activated} activated this week`;
-    const html = digestHtml(week, month, journeyWeek, journeyMonth, pilots);
+    const html = digestHtml(
+      week,
+      month,
+      journeyWeek,
+      journeyMonth,
+      onboardingWeek,
+      onboardingMonth,
+      pilots,
+    );
 
     let sent = 0;
     let failed = 0;
@@ -175,6 +197,32 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
 <p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>`;
 }
 
+function onboardingSection(
+  title: string,
+  funnel: OnboardingStepFunnel,
+): string {
+  const totals = funnel.totals;
+  return `<h2 style="margin:24px 0 8px;font-size:16px;color:#111827;">${title}</h2>
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+  <tr style="text-align:left;color:#6b7280;font-size:13px;">
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Registered</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Path</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Basics</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Data</th>
+    <th style="padding:4px 0;font-weight:500;">First-day handoff</th>
+  </tr>
+  <tr style="font-size:20px;color:#111827;font-weight:600;">
+    <td style="padding:2px 12px 2px 0;">${totals.signups}</td>
+    <td style="padding:2px 12px 2px 0;">${totals.intentCompleted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(totals.intentCompletionRate)}</span></td>
+    <td style="padding:2px 12px 2px 0;">${totals.basicsCompleted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(totals.basicsCompletionRate)}</span></td>
+    <td style="padding:2px 12px 2px 0;">${totals.dataCompleted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(totals.dataCompletionRate)}</span></td>
+    <td style="padding:2px 0;">${totals.allSetCompleted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(totals.allSetCompletionRate)}</span></td>
+  </tr>
+</table>
+<p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Stalled after ${funnel.stallDays} days: before path ${totals.stalledBeforeIntent} · basics ${totals.stalledAtBasics} · data ${totals.stalledAtData} · first-day handoff ${totals.stalledAtAllSet}.</p>
+<p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Evidence quality: ${funnel.dataQuality.fullyInstrumentedPractices} complete exact chain(s) · ${funnel.dataQuality.partiallyInstrumentedPractices} partial/invalid exact chain(s) · ${funnel.dataQuality.historicalInferredPractices} historical/inferred · ${funnel.dataQuality.noStepEvidencePractices} with no step evidence. Rates are sequential and no historical transition time is invented.</p>`;
+}
+
 type ClinicPilotQueue = Awaited<ReturnType<typeof loadClinicPilotQueue>>;
 
 function pilotSection(pilots: ClinicPilotQueue, now = new Date()): string {
@@ -195,6 +243,8 @@ function digestHtml(
   month: ActivationFunnel,
   journeyWeek: JourneyFunnel,
   journeyMonth: JourneyFunnel,
+  onboardingWeek: OnboardingStepFunnel,
+  onboardingMonth: OnboardingStepFunnel,
   pilots: ClinicPilotQueue,
 ): string {
   return `<!DOCTYPE html>
@@ -218,6 +268,8 @@ function digestHtml(
             <td style="padding:32px;">
               ${journeySection("Production journey · past 7 days", journeyWeek)}
               ${journeySection("Production journey · past 30 days", journeyMonth)}
+              ${onboardingSection("Guided setup · past 7 days", onboardingWeek)}
+              ${onboardingSection("Guided setup · past 30 days", onboardingMonth)}
               ${funnelSection("Past 7 days", week)}
               ${funnelSection("Past 30 days", month)}
               ${pilotSection(pilots)}

--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -235,7 +235,7 @@ function JourneyShell({
   // Do not advance or close until the server accepts the cursor. A local-only
   // optimistic cursor can strand a clinic at an earlier step after a reload.
   const persistCursor = useCallback(
-    async (stepId: string, dismissed?: boolean) => {
+    async (stepId: OnboardingJourneyStep["id"], dismissed?: boolean) => {
       await setJourneyProgress.mutateAsync({ stepId, dismissed });
       utils.settings.getOnboardingState.setData(undefined, (prev) =>
         prev

--- a/apps/web/components/onboarding/steps/choose-path.tsx
+++ b/apps/web/components/onboarding/steps/choose-path.tsx
@@ -49,6 +49,7 @@ export function ChoosePathStep({ register, state, setState }: StepProps) {
             ? {
                 ...prev,
                 onboardingIntent: state.onboardingIntent,
+                journeyStepId: "intent",
                 journeyDismissed: false,
               }
             : prev,

--- a/apps/web/components/tour/tour-provider.tsx
+++ b/apps/web/components/tour/tour-provider.tsx
@@ -113,6 +113,10 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
         ...prev,
         onboardingIntent: prev?.onboardingIntent ?? null,
         onboardingIntentSelectedAt: prev?.onboardingIntentSelectedAt ?? null,
+        journeyIntentCompletedAt: prev?.journeyIntentCompletedAt ?? null,
+        journeyBasicsCompletedAt: prev?.journeyBasicsCompletedAt ?? null,
+        journeyDataCompletedAt: prev?.journeyDataCompletedAt ?? null,
+        journeyAllSetCompletedAt: prev?.journeyAllSetCompletedAt ?? null,
         migrationHasCommittedChanges:
           prev?.migrationHasCommittedChanges ?? false,
         migrationLastCommittedAt: prev?.migrationLastCommittedAt ?? null,

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -58,6 +58,25 @@ describe("admin UI", () => {
     expect(source).toContain("Could not load the funnel.");
   });
 
+  it("shows exact four-step setup cohorts and seven-day stalls", () => {
+    expect(source).toContain("trpc.admin.onboardingStepFunnel.useQuery");
+    expect(source).toContain("Guided setup cohorts (30 days)");
+    expect(source).toContain("onboardingFunnel.totals.intentCompleted");
+    expect(source).toContain("onboardingFunnel.totals.basicsCompleted");
+    expect(source).toContain("onboardingFunnel.totals.dataCompleted");
+    expect(source).toContain("onboardingFunnel.totals.allSetCompleted");
+    expect(source).toContain("onboardingFunnel.totals.stalledBeforeIntent");
+    expect(source).toContain("onboardingFunnel.totals.stalledAtBasics");
+    expect(source).toContain("onboardingFunnel.totals.stalledAtData");
+    expect(source).toContain("onboardingFunnel.totals.stalledAtAllSet");
+    expect(source).toContain("onboardingFunnel.weeks.map");
+    expect(source).toContain("Registration week");
+    expect(compactSource).toContain("A clinic is stalled only after");
+    expect(compactSource).toContain(
+      "historical cursor-only progress remains explicitly inferred",
+    );
+  });
+
   it("shows a ranked activation recovery queue with verified contacts", () => {
     expect(source).toContain("trpc.admin.activationRecovery.useQuery");
     expect(source).toContain("Clinic activation recovery");

--- a/apps/web/lib/__tests__/onboarding-step-funnel.test.ts
+++ b/apps/web/lib/__tests__/onboarding-step-funnel.test.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const results: unknown[][] = [];
+  const db = {
+    execute: vi.fn(async () => results.shift() ?? []),
+  };
+  return {
+    db,
+    results,
+    withSystem: vi.fn(
+      async (database: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+        fn(database),
+    ),
+  };
+});
+
+vi.mock("@/lib/tenant-db", () => ({
+  withSystem: mocks.withSystem,
+}));
+
+const { computeOnboardingStepFunnel, ONBOARDING_STALL_DAYS } =
+  await import("@/lib/admin/onboarding-step-funnel");
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mocks.results.length = 0;
+});
+
+describe("onboarding step funnel", () => {
+  it("aggregates signup cohorts with sequential step rates and stalled counts", async () => {
+    mocks.results.push(
+      [
+        {
+          weekStart: "2026-07-27",
+          signups: "4",
+          intentCompleted: "3",
+          basicsCompleted: "2",
+          dataCompleted: "1",
+          allSetCompleted: "1",
+          stalledBeforeIntent: "1",
+          stalledAtBasics: "1",
+          stalledAtData: "1",
+          stalledAtAllSet: "0",
+        },
+        {
+          weekStart: "2026-08-03",
+          signups: 2,
+          intentCompleted: 1,
+          basicsCompleted: 1,
+          dataCompleted: 0,
+          allSetCompleted: 0,
+          stalledBeforeIntent: 0,
+          stalledAtBasics: 0,
+          stalledAtData: 0,
+          stalledAtAllSet: 0,
+        },
+      ],
+      [
+        {
+          fullyInstrumentedPractices: "2",
+          partiallyInstrumentedPractices: "1",
+          historicalInferredPractices: "2",
+          noStepEvidencePractices: "1",
+        },
+      ],
+    );
+
+    const result = await computeOnboardingStepFunnel(mocks.db as never, 30);
+
+    expect(result.days).toBe(30);
+    expect(result.stallDays).toBe(ONBOARDING_STALL_DAYS);
+    expect(result.weeks).toHaveLength(2);
+    expect(result.totals).toMatchObject({
+      signups: 6,
+      intentCompleted: 4,
+      basicsCompleted: 3,
+      dataCompleted: 1,
+      allSetCompleted: 1,
+      stalledBeforeIntent: 1,
+      stalledAtBasics: 1,
+      stalledAtData: 1,
+      stalledAtAllSet: 0,
+      intentCompletionRate: 4 / 6,
+      basicsCompletionRate: 3 / 4,
+      dataCompletionRate: 1 / 3,
+      allSetCompletionRate: 1,
+    });
+    expect(result.dataQuality).toEqual({
+      fullyInstrumentedPractices: 2,
+      partiallyInstrumentedPractices: 1,
+      historicalInferredPractices: 2,
+      noStepEvidencePractices: 1,
+    });
+    expect(mocks.withSystem).toHaveBeenCalledWith(
+      mocks.db,
+      expect.any(Function),
+    );
+  });
+
+  it("returns zero rates and quality counts for an empty cohort", async () => {
+    mocks.results.push([], []);
+
+    const result = await computeOnboardingStepFunnel(mocks.db as never, 7);
+
+    expect(result.totals).toEqual({
+      signups: 0,
+      intentCompleted: 0,
+      basicsCompleted: 0,
+      dataCompleted: 0,
+      allSetCompleted: 0,
+      stalledBeforeIntent: 0,
+      stalledAtBasics: 0,
+      stalledAtData: 0,
+      stalledAtAllSet: 0,
+      intentCompletionRate: 0,
+      basicsCompletionRate: 0,
+      dataCompletionRate: 0,
+      allSetCompletionRate: 0,
+    });
+    expect(result.dataQuality).toEqual({
+      fullyInstrumentedPractices: 0,
+      partiallyInstrumentedPractices: 0,
+      historicalInferredPractices: 0,
+      noStepEvidencePractices: 0,
+    });
+  });
+
+  it("keeps cohort and abandonment evidence privacy-safe and fail-closed", () => {
+    const source = readFileSync(
+      new URL("../admin/onboarding-step-funnel.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("p.deleted_at is null");
+    expect(source).toContain(
+      "p.settings ->> 'analyticsExcluded' is distinct from 'true'",
+    );
+    expect(source).toContain("pcm.milestone = 'registered'");
+    expect(source).toContain(
+      "date_trunc('week', p.created_at at time zone 'UTC')",
+    );
+    expect(source).toContain("and s.basics_done and s.data_done");
+    expect(source).toContain("pg_input_is_valid");
+    expect(source).toContain("between r.created_at and statement_timestamp()");
+    expect(source).toContain("b.bounded_basics_at >= b.exact_intent_at");
+    expect(source).toContain("b.bounded_data_at >= b.exact_basics_at");
+    expect(source).toContain("d.bounded_all_set_at >= d.exact_data_at");
+    expect(source).toContain("), false) as intent_done");
+    expect(source).toContain("), false) as legacy_evidence");
+    expect(source).toContain("'branding', 'team', 'agent', 'phone', 'billing'");
+    expect(source).toContain("'alongside', 'replace', 'explore', 'self_host'");
+    expect(source).toContain("and r.journey_step_raw in");
+    expect(source).toContain("p.settings -> 'onboardingState'");
+    expect(source).toContain("from migration_runs mr");
+    expect(source).toContain("mr.status = 'committed'");
+    expect(source).toContain("s.exact_intent_at is not null");
+    expect(source).toContain("s.exact_basics_at is not null");
+    expect(source).toContain("s.exact_data_at is not null");
+    expect(source).not.toContain("email");
+    expect(source).not.toContain("patient");
+    expect(source).not.toContain("client_name");
+    expect(source).not.toContain("practice_name");
+  });
+});

--- a/apps/web/lib/__tests__/onboarding-ui-states.test.ts
+++ b/apps/web/lib/__tests__/onboarding-ui-states.test.ts
@@ -87,6 +87,7 @@ describe("onboarding UI states", () => {
       "saveIntent.mutateAsync({ intent: state.onboardingIntent })",
     );
     expect(choosePath).toContain("onboardingIntent: state.onboardingIntent");
+    expect(choosePath).toContain('journeyStepId: "intent"');
     expect(choosePath).toContain("journeyDismissed: false");
     expect(settingsRouter).toContain("onboardingIntentSelectedAt");
   });

--- a/apps/web/lib/admin/onboarding-step-funnel.ts
+++ b/apps/web/lib/admin/onboarding-step-funnel.ts
@@ -1,0 +1,497 @@
+import { sql } from "drizzle-orm";
+import type { Database } from "@openpims/db/client";
+import { withSystem } from "@/lib/tenant-db";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const ONBOARDING_STALL_DAYS = 7;
+
+export interface OnboardingStepFunnelWeek {
+  weekStart: string;
+  signups: number;
+  intentCompleted: number;
+  basicsCompleted: number;
+  dataCompleted: number;
+  allSetCompleted: number;
+  stalledBeforeIntent: number;
+  stalledAtBasics: number;
+  stalledAtData: number;
+  stalledAtAllSet: number;
+}
+
+export interface OnboardingStepFunnelTotals extends Omit<
+  OnboardingStepFunnelWeek,
+  "weekStart"
+> {
+  intentCompletionRate: number;
+  basicsCompletionRate: number;
+  dataCompletionRate: number;
+  allSetCompletionRate: number;
+}
+
+export interface OnboardingStepFunnelDataQuality {
+  fullyInstrumentedPractices: number;
+  partiallyInstrumentedPractices: number;
+  historicalInferredPractices: number;
+  noStepEvidencePractices: number;
+}
+
+export interface OnboardingStepFunnel {
+  days: number;
+  stallDays: number;
+  weeks: OnboardingStepFunnelWeek[];
+  totals: OnboardingStepFunnelTotals;
+  dataQuality: OnboardingStepFunnelDataQuality;
+}
+
+interface FunnelRow {
+  weekStart: string;
+  signups: number | string;
+  intentCompleted: number | string;
+  basicsCompleted: number | string;
+  dataCompleted: number | string;
+  allSetCompleted: number | string;
+  stalledBeforeIntent: number | string;
+  stalledAtBasics: number | string;
+  stalledAtData: number | string;
+  stalledAtAllSet: number | string;
+}
+
+interface DataQualityRow {
+  fullyInstrumentedPractices: number | string;
+  partiallyInstrumentedPractices: number | string;
+  historicalInferredPractices: number | string;
+  noStepEvidencePractices: number | string;
+}
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const rows = (result as { rows?: unknown[] } | null)?.rows;
+  return Array.isArray(rows) ? (rows as T[]) : [];
+}
+
+function rate(part: number, whole: number): number {
+  return whole > 0 ? part / whole : 0;
+}
+
+function summarizeWeeks(
+  weeks: OnboardingStepFunnelWeek[],
+): OnboardingStepFunnelTotals {
+  const summed = weeks.reduce<Omit<OnboardingStepFunnelWeek, "weekStart">>(
+    (total, week) => ({
+      signups: total.signups + week.signups,
+      intentCompleted: total.intentCompleted + week.intentCompleted,
+      basicsCompleted: total.basicsCompleted + week.basicsCompleted,
+      dataCompleted: total.dataCompleted + week.dataCompleted,
+      allSetCompleted: total.allSetCompleted + week.allSetCompleted,
+      stalledBeforeIntent: total.stalledBeforeIntent + week.stalledBeforeIntent,
+      stalledAtBasics: total.stalledAtBasics + week.stalledAtBasics,
+      stalledAtData: total.stalledAtData + week.stalledAtData,
+      stalledAtAllSet: total.stalledAtAllSet + week.stalledAtAllSet,
+    }),
+    {
+      signups: 0,
+      intentCompleted: 0,
+      basicsCompleted: 0,
+      dataCompleted: 0,
+      allSetCompleted: 0,
+      stalledBeforeIntent: 0,
+      stalledAtBasics: 0,
+      stalledAtData: 0,
+      stalledAtAllSet: 0,
+    },
+  );
+  return {
+    ...summed,
+    intentCompletionRate: rate(summed.intentCompleted, summed.signups),
+    basicsCompletionRate: rate(summed.basicsCompleted, summed.intentCompleted),
+    dataCompletionRate: rate(summed.dataCompleted, summed.basicsCompleted),
+    allSetCompletionRate: rate(summed.allSetCompleted, summed.dataCompleted),
+  };
+}
+
+/**
+ * Signup-week cohorts for the four guided setup steps.
+ *
+ * New evidence is written as first-write-wins database timestamps. Historical
+ * clinics may contribute inferred completion counts from their last durable
+ * cursor, but never contribute fabricated timestamps to the seven-day stall
+ * queues. The data-quality totals keep those two evidence classes explicit.
+ */
+export async function computeOnboardingStepFunnel(
+  db: Database,
+  days: number,
+): Promise<OnboardingStepFunnel> {
+  const windowStart = new Date(Date.now() - days * DAY_MS).toISOString();
+  const stallCutoff = new Date(
+    Date.now() - ONBOARDING_STALL_DAYS * DAY_MS,
+  ).toISOString();
+
+  const { cohortResult, qualityResult } = await withSystem(db, async (tx) => {
+    const cohortResult = await tx.execute(sql`
+      with cohort as (
+        select
+          p.id,
+          p.created_at,
+          p.settings,
+          date_trunc('week', p.created_at at time zone 'UTC') as week_start,
+          (
+            p.settings -> 'onboardingState' ->> 'migrationHasCommittedChanges'
+              = 'true'
+            or exists (
+              select 1
+              from migration_runs mr
+              where mr.practice_id = p.id
+                and mr.status = 'committed'
+                and mr.deleted_at is null
+                and mr.imported_count + mr.reconciled_count > 0
+            )
+          ) as migration_committed,
+          exists (
+            select 1
+            from practice_conversion_milestones pcm
+            where pcm.practice_id = p.id
+              and pcm.milestone = 'registered'
+          ) as registered
+        from practices p
+        where p.deleted_at is null
+          and p.created_at >= ${windowStart}::timestamptz
+          and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+      ), raw_evidence as (
+        select
+          c.*,
+          nullif(c.settings -> 'onboardingState' ->> 'journeyStepId', '')
+            as journey_step_raw,
+          nullif(c.settings -> 'onboardingState' ->> 'onboardingIntent', '')
+            as onboarding_intent_raw,
+          nullif(c.settings ->> 'onboardingCompletedAt', '')
+            as legacy_all_set_raw,
+          nullif(
+            c.settings -> 'onboardingState' ->> 'journeyIntentCompletedAt',
+            ''
+          ) as exact_intent_raw,
+          nullif(
+            c.settings -> 'onboardingState' ->> 'journeyBasicsCompletedAt',
+            ''
+          ) as exact_basics_raw,
+          nullif(
+            c.settings -> 'onboardingState' ->> 'journeyDataCompletedAt',
+            ''
+          ) as exact_data_raw,
+          nullif(
+            c.settings -> 'onboardingState' ->> 'journeyAllSetCompletedAt',
+            ''
+          ) as exact_all_set_raw,
+          nullif(
+            c.settings -> 'onboardingState' ->> 'onboardingIntentSelectedAt',
+            ''
+          ) as legacy_intent_raw
+        from cohort c
+        where c.registered
+      ), cursor_evidence as (
+        select
+          r.*,
+          case
+            when r.onboarding_intent_raw in (
+              'alongside', 'replace', 'explore', 'self_host'
+            )
+              and r.journey_step_raw in ('intent', 'basics', 'data', 'allSet')
+              then r.journey_step_raw
+            when r.onboarding_intent_raw in (
+              'alongside', 'replace', 'explore', 'self_host'
+            )
+              and r.journey_step_raw in (
+              'branding', 'team', 'agent', 'phone', 'billing'
+            )
+              then case when r.migration_committed then 'allSet' else 'data' end
+          end as journey_step
+        from raw_evidence r
+      ), bounded_evidence as (
+        select
+          r.*,
+          (
+            r.exact_intent_raw is not null
+            or r.exact_basics_raw is not null
+            or r.exact_data_raw is not null
+            or r.exact_all_set_raw is not null
+          ) as has_exact_raw,
+          case
+            when pg_input_is_valid(r.exact_intent_raw, 'timestamptz')
+              then case
+                when r.exact_intent_raw::timestamptz
+                  between r.created_at and statement_timestamp()
+                  then r.exact_intent_raw::timestamptz
+              end
+          end as exact_intent_at,
+          case
+            when pg_input_is_valid(r.exact_basics_raw, 'timestamptz')
+              then case
+                when r.exact_basics_raw::timestamptz
+                  between r.created_at and statement_timestamp()
+                  then r.exact_basics_raw::timestamptz
+              end
+          end as bounded_basics_at,
+          case
+            when pg_input_is_valid(r.exact_data_raw, 'timestamptz')
+              then case
+                when r.exact_data_raw::timestamptz
+                  between r.created_at and statement_timestamp()
+                  then r.exact_data_raw::timestamptz
+              end
+          end as bounded_data_at,
+          case
+            when pg_input_is_valid(r.exact_all_set_raw, 'timestamptz')
+              then case
+                when r.exact_all_set_raw::timestamptz
+                  between r.created_at and statement_timestamp()
+                  then r.exact_all_set_raw::timestamptz
+              end
+          end as bounded_all_set_at,
+          case
+            when pg_input_is_valid(r.legacy_intent_raw, 'timestamptz')
+              then case
+                when r.legacy_intent_raw::timestamptz
+                  between r.created_at and statement_timestamp()
+                  then r.legacy_intent_raw::timestamptz
+              end
+          end as legacy_intent_at,
+          case
+            when pg_input_is_valid(r.legacy_all_set_raw, 'timestamptz')
+              then case
+                when r.legacy_all_set_raw::timestamptz
+                  between r.created_at and statement_timestamp()
+                  then r.legacy_all_set_raw::timestamptz
+              end
+          end as legacy_all_set_at
+        from cursor_evidence r
+      ), ordered_basics as (
+        select
+          b.*,
+          case
+            when b.exact_intent_at is not null
+              and b.bounded_basics_at >= b.exact_intent_at
+              then b.bounded_basics_at
+          end as exact_basics_at
+        from bounded_evidence b
+      ), ordered_data as (
+        select
+          b.*,
+          case
+            when b.exact_basics_at is not null
+              and b.bounded_data_at >= b.exact_basics_at
+              then b.bounded_data_at
+          end as exact_data_at
+        from ordered_basics b
+      ), ordered_all_set as (
+        select
+          d.*,
+          case
+            when d.exact_data_at is not null
+              and d.bounded_all_set_at >= d.exact_data_at
+              then d.bounded_all_set_at
+          end as exact_all_set_at
+        from ordered_data d
+      ), stage_evidence as (
+        select
+          e.*,
+          coalesce((
+            e.exact_intent_at is not null
+            or e.legacy_intent_at is not null
+            or e.journey_step in ('basics', 'data', 'allSet')
+            or e.legacy_all_set_at is not null
+          ), false) as intent_done,
+          coalesce((
+            e.exact_basics_at is not null
+            or e.journey_step in ('data', 'allSet')
+            or e.legacy_all_set_at is not null
+          ), false) as basics_done,
+          coalesce((
+            e.exact_data_at is not null
+            or e.journey_step = 'allSet'
+            or e.legacy_all_set_at is not null
+          ), false) as data_done,
+          (
+            e.exact_all_set_at is not null
+            or e.legacy_all_set_at is not null
+          ) as all_set_done
+        from ordered_all_set e
+      )
+      select
+        to_char(s.week_start, 'YYYY-MM-DD') as "weekStart",
+        count(*)::int as "signups",
+        count(*) filter (where s.intent_done)::int as "intentCompleted",
+        count(*) filter (
+          where s.intent_done and s.basics_done
+        )::int as "basicsCompleted",
+        count(*) filter (
+          where s.intent_done and s.basics_done and s.data_done
+        )::int as "dataCompleted",
+        count(*) filter (
+          where s.intent_done and s.basics_done and s.data_done
+            and s.all_set_done
+        )::int as "allSetCompleted",
+        count(*) filter (
+          where s.created_at <= ${stallCutoff}::timestamptz
+            and not s.intent_done
+        )::int as "stalledBeforeIntent",
+        count(*) filter (
+          where s.exact_intent_at is not null
+            and s.exact_intent_at <= ${stallCutoff}::timestamptz
+            and not s.basics_done
+        )::int as "stalledAtBasics",
+        count(*) filter (
+          where s.exact_basics_at is not null
+            and s.exact_basics_at <= ${stallCutoff}::timestamptz
+            and not s.data_done
+        )::int as "stalledAtData",
+        count(*) filter (
+          where s.exact_data_at is not null
+            and s.exact_data_at <= ${stallCutoff}::timestamptz
+            and not s.all_set_done
+        )::int as "stalledAtAllSet"
+      from stage_evidence s
+      group by s.week_start
+      order by s.week_start
+    `);
+
+    const qualityResult = await tx.execute(sql`
+      with cohort as (
+        select p.created_at, p.settings
+        from practices p
+        where p.deleted_at is null
+          and p.created_at >= ${windowStart}::timestamptz
+          and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+          and exists (
+            select 1
+            from practice_conversion_milestones pcm
+            where pcm.practice_id = p.id
+              and pcm.milestone = 'registered'
+          )
+      ), raw_evidence as (
+        select
+          created_at,
+          nullif(
+            settings -> 'onboardingState' ->> 'journeyIntentCompletedAt',
+            ''
+          ) as exact_intent_raw,
+          nullif(
+            settings -> 'onboardingState' ->> 'journeyBasicsCompletedAt',
+            ''
+          ) as exact_basics_raw,
+          nullif(
+            settings -> 'onboardingState' ->> 'journeyDataCompletedAt',
+            ''
+          ) as exact_data_raw,
+          nullif(
+            settings -> 'onboardingState' ->> 'journeyAllSetCompletedAt',
+            ''
+          ) as exact_all_set_raw,
+          nullif(
+            settings -> 'onboardingState' ->> 'onboardingIntentSelectedAt',
+            ''
+          ) as legacy_intent_raw,
+          nullif(settings ->> 'onboardingCompletedAt', '')
+            as legacy_all_set_raw,
+          nullif(settings -> 'onboardingState' ->> 'journeyStepId', '')
+            as journey_step,
+          nullif(settings -> 'onboardingState' ->> 'onboardingIntent', '')
+            as onboarding_intent
+        from cohort
+      ), evidence as (
+        select
+          (
+            exact_intent_raw is not null
+            or exact_basics_raw is not null
+            or exact_data_raw is not null
+            or exact_all_set_raw is not null
+          ) as has_exact_raw,
+          case
+            when pg_input_is_valid(exact_intent_raw, 'timestamptz')
+              and pg_input_is_valid(exact_basics_raw, 'timestamptz')
+              and pg_input_is_valid(exact_data_raw, 'timestamptz')
+              and pg_input_is_valid(exact_all_set_raw, 'timestamptz')
+              then (
+                exact_intent_raw::timestamptz
+                  between created_at and statement_timestamp()
+                and exact_basics_raw::timestamptz
+                  between exact_intent_raw::timestamptz and statement_timestamp()
+                and exact_data_raw::timestamptz
+                  between exact_basics_raw::timestamptz and statement_timestamp()
+                and exact_all_set_raw::timestamptz
+                  between exact_data_raw::timestamptz and statement_timestamp()
+              )
+            else false
+          end as fully_instrumented,
+          coalesce((
+            (
+              onboarding_intent in (
+                'alongside', 'replace', 'explore', 'self_host'
+              )
+              and journey_step in (
+                'intent', 'basics', 'data', 'allSet',
+                'branding', 'team', 'agent', 'phone', 'billing'
+              )
+            )
+            or case
+              when pg_input_is_valid(legacy_intent_raw, 'timestamptz')
+                then legacy_intent_raw::timestamptz
+                  between created_at and statement_timestamp()
+              else false
+            end
+            or case
+              when pg_input_is_valid(legacy_all_set_raw, 'timestamptz')
+                then legacy_all_set_raw::timestamptz
+                  between created_at and statement_timestamp()
+              else false
+            end
+          ), false) as legacy_evidence
+        from raw_evidence
+      )
+      select
+        count(*) filter (
+          where fully_instrumented
+        )::int as "fullyInstrumentedPractices",
+        count(*) filter (
+          where has_exact_raw and not fully_instrumented
+        )::int as "partiallyInstrumentedPractices",
+        count(*) filter (
+          where not has_exact_raw and legacy_evidence
+        )::int as "historicalInferredPractices",
+        count(*) filter (
+          where not has_exact_raw and not legacy_evidence
+        )::int as "noStepEvidencePractices"
+      from evidence
+    `);
+
+    return { cohortResult, qualityResult };
+  });
+
+  const weeks = rowsFromExecute<FunnelRow>(cohortResult).map((row) => ({
+    weekStart: row.weekStart,
+    signups: Number(row.signups) || 0,
+    intentCompleted: Number(row.intentCompleted) || 0,
+    basicsCompleted: Number(row.basicsCompleted) || 0,
+    dataCompleted: Number(row.dataCompleted) || 0,
+    allSetCompleted: Number(row.allSetCompleted) || 0,
+    stalledBeforeIntent: Number(row.stalledBeforeIntent) || 0,
+    stalledAtBasics: Number(row.stalledAtBasics) || 0,
+    stalledAtData: Number(row.stalledAtData) || 0,
+    stalledAtAllSet: Number(row.stalledAtAllSet) || 0,
+  }));
+  const quality = rowsFromExecute<DataQualityRow>(qualityResult)[0];
+
+  return {
+    days,
+    stallDays: ONBOARDING_STALL_DAYS,
+    weeks,
+    totals: summarizeWeeks(weeks),
+    dataQuality: {
+      fullyInstrumentedPractices:
+        Number(quality?.fullyInstrumentedPractices) || 0,
+      partiallyInstrumentedPractices:
+        Number(quality?.partiallyInstrumentedPractices) || 0,
+      historicalInferredPractices:
+        Number(quality?.historicalInferredPractices) || 0,
+      noStepEvidencePractices: Number(quality?.noStepEvidencePractices) || 0,
+    },
+  };
+}

--- a/apps/web/lib/onboarding/journey-plan.ts
+++ b/apps/web/lib/onboarding/journey-plan.ts
@@ -1,4 +1,12 @@
-export type OnboardingJourneyStepId = "intent" | "basics" | "data" | "allSet";
+export const ONBOARDING_JOURNEY_STEP_IDS = [
+  "intent",
+  "basics",
+  "data",
+  "allSet",
+] as const;
+
+export type OnboardingJourneyStepId =
+  (typeof ONBOARDING_JOURNEY_STEP_IDS)[number];
 
 export interface OnboardingJourneyStep {
   id: OnboardingJourneyStepId;
@@ -24,6 +32,10 @@ const retiredStepIds = new Set([
   "phone",
   "billing",
 ]);
+
+export function isRetiredOnboardingJourneyStepId(stepId: string): boolean {
+  return retiredStepIds.has(stepId);
+}
 
 /**
  * Preserve progress from the former nine-step journey. A clinic paused on a

--- a/apps/web/server/__tests__/admin-activation-funnel.test.ts
+++ b/apps/web/server/__tests__/admin-activation-funnel.test.ts
@@ -78,6 +78,15 @@ describe("admin activation funnel", () => {
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
+  it("rejects non-platform-admin onboarding cohort callers", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(
+      caller("clinic-admin@example.com").onboardingStepFunnel({ days: 30 }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
   it("sums weekly rows and computes activation and conversion rates", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     mocks.executeResults.push(

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -36,8 +36,7 @@ vi.mock("@/lib/billing/subscription-sync", () => ({
 
 vi.mock("@/lib/recovery-hold", () => ({
   RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
-  lockPracticeForExternalSideEffects:
-    mocks.lockPracticeForExternalSideEffects,
+  lockPracticeForExternalSideEffects: mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { settingsRouter } = await import("../routers/settings");
@@ -60,6 +59,8 @@ const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000005";
 const WAITLIST_ID = "00000000-0000-0000-0000-000000000006";
 const SCHEDULE_ID = "00000000-0000-0000-0000-000000000007";
 const LOCATION_ID = "00000000-0000-0000-0000-000000000008";
+const PRACTICE_CREATED_AT = new Date("2026-08-11T11:00:00.000Z");
+const DB_NOW = new Date("2026-08-11T13:00:00.000Z");
 
 function callerWithDb(db: Record<string, unknown>) {
   const session = {
@@ -222,6 +223,12 @@ describe("settings admin stale target safety", () => {
       callerWithDb(db).setOnboardingIntent({ intent: "unknown" as never }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
+    await expect(
+      callerWithDb(db).setJourneyProgress({
+        stepId: "billing" as never,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
     expect(updateSet).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -237,25 +244,302 @@ describe("settings admin stale target safety", () => {
 
     expect(updateSet).toHaveBeenCalledTimes(1);
     expect(SETTINGS_SOURCE).toContain(
-      "onboardingIntentStatePatch(input.intent, now)",
+      "onboardingIntentStatePatch(input.intent)",
     );
     expect(SETTINGS_SOURCE).toContain("'onboardingIntent', ${intent}");
     expect(SETTINGS_SOURCE).toContain("onboardingIntentSelectedAt");
+    expect(SETTINGS_SOURCE).toContain("journeyIntentCompletedAt");
+    expect(SETTINGS_SOURCE).toContain("'journeyStepId', case");
+    expect(SETTINGS_SOURCE).toContain("clock_timestamp()::text");
     expect(SETTINGS_SOURCE).toContain("journeyLastProgressAt");
   });
 
-  it("keeps setup start and completion cohort timestamps first-write-wins", () => {
+  it("keeps every setup completion timestamp first-write-wins", () => {
     expect(SETTINGS_SOURCE).toContain("function onboardingIntentStatePatch");
     expect(SETTINGS_SOURCE).toContain(
       "nullif(${practices.settings}->'onboardingState'->>'onboardingIntentSelectedAt', '')",
     );
     expect(SETTINGS_SOURCE).toContain("function onboardingCompletionPatch");
+    expect(SETTINGS_SOURCE).toContain("journeyBasicsCompletedAt");
+    expect(SETTINGS_SOURCE).toContain("journeyDataCompletedAt");
+    expect(SETTINGS_SOURCE).toContain("journeyAllSetCompletedAt");
     expect(SETTINGS_SOURCE).toContain(
       "nullif(${practices.settings}->>'onboardingCompletedAt', '')",
     );
     expect(SETTINGS_SOURCE).toContain(
-      "settings: onboardingCompletionPatch(completedAt)",
+      "settings: onboardingCompletionPatch(!settings.onboardingCompletedAt)",
     );
+    expect(SETTINGS_SOURCE).toContain(
+      "completing them must not fabricate four same-time stage transitions",
+    );
+    expect(SETTINGS_SOURCE).toContain('resolvedStep.stepId === "basics" &&');
+    expect(SETTINGS_SOURCE).toContain('input.stepId === "data"');
+    expect(SETTINGS_SOURCE).toContain('resolvedStep.stepId === "data" &&');
+    expect(SETTINGS_SOURCE).toContain('input.stepId === "allSet"');
+    expect(SETTINGS_SOURCE).toContain("input.dismissed !== true");
+    expect(SETTINGS_SOURCE).toContain('journeyStageEvidencePatch("allSet")');
+    expect(SETTINGS_SOURCE).toContain("validOrderedJourneyEvidence");
+  });
+
+  it("requires selected intent before an empty cursor can advance to basics", async () => {
+    const missingIntent = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: { onboardingState: {} },
+        },
+      ],
+    });
+    await expect(
+      callerWithDb(missingIntent.db).setJourneyProgress({ stepId: "basics" }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(missingIntent.updateSet).not.toHaveBeenCalled();
+
+    const selectedIntent = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              onboardingIntent: "alongside",
+              onboardingIntentSelectedAt: "2026-08-11T12:00:00.000Z",
+              journeyIntentCompletedAt: "2026-08-11T12:00:00.000Z",
+            },
+          },
+        },
+      ],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+    await expect(
+      callerWithDb(selectedIntent.db).setJourneyProgress({ stepId: "basics" }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("accepts an adjacent forward step under a row lock", async () => {
+    const { db, updateSet } = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              onboardingIntent: "alongside",
+              journeyStepId: "basics",
+              onboardingIntentSelectedAt: "2026-08-11T12:00:00.000Z",
+              journeyIntentCompletedAt: "2026-08-11T12:00:00.000Z",
+            },
+          },
+        },
+      ],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+
+    await expect(
+      callerWithDb(db).setJourneyProgress({
+        stepId: "data",
+        dismissed: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(updateSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a skipped or stale multi-step cursor without writing", async () => {
+    const { db, updateSet } = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              onboardingIntent: "alongside",
+              journeyStepId: "intent",
+              onboardingIntentSelectedAt: "2026-08-11T12:00:00.000Z",
+              journeyIntentCompletedAt: "2026-08-11T12:00:00.000Z",
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).setJourneyProgress({
+        stepId: "allSet",
+        dismissed: false,
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects an arbitrary stored cursor instead of treating it as legacy", async () => {
+    const { db, updateSet } = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              onboardingIntent: "alongside",
+              journeyStepId: "corrupt-step",
+              onboardingIntentSelectedAt: "2026-08-11T12:00:00.000Z",
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).setJourneyProgress({ stepId: "data" }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("resumes retired cursors from saved or ledger-backed migration evidence", async () => {
+    const savedMarker = createDb({
+      selectResults: [
+        [
+          {
+            createdAt: PRACTICE_CREATED_AT,
+            dbNow: DB_NOW,
+            settings: {
+              onboardingState: {
+                onboardingIntent: "alongside",
+                journeyStepId: "branding",
+                migrationHasCommittedChanges: true,
+              },
+            },
+          },
+        ],
+      ],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+    await expect(
+      callerWithDb(savedMarker.db).setJourneyProgress({ stepId: "allSet" }),
+    ).resolves.toEqual({ ok: true });
+
+    const ledger = createDb({
+      selectResults: [
+        [
+          {
+            createdAt: PRACTICE_CREATED_AT,
+            dbNow: DB_NOW,
+            settings: {
+              onboardingState: {
+                onboardingIntent: "alongside",
+                journeyStepId: "team",
+              },
+            },
+          },
+        ],
+        [{ id: "00000000-0000-0000-0000-000000000099" }],
+      ],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+    await expect(
+      callerWithDb(ledger.db).setJourneyProgress({ stepId: "allSet" }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("normalizes a retired cursor without intent back to the intent path", async () => {
+    const { db, updateSet } = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              journeyStepId: "billing",
+              migrationHasCommittedChanges: true,
+            },
+          },
+        },
+      ],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+
+    await expect(
+      callerWithDb(db).setJourneyProgress({ stepId: "allSet" }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(updateSet).not.toHaveBeenCalled();
+
+    await expect(
+      callerWithDb(db).setJourneyProgress({ stepId: "intent" }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("requires the all-set cursor and predecessor evidence before completion", async () => {
+    const incomplete = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              onboardingIntent: "alongside",
+              journeyStepId: "allSet",
+              journeyIntentCompletedAt: "2026-08-11T12:00:00.000Z",
+              journeyBasicsCompletedAt: "2026-08-11T12:01:00.000Z",
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(incomplete.db).completeOnboarding(),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    expect(incomplete.updateSet).not.toHaveBeenCalled();
+
+    const complete = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              onboardingIntent: "alongside",
+              journeyStepId: "allSet",
+              journeyIntentCompletedAt: "2026-08-11T12:00:00.000Z",
+              journeyBasicsCompletedAt: "2026-08-11T12:01:00.000Z",
+              journeyDataCompletedAt: "2026-08-11T12:02:00.000Z",
+            },
+          },
+        },
+      ],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+
+    await expect(
+      callerWithDb(complete.db).completeOnboarding(),
+    ).resolves.toEqual({ ok: true });
+    expect(complete.updateSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed or out-of-order exact predecessor evidence", async () => {
+    const { db, updateSet } = createDb({
+      selectRows: [
+        {
+          createdAt: PRACTICE_CREATED_AT,
+          dbNow: DB_NOW,
+          settings: {
+            onboardingState: {
+              onboardingIntent: "alongside",
+              journeyStepId: "allSet",
+              journeyIntentCompletedAt: "not-a-time",
+              journeyBasicsCompletedAt: "2026-08-11T12:01:00.000Z",
+              journeyDataCompletedAt: "2026-08-11T12:02:00.000Z",
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(callerWithDb(db).completeOnboarding()).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("lets the clinic owner become a veterinarian provider on the primary location", async () => {
@@ -371,14 +655,12 @@ describe("settings admin stale target safety", () => {
       updatedRows: [],
     });
 
-    // completeOnboarding writes with a guarded atomic update: the
-    // active-practice predicate excludes missing/deleted rows, so zero
-    // updated rows surfaces as NOT_FOUND and no fallback state is created.
+    // completeOnboarding locks and validates the active practice before write.
     await expect(callerWithDb(db).completeOnboarding()).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
     });
-    expect(updateSet).toHaveBeenCalledTimes(1);
+    expect(updateSet).not.toHaveBeenCalled();
     updateSet.mockClear();
 
     await expect(

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -26,6 +26,7 @@ import {
 import { isPlatformAdmin } from "@/lib/platform-admin";
 import { computeActivationFunnel } from "@/lib/admin/activation-funnel";
 import { computeJourneyFunnel } from "@/lib/admin/journey-funnel";
+import { computeOnboardingStepFunnel } from "@/lib/admin/onboarding-step-funnel";
 import { computeActivationRecovery } from "@/lib/admin/activation-recovery";
 import {
   CLINIC_PILOT_BLOCKERS,
@@ -3340,6 +3341,15 @@ export const adminRouter = createRouter({
         .optional(),
     )
     .query(({ input }) => computeActivationFunnel(db, input?.days ?? 30)),
+
+  /** Four-step guided-setup cohorts with a seven-day abandonment grace. */
+  onboardingStepFunnel: platformAdminProcedure
+    .input(
+      z
+        .object({ days: z.number().int().min(1).max(365).default(30) })
+        .optional(),
+    )
+    .query(({ input }) => computeOnboardingStepFunnel(db, input?.days ?? 30)),
 
   /** Ranked, cross-tenant operator queue for recovering clinic activation. */
   activationRecovery: platformAdminProcedure.query(() =>

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -81,6 +81,11 @@ import {
   ONBOARDING_INTENTS,
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
+import {
+  ONBOARDING_JOURNEY_STEP_IDS,
+  isRetiredOnboardingJourneyStepId,
+  type OnboardingJourneyStepId,
+} from "@/lib/onboarding/journey-plan";
 import { isValidMigrationSource } from "@/lib/import/sources";
 import { parseBookingPageConfig } from "@/lib/booking/page-config";
 import { takeAppointmentSchedulingLock } from "@/lib/scheduling/location";
@@ -251,11 +256,7 @@ const tourStepIdInput = z
   .max(128, "Tour step must be at most 128 characters")
   .nullish();
 
-const journeyStepIdInput = z
-  .string()
-  .trim()
-  .max(64, "Journey step must be at most 64 characters")
-  .nullish();
+const journeyStepIdInput = z.enum(ONBOARDING_JOURNEY_STEP_IDS);
 const onboardingIntentInput = z.enum(ONBOARDING_INTENTS);
 const migrationHelpSourceInput = z
   .string()
@@ -303,37 +304,230 @@ function settingsAndOnboardingStateMergePatch(
  * first time setup actually began. That timestamp is cohort evidence, not a
  * last-updated field.
  */
-function onboardingIntentStatePatch(intent: OnboardingIntent, now: string) {
+function onboardingIntentStatePatch(intent: OnboardingIntent) {
   return sql`jsonb_set(
     coalesce(${practices.settings}, '{}'::jsonb),
     '{onboardingState}',
     coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) ||
       jsonb_build_object(
         'onboardingIntent', ${intent},
+        'journeyStepId', case
+          when nullif(
+            ${practices.settings}->'onboardingState'->>'onboardingIntent',
+            ''
+          ) is null then 'intent'
+          else coalesce(
+            nullif(${practices.settings}->'onboardingState'->>'journeyStepId', ''),
+            'intent'
+          )
+        end,
         'onboardingIntentSelectedAt', coalesce(
           nullif(${practices.settings}->'onboardingState'->>'onboardingIntentSelectedAt', ''),
-          ${now}
+          clock_timestamp()::text
         ),
-        'journeyLastProgressAt', ${now},
+        'journeyIntentCompletedAt', coalesce(
+          nullif(${practices.settings}->'onboardingState'->>'journeyIntentCompletedAt', ''),
+          clock_timestamp()::text
+        ),
+        'journeyLastProgressAt', clock_timestamp()::text,
         'journeyDismissed', false
       )
   )`;
 }
 
-/** Keep setup completion first-write-wins while recording fresh activity. */
-function onboardingCompletionPatch(now: string) {
+function journeyStageEvidencePatch(stage: OnboardingJourneyStepId) {
+  const fieldByStage = {
+    intent: "journeyIntentCompletedAt",
+    basics: "journeyBasicsCompletedAt",
+    data: "journeyDataCompletedAt",
+    allSet: "journeyAllSetCompletedAt",
+  } as const;
+  const field = fieldByStage[stage];
+  return sql`jsonb_build_object(
+    ${sql.raw(`'${field}'`)},
+    coalesce(
+      nullif(${practices.settings}->'onboardingState'->>${field}, ''),
+      clock_timestamp()::text
+    )
+  )`;
+}
+
+function onboardingJourneyProgressPatch(
+  stepId: OnboardingJourneyStepId,
+  dismissed: boolean | undefined,
+  completedStage: "basics" | "data" | null,
+) {
+  const progressPatch = {
+    journeyStepId: stepId,
+    journeyLastProgressAt: null,
+    ...(dismissed === undefined ? {} : { journeyDismissed: dismissed }),
+  };
+  const evidencePatch = completedStage
+    ? journeyStageEvidencePatch(completedStage)
+    : sql`'{}'::jsonb`;
+
+  return sql`jsonb_set(
+    coalesce(${practices.settings}, '{}'::jsonb),
+    '{onboardingState}',
+    (
+      coalesce(${practices.settings}->'onboardingState', '{}'::jsonb)
+      || ${JSON.stringify(progressPatch)}::jsonb
+      || jsonb_build_object('journeyLastProgressAt', clock_timestamp()::text)
+      || ${evidencePatch}
+    )
+  )`;
+}
+
+function isAllowedJourneyTransition(
+  currentStepId: OnboardingJourneyStepId | null,
+  targetStepId: OnboardingJourneyStepId,
+  intentSelected: boolean,
+): boolean {
+  if (
+    targetStepId === "basics" &&
+    (currentStepId === null || currentStepId === "intent") &&
+    !intentSelected
+  ) {
+    return false;
+  }
+  const currentIndex =
+    currentStepId === null
+      ? -1
+      : ONBOARDING_JOURNEY_STEP_IDS.indexOf(currentStepId);
+  const targetIndex = ONBOARDING_JOURNEY_STEP_IDS.indexOf(targetStepId);
+  if (currentIndex >= 0) return Math.abs(targetIndex - currentIndex) <= 1;
+
+  return (
+    targetStepId === "intent" || (targetStepId === "basics" && intentSelected)
+  );
+}
+
+function validOrderedJourneyEvidence(input: {
+  createdAt: Date | string;
+  dbNow: Date | string;
+  intentAt?: string | null;
+  basicsAt?: string | null;
+  dataAt?: string | null;
+}): {
+  intent: boolean;
+  basics: boolean;
+  data: boolean;
+} {
+  const createdAt =
+    input.createdAt instanceof Date
+      ? input.createdAt.getTime()
+      : Date.parse(input.createdAt);
+  const dbNow =
+    input.dbNow instanceof Date
+      ? input.dbNow.getTime()
+      : Date.parse(input.dbNow);
+  const intentAt = input.intentAt ? Date.parse(input.intentAt) : Number.NaN;
+  const basicsAt = input.basicsAt ? Date.parse(input.basicsAt) : Number.NaN;
+  const dataAt = input.dataAt ? Date.parse(input.dataAt) : Number.NaN;
+  const intent =
+    Number.isFinite(intentAt) && intentAt >= createdAt && intentAt <= dbNow;
+  const basics =
+    intent &&
+    Number.isFinite(basicsAt) &&
+    basicsAt >= intentAt &&
+    basicsAt <= dbNow;
+  const data =
+    basics && Number.isFinite(dataAt) && dataAt >= basicsAt && dataAt <= dbNow;
+  return { intent, basics, data };
+}
+
+function hasValidBoundedJourneyTimestamp(
+  value: string | null | undefined,
+  createdAt: Date | string,
+  dbNow: Date | string,
+): boolean {
+  const timestamp = value ? Date.parse(value) : Number.NaN;
+  const lowerBound =
+    createdAt instanceof Date ? createdAt.getTime() : Date.parse(createdAt);
+  const upperBound =
+    dbNow instanceof Date ? dbNow.getTime() : Date.parse(dbNow);
+  return (
+    Number.isFinite(timestamp) &&
+    Number.isFinite(lowerBound) &&
+    Number.isFinite(upperBound) &&
+    timestamp >= lowerBound &&
+    timestamp <= upperBound
+  );
+}
+
+async function resolveStoredJourneyStep(
+  db: Database,
+  practiceId: string,
+  storedStepId: string | null | undefined,
+  onboardingIntentPresent: boolean,
+  legacyMigrationHasCommittedChanges: boolean,
+): Promise<{
+  stepId: OnboardingJourneyStepId | null;
+  retired: boolean;
+}> {
+  if (!onboardingIntentPresent) return { stepId: null, retired: false };
+  if (!storedStepId) return { stepId: null, retired: false };
+  if (
+    ONBOARDING_JOURNEY_STEP_IDS.includes(
+      storedStepId as OnboardingJourneyStepId,
+    )
+  ) {
+    return {
+      stepId: storedStepId as OnboardingJourneyStepId,
+      retired: false,
+    };
+  }
+  if (!isRetiredOnboardingJourneyStepId(storedStepId)) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: "Setup progress is invalid. Refresh and restart guided setup.",
+    });
+  }
+
+  if (legacyMigrationHasCommittedChanges) {
+    return { stepId: "allSet", retired: true };
+  }
+
+  const [committedMigration] = await db
+    .select({ id: migrationRuns.id })
+    .from(migrationRuns)
+    .where(
+      and(
+        eq(migrationRuns.practiceId, practiceId),
+        eq(migrationRuns.status, "committed"),
+        isNull(migrationRuns.deletedAt),
+        sql`${migrationRuns.importedCount} + ${migrationRuns.reconciledCount} > 0`,
+      ),
+    )
+    .limit(1);
+  return {
+    stepId: committedMigration ? "allSet" : "data",
+    retired: true,
+  };
+}
+
+/**
+ * Keep setup completion first-write-wins while recording fresh activity.
+ * Pre-instrumentation clinics keep their step times explicitly historical;
+ * completing them must not fabricate four same-time stage transitions.
+ */
+function onboardingCompletionPatch(recordAllSetEvidence: boolean) {
+  const stepEvidence = recordAllSetEvidence
+    ? journeyStageEvidencePatch("allSet")
+    : sql`'{}'::jsonb`;
   return sql`jsonb_set(
     jsonb_set(
       coalesce(${practices.settings}, '{}'::jsonb),
       '{onboardingCompletedAt}',
       to_jsonb(coalesce(
         nullif(${practices.settings}->>'onboardingCompletedAt', ''),
-        ${now}
+        clock_timestamp()::text
       )::text)
     ),
     '{onboardingState}',
-    coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) ||
-      jsonb_build_object('journeyLastProgressAt', ${now})
+    coalesce(${practices.settings}->'onboardingState', '{}'::jsonb)
+      || ${stepEvidence}
+      || jsonb_build_object('journeyLastProgressAt', clock_timestamp()::text)
   )`;
 }
 
@@ -508,6 +702,10 @@ interface PracticeSettings {
     /** Adoption pathway selected on the first guided-setup step. */
     onboardingIntent?: OnboardingIntent;
     onboardingIntentSelectedAt?: string;
+    journeyIntentCompletedAt?: string;
+    journeyBasicsCompletedAt?: string;
+    journeyDataCompletedAt?: string;
+    journeyAllSetCompletedAt?: string;
     /** Resume cursor for the "Make it yours" setup wizard (step id, not index). */
     journeyStepId?: string | null;
     /** Last successfully persisted journey action, used for stall recovery. */
@@ -1577,11 +1775,55 @@ export const settingsRouter = createRouter({
 
   /** Mark onboarding complete. */
   completeOnboarding: adminProcedure.mutation(async ({ ctx }) => {
-    const completedAt = new Date().toISOString();
+    const [practice] = await ctx.db
+      .select({
+        settings: practices.settings,
+        createdAt: practices.createdAt,
+        dbNow: sql<Date>`clock_timestamp()`,
+      })
+      .from(practices)
+      .where(activePracticeWhere(ctx.practiceId))
+      .for("update");
+    if (!practice) {
+      throw practiceNotFound();
+    }
+    const settings = (practice.settings ?? {}) as PracticeSettings;
+    const state = settings.onboardingState;
+    const resolvedStep = await resolveStoredJourneyStep(
+      ctx.db,
+      ctx.practiceId,
+      state?.journeyStepId,
+      Boolean(state?.onboardingIntent),
+      state?.migrationHasCommittedChanges === true,
+    );
+    const hasNewStepEvidence = Boolean(
+      state?.journeyIntentCompletedAt ||
+      state?.journeyDataCompletedAt ||
+      state?.journeyBasicsCompletedAt ||
+      state?.journeyAllSetCompletedAt,
+    );
+    const hasFullPredecessorEvidence = validOrderedJourneyEvidence({
+      createdAt: practice.createdAt,
+      dbNow: practice.dbNow,
+      intentAt: state?.journeyIntentCompletedAt,
+      basicsAt: state?.journeyBasicsCompletedAt,
+      dataAt: state?.journeyDataCompletedAt,
+    }).data;
+    if (
+      !settings.onboardingCompletedAt &&
+      (resolvedStep.stepId !== "allSet" ||
+        (hasNewStepEvidence && !hasFullPredecessorEvidence))
+    ) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Finish each guided setup step before completing setup.",
+      });
+    }
+
     const [updated] = await ctx.db
       .update(practices)
       .set({
-        settings: onboardingCompletionPatch(completedAt),
+        settings: onboardingCompletionPatch(!settings.onboardingCompletedAt),
       })
       .where(activePracticeWhere(ctx.practiceId))
       .returning({ id: practices.id });
@@ -1652,6 +1894,10 @@ export const settingsRouter = createRouter({
       setupDismissed: false,
       onboardingIntent: null,
       onboardingIntentSelectedAt: null,
+      journeyIntentCompletedAt: null,
+      journeyBasicsCompletedAt: null,
+      journeyDataCompletedAt: null,
+      journeyAllSetCompletedAt: null,
       journeyStepId: null,
       journeyLastProgressAt: null,
       journeyDismissed: false,
@@ -1709,11 +1955,10 @@ export const settingsRouter = createRouter({
   setOnboardingIntent: adminProcedure
     .input(z.object({ intent: onboardingIntentInput }))
     .mutation(async ({ ctx, input }) => {
-      const now = new Date().toISOString();
       const [updated] = await ctx.db
         .update(practices)
         .set({
-          settings: onboardingIntentStatePatch(input.intent, now),
+          settings: onboardingIntentStatePatch(input.intent),
         })
         .where(activePracticeWhere(ctx.practiceId))
         .returning({ id: practices.id });
@@ -1736,16 +1981,74 @@ export const settingsRouter = createRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const patch: Record<string, unknown> = {
-        journeyLastProgressAt: new Date().toISOString(),
-      };
-      if (input.stepId != null) patch.journeyStepId = input.stepId;
-      if (input.dismissed !== undefined)
-        patch.journeyDismissed = input.dismissed;
+      const [practice] = await ctx.db
+        .select({
+          settings: practices.settings,
+          createdAt: practices.createdAt,
+          dbNow: sql<Date>`clock_timestamp()`,
+        })
+        .from(practices)
+        .where(activePracticeWhere(ctx.practiceId))
+        .for("update");
+      if (!practice) {
+        throw practiceNotFound();
+      }
+      const state = ((practice.settings ?? {}) as PracticeSettings)
+        .onboardingState;
+      const resolvedStep = await resolveStoredJourneyStep(
+        ctx.db,
+        ctx.practiceId,
+        state?.journeyStepId,
+        Boolean(state?.onboardingIntent),
+        state?.migrationHasCommittedChanges === true,
+      );
+      const orderedEvidence = validOrderedJourneyEvidence({
+        createdAt: practice.createdAt,
+        dbNow: practice.dbNow,
+        intentAt: state?.journeyIntentCompletedAt,
+        basicsAt: state?.journeyBasicsCompletedAt,
+        dataAt: state?.journeyDataCompletedAt,
+      });
+      const intentSelected = hasValidBoundedJourneyTimestamp(
+        state?.onboardingIntentSelectedAt,
+        practice.createdAt,
+        practice.dbNow,
+      );
+      if (
+        !isAllowedJourneyTransition(
+          resolvedStep.stepId,
+          input.stepId,
+          intentSelected,
+        )
+      ) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "Setup progress changed in another session. Refresh and try again.",
+        });
+      }
+      const completedStage =
+        input.dismissed !== true &&
+        resolvedStep.stepId === "basics" &&
+        input.stepId === "data" &&
+        orderedEvidence.intent
+          ? "basics"
+          : input.dismissed !== true &&
+              resolvedStep.stepId === "data" &&
+              input.stepId === "allSet" &&
+              orderedEvidence.basics
+            ? "data"
+            : null;
 
       const [updated] = await ctx.db
         .update(practices)
-        .set({ settings: onboardingStateMergePatch(patch) })
+        .set({
+          settings: onboardingJourneyProgressPatch(
+            input.stepId,
+            input.dismissed,
+            completedStage,
+          ),
+        })
         .where(activePracticeWhere(ctx.practiceId))
         .returning({ id: practices.id });
       if (!updated) {
@@ -2267,9 +2570,7 @@ export const settingsRouter = createRouter({
       if (!practice) {
         throw practiceNotFound();
       }
-      if (
-        !(await lockPracticeForExternalSideEffects(ctx.db, ctx.practiceId))
-      ) {
+      if (!(await lockPracticeForExternalSideEffects(ctx.db, ctx.practiceId))) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
           message: RECOVERY_HOLD_BLOCK_MESSAGE,

--- a/docs/conversion-observability.md
+++ b/docs/conversion-observability.md
@@ -64,12 +64,23 @@ demo, demo submission before registration, and each canonical milestone after
 registration.
 
 Clinic setup reporting is similarly durable. Setup starts at the first saved
-`onboardingIntentSelectedAt` (with the legacy step cursor or completion marker
-as fallbacks), and that first timestamp never changes when a clinic revisits its
-path. `journeyLastProgressAt` advances only after a setup action is persisted
-successfully and is used to age stalled setup in the recovery queue. Completion
-is also first-write-wins, so reopening or replaying the finish action cannot
-move a clinic into a newer cohort.
+`onboardingIntentSelectedAt`. The four-step cohort also records
+`journeyIntentCompletedAt`, `journeyBasicsCompletedAt`,
+`journeyDataCompletedAt`, and `journeyAllSetCompletedAt`. These timestamps use
+the database clock, are first-write-wins, and are added only on a row-locked,
+validated forward transition. Back, “finish later,” retries, and stale clients
+cannot advance or rewrite them. `journeyLastProgressAt` still advances after any
+successfully persisted cursor action and is used by the setup-recovery queue.
+
+The platform-admin setup cohort groups clinics by UTC registration week and
+shows sequential path → basics → data → first-day-handoff rates. A step becomes
+stalled only after seven full days without its successor. Historical cursors
+may contribute inferred completion counts, but never receive a synthetic
+transition time or enter the prospective stall queues; exact, inferred, and
+missing coverage are reported separately, with partial or invalid exact chains
+called out instead of promoted to completed evidence. Guided completion remains
+first-write-wins, so reopening or replaying Finish cannot move a clinic into a
+newer cohort.
 
 Sample clinic IDs are cumulative provenance. Clearing sample data soft-deletes
 the rows but retains every ID with a `clearedAt` marker; reseeding merges new IDs


### PR DESCRIPTION
## What changed

- Record first-write, database-clock completion evidence for each guided onboarding step.
- Serialize and validate setup cursor transitions, including stale clients, backward navigation, retired cursors, and legacy migration evidence.
- Add a privacy-safe platform-admin onboarding cohort dashboard and weekly activation-digest section.
- Report sequential conversion, seven-day stalls, and complete/partial/historical/missing evidence quality without inventing historical timestamps.

## Why

The existing activation funnel could show registration and eventual activation, but it could not identify where a clinic stopped inside guided setup. Mutable cursors also could not safely represent first attainment. This release makes the four-step setup path measurable without adding signup friction or exposing participant identities.

## Safety and compatibility

- No schema migration or RLS change is required; evidence remains in the existing tenant-protected practice settings document.
- Timestamps are generated by PostgreSQL, first-write-wins, and written only for validated forward transitions.
- Missing intent resets stale live or retired cursors to the beginning; arbitrary cursors fail closed.
- Historical cursors can contribute inferred completion counts but never prospective stall timestamps.
- Cross-tenant reporting remains platform-admin-only and aggregate-only.

## Validation

- `pnpm --filter @openpims/web type-check`
- `pnpm --filter @openpims/web test` — 3,888 passed; 6 expected integration skips
- `git diff --check`
- Production read-only execution of the new PostgreSQL cohort query: 10/10 registered clinics reconciled across evidence-quality buckets, with three mature pre-intent stalls identified
- Independent read-only blocker audit: no blockers
