### PR TITLE
Add private Shepherd archive preflight

### DIFF
--- a/apps/web/lib/import/__tests__/archive-preflight.test.ts
+++ b/apps/web/lib/import/__tests__/archive-preflight.test.ts
@@ -1,0 +1,1407 @@
+import { createHash, randomBytes } from "node:crypto";
+import { execFile } from "node:child_process";
+import { deflateRawSync } from "node:zlib";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  MIGRATION_ARCHIVE_LIMITS,
+  aggregateArchiveEntryBudgetExceeded,
+  candidateCompressionRatioExceedsLimit,
+  preflightMigrationArchives,
+  scanBoundedCsvStructure,
+  writeMigrationArchiveEvidence,
+} from "../archive-preflight";
+import {
+  MIGRATION_ARCHIVE_MANIFEST_LIMITS,
+  validatedMigrationArchiveCliPaths,
+} from "../../../scripts/preflight-migration-archives";
+import { IMPORT_CSV_MAX_BYTES, IMPORT_MAX_ROWS } from "../policy";
+
+const LOCAL_SIGNATURE = 0x04034b50;
+const CENTRAL_SIGNATURE = 0x02014b50;
+const EOCD_SIGNATURE = 0x06054b50;
+
+type SyntheticEntry = {
+  name: string;
+  data: Buffer | string;
+  method?: 0 | 8 | 12;
+  flags?: number;
+  versionMadeBy?: number;
+  externalAttributes?: number;
+  crcOverride?: number;
+  advertisedUncompressedBytes?: number;
+  localHeaderOffsetOverride?: number;
+  extra?: Buffer;
+  gapBefore?: Buffer;
+  compressedSuffix?: Buffer;
+};
+
+type SyntheticZipOptions = {
+  prefix?: Buffer;
+  diskNumber?: number;
+  zip64Eocd?: boolean;
+  truncateBytes?: number;
+};
+
+const directories: string[] = [];
+const execFileAsync = promisify(execFile);
+
+async function runPreflightCli(manifestPath: string): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  argv: string[];
+}> {
+  const executable = join(process.cwd(), "node_modules/.bin/tsx");
+  const argv = [
+    "scripts/preflight-migration-archives.ts",
+    "--manifest",
+    manifestPath,
+  ];
+  try {
+    const result = await execFileAsync(executable, argv, {
+      cwd: process.cwd(),
+    });
+    return { exitCode: 0, stdout: result.stdout, stderr: result.stderr, argv };
+  } catch (error) {
+    const failure = error as {
+      code?: number | string;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      exitCode: typeof failure.code === "number" ? failure.code : 1,
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? "",
+      argv,
+    };
+  }
+}
+
+async function privateDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "openvpm-archive-test-"));
+  directories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+let crcTable: Uint32Array | undefined;
+
+function crc32(buffer: Buffer): number {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let index = 0; index < 256; index++) {
+      let value = index;
+      for (let bit = 0; bit < 8; bit++) {
+        value = (value & 1) !== 0 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+      }
+      crcTable[index] = value >>> 0;
+    }
+  }
+  let value = 0xffffffff;
+  for (const byte of buffer) {
+    value = crcTable[(value ^ byte) & 0xff]! ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+function makeZip(
+  entries: readonly SyntheticEntry[],
+  options: SyntheticZipOptions = {},
+): Buffer {
+  const prefix = options.prefix ?? Buffer.alloc(0);
+  const localParts: Buffer[] = [prefix];
+  const centralParts: Buffer[] = [];
+  let localOffset = prefix.length;
+
+  for (const entry of entries) {
+    if (entry.gapBefore) {
+      localParts.push(entry.gapBefore);
+      localOffset += entry.gapBefore.length;
+    }
+    const name = Buffer.from(entry.name, "utf8");
+    const raw = Buffer.isBuffer(entry.data)
+      ? entry.data
+      : Buffer.from(entry.data, "utf8");
+    const method = entry.method ?? 8;
+    const compressedPayload = method === 8 ? deflateRawSync(raw) : raw;
+    const compressed = entry.compressedSuffix
+      ? Buffer.concat([compressedPayload, entry.compressedSuffix])
+      : compressedPayload;
+    const flags = (entry.flags ?? 0) | 0x800;
+    const checksum = entry.crcOverride ?? crc32(raw);
+    const advertisedUncompressedBytes =
+      entry.advertisedUncompressedBytes ?? raw.length;
+    const extra = entry.extra ?? Buffer.alloc(0);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(LOCAL_SIGNATURE, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(flags, 6);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(checksum >>> 0, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(advertisedUncompressedBytes, 22);
+    local.writeUInt16LE(name.length, 26);
+    local.writeUInt16LE(extra.length, 28);
+    localParts.push(local, name, extra, compressed);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(CENTRAL_SIGNATURE, 0);
+    central.writeUInt16LE(entry.versionMadeBy ?? 0x0314, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(flags, 8);
+    central.writeUInt16LE(method, 10);
+    central.writeUInt32LE(checksum >>> 0, 16);
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(advertisedUncompressedBytes, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt16LE(extra.length, 30);
+    central.writeUInt32LE(entry.externalAttributes ?? 0, 38);
+    central.writeUInt32LE(entry.localHeaderOffsetOverride ?? localOffset, 42);
+    centralParts.push(central, name, extra);
+    localOffset +=
+      local.length + name.length + extra.length + compressed.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(EOCD_SIGNATURE, 0);
+  eocd.writeUInt16LE(options.diskNumber ?? 0, 4);
+  eocd.writeUInt16LE(options.diskNumber ?? 0, 6);
+  eocd.writeUInt16LE(options.zip64Eocd ? 0xffff : entries.length, 8);
+  eocd.writeUInt16LE(options.zip64Eocd ? 0xffff : entries.length, 10);
+  eocd.writeUInt32LE(centralDirectory.length, 12);
+  eocd.writeUInt32LE(localOffset, 16);
+  const complete = Buffer.concat([...localParts, centralDirectory, eocd]);
+  return options.truncateBytes
+    ? complete.subarray(0, complete.length - options.truncateBytes)
+    : complete;
+}
+
+function patchEocd(
+  archive: Buffer,
+  patch: (copy: Buffer, eocdOffset: number) => void,
+): Buffer {
+  const copy = Buffer.from(archive);
+  const eocdOffset = copy.length - 22;
+  expect(copy.readUInt32LE(eocdOffset)).toBe(EOCD_SIGNATURE);
+  patch(copy, eocdOffset);
+  return copy;
+}
+
+async function archiveWith(
+  entries: readonly SyntheticEntry[],
+  options?: SyntheticZipOptions,
+): Promise<string> {
+  const directory = await privateDirectory();
+  const path = join(directory, "archive.zip");
+  await writeFile(path, makeZip(entries, options));
+  await chmod(path, 0o600);
+  return path;
+}
+
+async function privateManifest(
+  directory: string,
+  archives: readonly string[],
+  evidence = join(directory, "evidence.json"),
+): Promise<string> {
+  const manifestPath = join(directory, "manifest.json");
+  await writeFile(manifestPath, JSON.stringify({ archives, evidence }));
+  await chmod(manifestPath, 0o600);
+  return manifestPath;
+}
+
+function validClientCsv(id = "synthetic-1"): string {
+  return `firstName,lastName,clientId\nSynthetic,Owner,${id}\n`;
+}
+
+function firstArchiveBlocker(
+  evidence: Awaited<ReturnType<typeof preflightMigrationArchives>>,
+): string | undefined {
+  return evidence.archives[0]?.blockerCodes[0];
+}
+
+describe("migration archive preflight", () => {
+  it("classifies a safe client CSV without exposing its entry name or values", async () => {
+    const privateCanary = "PRIVATE-CANARY-NEVER-EMIT";
+    const archive = await archiveWith([
+      {
+        name: `${privateCanary}.csv`,
+        data: validClientCsv(privateCanary),
+      },
+      { name: "opaque-document.pdf", data: "%PDF synthetic" },
+    ]);
+
+    const evidence = await preflightMigrationArchives(
+      [archive],
+      new Date("2026-08-11T12:00:00.000Z"),
+    );
+    expect(evidence).toMatchObject({
+      networkUsed: false,
+      databaseUsed: false,
+      archiveExtractionUsed: false,
+      authoritativeImportClaim: false,
+      safeToContinueOfflineReview: true,
+      readyForAuthoritativeCsvPreview: true,
+      requiresUnsupportedDataReview: true,
+      archives: [
+        {
+          alias: "archive-01",
+          status: "safe",
+          entryCount: 2,
+          csvCandidateCount: 1,
+          unsupportedEntryCount: 1,
+          candidates: [
+            {
+              opaqueId: "archive-01-entry-000001",
+              inferredMode: "clients",
+              sourceRows: 1,
+              validRows: 1,
+              status: "valid",
+              crcVerified: true,
+              utf8Valid: true,
+            },
+          ],
+        },
+      ],
+    });
+    const serialized = JSON.stringify(evidence);
+    expect(serialized).not.toContain(privateCanary);
+    expect(serialized).not.toContain(archive);
+    expect(serialized).not.toContain("firstName");
+  });
+
+  it.each([
+    ["../outside.csv", "entry_path_invalid"],
+    ["/absolute.csv", "entry_path_invalid"],
+    ["C:/windows.csv", "entry_path_invalid"],
+    ["folder\\windows.csv", "entry_path_invalid"],
+    ["folder//empty.csv", "entry_path_invalid"],
+    ["nested/archive.zip", "nested_archive_rejected"],
+  ])("rejects unsafe or nested entry paths", async (name, blocker) => {
+    const archive = await archiveWith([{ name, data: validClientCsv() }]);
+    const evidence = await preflightMigrationArchives([archive]);
+    expect(firstArchiveBlocker(evidence)).toBe(blocker);
+    expect(evidence.archives[0]?.candidates).toEqual([]);
+  });
+
+  it("rejects normalized case-insensitive entry collisions", async () => {
+    const archive = await archiveWith([
+      { name: "Folder/CLIENTS.csv", data: validClientCsv("one") },
+      { name: "folder/clients.CSV", data: validClientCsv("two") },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([archive])),
+    ).toBe("entry_path_collision");
+  });
+
+  it("rejects file-prefix and NFKC-introduced path collisions or traversal", async () => {
+    const prefixCollision = await archiveWith([
+      { name: "folder", data: "opaque", method: 0 },
+      { name: "folder/clients.csv", data: validClientCsv(), method: 0 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([prefixCollision])),
+    ).toBe("entry_path_collision");
+
+    const normalizedTraversal = await archiveWith([
+      { name: "folder/\uFF0E/clients.csv", data: validClientCsv(), method: 0 },
+    ]);
+    expect(
+      firstArchiveBlocker(
+        await preflightMigrationArchives([normalizedTraversal]),
+      ),
+    ).toBe("entry_path_invalid");
+
+    const normalizedSeparator = await archiveWith([
+      {
+        name: "folder\uFF0F..\uFF0Fclients.csv",
+        data: validClientCsv(),
+        method: 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(
+        await preflightMigrationArchives([normalizedSeparator]),
+      ),
+    ).toBe("entry_path_invalid");
+  });
+
+  it.each([
+    [0o120777, "entry_symlink_rejected"],
+    [0o020666, "entry_special_file_rejected"],
+  ])("rejects Unix symlink and special entries", async (mode, blocker) => {
+    const archive = await archiveWith([
+      {
+        name: "unsafe.csv",
+        data: validClientCsv(),
+        externalAttributes: (mode << 16) >>> 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([archive])),
+    ).toBe(blocker);
+  });
+
+  it("rejects encrypted and unsupported-compression entries", async () => {
+    const encrypted = await archiveWith([
+      { name: "encrypted.csv", data: validClientCsv(), flags: 0x1 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([encrypted])),
+    ).toBe("entry_encrypted_rejected");
+
+    const unsupported = await archiveWith([
+      { name: "compressed.csv", data: validClientCsv(), method: 12 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([unsupported])),
+    ).toBe("entry_compression_unsupported");
+  });
+
+  it("rejects data descriptors and unsupported ZIP flags", async () => {
+    const descriptor = await archiveWith([
+      { name: "descriptor.csv", data: validClientCsv(), flags: 0x8 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([descriptor])),
+    ).toBe("entry_data_descriptor_rejected");
+
+    const maskedHeader = await archiveWith([
+      { name: "masked.csv", data: validClientCsv(), flags: 0x2000 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([maskedHeader])),
+    ).toBe("entry_flags_unsupported");
+  });
+
+  it("requires Unix entry type/path agreement and canonical empty directories", async () => {
+    const regularWithSlash = await archiveWith([
+      {
+        name: "regular/",
+        data: "",
+        method: 0,
+        externalAttributes: (0o100644 << 16) >>> 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([regularWithSlash])),
+    ).toBe("entry_type_path_mismatch");
+
+    const directoryWithoutSlash = await archiveWith([
+      {
+        name: "directory",
+        data: "",
+        method: 0,
+        externalAttributes: (0o040755 << 16) >>> 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(
+        await preflightMigrationArchives([directoryWithoutSlash]),
+      ),
+    ).toBe("entry_type_path_mismatch");
+
+    const payloadDirectory = await archiveWith([
+      { name: "payload/", data: "hidden", method: 0 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([payloadDirectory])),
+    ).toBe("directory_payload_rejected");
+
+    const compressedDirectory = await archiveWith([
+      { name: "compressed/", data: "" },
+    ]);
+    expect(
+      firstArchiveBlocker(
+        await preflightMigrationArchives([compressedDirectory]),
+      ),
+    ).toBe("directory_payload_rejected");
+
+    const crcDirectory = await archiveWith([
+      { name: "crc/", data: "", method: 0, crcOverride: 1 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([crcDirectory])),
+    ).toBe("directory_payload_rejected");
+  });
+
+  it.each([
+    ["sfx", { prefix: Buffer.from("SFX!") }, "archive_sfx_rejected"],
+    ["multidisk", { diskNumber: 1 }, "archive_multidisk_rejected"],
+    ["zip64", { zip64Eocd: true }, "archive_zip64_rejected"],
+  ] as const)("rejects %s containers", async (_label, options, blocker) => {
+    const archive = await archiveWith(
+      [{ name: "clients.csv", data: validClientCsv() }],
+      options,
+    );
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([archive])),
+    ).toBe(blocker);
+  });
+
+  it("rejects a corrupt CRC without exposing raw CSV data", async () => {
+    const privateCanary = "PRIVATE-CRC-CANARY";
+    const archive = await archiveWith([
+      {
+        name: "clients.csv",
+        data: validClientCsv(privateCanary),
+        crcOverride: 0,
+      },
+    ]);
+    const evidence = await preflightMigrationArchives([archive]);
+    expect(firstArchiveBlocker(evidence)).toBe("candidate_crc_mismatch");
+    expect(JSON.stringify(evidence)).not.toContain(privateCanary);
+  });
+
+  it("rejects trailing bytes after a valid deflate stream", async () => {
+    const privateCanary = "PRIVATE-DEFLATE-TRAILER-CANARY";
+    const archive = await archiveWith([
+      {
+        name: "clients.csv",
+        data: validClientCsv(),
+        compressedSuffix: Buffer.from(privateCanary),
+      },
+    ]);
+    const evidence = await preflightMigrationArchives([archive]);
+    expect(firstArchiveBlocker(evidence)).toBe(
+      "candidate_trailing_data_rejected",
+    );
+    expect(JSON.stringify(evidence)).not.toContain(privateCanary);
+  });
+
+  it("rejects invalid UTF-8 after integrity validation", async () => {
+    const archive = await archiveWith([
+      { name: "clients.csv", data: Buffer.from([0xff, 0xfe, 0xfd]), method: 0 },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([archive])),
+    ).toBe("candidate_utf8_invalid");
+  });
+
+  it("rejects advertised and actual-output compression bombs", async () => {
+    const ratioBomb = await archiveWith([
+      {
+        name: "ratio.csv",
+        data: Buffer.alloc(1_000_000, 0x61),
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([ratioBomb])),
+    ).toBe("candidate_ratio_too_large");
+
+    const actualOutputBomb = await archiveWith([
+      {
+        name: "output.csv",
+        data: randomBytes(IMPORT_CSV_MAX_BYTES + 1),
+        advertisedUncompressedBytes: 100,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([actualOutputBomb])),
+    ).toBe("candidate_output_too_large");
+  });
+
+  it("accepts the exact byte cap and rejects one byte over", async () => {
+    const prefix = Buffer.from("firstName,lastName,clientId,payload\nA,B,id,");
+    const remainingBytes = IMPORT_CSV_MAX_BYTES - prefix.length;
+    const exact = Buffer.concat([
+      prefix,
+      Buffer.from(
+        randomBytes(Math.ceil(remainingBytes / 2))
+          .toString("hex")
+          .slice(0, remainingBytes),
+        "ascii",
+      ),
+    ]);
+    expect(exact.length).toBe(IMPORT_CSV_MAX_BYTES);
+    const exactArchive = await archiveWith([
+      { name: "exact.csv", data: exact, method: 0 },
+    ]);
+    const exactEvidence = await preflightMigrationArchives([exactArchive]);
+    expect(firstArchiveBlocker(exactEvidence)).toBeUndefined();
+    expect(exactEvidence.archives[0]?.candidates[0]).toMatchObject({
+      inferredMode: "clients",
+      validRows: 1,
+    });
+
+    const overArchive = await archiveWith([
+      {
+        name: "over.csv",
+        data: Buffer.concat([exact, Buffer.from("x")]),
+        method: 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([overArchive])),
+    ).toBe("candidate_output_too_large");
+  });
+
+  it("accepts the exact source-row cap and rejects one row over", async () => {
+    const header = "firstName,lastName,clientId\n";
+    const rows = Array.from(
+      { length: IMPORT_MAX_ROWS },
+      (_, index) => `A,B,synthetic-${index}\n`,
+    ).join("");
+    const exactArchive = await archiveWith([
+      { name: "exact-rows.csv", data: `${header}${rows}`, method: 0 },
+    ]);
+    const exactEvidence = await preflightMigrationArchives([exactArchive]);
+    expect(firstArchiveBlocker(exactEvidence)).toBeUndefined();
+    expect(exactEvidence.archives[0]?.candidates[0]).toMatchObject({
+      sourceRows: IMPORT_MAX_ROWS,
+      validRows: IMPORT_MAX_ROWS,
+    });
+
+    const overArchive = await archiveWith([
+      {
+        name: "over-rows.csv",
+        data: `${header}${rows}A,B,one-too-many\n`,
+        method: 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([overArchive])),
+    ).toBe("candidate_csv_structure_limit_exceeded");
+  });
+
+  it("marks exact candidate content duplicated across archives", async () => {
+    const content = validClientCsv();
+    const first = await archiveWith([{ name: "first.csv", data: content }]);
+    const second = await archiveWith([{ name: "second.csv", data: content }]);
+    const evidence = await preflightMigrationArchives([first, second]);
+    expect(evidence.exactDuplicateCandidateCount).toBe(1);
+    expect(evidence.archives.flatMap((archive) => archive.candidates)).toEqual([
+      expect.objectContaining({ duplicateContent: true }),
+      expect.objectContaining({ duplicateContent: true }),
+    ]);
+    expect(evidence.readyForAuthoritativeCsvPreview).toBe(false);
+  });
+
+  it("redacts raw duplicate headers and invalid source values", async () => {
+    const privateCanary = "PRIVATE-PARSER-CANARY";
+    const archive = await archiveWith([
+      {
+        name: `${privateCanary}.csv`,
+        data: `${privateCanary},${privateCanary}\n${privateCanary},${privateCanary}\n`,
+      },
+    ]);
+    const evidence = await preflightMigrationArchives([archive]);
+    expect(firstArchiveBlocker(evidence)).toBe("candidate_csv_invalid");
+    expect(evidence.archives[0]?.candidates[0]?.errorCategories).toEqual({
+      duplicate_header: 1,
+    });
+    expect(JSON.stringify(evidence)).not.toContain(privateCanary);
+  });
+
+  it("rejects a local header whose data offset enters the central directory", async () => {
+    const base = makeZip([{ name: "clients.csv", data: validClientCsv() }]);
+    const centralOffset = base.readUInt32LE(base.length - 6);
+    const archive = await archiveWith([
+      {
+        name: "clients.csv",
+        data: validClientCsv(),
+        localHeaderOffsetOverride: centralOffset,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([archive])),
+    ).toBe("entry_span_invalid");
+  });
+
+  it("validates every local span and rejects hidden prefixes, gaps, and aliases", async () => {
+    const unsupportedOffset = await archiveWith([
+      {
+        name: "opaque.bin",
+        data: "opaque",
+        method: 0,
+        localHeaderOffsetOverride: 999_999,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(
+        await preflightMigrationArchives([unsupportedOffset]),
+      ),
+    ).toBe("entry_span_invalid");
+
+    const gap = await archiveWith([
+      { name: "first.bin", data: "one", method: 0 },
+      {
+        name: "clients.csv",
+        data: validClientCsv(),
+        method: 0,
+        gapBefore: Buffer.from("hidden-gap"),
+      },
+    ]);
+    expect(firstArchiveBlocker(await preflightMigrationArchives([gap]))).toBe(
+      "entry_span_gap",
+    );
+
+    const fakeHeaderPrefix = Buffer.concat([
+      Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+      Buffer.from("unclaimed-prefix"),
+    ]);
+    const prefixed = await archiveWith(
+      [{ name: "clients.csv", data: validClientCsv(), method: 0 }],
+      { prefix: fakeHeaderPrefix },
+    );
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([prefixed])),
+    ).toBe("entry_span_gap");
+
+    const overlapping = await archiveWith([
+      { name: "first.bin", data: "one", method: 0 },
+      {
+        name: "second.bin",
+        data: "two",
+        method: 0,
+        localHeaderOffsetOverride: 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([overlapping])),
+    ).toBe("entry_local_header_mismatch");
+  });
+
+  it("bounds logical records, columns, and cells before the eager CSV parser", async () => {
+    for (const bomb of [
+      "\n".repeat(MIGRATION_ARCHIVE_LIMITS.csvLogicalRecords + 1),
+      "\r".repeat(MIGRATION_ARCHIVE_LIMITS.csvLogicalRecords + 1),
+      "\r\n".repeat(MIGRATION_ARCHIVE_LIMITS.csvLogicalRecords + 1),
+      `${",".repeat(MIGRATION_ARCHIVE_LIMITS.csvColumnsPerRecord)}\n`,
+      `${`${"x,".repeat(499)}x\n`.repeat(2_001)}`,
+    ]) {
+      const archive = await archiveWith([
+        { name: "bounded.csv", data: bomb, method: 0 },
+      ]);
+      expect(
+        firstArchiveBlocker(await preflightMigrationArchives([archive])),
+      ).toBe("candidate_csv_structure_limit_exceeded");
+    }
+
+    const quotedNewline = await archiveWith([
+      {
+        name: "quoted.csv",
+        data: 'firstName,lastName,clientId,payload\nA,B,synthetic,"line one\nline two"\n',
+        method: 0,
+      },
+    ]);
+    const quotedEvidence = await preflightMigrationArchives([quotedNewline]);
+    expect(firstArchiveBlocker(quotedEvidence)).toBeUndefined();
+    expect(quotedEvidence.archives[0]?.candidates[0]?.sourceRows).toBe(1);
+
+    const scan = scanBoundedCsvStructure('a,b\n"one\nline",two\n');
+    expect(scan).toMatchObject({
+      logicalRecords: 2,
+      maximumColumns: 2,
+      unterminatedQuote: false,
+      exceedsLimits: false,
+    });
+    expect(
+      scanBoundedCsvStructure(
+        `${"x,".repeat(MIGRATION_ARCHIVE_LIMITS.csvColumnsPerRecord - 1)}x\n`,
+      ).exceedsLimits,
+    ).toBe(false);
+    expect(
+      scanBoundedCsvStructure(
+        `${"x,".repeat(MIGRATION_ARCHIVE_LIMITS.csvColumnsPerRecord)}x\n`,
+      ).exceedsLimits,
+    ).toBe(true);
+    const fiveHundredCells = `${"x,".repeat(499)}x\n`;
+    expect(
+      scanBoundedCsvStructure(fiveHundredCells.repeat(2_000)).totalCells,
+    ).toBe(MIGRATION_ARCHIVE_LIMITS.csvTotalCells);
+    expect(
+      scanBoundedCsvStructure(fiveHundredCells.repeat(2_000)).exceedsLimits,
+    ).toBe(false);
+    expect(
+      scanBoundedCsvStructure(`${fiveHundredCells.repeat(2_000)}x\n`)
+        .exceedsLimits,
+    ).toBe(true);
+    expect(
+      scanBoundedCsvStructure(
+        "\n".repeat(MIGRATION_ARCHIVE_LIMITS.csvLogicalRecords),
+      ).exceedsLimits,
+    ).toBe(false);
+
+    const source = await readFile(
+      join(process.cwd(), "lib/import/archive-preflight.ts"),
+      "utf8",
+    );
+    expect(source.indexOf("scanBoundedCsvStructure(text)")).toBeLessThan(
+      source.indexOf("parseCsv(text)"),
+    );
+  });
+
+  it("categorizes unterminated quotes without retaining parser text", async () => {
+    const archive = await archiveWith([
+      { name: "quotes.csv", data: 'firstName,lastName\n"private', method: 0 },
+    ]);
+    const evidence = await preflightMigrationArchives([archive]);
+    expect(firstArchiveBlocker(evidence)).toBe("candidate_csv_invalid");
+    expect(evidence.archives[0]?.candidates[0]?.errorCategories).toEqual({
+      unterminated_quote: 1,
+    });
+  });
+
+  it("bounds candidate evidence per archive and across the manifest", async () => {
+    const entries = (count: number, prefix: string): SyntheticEntry[] =>
+      Array.from({ length: count }, (_, index) => ({
+        name: `${prefix}-${index}.csv`,
+        data: "",
+        method: 0,
+      }));
+    const tooMany = await archiveWith([
+      ...entries(MIGRATION_ARCHIVE_LIMITS.csvCandidatesPerArchive + 1, "one"),
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([tooMany])),
+    ).toBe("csv_candidate_limit_exceeded");
+
+    const first = await archiveWith([
+      ...entries(MIGRATION_ARCHIVE_LIMITS.csvCandidatesPerArchive, "first"),
+    ]);
+    const second = await archiveWith([
+      ...entries(MIGRATION_ARCHIVE_LIMITS.csvCandidatesPerArchive, "second"),
+    ]);
+    const third = await archiveWith([
+      { name: "last.csv", data: "", method: 0 },
+    ]);
+    const aggregate = await preflightMigrationArchives([first, second, third]);
+    expect(aggregate.archives[2]?.blockerCodes).toEqual([
+      "csv_candidate_limit_exceeded",
+    ]);
+    expect(
+      aggregate.archives.reduce(
+        (count, archive) => count + archive.candidates.length,
+        0,
+      ),
+    ).toBe(MIGRATION_ARCHIVE_LIMITS.aggregateCsvCandidates);
+  });
+
+  it("keeps aggregate entry exhaustion monotonic after an overflow archive", async () => {
+    const compactArchive = async (
+      count: number,
+      prefix: string,
+    ): Promise<string> =>
+      archiveWith(
+        Array.from({ length: count }, (_, index) => ({
+          name: `${prefix}-${index}.bin`,
+          data: "x",
+          method: 0 as const,
+        })),
+      );
+    const archives = await Promise.all([
+      compactArchive(5, "first"),
+      compactArchive(4, "second"),
+      compactArchive(2, "overflow"),
+      compactArchive(1, "after-overflow"),
+    ]);
+
+    const evidence = await preflightMigrationArchives(
+      archives,
+      new Date("2026-08-11T12:00:00.000Z"),
+      { aggregateEntryLimitOverride: 10 },
+    );
+    expect(evidence.archives.map((archive) => archive.entryCount)).toEqual([
+      5, 4, 2, 1,
+    ]);
+    expect(
+      evidence.archives.map((archive) => archive.unsupportedEntryCount),
+    ).toEqual([5, 4, 0, 0]);
+    expect(evidence.archives.map((archive) => archive.status)).toEqual([
+      "safe",
+      "safe",
+      "blocked",
+      "blocked",
+    ]);
+    expect(evidence.archives.map((archive) => archive.blockerCodes)).toEqual([
+      [],
+      [],
+      ["aggregate_entry_limit_exceeded"],
+      ["aggregate_entry_limit_exceeded"],
+    ]);
+    expect(evidence.safeToContinueOfflineReview).toBe(false);
+  });
+
+  it("keeps reading the opened archive inode when its path is replaced", async () => {
+    const directory = await privateDirectory();
+    const archive = join(directory, "archive.zip");
+    const movedOriginal = join(directory, "opened-original.zip");
+    const originalBytes = makeZip([
+      { name: "clients.csv", data: validClientCsv("original") },
+    ]);
+    const replacementBytes = Buffer.from("replacement-path-is-not-a-zip");
+    await writeFile(archive, originalBytes);
+    await chmod(archive, 0o600);
+
+    const evidence = await preflightMigrationArchives(
+      [archive],
+      new Date("2026-08-11T12:00:00.000Z"),
+      {
+        afterArchiveInitialHash: async () => {
+          await rename(archive, movedOriginal);
+          await writeFile(archive, replacementBytes);
+          await chmod(archive, 0o600);
+        },
+      },
+    );
+    // Renaming the opened inode changes its ctime, so the conservative final
+    // stability check blocks. The blocker and original hash prove the reader
+    // stayed on the opened FD instead of parsing the invalid replacement path.
+    expect(firstArchiveBlocker(evidence)).toBe("input_changed_during_read");
+    expect(evidence.archives[0]?.archiveSha256).toBe(
+      createHash("sha256").update(originalBytes).digest("hex"),
+    );
+  });
+
+  it("detects a same-inode archive mutation after the initial hash", async () => {
+    const directory = await privateDirectory();
+    const archive = join(directory, "archive.zip");
+    const mutatedBytes = makeZip([
+      { name: "clients.csv", data: validClientCsv("mutated!"), method: 0 },
+    ]);
+    const stableOriginal = makeZip([
+      { name: "clients.csv", data: validClientCsv("original"), method: 0 },
+    ]);
+    expect(mutatedBytes.length).toBe(stableOriginal.length);
+    await writeFile(archive, stableOriginal);
+    await chmod(archive, 0o600);
+    const inodeBefore = (await stat(archive)).ino;
+
+    const evidence = await preflightMigrationArchives([archive], new Date(), {
+      afterArchiveInitialHash: async () => {
+        await writeFile(archive, mutatedBytes);
+        expect((await stat(archive)).ino).toBe(inodeBefore);
+      },
+    });
+    expect(firstArchiveBlocker(evidence)).toBe("input_changed_during_read");
+    expect(evidence.archives[0]?.archiveSha256).toBe(
+      createHash("sha256").update(stableOriginal).digest("hex"),
+    );
+  });
+
+  it("detects a manifest mutation after the first same-FD read", async () => {
+    const directory = await privateDirectory();
+    const firstArchive = join(directory, "first.zip");
+    const otherArchive = join(directory, "other.zip");
+    const evidencePath = join(directory, "evidence.json");
+    await writeFile(firstArchive, makeZip([]));
+    await writeFile(otherArchive, makeZip([]));
+    await chmod(firstArchive, 0o600);
+    await chmod(otherArchive, 0o600);
+    const manifestPath = await privateManifest(
+      directory,
+      [firstArchive],
+      evidencePath,
+    );
+    const replacement = JSON.stringify({
+      archives: [otherArchive],
+      evidence: evidencePath,
+    });
+    expect(replacement.length).toBe((await readFile(manifestPath)).length);
+
+    await expect(
+      validatedMigrationArchiveCliPaths(
+        { manifestPath },
+        {
+          afterManifestFirstRead: async () => {
+            await writeFile(manifestPath, replacement);
+          },
+        },
+      ),
+    ).rejects.toThrow("manifest_changed");
+  });
+
+  it("rejects a symlink input and opens the source once before stat/hash/read", async () => {
+    const directory = await privateDirectory();
+    const target = join(directory, "target.zip");
+    const link = join(directory, "link.zip");
+    await writeFile(
+      target,
+      makeZip([{ name: "clients.csv", data: validClientCsv() }]),
+    );
+    await chmod(target, 0o600);
+    await symlink(target, link);
+    const manifestPath = join(directory, "manifest.json");
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        archives: [link],
+        evidence: join(directory, "evidence.json"),
+      }),
+    );
+    await chmod(manifestPath, 0o600);
+    const cliPaths = await validatedMigrationArchiveCliPaths({
+      manifestPath,
+    });
+    expect(basename(cliPaths.archivePaths[0]!)).toBe("link.zip");
+    expect(cliPaths.archivePaths[0]).not.toBe(await realpath(link));
+    expect(
+      firstArchiveBlocker(
+        await preflightMigrationArchives(cliPaths.archivePaths),
+      ),
+    ).toBe("input_symlink_rejected");
+
+    const source = await readFile(
+      join(process.cwd(), "lib/import/archive-preflight.ts"),
+      "utf8",
+    );
+    const openIndex = source.indexOf("handle = await open(");
+    const statIndex = source.indexOf(
+      "const pathStat = await handle.stat()",
+      openIndex,
+    );
+    const hashIndex = source.indexOf("sha256FileHandle(handle", statIndex);
+    const inspectIndex = source.indexOf(
+      "const inspected = await inspectArchive(",
+      hashIndex,
+    );
+    const finalHashIndex = source.indexOf(
+      "sha256FileHandle(handle",
+      hashIndex + 1,
+    );
+    expect(openIndex).toBeGreaterThan(0);
+    expect(statIndex).toBeGreaterThan(openIndex);
+    expect(hashIndex).toBeGreaterThan(statIndex);
+    expect(inspectIndex).toBeGreaterThan(hashIndex);
+    expect(finalHashIndex).toBeGreaterThan(inspectIndex);
+    expect(source).not.toContain("createReadStream(path)");
+    expect(source).not.toContain("lstat(path)");
+  });
+
+  it("writes exclusive aggregate evidence with mode 0600", async () => {
+    const directory = await privateDirectory();
+    const archive = join(directory, "archive.zip");
+    const evidencePath = join(directory, "evidence.json");
+    await writeFile(
+      archive,
+      makeZip([{ name: "clients.csv", data: validClientCsv() }]),
+    );
+    await chmod(archive, 0o600);
+    const evidence = await preflightMigrationArchives([archive]);
+    await writeMigrationArchiveEvidence(evidencePath, evidence);
+    expect((await stat(evidencePath)).mode & 0o777).toBe(0o600);
+    await expect(
+      writeMigrationArchiveEvidence(evidencePath, evidence),
+    ).rejects.toMatchObject({ code: "EEXIST" });
+  });
+
+  it("rejects source archive permissions that are not owner-only", async () => {
+    const archive = await archiveWith([
+      { name: "clients.csv", data: validClientCsv() },
+    ]);
+    await chmod(archive, 0o644);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([archive])),
+    ).toBe("input_permissions_too_open");
+  });
+
+  it("validates a private exact-shape manifest and canonical duplicates", async () => {
+    const directory = await privateDirectory();
+    const archiveDirectory = join(directory, "archives");
+    const archiveAlias = join(directory, "archive-alias");
+    await mkdir(archiveDirectory, { mode: 0o700 });
+    await chmod(archiveDirectory, 0o700);
+    const archive = join(archiveDirectory, "archive.zip");
+    await writeFile(
+      archive,
+      makeZip([{ name: "clients.csv", data: validClientCsv() }]),
+    );
+    await chmod(archive, 0o600);
+    await symlink(archiveDirectory, archiveAlias);
+    const manifestPath = await privateManifest(directory, [
+      archive,
+      join(archiveAlias, "archive.zip"),
+    ]);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("manifest_duplicate_archives");
+
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        archives: [archive],
+        evidence: join(directory, "evidence.json"),
+        unexpected: true,
+      }),
+    );
+    await chmod(manifestPath, 0o600);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("manifest_invalid");
+
+    await writeFile(manifestPath, Buffer.from([0xff]));
+    await chmod(manifestPath, 0o600);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("manifest_invalid");
+
+    await writeFile(manifestPath, Buffer.alloc(64_001, 0x78));
+    await chmod(manifestPath, 0o600);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("manifest_size_invalid");
+  });
+
+  it("rejects symlink, open, and non-private-parent manifests", async () => {
+    const directory = await privateDirectory();
+    const archive = join(directory, "archive.zip");
+    await writeFile(
+      archive,
+      makeZip([{ name: "clients.csv", data: validClientCsv() }]),
+    );
+    await chmod(archive, 0o600);
+    const manifestPath = await privateManifest(directory, [archive]);
+
+    await chmod(manifestPath, 0o644);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("manifest_permissions_invalid");
+    await chmod(manifestPath, 0o600);
+
+    const manifestLink = join(directory, "manifest-link.json");
+    await symlink(manifestPath, manifestLink);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath: manifestLink }),
+    ).rejects.toThrow("manifest_symlink_rejected");
+
+    await chmod(directory, 0o755);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("private_parent_required");
+  });
+
+  it("rejects direct and canonical-parent-symlink repository paths", async () => {
+    await expect(
+      validatedMigrationArchiveCliPaths({
+        manifestPath: join(process.cwd(), "package.json"),
+      }),
+    ).rejects.toThrow("repository_paths_rejected");
+
+    const directory = await privateDirectory();
+    const repositoryAlias = join(directory, "repository-alias");
+    await symlink(process.cwd(), repositoryAlias);
+    await expect(
+      validatedMigrationArchiveCliPaths({
+        manifestPath: join(repositoryAlias, "package.json"),
+      }),
+    ).rejects.toThrow("repository_paths_rejected");
+
+    const directReferenceManifest = await privateManifest(directory, [
+      join(process.cwd(), "package.json"),
+    ]);
+    await expect(
+      validatedMigrationArchiveCliPaths({
+        manifestPath: directReferenceManifest,
+      }),
+    ).rejects.toThrow("repository_paths_rejected");
+
+    await writeFile(
+      directReferenceManifest,
+      JSON.stringify({
+        archives: [join(repositoryAlias, "package.json")],
+        evidence: join(directory, "evidence.json"),
+      }),
+    );
+    await chmod(directReferenceManifest, 0o600);
+    await expect(
+      validatedMigrationArchiveCliPaths({
+        manifestPath: directReferenceManifest,
+      }),
+    ).rejects.toThrow("repository_paths_rejected");
+  });
+
+  it("keeps archive and evidence paths out of argv, output, and evidence", async () => {
+    const directory = await privateDirectory();
+    const archiveCanary = "PRIVATE-ARCHIVE-PATH-CANARY";
+    const evidenceCanary = "PRIVATE-EVIDENCE-PATH-CANARY";
+    const valueCanary = "PRIVATE-VALUE-CANARY";
+    const archive = join(directory, `${archiveCanary}.zip`);
+    const evidencePath = join(directory, `${evidenceCanary}.json`);
+    await writeFile(
+      archive,
+      makeZip([
+        {
+          name: `${valueCanary}.csv`,
+          data: validClientCsv(valueCanary),
+        },
+      ]),
+    );
+    await chmod(archive, 0o600);
+    const manifestPath = await privateManifest(
+      directory,
+      [archive],
+      evidencePath,
+    );
+    const result = await runPreflightCli(manifestPath);
+    expect(JSON.stringify(result.argv)).not.toContain(archiveCanary);
+    expect(JSON.stringify(result.argv)).not.toContain(evidenceCanary);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Migration archive preflight complete.\n");
+    expect(result.stderr).toBe("");
+    const serializedEvidence = await readFile(evidencePath, "utf8");
+    for (const canary of [archiveCanary, evidenceCanary, valueCanary]) {
+      expect(result.stdout).not.toContain(canary);
+      expect(result.stderr).not.toContain(canary);
+      expect(serializedEvidence).not.toContain(canary);
+    }
+    expect(serializedEvidence).not.toContain(archive);
+    expect(serializedEvidence).not.toContain(evidencePath);
+    expect((await stat(evidencePath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("returns exit 2 with redacted evidence for a blocked archive", async () => {
+    const directory = await privateDirectory();
+    const canary = "PRIVATE-BLOCKED-ARCHIVE-CANARY";
+    const archive = join(directory, `${canary}.zip`);
+    const evidencePath = join(directory, "evidence.json");
+    await writeFile(archive, `not-a-zip-${canary}`);
+    await chmod(archive, 0o600);
+    const manifestPath = await privateManifest(
+      directory,
+      [archive],
+      evidencePath,
+    );
+
+    const result = await runPreflightCli(manifestPath);
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe("Migration archive preflight complete.\n");
+    expect(result.stderr).toBe("");
+    const serializedEvidence = await readFile(evidencePath, "utf8");
+    expect(serializedEvidence).toContain('"archive_not_zip"');
+    for (const output of [
+      result.stdout,
+      result.stderr,
+      serializedEvidence,
+      JSON.stringify(result.argv),
+    ]) {
+      expect(output).not.toContain(canary);
+      expect(output).not.toContain(archive);
+    }
+  });
+
+  it("returns exit 1 generically for pre-existing evidence and fatal manifests", async () => {
+    const directory = await privateDirectory();
+    const canary = "PRIVATE-FATAL-CLI-CANARY";
+    const archive = join(directory, `${canary}.zip`);
+    const evidencePath = join(directory, `${canary}-evidence.json`);
+    await writeFile(archive, makeZip([]));
+    await chmod(archive, 0o600);
+    await writeFile(evidencePath, "existing");
+    await chmod(evidencePath, 0o600);
+    const manifestPath = await privateManifest(
+      directory,
+      [archive],
+      evidencePath,
+    );
+
+    const existingEvidence = await runPreflightCli(manifestPath);
+    expect(existingEvidence).toMatchObject({
+      exitCode: 1,
+      stdout: "",
+      stderr:
+        "Migration archive preflight could not complete safely. No archive details were printed.\n",
+    });
+    expect(await readFile(evidencePath, "utf8")).toBe("existing");
+
+    await writeFile(manifestPath, `{"invalid":"${canary}"}`);
+    await chmod(manifestPath, 0o600);
+    const fatalManifest = await runPreflightCli(manifestPath);
+    expect(fatalManifest).toMatchObject({
+      exitCode: 1,
+      stdout: "",
+      stderr:
+        "Migration archive preflight could not complete safely. No archive details were printed.\n",
+    });
+    for (const output of [
+      existingEvidence.stdout,
+      existingEvidence.stderr,
+      fatalManifest.stdout,
+      fatalManifest.stderr,
+      JSON.stringify(existingEvidence.argv),
+      JSON.stringify(fatalManifest.argv),
+    ]) {
+      expect(output).not.toContain(canary);
+      expect(output).not.toContain(archive);
+      expect(output).not.toContain(evidencePath);
+    }
+  });
+
+  it("keeps configured ratio and platform caps in evidence", async () => {
+    const archive = await archiveWith([
+      { name: "clients.csv", data: validClientCsv() },
+    ]);
+    const evidence = await preflightMigrationArchives([archive]);
+    expect(evidence.limits).toMatchObject({
+      candidateCompressionRatio:
+        MIGRATION_ARCHIVE_LIMITS.candidateCompressionRatio,
+      csvBytes: IMPORT_CSV_MAX_BYTES,
+      csvRows: IMPORT_MAX_ROWS,
+    });
+  });
+
+  it("pins every public archive and manifest resource limit", () => {
+    expect(MIGRATION_ARCHIVE_LIMITS).toEqual({
+      archiveBytes: 2_000_000_000,
+      centralDirectoryBytes: 64_000_000,
+      entries: 50_000,
+      advertisedUncompressedBytes: 10_000_000_000,
+      aggregateEntries: 100_000,
+      csvCandidatesPerArchive: 128,
+      aggregateCsvCandidates: 256,
+      candidateCompressedBytes: 5_065_536,
+      candidateCompressionRatio: 200,
+      csvLogicalRecords: 10_001,
+      csvColumnsPerRecord: 512,
+      csvTotalCells: 1_000_000,
+    });
+    expect(MIGRATION_ARCHIVE_MANIFEST_LIMITS).toEqual({
+      bytes: 64_000,
+      archives: 32,
+      pathCharacters: 4_096,
+    });
+    expect(IMPORT_CSV_MAX_BYTES).toBe(5_000_000);
+    expect(IMPORT_MAX_ROWS).toBe(10_000);
+    expect(candidateCompressionRatioExceedsLimit(1, 200)).toBe(false);
+    expect(candidateCompressionRatioExceedsLimit(10, 2_000)).toBe(false);
+    expect(candidateCompressionRatioExceedsLimit(10, 2_001)).toBe(true);
+    expect(aggregateArchiveEntryBudgetExceeded(99_999, 1)).toBe(false);
+    expect(aggregateArchiveEntryBudgetExceeded(100_000, 1)).toBe(true);
+  });
+
+  it("blocks sparse archive, central-directory, and entry-count limits", async () => {
+    const directory = await privateDirectory();
+    const sparse = join(directory, "sparse.zip");
+    const sparseHandle = await open(sparse, "w", 0o600);
+    await sparseHandle.truncate(2_000_000_001);
+    await sparseHandle.close();
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([sparse])),
+    ).toBe("archive_too_large");
+
+    const centralTooLarge = patchEocd(makeZip([]), (copy, eocdOffset) => {
+      copy.writeUInt32LE(64_000_001, eocdOffset + 12);
+    });
+    const centralPath = join(directory, "central.zip");
+    await writeFile(centralPath, centralTooLarge);
+    await chmod(centralPath, 0o600);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([centralPath])),
+    ).toBe("central_directory_too_large");
+
+    const entriesTooMany = patchEocd(makeZip([]), (copy, eocdOffset) => {
+      copy.writeUInt16LE(50_001, eocdOffset + 8);
+      copy.writeUInt16LE(50_001, eocdOffset + 10);
+    });
+    const entryPath = join(directory, "entries.zip");
+    await writeFile(entryPath, entriesTooMany);
+    await chmod(entryPath, 0o600);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([entryPath])),
+    ).toBe("too_many_entries");
+  });
+
+  it("blocks advertised-output and compressed-candidate limits", async () => {
+    const advertised = await archiveWith([
+      {
+        name: "one.bin",
+        data: "one",
+        advertisedUncompressedBytes: 4_000_000_000,
+      },
+      {
+        name: "two.bin",
+        data: "two",
+        advertisedUncompressedBytes: 4_000_000_000,
+      },
+      {
+        name: "three.bin",
+        data: "three",
+        advertisedUncompressedBytes: 4_000_000_000,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([advertised])),
+    ).toBe("advertised_output_too_large");
+
+    const compressed = await archiveWith([
+      {
+        name: "large.csv",
+        data: Buffer.alloc(5_065_537, 0x78),
+        method: 0,
+      },
+    ]);
+    expect(
+      firstArchiveBlocker(await preflightMigrationArchives([compressed])),
+    ).toBe("candidate_compressed_too_large");
+  });
+
+  it("blocks manifest archive-count and path-length limits", async () => {
+    const directory = await privateDirectory();
+    const manifestPath = join(directory, "manifest.json");
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        archives: Array.from(
+          { length: 33 },
+          (_, index) => `/private/archive-${index}.zip`,
+        ),
+        evidence: join(directory, "evidence.json"),
+      }),
+    );
+    await chmod(manifestPath, 0o600);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("manifest_invalid");
+
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        archives: [`/${"x".repeat(4_096)}`],
+        evidence: join(directory, "evidence.json"),
+      }),
+    );
+    await chmod(manifestPath, 0o600);
+    await expect(
+      validatedMigrationArchiveCliPaths({ manifestPath }),
+    ).rejects.toThrow("manifest_invalid");
+  });
+
+  it("links the operator preflight without expanding self-serve migration scope", async () => {
+    const migrationGuide = await readFile(
+      join(process.cwd(), "../../docs/migrating-to-openvpm.md"),
+      "utf8",
+    );
+    expect(migrationGuide).toContain(
+      "[Shepherd migration archive preflight](shepherd-migration-archive-preflight.md)",
+    );
+    expect(migrationGuide).toContain(
+      "does not\nexpand the self-serve importer",
+    );
+    expect(migrationGuide).toContain(
+      "reviewed CSV dry run remains authoritative",
+    );
+  });
+});

--- a/apps/web/lib/import/archive-preflight.ts
+++ b/apps/web/lib/import/archive-preflight.ts
@@ -1,0 +1,1284 @@
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { open } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { inflateRawSync } from "node:zlib";
+import {
+  csvToClientRecords,
+  csvToPatientRecords,
+  csvToSoapNoteRecords,
+  csvToVaccinationRecords,
+} from "@/lib/csv/import";
+import { parseCsv } from "@/lib/csv/parse";
+import { IMPORT_CSV_MAX_BYTES, IMPORT_MAX_ROWS } from "@/lib/import/policy";
+import type { MigrationImportMode } from "@/lib/import/sources";
+
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_FILE_HEADER_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const ZIP64_EXTRA_FIELD_ID = 0x0001;
+const UNICODE_PATH_EXTRA_FIELD_ID = 0x7075;
+const AES_EXTRA_FIELD_ID = 0x9901;
+const ZIP_EOCD_MIN_BYTES = 22;
+const ZIP_MAX_COMMENT_BYTES = 65_535;
+
+export const MIGRATION_ARCHIVE_LIMITS = {
+  archiveBytes: 2_000_000_000,
+  centralDirectoryBytes: 64_000_000,
+  entries: 50_000,
+  advertisedUncompressedBytes: 10_000_000_000,
+  aggregateEntries: 100_000,
+  csvCandidatesPerArchive: 128,
+  aggregateCsvCandidates: 256,
+  candidateCompressedBytes: IMPORT_CSV_MAX_BYTES + 65_536,
+  candidateCompressionRatio: 200,
+  csvLogicalRecords: IMPORT_MAX_ROWS + 1,
+  csvColumnsPerRecord: 512,
+  csvTotalCells: 1_000_000,
+} as const;
+
+export function candidateCompressionRatioExceedsLimit(
+  compressedBytes: number,
+  uncompressedBytes: number,
+): boolean {
+  return (
+    uncompressedBytes / Math.max(1, compressedBytes) >
+    MIGRATION_ARCHIVE_LIMITS.candidateCompressionRatio
+  );
+}
+
+export function aggregateArchiveEntryBudgetExceeded(
+  consumedEntries: number,
+  incomingEntries: number,
+  aggregateEntryLimit: number = MIGRATION_ARCHIVE_LIMITS.aggregateEntries,
+): boolean {
+  return consumedEntries + incomingEntries > aggregateEntryLimit;
+}
+
+export type MigrationArchivePreflightTestHooks = {
+  /** Test-only synchronization point. Production callers must leave this unset. */
+  afterArchiveInitialHash?: (context: {
+    alias: string;
+  }) => void | Promise<void>;
+  /** Test-only compact substitute for the public 100,000-entry aggregate cap. */
+  aggregateEntryLimitOverride?: number;
+};
+
+export type ArchiveBlockerCode =
+  | "input_not_regular_file"
+  | "input_symlink_rejected"
+  | "input_owner_mismatch"
+  | "input_permissions_too_open"
+  | "input_owner_check_unavailable"
+  | "archive_too_large"
+  | "archive_truncated"
+  | "archive_not_zip"
+  | "archive_sfx_rejected"
+  | "archive_zip64_rejected"
+  | "archive_multidisk_rejected"
+  | "central_directory_too_large"
+  | "central_directory_invalid"
+  | "too_many_entries"
+  | "aggregate_entry_limit_exceeded"
+  | "csv_candidate_limit_exceeded"
+  | "advertised_output_too_large"
+  | "entry_path_invalid"
+  | "entry_path_collision"
+  | "entry_name_encoding_invalid"
+  | "entry_symlink_rejected"
+  | "entry_special_file_rejected"
+  | "entry_type_path_mismatch"
+  | "entry_encrypted_rejected"
+  | "entry_flags_unsupported"
+  | "entry_compression_unsupported"
+  | "entry_data_descriptor_rejected"
+  | "entry_zip64_rejected"
+  | "entry_unicode_path_override_rejected"
+  | "entry_local_header_mismatch"
+  | "entry_span_invalid"
+  | "entry_span_gap"
+  | "directory_payload_rejected"
+  | "nested_archive_rejected"
+  | "candidate_compressed_too_large"
+  | "candidate_output_too_large"
+  | "candidate_ratio_too_large"
+  | "candidate_local_header_mismatch"
+  | "candidate_data_out_of_bounds"
+  | "candidate_decompression_failed"
+  | "candidate_trailing_data_rejected"
+  | "candidate_size_mismatch"
+  | "candidate_crc_mismatch"
+  | "candidate_utf8_invalid"
+  | "candidate_csv_structure_limit_exceeded"
+  | "candidate_row_limit_exceeded"
+  | "candidate_csv_invalid"
+  | "candidate_schema_unrecognized"
+  | "candidate_schema_ambiguous"
+  | "input_read_failed"
+  | "input_changed_during_read";
+
+export type SafeCsvErrorCategory =
+  | "unterminated_quote"
+  | "invalid_header"
+  | "duplicate_header"
+  | "extra_columns"
+  | "missing_column"
+  | "empty_csv"
+  | "missing_identity"
+  | "invalid_email"
+  | "external_id_too_long"
+  | "missing_name"
+  | "invalid_species"
+  | "invalid_date"
+  | "missing_content"
+  | "field_too_long"
+  | "other";
+
+export type ArchiveCandidateEvidence = {
+  opaqueId: string;
+  compressedBytes: number;
+  uncompressedBytes: number;
+  contentSha256: string | null;
+  crcVerified: boolean;
+  utf8Valid: boolean;
+  sourceRows: number | null;
+  validRows: number;
+  errorCount: number;
+  errorCategories: Partial<Record<SafeCsvErrorCategory, number>>;
+  modeCandidates: MigrationImportMode[];
+  inferredMode: MigrationImportMode | null;
+  status: "valid" | "review_required" | "blocked";
+  blockerCodes: ArchiveBlockerCode[];
+  duplicateContent: boolean;
+};
+
+export type ArchiveEvidence = {
+  alias: string;
+  archiveSha256: string | null;
+  archiveBytes: number | null;
+  entryCount: number;
+  directoryEntryCount: number;
+  csvCandidateCount: number;
+  unsupportedEntryCount: number;
+  advertisedCompressedBytes: number;
+  advertisedUncompressedBytes: number;
+  status: "safe" | "review_required" | "blocked";
+  blockerCodes: ArchiveBlockerCode[];
+  candidates: ArchiveCandidateEvidence[];
+};
+
+export type MigrationArchivePreflightEvidence = {
+  schemaVersion: 1;
+  generatedAt: string;
+  tool: "openvpm_migration_archive_preflight";
+  source: "shepherd";
+  networkUsed: false;
+  databaseUsed: false;
+  archiveExtractionUsed: false;
+  authoritativeImportClaim: false;
+  limits: typeof MIGRATION_ARCHIVE_LIMITS & {
+    csvBytes: number;
+    csvRows: number;
+  };
+  archives: ArchiveEvidence[];
+  exactDuplicateCandidateCount: number;
+  safeToContinueOfflineReview: boolean;
+  readyForAuthoritativeCsvPreview: boolean;
+  requiresUnsupportedDataReview: boolean;
+};
+
+type CentralDirectoryEntry = {
+  nameBytes: Buffer;
+  localHeaderOffset: number;
+  dataOffset: number;
+  spanEnd: number;
+  generalPurposeFlags: number;
+  compressionMethod: number;
+  crc32: number;
+  compressedBytes: number;
+  uncompressedBytes: number;
+  isDirectory: boolean;
+  isCsv: boolean;
+};
+
+type InspectedArchive = {
+  centralDirectoryOffset: number;
+  entries: CentralDirectoryEntry[];
+  directoryEntryCount: number;
+  unsupportedEntryCount: number;
+  advertisedCompressedBytes: number;
+  advertisedUncompressedBytes: number;
+};
+
+class SafeArchiveError extends Error {
+  constructor(readonly code: ArchiveBlockerCode) {
+    super(code);
+    this.name = "SafeArchiveError";
+  }
+}
+
+function safeError(error: unknown): SafeArchiveError {
+  return error instanceof SafeArchiveError
+    ? error
+    : new SafeArchiveError("input_read_failed");
+}
+
+async function readExactly(
+  handle: FileHandle,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  if (length < 0 || position < 0 || !Number.isSafeInteger(length + position)) {
+    throw new SafeArchiveError("archive_truncated");
+  }
+  const buffer = Buffer.alloc(length);
+  let consumed = 0;
+  while (consumed < length) {
+    const result = await handle.read(
+      buffer,
+      consumed,
+      length - consumed,
+      position + consumed,
+    );
+    if (result.bytesRead === 0) {
+      throw new SafeArchiveError("archive_truncated");
+    }
+    consumed += result.bytesRead;
+  }
+  return buffer;
+}
+
+async function sha256FileHandle(
+  handle: FileHandle,
+  fileBytes: number,
+): Promise<string> {
+  const hash = createHash("sha256");
+  const chunkBytes = 1024 * 1024;
+  for (let position = 0; position < fileBytes; position += chunkBytes) {
+    hash.update(
+      await readExactly(
+        handle,
+        position,
+        Math.min(chunkBytes, fileBytes - position),
+      ),
+    );
+  }
+  return hash.digest("hex");
+}
+
+function hasExtraField(extra: Buffer, wantedId: number): boolean {
+  let offset = 0;
+  while (offset < extra.length) {
+    if (offset + 4 > extra.length) {
+      throw new SafeArchiveError("central_directory_invalid");
+    }
+    const id = extra.readUInt16LE(offset);
+    const length = extra.readUInt16LE(offset + 2);
+    offset += 4;
+    if (offset + length > extra.length) {
+      throw new SafeArchiveError("central_directory_invalid");
+    }
+    if (id === wantedId) return true;
+    offset += length;
+  }
+  return false;
+}
+
+function decodeEntryName(nameBytes: Buffer, utf8: boolean): string {
+  try {
+    if (!utf8 && nameBytes.some((byte) => byte >= 0x80)) {
+      throw new SafeArchiveError("entry_name_encoding_invalid");
+    }
+    return new TextDecoder("utf-8", { fatal: true }).decode(nameBytes);
+  } catch (error) {
+    if (error instanceof SafeArchiveError) throw error;
+    throw new SafeArchiveError("entry_name_encoding_invalid");
+  }
+}
+
+function validateEntryPath(name: string): string {
+  if (
+    name.length === 0 ||
+    /[\u0000-\u001f\u007f]/u.test(name) ||
+    name.includes("\\") ||
+    name.startsWith("/") ||
+    name.startsWith("//") ||
+    /^[a-z]:/iu.test(name)
+  ) {
+    throw new SafeArchiveError("entry_path_invalid");
+  }
+  const isDirectory = name.endsWith("/");
+  const parts = name.split("/");
+  if (isDirectory) parts.pop();
+  if (
+    parts.length === 0 ||
+    parts.some((part) => part === "" || part === "." || part === "..")
+  ) {
+    throw new SafeArchiveError("entry_path_invalid");
+  }
+  return `${parts.join("/")}${isDirectory ? "/" : ""}`.normalize("NFC");
+}
+
+type PathTrieNode = {
+  children: Map<string, PathTrieNode>;
+  kind: "file" | "directory" | null;
+};
+
+function collisionPathParts(path: string): string[] {
+  const compatibilitySafePath = validateEntryPath(path.normalize("NFKC"));
+  const withoutTrailingSlash = compatibilitySafePath.endsWith("/")
+    ? compatibilitySafePath.slice(0, -1)
+    : compatibilitySafePath;
+  return withoutTrailingSlash.normalize("NFKC").toLowerCase().split("/");
+}
+
+function addPathToTrie(root: PathTrieNode, path: string): void {
+  const isDirectory = path.endsWith("/");
+  const parts = collisionPathParts(path);
+  let node = root;
+  for (const part of parts) {
+    if (node.kind === "file") {
+      throw new SafeArchiveError("entry_path_collision");
+    }
+    const child = node.children.get(part) ?? {
+      children: new Map<string, PathTrieNode>(),
+      kind: null,
+    };
+    node.children.set(part, child);
+    node = child;
+  }
+  if (node.kind !== null) {
+    throw new SafeArchiveError("entry_path_collision");
+  }
+  if (!isDirectory && node.children.size > 0) {
+    throw new SafeArchiveError("entry_path_collision");
+  }
+  node.kind = isDirectory ? "directory" : "file";
+}
+
+function isNestedArchiveName(name: string): boolean {
+  return /\.(?:zip|zipx|7z|rar|tar|tgz|gz|bz2|xz)$/iu.test(name);
+}
+
+function inspectUnixFileType(
+  versionMadeBy: number,
+  externalAttributes: number,
+  pathIsDirectory: boolean,
+): void {
+  const host = versionMadeBy >>> 8;
+  if (host !== 3) return;
+  const mode = externalAttributes >>> 16;
+  const type = mode & 0o170000;
+  if (type === 0) return;
+  if (type === 0o100000 && !pathIsDirectory) return;
+  if (type === 0o040000 && pathIsDirectory) return;
+  if (type === 0o120000) {
+    throw new SafeArchiveError("entry_symlink_rejected");
+  }
+  if (type === 0o100000 || type === 0o040000) {
+    throw new SafeArchiveError("entry_type_path_mismatch");
+  }
+  throw new SafeArchiveError("entry_special_file_rejected");
+}
+
+async function inspectArchive(
+  handle: FileHandle,
+  archiveBytes: number,
+  onDeclaredEntryCount: (entryCount: number) => void,
+): Promise<InspectedArchive> {
+  if (archiveBytes < ZIP_EOCD_MIN_BYTES) {
+    throw new SafeArchiveError("archive_not_zip");
+  }
+  const tailBytes = Math.min(
+    archiveBytes,
+    ZIP_EOCD_MIN_BYTES + ZIP_MAX_COMMENT_BYTES,
+  );
+  const tail = await readExactly(handle, archiveBytes - tailBytes, tailBytes);
+  let eocdInTail = -1;
+  for (let offset = tail.length - ZIP_EOCD_MIN_BYTES; offset >= 0; offset--) {
+    if (tail.readUInt32LE(offset) !== END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+      continue;
+    }
+    const commentBytes = tail.readUInt16LE(offset + 20);
+    if (offset + ZIP_EOCD_MIN_BYTES + commentBytes === tail.length) {
+      eocdInTail = offset;
+      break;
+    }
+  }
+  if (eocdInTail < 0) throw new SafeArchiveError("archive_not_zip");
+
+  const eocdOffset = archiveBytes - tailBytes + eocdInTail;
+  const diskNumber = tail.readUInt16LE(eocdInTail + 4);
+  const centralDisk = tail.readUInt16LE(eocdInTail + 6);
+  const entriesOnDisk = tail.readUInt16LE(eocdInTail + 8);
+  const entryCount = tail.readUInt16LE(eocdInTail + 10);
+  const centralDirectoryBytes = tail.readUInt32LE(eocdInTail + 12);
+  const centralDirectoryOffset = tail.readUInt32LE(eocdInTail + 16);
+
+  if (
+    entryCount === 0xffff ||
+    entriesOnDisk === 0xffff ||
+    centralDirectoryBytes === 0xffffffff ||
+    centralDirectoryOffset === 0xffffffff
+  ) {
+    throw new SafeArchiveError("archive_zip64_rejected");
+  }
+  if (diskNumber !== 0 || centralDisk !== 0 || entriesOnDisk !== entryCount) {
+    throw new SafeArchiveError("archive_multidisk_rejected");
+  }
+  // Enforce the manifest-wide budget at the EOCD boundary, before allocating
+  // or iterating over the central directory.
+  onDeclaredEntryCount(entryCount);
+  if (entryCount > MIGRATION_ARCHIVE_LIMITS.entries) {
+    throw new SafeArchiveError("too_many_entries");
+  }
+  if (centralDirectoryBytes > MIGRATION_ARCHIVE_LIMITS.centralDirectoryBytes) {
+    throw new SafeArchiveError("central_directory_too_large");
+  }
+  if (centralDirectoryOffset + centralDirectoryBytes !== eocdOffset) {
+    throw new SafeArchiveError("central_directory_invalid");
+  }
+
+  const firstSignature = (await readExactly(handle, 0, 4)).readUInt32LE(0);
+  if (
+    (entryCount > 0 && firstSignature !== LOCAL_FILE_HEADER_SIGNATURE) ||
+    (entryCount === 0 && firstSignature !== END_OF_CENTRAL_DIRECTORY_SIGNATURE)
+  ) {
+    throw new SafeArchiveError("archive_sfx_rejected");
+  }
+
+  const central = await readExactly(
+    handle,
+    centralDirectoryOffset,
+    centralDirectoryBytes,
+  );
+  const entries: CentralDirectoryEntry[] = [];
+  const pathTrie: PathTrieNode = { children: new Map(), kind: null };
+  let offset = 0;
+  let directoryEntryCount = 0;
+  let unsupportedEntryCount = 0;
+  let advertisedCompressedBytes = 0;
+  let advertisedUncompressedBytes = 0;
+
+  for (let index = 0; index < entryCount; index++) {
+    if (
+      offset + 46 > central.length ||
+      central.readUInt32LE(offset) !== CENTRAL_FILE_HEADER_SIGNATURE
+    ) {
+      throw new SafeArchiveError("central_directory_invalid");
+    }
+    const versionMadeBy = central.readUInt16LE(offset + 4);
+    const generalPurposeFlags = central.readUInt16LE(offset + 8);
+    const compressionMethod = central.readUInt16LE(offset + 10);
+    const expectedCrc32 = central.readUInt32LE(offset + 16);
+    const compressedBytes = central.readUInt32LE(offset + 20);
+    const uncompressedBytes = central.readUInt32LE(offset + 24);
+    const nameLength = central.readUInt16LE(offset + 28);
+    const extraLength = central.readUInt16LE(offset + 30);
+    const commentLength = central.readUInt16LE(offset + 32);
+    const diskStart = central.readUInt16LE(offset + 34);
+    const externalAttributes = central.readUInt32LE(offset + 38);
+    const localHeaderOffset = central.readUInt32LE(offset + 42);
+    const recordLength = 46 + nameLength + extraLength + commentLength;
+    if (offset + recordLength > central.length) {
+      throw new SafeArchiveError("central_directory_invalid");
+    }
+    if (
+      compressedBytes === 0xffffffff ||
+      uncompressedBytes === 0xffffffff ||
+      localHeaderOffset === 0xffffffff ||
+      diskStart === 0xffff
+    ) {
+      throw new SafeArchiveError("entry_zip64_rejected");
+    }
+    if (diskStart !== 0) {
+      throw new SafeArchiveError("archive_multidisk_rejected");
+    }
+    if (
+      (generalPurposeFlags & 0x1) !== 0 ||
+      (generalPurposeFlags & 0x40) !== 0
+    ) {
+      throw new SafeArchiveError("entry_encrypted_rejected");
+    }
+    if ((generalPurposeFlags & 0x8) !== 0) {
+      throw new SafeArchiveError("entry_data_descriptor_rejected");
+    }
+    if (compressionMethod !== 0 && compressionMethod !== 8) {
+      throw new SafeArchiveError("entry_compression_unsupported");
+    }
+    const allowedFlags = 0x800 | (compressionMethod === 8 ? 0x6 : 0);
+    if ((generalPurposeFlags & (0xffff ^ allowedFlags)) !== 0) {
+      throw new SafeArchiveError("entry_flags_unsupported");
+    }
+    const nameBytes = central.subarray(offset + 46, offset + 46 + nameLength);
+    const extra = central.subarray(
+      offset + 46 + nameLength,
+      offset + 46 + nameLength + extraLength,
+    );
+    if (hasExtraField(extra, ZIP64_EXTRA_FIELD_ID)) {
+      throw new SafeArchiveError("entry_zip64_rejected");
+    }
+    if (hasExtraField(extra, UNICODE_PATH_EXTRA_FIELD_ID)) {
+      throw new SafeArchiveError("entry_unicode_path_override_rejected");
+    }
+    if (hasExtraField(extra, AES_EXTRA_FIELD_ID)) {
+      throw new SafeArchiveError("entry_encrypted_rejected");
+    }
+    const name = decodeEntryName(
+      nameBytes,
+      (generalPurposeFlags & 0x800) !== 0,
+    );
+    const safeName = validateEntryPath(name);
+    const pathIsDirectory = safeName.endsWith("/");
+    inspectUnixFileType(versionMadeBy, externalAttributes, pathIsDirectory);
+    addPathToTrie(pathTrie, safeName);
+    if (isNestedArchiveName(safeName)) {
+      throw new SafeArchiveError("nested_archive_rejected");
+    }
+
+    if (
+      pathIsDirectory &&
+      (compressionMethod !== 0 ||
+        compressedBytes !== 0 ||
+        uncompressedBytes !== 0 ||
+        expectedCrc32 !== 0)
+    ) {
+      throw new SafeArchiveError("directory_payload_rejected");
+    }
+    if (compressionMethod === 0 && compressedBytes !== uncompressedBytes) {
+      throw new SafeArchiveError("entry_local_header_mismatch");
+    }
+    advertisedCompressedBytes += compressedBytes;
+    advertisedUncompressedBytes += uncompressedBytes;
+    if (
+      !Number.isSafeInteger(advertisedCompressedBytes) ||
+      !Number.isSafeInteger(advertisedUncompressedBytes)
+    ) {
+      throw new SafeArchiveError("advertised_output_too_large");
+    }
+    if (
+      advertisedUncompressedBytes >
+      MIGRATION_ARCHIVE_LIMITS.advertisedUncompressedBytes
+    ) {
+      throw new SafeArchiveError("advertised_output_too_large");
+    }
+    const isCsv = !pathIsDirectory && safeName.toLowerCase().endsWith(".csv");
+    if (pathIsDirectory) directoryEntryCount++;
+    else if (!isCsv) unsupportedEntryCount++;
+    entries.push({
+      nameBytes: Buffer.from(nameBytes),
+      localHeaderOffset,
+      dataOffset: 0,
+      spanEnd: 0,
+      generalPurposeFlags,
+      compressionMethod,
+      crc32: expectedCrc32,
+      compressedBytes,
+      uncompressedBytes,
+      isDirectory: pathIsDirectory,
+      isCsv,
+    });
+    offset += recordLength;
+  }
+  if (offset !== central.length) {
+    throw new SafeArchiveError("central_directory_invalid");
+  }
+
+  for (const entry of entries) {
+    // Data descriptors were rejected while reading the central record. Local
+    // sizes are therefore authoritative enough to compare byte-for-byte.
+    if (
+      entry.localHeaderOffset < 0 ||
+      entry.localHeaderOffset + 30 > centralDirectoryOffset
+    ) {
+      throw new SafeArchiveError("entry_span_invalid");
+    }
+    const localHeader = await readExactly(handle, entry.localHeaderOffset, 30);
+    if (localHeader.readUInt32LE(0) !== LOCAL_FILE_HEADER_SIGNATURE) {
+      throw new SafeArchiveError("entry_local_header_mismatch");
+    }
+    const localFlags = localHeader.readUInt16LE(6);
+    const localCompression = localHeader.readUInt16LE(8);
+    const localCrc32 = localHeader.readUInt32LE(14);
+    const localCompressedBytes = localHeader.readUInt32LE(18);
+    const localUncompressedBytes = localHeader.readUInt32LE(22);
+    const localNameLength = localHeader.readUInt16LE(26);
+    const localExtraLength = localHeader.readUInt16LE(28);
+    const dataOffset =
+      entry.localHeaderOffset + 30 + localNameLength + localExtraLength;
+    const spanEnd = dataOffset + entry.compressedBytes;
+    if (
+      !Number.isSafeInteger(dataOffset) ||
+      !Number.isSafeInteger(spanEnd) ||
+      dataOffset > centralDirectoryOffset ||
+      spanEnd > centralDirectoryOffset ||
+      spanEnd < dataOffset
+    ) {
+      throw new SafeArchiveError("entry_span_invalid");
+    }
+    const localName = await readExactly(
+      handle,
+      entry.localHeaderOffset + 30,
+      localNameLength,
+    );
+    const localExtra = await readExactly(
+      handle,
+      entry.localHeaderOffset + 30 + localNameLength,
+      localExtraLength,
+    );
+    if (
+      localFlags !== entry.generalPurposeFlags ||
+      localCompression !== entry.compressionMethod ||
+      localCrc32 !== entry.crc32 ||
+      localCompressedBytes !== entry.compressedBytes ||
+      localUncompressedBytes !== entry.uncompressedBytes ||
+      !localName.equals(entry.nameBytes)
+    ) {
+      throw new SafeArchiveError("entry_local_header_mismatch");
+    }
+    if (hasExtraField(localExtra, ZIP64_EXTRA_FIELD_ID)) {
+      throw new SafeArchiveError("entry_zip64_rejected");
+    }
+    if (hasExtraField(localExtra, UNICODE_PATH_EXTRA_FIELD_ID)) {
+      throw new SafeArchiveError("entry_unicode_path_override_rejected");
+    }
+    if (hasExtraField(localExtra, AES_EXTRA_FIELD_ID)) {
+      throw new SafeArchiveError("entry_encrypted_rejected");
+    }
+    entry.dataOffset = dataOffset;
+    entry.spanEnd = spanEnd;
+  }
+  const spans = [...entries].sort(
+    (left, right) => left.localHeaderOffset - right.localHeaderOffset,
+  );
+  let claimedThrough = 0;
+  for (const entry of spans) {
+    if (entry.localHeaderOffset !== claimedThrough) {
+      throw new SafeArchiveError("entry_span_gap");
+    }
+    claimedThrough = entry.spanEnd;
+  }
+  if (claimedThrough !== centralDirectoryOffset) {
+    throw new SafeArchiveError("entry_span_gap");
+  }
+  return {
+    centralDirectoryOffset,
+    entries,
+    directoryEntryCount,
+    unsupportedEntryCount,
+    advertisedCompressedBytes,
+    advertisedUncompressedBytes,
+  };
+}
+
+let crcTable: Uint32Array | undefined;
+
+function crc32(buffer: Buffer): number {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let index = 0; index < 256; index++) {
+      let value = index;
+      for (let bit = 0; bit < 8; bit++) {
+        value = (value & 1) !== 0 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+      }
+      crcTable[index] = value >>> 0;
+    }
+  }
+  let value = 0xffffffff;
+  for (const byte of buffer) {
+    value = crcTable[(value ^ byte) & 0xff]! ^ (value >>> 8);
+  }
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+function categorizeCsvError(error: string): SafeCsvErrorCategory {
+  const normalized = error.toLowerCase();
+  if (
+    normalized.includes("unterminated quoted") ||
+    normalized === "unterminated_quote"
+  ) {
+    return "unterminated_quote";
+  }
+  if (normalized.includes("duplicate columns")) return "duplicate_header";
+  if (normalized.includes("header column")) return "invalid_header";
+  if (normalized.includes("columns; expected")) return "extra_columns";
+  if (normalized.includes("missing a recognized")) return "missing_column";
+  if (
+    normalized.includes("csv is empty") ||
+    normalized.includes("no data rows")
+  ) {
+    return "empty_csv";
+  }
+  if (
+    normalized.includes("owner reference") ||
+    normalized.includes("patient id or owner") ||
+    normalized.includes("external client id is required")
+  ) {
+    return "missing_identity";
+  }
+  if (normalized.includes("email is not a valid")) return "invalid_email";
+  if (normalized.includes("external id is too long")) {
+    return "external_id_too_long";
+  }
+  if (
+    normalized.includes("name is required") ||
+    normalized.includes("firstname and lastname")
+  ) {
+    return "missing_name";
+  }
+  if (normalized.includes("species must be")) return "invalid_species";
+  if (
+    normalized.includes("must be a date") ||
+    normalized.includes("read as a date")
+  ) {
+    return "invalid_date";
+  }
+  if (normalized.includes("needs at least one note")) return "missing_content";
+  if (normalized.includes("too long")) return "field_too_long";
+  return "other";
+}
+
+function errorCategoryCounts(
+  errors: readonly string[],
+): Partial<Record<SafeCsvErrorCategory, number>> {
+  const counts: Partial<Record<SafeCsvErrorCategory, number>> = {};
+  for (const error of errors) {
+    const category = categorizeCsvError(error);
+    counts[category] = (counts[category] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function preflightOnlyFailure(errors: readonly string[]): boolean {
+  return errors.some((error) => {
+    const normalized = error.toLowerCase();
+    return (
+      normalized.startsWith("csv is missing") ||
+      normalized.startsWith("csv is empty") ||
+      normalized.includes("no data rows")
+    );
+  });
+}
+
+export function scanBoundedCsvStructure(text: string): {
+  logicalRecords: number;
+  maximumColumns: number;
+  totalCells: number;
+  unterminatedQuote: boolean;
+  exceedsLimits: boolean;
+} {
+  let completedCells = 0;
+  let currentColumns = 1;
+  let logicalRecords = 0;
+  let maximumColumns = 1;
+  let inQuotes = false;
+  let currentRecordHasInput = false;
+
+  for (let index = 0; index < text.length; index++) {
+    const character = text[index]!;
+    currentRecordHasInput = true;
+    if (inQuotes) {
+      if (character === '"') {
+        if (text[index + 1] === '"') {
+          index++;
+        } else {
+          inQuotes = false;
+        }
+      }
+      continue;
+    }
+    if (character === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (character === ",") {
+      currentColumns++;
+      maximumColumns = Math.max(maximumColumns, currentColumns);
+      if (
+        currentColumns > MIGRATION_ARCHIVE_LIMITS.csvColumnsPerRecord ||
+        completedCells + currentColumns > MIGRATION_ARCHIVE_LIMITS.csvTotalCells
+      ) {
+        return {
+          logicalRecords,
+          maximumColumns,
+          totalCells: completedCells + currentColumns,
+          unterminatedQuote: false,
+          exceedsLimits: true,
+        };
+      }
+      continue;
+    }
+    if (character === "\n" || character === "\r") {
+      if (character === "\r" && text[index + 1] === "\n") index++;
+      logicalRecords++;
+      completedCells += currentColumns;
+      if (
+        logicalRecords > MIGRATION_ARCHIVE_LIMITS.csvLogicalRecords ||
+        completedCells > MIGRATION_ARCHIVE_LIMITS.csvTotalCells
+      ) {
+        return {
+          logicalRecords,
+          maximumColumns,
+          totalCells: completedCells,
+          unterminatedQuote: false,
+          exceedsLimits: true,
+        };
+      }
+      currentColumns = 1;
+      currentRecordHasInput = false;
+    }
+  }
+  if (inQuotes) {
+    return {
+      logicalRecords,
+      maximumColumns,
+      totalCells: completedCells,
+      unterminatedQuote: true,
+      exceedsLimits: false,
+    };
+  }
+  if (currentRecordHasInput) {
+    logicalRecords++;
+    completedCells += currentColumns;
+  }
+  return {
+    logicalRecords,
+    maximumColumns,
+    totalCells: completedCells,
+    unterminatedQuote: false,
+    exceedsLimits:
+      logicalRecords > MIGRATION_ARCHIVE_LIMITS.csvLogicalRecords ||
+      completedCells > MIGRATION_ARCHIVE_LIMITS.csvTotalCells,
+  };
+}
+
+function classifyCsv(text: string): {
+  sourceRows: number | null;
+  validRows: number;
+  errors: string[];
+  modeCandidates: MigrationImportMode[];
+  inferredMode: MigrationImportMode | null;
+  blockerCodes: ArchiveBlockerCode[];
+} {
+  const structuralScan = scanBoundedCsvStructure(text);
+  if (structuralScan.exceedsLimits) {
+    return {
+      sourceRows: null,
+      validRows: 0,
+      errors: [],
+      modeCandidates: [],
+      inferredMode: null,
+      blockerCodes: ["candidate_csv_structure_limit_exceeded"],
+    };
+  }
+  if (structuralScan.unterminatedQuote) {
+    return {
+      sourceRows: null,
+      validRows: 0,
+      errors: ["unterminated_quote"],
+      modeCandidates: [],
+      inferredMode: null,
+      blockerCodes: ["candidate_csv_invalid"],
+    };
+  }
+  const parsed = parseCsv(text);
+  if (parsed.errors.length > 0) {
+    return {
+      sourceRows: null,
+      validRows: 0,
+      errors: parsed.errors,
+      modeCandidates: [],
+      inferredMode: null,
+      blockerCodes: ["candidate_csv_invalid"],
+    };
+  }
+  if (parsed.rows.length > IMPORT_MAX_ROWS) {
+    return {
+      sourceRows: parsed.rows.length,
+      validRows: 0,
+      errors: [],
+      modeCandidates: [],
+      inferredMode: null,
+      blockerCodes: ["candidate_row_limit_exceeded"],
+    };
+  }
+  const attempts = [
+    { mode: "clients" as const, result: csvToClientRecords(text) },
+    { mode: "patients" as const, result: csvToPatientRecords(text) },
+    { mode: "vaccinations" as const, result: csvToVaccinationRecords(text) },
+    { mode: "soapNotes" as const, result: csvToSoapNoteRecords(text) },
+  ];
+  const matches = attempts.filter(
+    ({ result }) => !preflightOnlyFailure(result.errors),
+  );
+  if (matches.length === 0) {
+    return {
+      sourceRows: parsed.rows.length,
+      validRows: 0,
+      errors: [],
+      modeCandidates: [],
+      inferredMode: null,
+      blockerCodes: ["candidate_schema_unrecognized"],
+    };
+  }
+  if (matches.length > 1) {
+    return {
+      sourceRows: parsed.rows.length,
+      validRows: 0,
+      errors: [],
+      modeCandidates: matches.map(({ mode }) => mode),
+      inferredMode: null,
+      blockerCodes: ["candidate_schema_ambiguous"],
+    };
+  }
+  const match = matches[0]!;
+  return {
+    sourceRows: parsed.rows.length,
+    validRows: match.result.records.length,
+    errors: match.result.errors,
+    modeCandidates: [match.mode],
+    inferredMode: match.mode,
+    blockerCodes: [],
+  };
+}
+
+async function inspectCsvCandidate(
+  handle: FileHandle,
+  centralDirectoryOffset: number,
+  entry: CentralDirectoryEntry,
+  opaqueId: string,
+): Promise<ArchiveCandidateEvidence> {
+  const base: ArchiveCandidateEvidence = {
+    opaqueId,
+    compressedBytes: entry.compressedBytes,
+    uncompressedBytes: entry.uncompressedBytes,
+    contentSha256: null,
+    crcVerified: false,
+    utf8Valid: false,
+    sourceRows: null,
+    validRows: 0,
+    errorCount: 0,
+    errorCategories: {},
+    modeCandidates: [],
+    inferredMode: null,
+    status: "blocked",
+    blockerCodes: [],
+    duplicateContent: false,
+  };
+  try {
+    if (
+      entry.compressedBytes > MIGRATION_ARCHIVE_LIMITS.candidateCompressedBytes
+    ) {
+      throw new SafeArchiveError("candidate_compressed_too_large");
+    }
+    if (entry.uncompressedBytes > IMPORT_CSV_MAX_BYTES) {
+      throw new SafeArchiveError("candidate_output_too_large");
+    }
+    if (
+      candidateCompressionRatioExceedsLimit(
+        entry.compressedBytes,
+        entry.uncompressedBytes,
+      )
+    ) {
+      throw new SafeArchiveError("candidate_ratio_too_large");
+    }
+
+    if (
+      entry.dataOffset >= centralDirectoryOffset ||
+      entry.spanEnd > centralDirectoryOffset
+    ) {
+      throw new SafeArchiveError("candidate_data_out_of_bounds");
+    }
+    const compressed = await readExactly(
+      handle,
+      entry.dataOffset,
+      entry.compressedBytes,
+    );
+    let output: Buffer;
+    if (entry.compressionMethod === 0) {
+      output = compressed;
+    } else {
+      try {
+        // Node returns this documented shape for `info: true`, but the current
+        // @types/node sync overload still declares Buffer for every option.
+        const inflated = inflateRawSync(compressed, {
+          maxOutputLength: IMPORT_CSV_MAX_BYTES + 1,
+          info: true,
+        }) as unknown as {
+          buffer: Buffer;
+          engine: { bytesWritten: number };
+        };
+        if (inflated.engine.bytesWritten !== compressed.length) {
+          throw new SafeArchiveError("candidate_trailing_data_rejected");
+        }
+        output = inflated.buffer;
+      } catch (error) {
+        if (error instanceof SafeArchiveError) throw error;
+        const code = (error as { code?: string } | null)?.code;
+        if (code === "ERR_BUFFER_TOO_LARGE") {
+          throw new SafeArchiveError("candidate_output_too_large");
+        }
+        throw new SafeArchiveError("candidate_decompression_failed");
+      }
+    }
+    if (output.length > IMPORT_CSV_MAX_BYTES) {
+      throw new SafeArchiveError("candidate_output_too_large");
+    }
+    if (output.length !== entry.uncompressedBytes) {
+      throw new SafeArchiveError("candidate_size_mismatch");
+    }
+    if (
+      candidateCompressionRatioExceedsLimit(compressed.length, output.length)
+    ) {
+      throw new SafeArchiveError("candidate_ratio_too_large");
+    }
+    if (crc32(output) !== entry.crc32) {
+      throw new SafeArchiveError("candidate_crc_mismatch");
+    }
+    base.crcVerified = true;
+    base.contentSha256 = createHash("sha256").update(output).digest("hex");
+    if (
+      output.length >= 4 &&
+      output.readUInt32LE(0) === LOCAL_FILE_HEADER_SIGNATURE
+    ) {
+      throw new SafeArchiveError("nested_archive_rejected");
+    }
+    let text: string;
+    try {
+      text = new TextDecoder("utf-8", { fatal: true }).decode(output);
+    } catch {
+      throw new SafeArchiveError("candidate_utf8_invalid");
+    }
+    base.utf8Valid = true;
+    const classification = classifyCsv(text);
+    base.sourceRows = classification.sourceRows;
+    base.validRows = classification.validRows;
+    base.errorCount = classification.errors.length;
+    base.errorCategories = errorCategoryCounts(classification.errors);
+    base.modeCandidates = classification.modeCandidates;
+    base.inferredMode = classification.inferredMode;
+    base.blockerCodes = classification.blockerCodes;
+    base.status =
+      classification.blockerCodes.length > 0
+        ? "blocked"
+        : classification.errors.length > 0
+          ? "review_required"
+          : "valid";
+    return base;
+  } catch (error) {
+    base.blockerCodes = [safeError(error).code];
+    return base;
+  }
+}
+
+async function processArchive(
+  path: string,
+  alias: string,
+  consumedEntryCount: number,
+  aggregateEntryLimit: number,
+  remainingCandidateBudget: number,
+  testHooks?: MigrationArchivePreflightTestHooks,
+): Promise<ArchiveEvidence> {
+  const evidence: ArchiveEvidence = {
+    alias,
+    archiveSha256: null,
+    archiveBytes: null,
+    entryCount: 0,
+    directoryEntryCount: 0,
+    csvCandidateCount: 0,
+    unsupportedEntryCount: 0,
+    advertisedCompressedBytes: 0,
+    advertisedUncompressedBytes: 0,
+    status: "blocked",
+    blockerCodes: [],
+    candidates: [],
+  };
+  let handle: FileHandle | undefined;
+  try {
+    try {
+      handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    } catch (error) {
+      if ((error as { code?: string } | null)?.code === "ELOOP") {
+        throw new SafeArchiveError("input_symlink_rejected");
+      }
+      throw new SafeArchiveError("input_read_failed");
+    }
+    const pathStat = await handle.stat();
+    if (!pathStat.isFile()) {
+      throw new SafeArchiveError("input_not_regular_file");
+    }
+    if (typeof process.getuid !== "function") {
+      throw new SafeArchiveError("input_owner_check_unavailable");
+    }
+    if (pathStat.uid !== process.getuid()) {
+      throw new SafeArchiveError("input_owner_mismatch");
+    }
+    if ((pathStat.mode & 0o077) !== 0) {
+      throw new SafeArchiveError("input_permissions_too_open");
+    }
+    evidence.archiveBytes = pathStat.size;
+    if (pathStat.size > MIGRATION_ARCHIVE_LIMITS.archiveBytes) {
+      throw new SafeArchiveError("archive_too_large");
+    }
+    const initialHash = await sha256FileHandle(handle, pathStat.size);
+    evidence.archiveSha256 = initialHash;
+    await testHooks?.afterArchiveInitialHash?.({ alias });
+    const inspected = await inspectArchive(
+      handle,
+      pathStat.size,
+      (declaredEntryCount) => {
+        // A blocked overflow declaration remains visible and is consumed by
+        // the outer manifest loop, keeping exhaustion monotonic.
+        evidence.entryCount = declaredEntryCount;
+        if (
+          aggregateArchiveEntryBudgetExceeded(
+            consumedEntryCount,
+            declaredEntryCount,
+            aggregateEntryLimit,
+          )
+        ) {
+          throw new SafeArchiveError("aggregate_entry_limit_exceeded");
+        }
+      },
+    );
+    evidence.entryCount = inspected.entries.length;
+    evidence.directoryEntryCount = inspected.directoryEntryCount;
+    evidence.unsupportedEntryCount = inspected.unsupportedEntryCount;
+    evidence.advertisedCompressedBytes = inspected.advertisedCompressedBytes;
+    evidence.advertisedUncompressedBytes =
+      inspected.advertisedUncompressedBytes;
+    const candidates = inspected.entries.filter((entry) => entry.isCsv);
+    if (
+      candidates.length > MIGRATION_ARCHIVE_LIMITS.csvCandidatesPerArchive ||
+      candidates.length > remainingCandidateBudget
+    ) {
+      throw new SafeArchiveError("csv_candidate_limit_exceeded");
+    }
+    evidence.csvCandidateCount = candidates.length;
+    for (let index = 0; index < candidates.length; index++) {
+      evidence.candidates.push(
+        await inspectCsvCandidate(
+          handle,
+          inspected.centralDirectoryOffset,
+          candidates[index]!,
+          `${alias}-entry-${String(index + 1).padStart(6, "0")}`,
+        ),
+      );
+    }
+    const finalHash = await sha256FileHandle(handle, pathStat.size);
+    const finalStat = await handle.stat();
+    if (
+      finalHash !== initialHash ||
+      finalStat.size !== pathStat.size ||
+      finalStat.mtimeMs !== pathStat.mtimeMs ||
+      finalStat.ctimeMs !== pathStat.ctimeMs
+    ) {
+      throw new SafeArchiveError("input_changed_during_read");
+    }
+    const candidateBlocked = evidence.candidates.flatMap(
+      (candidate) => candidate.blockerCodes,
+    );
+    evidence.blockerCodes = [...new Set(candidateBlocked)].sort();
+    evidence.status =
+      evidence.blockerCodes.length > 0
+        ? "blocked"
+        : evidence.candidates.some(
+              (candidate) => candidate.status === "review_required",
+            )
+          ? "review_required"
+          : "safe";
+    return evidence;
+  } catch (error) {
+    evidence.blockerCodes = [safeError(error).code];
+    evidence.status = "blocked";
+    evidence.candidates = [];
+    evidence.csvCandidateCount = 0;
+    return evidence;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+export async function preflightMigrationArchives(
+  archivePaths: readonly string[],
+  now: Date = new Date(),
+  testHooks?: MigrationArchivePreflightTestHooks,
+): Promise<MigrationArchivePreflightEvidence> {
+  const archives: ArchiveEvidence[] = [];
+  let consumedEntries = 0;
+  let consumedCandidates = 0;
+  const aggregateEntryLimit =
+    testHooks?.aggregateEntryLimitOverride ??
+    MIGRATION_ARCHIVE_LIMITS.aggregateEntries;
+  for (let index = 0; index < archivePaths.length; index++) {
+    const archive = await processArchive(
+      archivePaths[index]!,
+      `archive-${String(index + 1).padStart(2, "0")}`,
+      consumedEntries,
+      aggregateEntryLimit,
+      MIGRATION_ARCHIVE_LIMITS.aggregateCsvCandidates - consumedCandidates,
+      testHooks,
+    );
+    archives.push(archive);
+    consumedEntries += archive.entryCount;
+    consumedCandidates += archive.csvCandidateCount;
+  }
+  const byContentHash = new Map<string, ArchiveCandidateEvidence[]>();
+  for (const candidate of archives.flatMap((archive) => archive.candidates)) {
+    if (!candidate.contentSha256) continue;
+    const matches = byContentHash.get(candidate.contentSha256) ?? [];
+    matches.push(candidate);
+    byContentHash.set(candidate.contentSha256, matches);
+  }
+  let exactDuplicateCandidateCount = 0;
+  for (const matches of byContentHash.values()) {
+    if (matches.length < 2) continue;
+    exactDuplicateCandidateCount += matches.length - 1;
+    for (const match of matches) match.duplicateContent = true;
+  }
+  const allCandidates = archives.flatMap((archive) => archive.candidates);
+  return {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    tool: "openvpm_migration_archive_preflight",
+    source: "shepherd",
+    networkUsed: false,
+    databaseUsed: false,
+    archiveExtractionUsed: false,
+    authoritativeImportClaim: false,
+    limits: {
+      ...MIGRATION_ARCHIVE_LIMITS,
+      csvBytes: IMPORT_CSV_MAX_BYTES,
+      csvRows: IMPORT_MAX_ROWS,
+    },
+    archives,
+    exactDuplicateCandidateCount,
+    safeToContinueOfflineReview: archives.every(
+      (archive) => archive.status !== "blocked",
+    ),
+    readyForAuthoritativeCsvPreview:
+      allCandidates.length > 0 &&
+      archives.every((archive) => archive.status === "safe") &&
+      allCandidates.every(
+        (candidate) =>
+          candidate.status === "valid" && !candidate.duplicateContent,
+      ),
+    requiresUnsupportedDataReview: archives.some(
+      (archive) => archive.unsupportedEntryCount > 0,
+    ),
+  };
+}
+
+export async function writeMigrationArchiveEvidence(
+  evidencePath: string,
+  evidence: MigrationArchivePreflightEvidence,
+): Promise<void> {
+  const handle = await open(evidencePath, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+    await handle.sync();
+    await handle.chmod(0o600);
+  } finally {
+    await handle.close();
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:sms-concurrency": "MESSAGING_PROVISIONING_ENABLED=false MESSAGING_INBOUND_ENABLED=false MESSAGING_SENDING_ENABLED=false SMS_CONCURRENCY_DB_INTEGRATION=1 vitest run lib/messaging/__tests__/sms-concurrency-drill.integration.test.ts",
+    "migration:preflight-archives": "tsx scripts/preflight-migration-archives.ts",
     "backup:verify-evidence": "node scripts/verify-backup-evidence.mjs",
     "backup:recover-practice": "tsx scripts/recover-practice.ts"
   },

--- a/apps/web/scripts/preflight-migration-archives.ts
+++ b/apps/web/scripts/preflight-migration-archives.ts
@@ -1,0 +1,261 @@
+import { constants as fsConstants } from "node:fs";
+import { open, realpath, stat } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  preflightMigrationArchives,
+  writeMigrationArchiveEvidence,
+} from "../lib/import/archive-preflight";
+
+export const MIGRATION_ARCHIVE_MANIFEST_LIMITS = {
+  bytes: 64_000,
+  archives: 32,
+  pathCharacters: 4_096,
+} as const;
+
+export type MigrationArchiveManifestTestHooks = {
+  /** Test-only synchronization point. Production callers must leave this unset. */
+  afterManifestFirstRead?: () => void | Promise<void>;
+};
+
+type MigrationArchiveCliArgs = {
+  manifestPath: string;
+};
+
+export type ValidatedMigrationArchiveCliPaths = {
+  archivePaths: string[];
+  evidencePath: string;
+};
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  pnpm migration:preflight-archives --manifest /private/archive-manifest.json",
+    "",
+    "The private manifest contains archive paths so source paths never appear in process arguments.",
+    "Manifest, archive, and evidence paths must be outside the repository.",
+  ].join("\n");
+}
+
+function parseArgs(argv: readonly string[]): MigrationArchiveCliArgs {
+  let manifestPath: string | undefined;
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    }
+    if (argument === "--manifest") {
+      const value = argv[++index];
+      if (!value || manifestPath) throw new Error("invalid_arguments");
+      manifestPath = value;
+      continue;
+    }
+    throw new Error("invalid_arguments");
+  }
+  if (!manifestPath) throw new Error("invalid_arguments");
+  if (!isAbsolute(manifestPath)) throw new Error("absolute_paths_required");
+  return { manifestPath };
+}
+
+function isWithin(root: string, target: string): boolean {
+  const pathFromRoot = relative(root, target);
+  return (
+    pathFromRoot === "" ||
+    (!pathFromRoot.startsWith(`..${sep}`) && pathFromRoot !== "..")
+  );
+}
+
+async function canonicalPathWithoutFollowingFinalComponent(
+  path: string,
+  repositoryRoot: string,
+): Promise<string> {
+  if (path.endsWith(sep)) throw new Error("file_path_required");
+  const name = basename(path);
+  if (!name || name === "." || name === "..") {
+    throw new Error("file_path_required");
+  }
+  const canonicalParent = await realpath(dirname(path));
+  const canonicalPath = resolve(canonicalParent, name);
+  if (isWithin(repositoryRoot, canonicalPath)) {
+    throw new Error("repository_paths_rejected");
+  }
+  const parentStat = await stat(canonicalParent);
+  if (
+    typeof process.getuid !== "function" ||
+    parentStat.uid !== process.getuid() ||
+    (parentStat.mode & 0o077) !== 0
+  ) {
+    throw new Error("private_parent_required");
+  }
+  return canonicalPath;
+}
+
+async function readPrivateManifest(
+  manifestPath: string,
+  testHooks?: MigrationArchiveManifestTestHooks,
+): Promise<{
+  archives: string[];
+  evidence: string;
+}> {
+  let handle: FileHandle | undefined;
+  try {
+    try {
+      handle = await open(
+        manifestPath,
+        fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+      );
+    } catch (error) {
+      if ((error as { code?: string } | null)?.code === "ELOOP") {
+        throw new Error("manifest_symlink_rejected");
+      }
+      throw error;
+    }
+    const before = await handle.stat();
+    if (!before.isFile()) throw new Error("manifest_not_regular");
+    if (
+      typeof process.getuid !== "function" ||
+      before.uid !== process.getuid()
+    ) {
+      throw new Error("manifest_owner_invalid");
+    }
+    if ((before.mode & 0o077) !== 0) {
+      throw new Error("manifest_permissions_invalid");
+    }
+    if (
+      before.size < 1 ||
+      before.size > MIGRATION_ARCHIVE_MANIFEST_LIMITS.bytes
+    ) {
+      throw new Error("manifest_size_invalid");
+    }
+    const first = Buffer.alloc(before.size);
+    const firstRead = await handle.read(first, 0, first.length, 0);
+    if (firstRead.bytesRead !== first.length)
+      throw new Error("manifest_changed");
+    await testHooks?.afterManifestFirstRead?.();
+    const second = Buffer.alloc(before.size);
+    const secondRead = await handle.read(second, 0, second.length, 0);
+    if (secondRead.bytesRead !== second.length || !second.equals(first)) {
+      throw new Error("manifest_changed");
+    }
+    const after = await handle.stat();
+    if (
+      after.size !== before.size ||
+      after.mtimeMs !== before.mtimeMs ||
+      after.ctimeMs !== before.ctimeMs
+    ) {
+      throw new Error("manifest_changed");
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(
+        new TextDecoder("utf-8", { fatal: true }).decode(first),
+      );
+    } catch {
+      throw new Error("manifest_invalid");
+    }
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      Object.keys(parsed).length !== 2 ||
+      !Object.prototype.hasOwnProperty.call(parsed, "archives") ||
+      !Object.prototype.hasOwnProperty.call(parsed, "evidence")
+    ) {
+      throw new Error("manifest_invalid");
+    }
+    const manifest = parsed as { archives?: unknown; evidence?: unknown };
+    const archives = manifest.archives;
+    if (
+      !Array.isArray(archives) ||
+      archives.length < 1 ||
+      archives.length > MIGRATION_ARCHIVE_MANIFEST_LIMITS.archives ||
+      archives.some(
+        (path) =>
+          typeof path !== "string" ||
+          path.length < 1 ||
+          path.length > MIGRATION_ARCHIVE_MANIFEST_LIMITS.pathCharacters ||
+          path.includes("\0") ||
+          !isAbsolute(path),
+      ) ||
+      new Set(archives).size !== archives.length
+    ) {
+      throw new Error("manifest_invalid");
+    }
+    if (
+      typeof manifest.evidence !== "string" ||
+      manifest.evidence.length < 1 ||
+      manifest.evidence.length >
+        MIGRATION_ARCHIVE_MANIFEST_LIMITS.pathCharacters ||
+      manifest.evidence.includes("\0") ||
+      !isAbsolute(manifest.evidence)
+    ) {
+      throw new Error("manifest_invalid");
+    }
+    return { archives: archives as string[], evidence: manifest.evidence };
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+export async function validatedMigrationArchiveCliPaths(
+  input: MigrationArchiveCliArgs,
+  testHooks?: MigrationArchiveManifestTestHooks,
+): Promise<ValidatedMigrationArchiveCliPaths> {
+  const repositoryRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../..",
+  );
+  const manifestPath = await canonicalPathWithoutFollowingFinalComponent(
+    input.manifestPath,
+    repositoryRoot,
+  );
+  const manifest = await readPrivateManifest(manifestPath, testHooks);
+  const archivePaths = await Promise.all(
+    manifest.archives.map((archivePath) =>
+      canonicalPathWithoutFollowingFinalComponent(archivePath, repositoryRoot),
+    ),
+  );
+  if (new Set(archivePaths).size !== archivePaths.length) {
+    throw new Error("manifest_duplicate_archives");
+  }
+  const evidencePath = await canonicalPathWithoutFollowingFinalComponent(
+    manifest.evidence,
+    repositoryRoot,
+  );
+  if (archivePaths.includes(evidencePath)) {
+    throw new Error("evidence_archive_collision");
+  }
+  return { archivePaths, evidencePath };
+}
+
+async function main(): Promise<void> {
+  process.umask(0o077);
+  const input = await validatedMigrationArchiveCliPaths(
+    parseArgs(process.argv.slice(2)),
+  );
+  const evidence = await preflightMigrationArchives(input.archivePaths);
+  await writeMigrationArchiveEvidence(input.evidencePath, evidence);
+  process.stdout.write("Migration archive preflight complete.\n");
+  if (!evidence.safeToContinueOfflineReview) process.exitCode = 2;
+}
+
+if (
+  process.argv[1] &&
+  resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])
+) {
+  main().catch(() => {
+    process.stderr.write(
+      "Migration archive preflight could not complete safely. No archive details were printed.\n",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/docs/migrating-to-openvpm.md
+++ b/docs/migrating-to-openvpm.md
@@ -43,6 +43,12 @@ Headers are matched loosely (case, spaces, and underscores do not matter) and co
 - **Shepherd**: Reports → export client and patient lists as CSV. For your full record set, ask Shepherd support for your data export; Shepherd is cloud based, so support sends the files.
 - **Anything else**: any spreadsheet saved as CSV works. When in doubt, share a de-identified sample through the approved secure channel and we will confirm the mapping.
 
+For an approved assisted Shepherd full-export review, operators must first use
+the [Shepherd migration archive preflight](shepherd-migration-archive-preflight.md)
+to produce privacy-minimized structural evidence. That local preflight does not
+expand the self-serve importer, prove importability, or authorize a production
+write; the reviewed CSV dry run remains authoritative.
+
 ## Import order (it matters)
 
 1. **Clients first.** Pets link to owners by the persisted source client ID or email, so owners must exist before pets.

--- a/docs/shepherd-migration-archive-preflight.md
+++ b/docs/shepherd-migration-archive-preflight.md
@@ -1,0 +1,108 @@
+# Shepherd migration archive preflight
+
+This operator procedure inventories a clinic migration ZIP without extracting
+it. It runs locally, reads no database, makes no network request, and writes one
+aggregate evidence file with mode `0600`.
+
+It is a structural safety and CSV compatibility check. It is not proof that a
+file can be imported and it does not claim that unsupported records have been
+migrated.
+
+## Private workspace
+
+Use an encrypted, clinic-authorized workstation. Create a private directory
+outside the OpenVPM repository and outside cloud-synced folders. Keep the
+original archives there with permissions limited to the current user. The tool
+enforces that the containing private directory, manifest, and archives are
+owned by the current user and grant no permissions to group or other users. Use
+`chmod 700` for the containing directory and `chmod 600` for the manifest and
+archives as the recommended operator setup; more restrictive owner permissions
+also satisfy the privacy check. Do not put private names in any directory or
+filename. The evidence file is created with mode `0600`.
+
+The command rejects manifest, archive, and evidence paths inside the repository.
+It also rejects symbolic-link inputs and refuses to overwrite an evidence file.
+
+Create a `0600` manifest with this exact shape:
+
+```json
+{
+  "archives": [
+    "/absolute/private/path/archive-a.zip",
+    "/absolute/private/path/archive-b.zip"
+  ],
+  "evidence": "/absolute/private/path/preflight-evidence.json"
+}
+```
+
+The manifest keeps archive and evidence paths out of shell history and process
+listings. Give the manifest itself an opaque path.
+
+## Run
+
+From `apps/web`, use opaque local archive names:
+
+```sh
+pnpm migration:preflight-archives \
+  --manifest /absolute/private/path/archive-manifest.json
+```
+
+The terminal prints only a generic completion or failure message. It never
+prints input paths, entry names, CSV headers, source values, or parser errors.
+
+Exit status `0` means the archive structure is safe for the next review. Exit
+status `2` means the evidence was written but at least one archive was blocked.
+Exit status `1` means the command itself could not complete safely.
+
+## What is rejected
+
+The preflight rejects self-extracting, ZIP64, and multi-disk ZIPs; encrypted or
+unsupported ZIP flags and compression methods; data descriptors; recognized
+nested-archive names and ZIP magic in CSV candidates; absolute, Windows,
+backslash, empty, dot, or parent paths; NFKC-normalized, case-insensitive, and
+file/directory-prefix path collisions; symbolic links, special files, and
+directory payloads; malformed or non-contiguous local spans; CSV CRC failures;
+invalid UTF-8 CSVs; and bounded-size or CSV compression-ratio violations. It
+never uses archive entry paths to create files.
+
+CSV candidates must fit the same limits as the product: at most 5,000,000
+UTF-8 bytes and at most 10,000 source rows. Candidate bytes are held only in
+memory and passed through the existing client, patient, vaccination, and SOAP
+CSV mappers. Before that eager parser boundary, a quote-aware scan bounds input
+to 10,001 logical records including the header and blank records, 512 columns
+per logical record, and 1,000,000 total cells. Raw mapper errors are converted
+to fixed aggregate categories.
+
+Evidence growth is also bounded to 128 CSV candidates per archive and 256 CSV
+candidates across the manifest. Total advertised entries across the manifest
+are capped at 100,000.
+
+## Evidence review
+
+The JSON evidence contains only:
+
+- opaque archive and entry identifiers;
+- SHA-256 content identities, sizes, counts, and safety codes;
+- CRC and UTF-8 results;
+- supported import mode candidates and aggregate row/error counts;
+- exact duplicate-content counts across the supplied archives;
+- explicit `networkUsed`, `databaseUsed`, `archiveExtractionUsed`, and
+  `authoritativeImportClaim` flags.
+
+It contains no filenames, paths, headers, cell values, names, contact details,
+clinical notes, external identifiers, or raw parser messages. Do not commit the
+evidence file even though it is privacy-minimized.
+
+Unsupported non-CSV entry headers and spans are structurally validated, but
+their payloads are not decompressed, CRC-checked, content-hashed, or scanned for
+disguised nested formats. They remain opaque and are counted only. Their
+presence sets `requiresUnsupportedDataReview`; they must not be treated as
+migrated or content-verified.
+
+## Authoritative preview
+
+After the offline evidence and any required header mapping have been reviewed,
+use the platform's administrator CSV dry-run. Keep the migration source exactly
+`shepherd` and use the reviewed protocol. Process clients first, then patients,
+then vaccinations, then SOAP notes. The server preview is the authoritative
+duplicate, reconciliation, and unmatched-record plan; this offline tool is not.


### PR DESCRIPTION
## What changed

- add an operator-only, offline Shepherd ZIP preflight that never extracts archive contents
- require a private manifest so participant archive and evidence paths never appear in process arguments
- validate ZIP structure, entry paths/types, resource bounds, CRCs, UTF-8, and supported CSV shapes before reviewed import
- emit only bounded, opaque, privacy-minimized evidence with no filenames, headers, cells, identities, or row excerpts
- document the assisted migration boundary and add the package command
- add adversarial tests for archive bombs, path tricks, corruption, mutation races, CLI failure/redaction contracts, and exact resource limits

## Why

Shepherd full exports may arrive as ZIP archives containing participant data and attachments. We need a reviewable way to establish structural safety and identify supported CSV candidates without extracting files, leaking paths or content, claiming importability, or touching a database/network.

## Impact

Operators can generate local structural evidence before the existing reviewed CSV dry run. This does not expand the self-serve importer, inspect unsupported attachments as migrated data, or authorize production writes.

## Validation

- focused archive preflight suite: 49/49
- full web suite: 3,923 passed / 6 skipped (before the final aggregate-accounting regression)
- web TypeScript check
- Prettier
- tracked and untracked diff checks
- independent security/reliability re-review: no blocker
