### PR TITLE
Harden subscription conversion lifecycle

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1524,7 +1524,8 @@ function BillingTab() {
                   data.billingStatus === "trialing" &&
                     "bg-blue-100 text-blue-700",
                   data.billingStatus === "past_due" &&
-                    "bg-red-100 text-red-700",
+                    "bg-amber-100 text-amber-800",
+                  data.billingStatus === "unpaid" && "bg-red-100 text-red-700",
                   (data.billingStatus === "canceled" ||
                     data.billingStatus === "none") &&
                     "bg-gray-100 text-gray-600",
@@ -1613,9 +1614,10 @@ function BillingTab() {
           </div>
         )}
         {data.billingStatus === "past_due" && (
-          <p className="mt-3 text-sm text-red-600">
-            Your last payment failed. Update your payment method to restore
-            write access.
+          <p className="mt-3 text-sm text-amber-700">
+            Your last payment failed, and Stripe is retrying it. Your clinic
+            remains available; update your payment method to prevent an
+            interruption.
           </p>
         )}
         {showSyncNote && (

--- a/apps/web/app/api/webhooks/stripe-subscription/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe-subscription/route.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
     const result = selectResults.shift() ?? [];
     const builder = {
       from: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
       where: vi.fn(() => builder),
       limit: vi.fn(async () => result),
       then: (
@@ -42,7 +43,17 @@ const mocks = vi.hoisted(() => {
     syncPracticeSubscriptionQuantities: vi.fn(async () => ({ status: "ok" })),
     alertOps: vi.fn(async () => undefined),
     sendLifecycleEmail: vi.fn(
-      async (_opts: { send: () => Promise<unknown> }) => undefined,
+      async (_opts: {
+        send: () => Promise<unknown>;
+        stillEligible?: (tx: unknown) => Promise<boolean>;
+      }): Promise<{
+        sent: boolean;
+        deduped: boolean;
+        dedupeState?: "sent" | "in_flight" | "failed";
+      }> => ({
+        sent: true,
+        deduped: false,
+      }),
     ),
     sendPaymentReceiptEmail: vi.fn(async () => undefined),
     sendPaymentFailedEmail: vi.fn(async () => undefined),
@@ -156,7 +167,7 @@ function checkoutCompletedEvent() {
 }
 
 function stripeSubscription(
-  status: "trialing" | "active" = "active",
+  status: "trialing" | "active" | "past_due" | "unpaid" | "canceled" = "active",
   metadata: Record<string, string> = { practiceId: PRACTICE_ID },
 ) {
   return {
@@ -172,7 +183,7 @@ function stripeSubscription(
 }
 
 function subscriptionUpdatedEvent(
-  status: "trialing" | "active" = "active",
+  status: "trialing" | "active" | "past_due" | "unpaid" = "active",
   eventId = "evt_subscription",
 ) {
   return {
@@ -214,7 +225,7 @@ function invoicePaymentSucceededEvent(subscriptionId?: string) {
   };
 }
 
-function invoicePaymentFailedEvent() {
+function invoicePaymentFailedEvent(subscriptionId = SUBSCRIPTION_ID) {
   return {
     id: "evt_invoice_failed",
     type: "invoice.payment_failed",
@@ -228,6 +239,14 @@ function invoicePaymentFailedEvent() {
         next_payment_attempt: Math.floor(
           Date.parse("2026-07-01T02:00:00.000Z") / 1000,
         ),
+        parent: {
+          type: "subscription_details",
+          quote_details: null,
+          subscription_details: {
+            metadata: { practiceId: PRACTICE_ID },
+            subscription: subscriptionId,
+          },
+        },
       },
     },
   };
@@ -235,8 +254,15 @@ function invoicePaymentFailedEvent() {
 
 function invokeLifecycleSendOnce() {
   mocks.sendLifecycleEmail.mockImplementationOnce(
-    async (opts: { send: () => Promise<unknown> }) => {
+    async (opts: {
+      send: () => Promise<unknown>;
+      stillEligible?: (tx: unknown) => Promise<boolean>;
+    }) => {
+      if (opts.stillEligible && !(await opts.stillEligible(mocks.db))) {
+        return { sent: false, deduped: false };
+      }
       await opts.send();
+      return { sent: true, deduped: false };
     },
   );
 }
@@ -245,6 +271,18 @@ afterEach(() => {
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
   mocks.updateReturns.length = 0;
+  mocks.withSystem.mockImplementation(
+    async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.db),
+  );
+  mocks.sendLifecycleEmail.mockImplementation(
+    async (_opts: {
+      send: () => Promise<unknown>;
+      stillEligible?: (tx: unknown) => Promise<boolean>;
+    }) => ({
+      sent: true,
+      deduped: false,
+    }),
+  );
   mocks.claimStripeEvent.mockResolvedValue(true);
   mocks.attachStripeEventPractice.mockResolvedValue(undefined);
   mocks.projectStripeConversionMilestonesForEvent.mockResolvedValue(1);
@@ -346,6 +384,28 @@ describe("Stripe subscription webhook", () => {
     expect(mocks.syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
   });
 
+  it("does not let a delayed old Checkout replace a newer subscription identity", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      checkoutCompletedEvent(),
+    );
+    // The initial link CAS loses because the practice already stores another
+    // customer or subscription identity.
+    mocks.updateReturns.push([]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.retrieveSubscription).not.toHaveBeenCalled();
+    expect(mocks.attachStripeEventPractice).not.toHaveBeenCalled();
+    expect(mocks.syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
+    expect(ROUTE_SOURCE).toMatch(
+      /isNull\(practices\.stripeSubscriptionId\)[\s\S]*eq\(practices\.stripeSubscriptionId, subscriptionId\)/,
+    );
+    expect(ROUTE_SOURCE).toMatch(
+      /isNull\(practices\.stripeCustomerId\)[\s\S]*eq\(practices\.stripeCustomerId, customerId\)/,
+    );
+  });
+
   it("applies subscription updates only after touching an active practice", async () => {
     process.env.STRIPE_PRICE_CLOUD_LOCATION = PRICE_ID;
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
@@ -378,6 +438,78 @@ describe("Stripe subscription webhook", () => {
     expect(
       mocks.projectStripeConversionMilestonesForEvent,
     ).not.toHaveBeenCalled();
+  });
+
+  it("re-reads current Stripe state before applying an out-of-order subscription update", async () => {
+    process.env.STRIPE_PRICE_CLOUD_LOCATION = PRICE_ID;
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      subscriptionUpdatedEvent("past_due", "evt_stale_past_due"),
+    );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("unpaid"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.retrieveSubscription).toHaveBeenCalledWith(SUBSCRIPTION_ID);
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingStatus: "unpaid",
+        stripeSubscriptionId: SUBSCRIPTION_ID,
+      }),
+    );
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "past_due" }),
+    );
+  });
+
+  it("does not let an older subscription replace a newer stored identity", async () => {
+    const oldSubscriptionId = "sub_old";
+    const newSubscriptionId = "sub_new";
+    const event = subscriptionUpdatedEvent("active", "evt_old_subscription");
+    event.data.object.id = oldSubscriptionId;
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(event);
+    mocks.retrieveSubscription.mockResolvedValueOnce({
+      ...stripeSubscription("active"),
+      id: oldSubscriptionId,
+    });
+    // The identity-CAS update loses because the clinic now stores sub_new;
+    // the follow-up read classifies this as a stale old-subscription event.
+    mocks.updateReturns.push([]);
+    mocks.selectResults.push([{ stripeSubscriptionId: newSubscriptionId }]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
+    expect(ROUTE_SOURCE).toMatch(
+      /or\(\s*isNull\(practices\.stripeSubscriptionId\),\s*eq\(practices\.stripeSubscriptionId, sub\.id\)/s,
+    );
+  });
+
+  it("does not reattach a terminal subscription after its id was cleared", async () => {
+    const event = subscriptionUpdatedEvent(
+      "past_due",
+      "evt_delayed_terminal_subscription",
+    );
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(event);
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("canceled"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingStatus: "canceled",
+        stripeSubscriptionId: null,
+      }),
+    );
+    expect(mocks.syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
   });
 
   it("does not manufacture payment evidence from a zero-dollar invoice", async () => {
@@ -414,7 +546,9 @@ describe("Stripe subscription webhook", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ received: true });
     expect(mocks.retrieveSubscription).toHaveBeenCalledWith(SUBSCRIPTION_ID);
-    expect(mocks.select).not.toHaveBeenCalled();
+    // Post-commit delivery checks the exact event attribution and finds none;
+    // it never falls back from this strict subscription mapping to customer id.
+    expect(mocks.select).toHaveBeenCalledTimes(2);
     expect(mocks.attachStripeEventPractice).not.toHaveBeenCalled();
     expect(mocks.sendLifecycleEmail).not.toHaveBeenCalled();
     expect(
@@ -508,6 +642,9 @@ describe("Stripe subscription webhook", () => {
     const event = subscriptionUpdatedEvent();
     event.data.object.metadata = {};
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(event);
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("active", {}),
+    );
     mocks.selectResults.push([
       { id: PRACTICE_ID, stripeSubscriptionId: SUBSCRIPTION_ID },
     ]);
@@ -528,6 +665,9 @@ describe("Stripe subscription webhook", () => {
     const event = subscriptionUpdatedEvent();
     event.data.object.metadata = {};
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(event);
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("active", {}),
+    );
     mocks.selectResults.push([
       { id: PRACTICE_ID, stripeSubscriptionId: SUBSCRIPTION_ID },
       {
@@ -551,14 +691,15 @@ describe("Stripe subscription webhook", () => {
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
       invoicePaymentSucceededEvent(),
     );
-    mocks.selectResults.push([
-      {
-        id: PRACTICE_ID,
-        email: " Owner@Example.COM ",
-        name: "Westside Vet",
-        timezone: "America/Los_Angeles",
-      },
-    ]);
+    const practice = {
+      id: PRACTICE_ID,
+      email: " Owner@Example.COM ",
+      name: "Westside Vet",
+      timezone: "America/Los_Angeles",
+    };
+    // First resolve/attach the customer-only invoice inside the billing
+    // transaction, then re-read that durable event attribution post-commit.
+    mocks.selectResults.push([practice], [practice]);
     invokeLifecycleSendOnce();
 
     const response = await POST(stripeRequest());
@@ -570,6 +711,7 @@ describe("Stripe subscription webhook", () => {
         to: "owner@example.com",
         emailType: "receipt",
         dedupeKey: "lc:receipt:in_paid",
+        retryOnFail: true,
       }),
     );
     expect(mocks.sendPaymentReceiptEmail).toHaveBeenCalledWith({
@@ -578,7 +720,38 @@ describe("Stripe subscription webhook", () => {
       amount: "$79.00",
       periodLabel: "June 30, 2026 – July 31, 2026",
       invoiceUrl: "https://billing.stripe.test/in_paid",
+      idempotencyKey: "lc:receipt:in_paid",
     });
+  });
+
+  it("fails closed when a customer-only receipt maps to multiple active practices", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentSucceededEvent(),
+    );
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: "owner@example.com",
+        name: "Westside Vet",
+        timezone: "America/New_York",
+      },
+      {
+        id: "00000000-0000-0000-0000-0000000000bb",
+        email: "other@example.com",
+        name: "Other Vet",
+        timezone: "America/New_York",
+      },
+    ]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.attachStripeEventPractice).not.toHaveBeenCalled();
+    expect(mocks.sendLifecycleEmail).not.toHaveBeenCalled();
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Subscription webhook handler error",
+      expect.stringContaining("maps to multiple active practices"),
+    );
   });
 
   it("self-heals subscription state from a positive paid invoice", async () => {
@@ -634,6 +807,122 @@ describe("Stripe subscription webhook", () => {
     expect(mocks.sendPaymentReceiptEmail).toHaveBeenCalledOnce();
   });
 
+  it("delivers lifecycle email only after the billing transaction resolves", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentSucceededEvent(),
+    );
+    const practice = {
+      id: PRACTICE_ID,
+      email: "owner@example.com",
+      name: "Westside Vet",
+      timezone: "America/New_York",
+    };
+    mocks.selectResults.push([practice], [practice]);
+    let withSystemCalls = 0;
+    let billingTransactionResolved = false;
+    mocks.withSystem.mockImplementation(async (_db, fn) => {
+      withSystemCalls += 1;
+      const result = await fn(mocks.db);
+      if (withSystemCalls === 1) billingTransactionResolved = true;
+      return result;
+    });
+    mocks.sendLifecycleEmail.mockImplementationOnce(async (opts) => {
+      expect(billingTransactionResolved).toBe(true);
+      await opts.send();
+      return { sent: true, deduped: false };
+    });
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.withSystem).toHaveBeenCalledTimes(2);
+    expect(mocks.sendPaymentReceiptEmail).toHaveBeenCalledOnce();
+  });
+
+  it("uses durable event attribution to finish email on a duplicate Stripe delivery", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentSucceededEvent(),
+    );
+    mocks.claimStripeEvent.mockResolvedValueOnce(false);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: "owner@example.com",
+        name: "Westside Vet",
+        timezone: "America/New_York",
+      },
+    ]);
+    invokeLifecycleSendOnce();
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.attachStripeEventPractice).not.toHaveBeenCalled();
+    expect(mocks.sendPaymentReceiptEmail).toHaveBeenCalledOnce();
+  });
+
+  it("returns 500 while a duplicate lifecycle claim is still in flight", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentSucceededEvent(),
+    );
+    mocks.claimStripeEvent.mockResolvedValueOnce(false);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: "owner@example.com",
+        name: "Westside Vet",
+        timezone: "America/New_York",
+        billingStatus: "active",
+      },
+    ]);
+    mocks.sendLifecycleEmail.mockResolvedValueOnce({
+      sent: false,
+      deduped: true,
+      dedupeState: "in_flight",
+    });
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.sendPaymentReceiptEmail).not.toHaveBeenCalled();
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Subscription lifecycle delivery error",
+      expect.stringContaining("does not have a durable sent outcome"),
+    );
+  });
+
+  it("returns 500 so Stripe retries a post-commit lifecycle delivery failure", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentSucceededEvent(),
+    );
+    const practice = {
+      id: PRACTICE_ID,
+      email: "owner@example.com",
+      name: "Westside Vet",
+      timezone: "America/New_York",
+    };
+    mocks.selectResults.push([practice], [practice]);
+    mocks.sendLifecycleEmail.mockResolvedValueOnce({
+      sent: false,
+      deduped: false,
+    });
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Handler error" });
+    expect(mocks.attachStripeEventPractice).toHaveBeenCalledWith(mocks.db, {
+      eventId: "evt_invoice_paid",
+      endpoint: "subscription",
+      practiceId: PRACTICE_ID,
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Subscription lifecycle delivery error",
+      expect.stringContaining("failed after billing state committed"),
+    );
+  });
+
   it("skips subscription receipts when the billing contact is blank", async () => {
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
       invoicePaymentSucceededEvent(),
@@ -658,35 +947,54 @@ describe("Stripe subscription webhook", () => {
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
       invoicePaymentFailedEvent(),
     );
-    mocks.selectResults.push([
-      {
-        id: PRACTICE_ID,
-        email: " Owner@Example.COM ",
-        name: "Westside Vet",
-        timezone: "America/Los_Angeles",
-      },
-    ]);
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("past_due"),
+    );
+    mocks.selectResults.push(
+      [
+        {
+          id: PRACTICE_ID,
+          email: " Owner@Example.COM ",
+          name: "Westside Vet",
+          timezone: "America/Los_Angeles",
+          billingStatus: "past_due",
+        },
+      ],
+      [{ id: PRACTICE_ID }],
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
     invokeLifecycleSendOnce();
 
     const response = await POST(stripeRequest());
 
     await expect(response.json()).resolves.toEqual({ received: true });
-    expect(mocks.updateSet).toHaveBeenCalledWith({
-      billingStatus: "past_due",
-    });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingStatus: "past_due",
+        stripeSubscriptionId: SUBSCRIPTION_ID,
+      }),
+    );
+    expect(mocks.retrieveSubscription).toHaveBeenCalledWith(SUBSCRIPTION_ID);
     expect(mocks.sendLifecycleEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: PRACTICE_ID,
         to: "owner@example.com",
         emailType: "dunning",
         dedupeKey: "lc:dunning:in_failed:2",
+        retryOnFail: true,
       }),
     );
+    expect(mocks.attachStripeEventPractice).toHaveBeenCalledWith(mocks.db, {
+      eventId: "evt_invoice_failed",
+      endpoint: "subscription",
+      practiceId: PRACTICE_ID,
+    });
     expect(mocks.sendPaymentFailedEmail).toHaveBeenCalledWith({
       to: "owner@example.com",
       practiceName: "Westside Vet",
       amount: "$79.00",
       nextRetryDate: "June 30, 2026",
+      idempotencyKey: "lc:dunning:in_failed:2",
     });
   });
 
@@ -694,23 +1002,93 @@ describe("Stripe subscription webhook", () => {
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
       invoicePaymentFailedEvent(),
     );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("past_due"),
+    );
     mocks.selectResults.push([
       {
         id: PRACTICE_ID,
         email: "\t",
         name: "Westside Vet",
         timezone: "America/Los_Angeles",
+        billingStatus: "past_due",
+      },
+    ]);
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "past_due" }),
+    );
+    expect(mocks.sendLifecycleEmail).not.toHaveBeenCalled();
+    expect(mocks.sendPaymentFailedEmail).not.toHaveBeenCalled();
+  });
+
+  it("blocks stale dunning when final locked eligibility no longer matches", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentFailedEvent(),
+    );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("past_due"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+    mocks.selectResults.push(
+      [
+        {
+          id: PRACTICE_ID,
+          email: "owner@example.com",
+          name: "Westside Vet",
+          timezone: "America/New_York",
+          billingStatus: "past_due",
+        },
+      ],
+      [],
+    );
+    invokeLifecycleSendOnce();
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.sendPaymentFailedEmail).not.toHaveBeenCalled();
+    expect(mocks.sendLifecycleEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ stillEligible: expect.any(Function) }),
+    );
+  });
+
+  it("does not let a stale failed-invoice event reopen terminal unpaid access", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentFailedEvent(),
+    );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("unpaid"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: "owner@example.com",
+        name: "Westside Vet",
+        timezone: "America/New_York",
+        billingStatus: "unpaid",
       },
     ]);
 
     const response = await POST(stripeRequest());
 
-    await expect(response.json()).resolves.toEqual({ received: true });
-    expect(mocks.updateSet).toHaveBeenCalledWith({
-      billingStatus: "past_due",
-    });
+    expect(response.status).toBe(200);
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "unpaid" }),
+    );
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "past_due" }),
+    );
     expect(mocks.sendLifecycleEmail).not.toHaveBeenCalled();
-    expect(mocks.sendPaymentFailedEmail).not.toHaveBeenCalled();
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Subscription payment failed",
+      expect.stringContaining("current subscription state is unpaid"),
+    );
   });
 
   it("keeps destructive and customer webhook updates active-practice scoped", () => {

--- a/apps/web/app/api/webhooks/stripe-subscription/route.ts
+++ b/apps/web/app/api/webhooks/stripe-subscription/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, eq, isNull, or } from "drizzle-orm";
 import type Stripe from "stripe";
 import { db } from "@openpims/db/client";
-import { practices } from "@openpims/db";
+import { practices, stripeEvents } from "@openpims/db";
 import { constructSubscriptionWebhookEvent, stripe } from "@/lib/stripe";
 import {
   tierForStripePrice,
@@ -77,15 +77,17 @@ export async function POST(req: NextRequest) {
   }
 
   const conversionEvidence = conversionEvidenceForEvent(event);
+  let eventClaimed = false;
+  let failedSubscriptionStatus: string | null = null;
   try {
-    await withSystem(db, async (tx) => {
+    eventClaimed = await withSystem(db, async (tx) => {
       const claimed = await claimStripeEvent(tx, {
         eventId: event.id,
         endpoint: "subscription",
         eventType: event.type,
         ...(conversionEvidence ? { evidence: conversionEvidence } : {}),
       });
-      if (!claimed) return;
+      if (!claimed) return false;
 
       switch (event.type) {
         case "checkout.session.completed": {
@@ -98,15 +100,29 @@ export async function POST(req: NextRequest) {
               : (s.subscription?.id ?? null);
           let activePracticeId: string | null = null;
           if (practiceId && s.customer) {
+            const customerId =
+              typeof s.customer === "string" ? s.customer : s.customer.id;
             const [practice] = await tx
               .update(practices)
               .set({
-                stripeCustomerId:
-                  typeof s.customer === "string" ? s.customer : s.customer!.id,
+                stripeCustomerId: customerId,
                 stripeSubscriptionId: subscriptionId,
               })
               .where(
-                and(eq(practices.id, practiceId), isNull(practices.deletedAt)),
+                and(
+                  eq(practices.id, practiceId),
+                  isNull(practices.deletedAt),
+                  or(
+                    isNull(practices.stripeCustomerId),
+                    eq(practices.stripeCustomerId, customerId),
+                  ),
+                  subscriptionId
+                    ? or(
+                        isNull(practices.stripeSubscriptionId),
+                        eq(practices.stripeSubscriptionId, subscriptionId),
+                      )
+                    : isNull(practices.stripeSubscriptionId),
+                ),
               )
               .returning({ id: practices.id });
             activePracticeId = practice?.id ?? null;
@@ -145,7 +161,18 @@ export async function POST(req: NextRequest) {
 
         case "customer.subscription.created":
         case "customer.subscription.updated": {
-          await applySubscription(tx, event.data.object as Stripe.Subscription);
+          const historical = event.data.object as Stripe.Subscription;
+          if (!stripe) {
+            throw new Error(
+              "Stripe is unavailable while reconciling a subscription lifecycle event.",
+            );
+          }
+          // Stripe does not guarantee event order. The signed event proves a
+          // transition occurred, but only a current GET is authoritative for
+          // access. This prevents stale past_due/trialing callbacks from
+          // overwriting a newer unpaid/active/canceled state.
+          const current = await stripe.subscriptions.retrieve(historical.id);
+          await applySubscription(tx, current);
           break;
         }
 
@@ -196,35 +223,16 @@ export async function POST(req: NextRequest) {
                 subscription,
               );
             }
-            const practice = subscriptionPracticeId
-              ? await practiceById(tx, subscriptionPracticeId)
+            const practiceId = subscriptionPracticeId
+              ? subscriptionPracticeId
               : subscriptionId
                 ? null
-                : await practiceForCustomer(tx, customerId);
-            if (practice && conversionEvidence) {
+                : (await practiceForCustomer(tx, customerId))?.id;
+            if (practiceId) {
               await attachStripeEventPractice(tx, {
                 eventId: event.id,
                 endpoint: "subscription",
-                practiceId: practice.id,
-              });
-            }
-            const to = billingContactEmail(practice?.email);
-            if (practice && to) {
-              const practiceName = practice.name ?? "your practice";
-              await sendLifecycleEmail({
-                practiceId: practice.id,
-                to,
-                emailType: "receipt",
-                dedupeKey: `lc:receipt:${inv.id}`,
-                category: "transactional",
-                send: () =>
-                  sendPaymentReceiptEmail({
-                    to,
-                    practiceName,
-                    amount: formatMoney(inv.amount_paid, inv.currency),
-                    periodLabel: invoicePeriodLabel(inv, practice.timezone),
-                    invoiceUrl: inv.hosted_invoice_url ?? undefined,
-                  }),
+                practiceId,
               });
             }
           }
@@ -233,45 +241,29 @@ export async function POST(req: NextRequest) {
 
         case "invoice.payment_failed": {
           const inv = event.data.object as Stripe.Invoice;
-          const customerId =
-            typeof inv.customer === "string" ? inv.customer : inv.customer?.id;
-          if (customerId) {
-            await tx
-              .update(practices)
-              .set({ billingStatus: "past_due" })
-              .where(
-                and(
-                  eq(practices.stripeCustomerId, customerId),
-                  isNull(practices.deletedAt),
-                ),
-              );
-            await alertOps(
-              "Subscription payment failed",
-              `Stripe customer ${customerId} had a failed subscription payment; marked past_due.`,
+          const subscriptionId = subscriptionIdForInvoice(inv);
+          if (!subscriptionId) break;
+          if (!stripe) {
+            throw new Error(
+              "Stripe is unavailable while reconciling a failed invoice.",
             );
-            const practice = await practiceForCustomer(tx, customerId);
-            const to = billingContactEmail(practice?.email);
-            if (practice && to) {
-              const practiceName = practice.name ?? "your practice";
-              await sendLifecycleEmail({
-                practiceId: practice.id,
-                to,
-                emailType: "dunning",
-                // One dunning email per Stripe retry attempt.
-                dedupeKey: `lc:dunning:${inv.id}:${inv.attempt_count ?? 0}`,
-                category: "transactional",
-                send: () =>
-                  sendPaymentFailedEmail({
-                    to,
-                    practiceName,
-                    amount: formatMoney(inv.amount_due, inv.currency),
-                    nextRetryDate: formatUnixDate(
-                      inv.next_payment_attempt,
-                      practice.timezone,
-                    ),
-                  }),
-              });
-            }
+          }
+          // A failed-invoice callback is historical evidence, not current
+          // entitlement state. Re-read the subscription so a late callback
+          // cannot overwrite a newer active/unpaid/canceled status and reopen
+          // or close clinic writes out of order.
+          const subscription =
+            await stripe.subscriptions.retrieve(subscriptionId);
+          failedSubscriptionStatus = normalizeBillingStatus(
+            subscription.status,
+          );
+          const practiceId = await applySubscription(tx, subscription);
+          if (practiceId) {
+            await attachStripeEventPractice(tx, {
+              eventId: event.id,
+              endpoint: "subscription",
+              practiceId,
+            });
           }
           break;
         }
@@ -280,6 +272,7 @@ export async function POST(req: NextRequest) {
           // Ignore other event types.
           break;
       }
+      return true;
     });
   } catch (err) {
     console.error("[Stripe Subscription Webhook] handler error:", err);
@@ -287,6 +280,46 @@ export async function POST(req: NextRequest) {
       "Subscription webhook handler error",
       `Event ${event.type} failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+    return NextResponse.json({ error: "Handler error" }, { status: 500 });
+  }
+
+  // Lifecycle delivery deliberately runs only after the Stripe claim and
+  // subscription/practice mutations commit. sendLifecycleEmail takes its own
+  // practice-row recovery lock; awaiting it inside the transaction above
+  // would make that inner transaction wait on the outer practice update while
+  // the outer transaction waited for the email, a self-deadlock. Run this for
+  // duplicate Stripe deliveries too: if the process committed billing state
+  // and died before email delivery, Stripe's retry can still claim or converge
+  // the lifecycle email by its own dedupe key.
+  try {
+    if (
+      eventClaimed &&
+      event.type === "invoice.payment_failed" &&
+      failedSubscriptionStatus &&
+      failedSubscriptionStatus !== "active" &&
+      failedSubscriptionStatus !== "trialing"
+    ) {
+      const inv = event.data.object as Stripe.Invoice;
+      const customerId = stripeInvoiceCustomerId(inv);
+      if (customerId) {
+        await alertOps(
+          "Subscription payment failed",
+          `Stripe customer ${customerId} had a failed subscription payment; current subscription state is ${failedSubscriptionStatus}.`,
+        );
+      }
+    }
+    await deliverSubscriptionLifecycleEmail(event);
+  } catch (err) {
+    console.error(
+      "[Stripe Subscription Webhook] lifecycle delivery error:",
+      err,
+    );
+    await alertOps(
+      "Subscription lifecycle delivery error",
+      `Event ${event.type} failed after billing state committed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    // The Stripe claim has already committed. Returning 500 is intentional:
+    // redelivery skips the billing mutation but retries this deduped email.
     return NextResponse.json({ error: "Handler error" }, { status: 500 });
   }
 
@@ -311,6 +344,102 @@ export async function POST(req: NextRequest) {
   return NextResponse.json({ received: true });
 }
 
+async function deliverSubscriptionLifecycleEmail(
+  event: Stripe.Event,
+): Promise<void> {
+  if (
+    event.type !== "invoice.payment_succeeded" &&
+    event.type !== "invoice.payment_failed"
+  ) {
+    return;
+  }
+
+  const invoice = event.data.object as Stripe.Invoice;
+  if (
+    event.type === "invoice.payment_succeeded" &&
+    (invoice.amount_paid ?? 0) <= 0
+  ) {
+    return;
+  }
+  const practice = await withSystem(db, (tx) =>
+    practiceForLifecycleEvent(tx, event.id),
+  );
+  const to = billingContactEmail(practice?.email);
+  if (!practice || !to) return;
+  if (
+    event.type === "invoice.payment_failed" &&
+    practice.billingStatus !== "past_due"
+  ) {
+    return;
+  }
+  const practiceName = practice.name ?? "your practice";
+
+  const result =
+    event.type === "invoice.payment_succeeded"
+      ? await sendLifecycleEmail({
+          practiceId: practice.id,
+          to,
+          emailType: "receipt",
+          dedupeKey: `lc:receipt:${invoice.id}`,
+          category: "transactional",
+          retryOnFail: true,
+          send: () =>
+            sendPaymentReceiptEmail({
+              to,
+              practiceName,
+              amount: formatMoney(invoice.amount_paid, invoice.currency),
+              periodLabel: invoicePeriodLabel(invoice, practice.timezone),
+              invoiceUrl: invoice.hosted_invoice_url ?? undefined,
+              idempotencyKey: `lc:receipt:${invoice.id}`,
+            }),
+        })
+      : await sendLifecycleEmail({
+          practiceId: practice.id,
+          to,
+          emailType: "dunning",
+          // One dunning email per Stripe retry attempt.
+          dedupeKey: `lc:dunning:${invoice.id}:${invoice.attempt_count ?? 0}`,
+          category: "transactional",
+          retryOnFail: true,
+          stillEligible: async (tx) => {
+            const subscriptionId = subscriptionIdForInvoice(invoice);
+            if (!subscriptionId) return false;
+            const [eligible] = await tx
+              .select({ id: practices.id })
+              .from(practices)
+              .where(
+                and(
+                  eq(practices.id, practice.id),
+                  eq(practices.billingStatus, "past_due"),
+                  eq(practices.stripeSubscriptionId, subscriptionId),
+                  isNull(practices.deletedAt),
+                ),
+              )
+              .limit(1);
+            return Boolean(eligible);
+          },
+          send: () =>
+            sendPaymentFailedEmail({
+              to,
+              practiceName,
+              amount: formatMoney(invoice.amount_due, invoice.currency),
+              nextRetryDate: formatUnixDate(
+                invoice.next_payment_attempt,
+                practice.timezone,
+              ),
+              idempotencyKey: `lc:dunning:${invoice.id}:${invoice.attempt_count ?? 0}`,
+            }),
+        });
+
+  const deliveryCompleted =
+    result.sent || (result.deduped && result.dedupeState === "sent");
+  if (!deliveryCompleted) {
+    throw new Error(
+      `${event.type} lifecycle email does not have a durable sent outcome.`,
+    );
+  }
+}
+
 /** Apply a subscription's tier/status/trial through one shared mapping path. */
 async function applySubscription(
   tx: typeof db,
@@ -329,19 +458,45 @@ async function applySubscription(
   const customerId =
     typeof sub.customer === "string" ? sub.customer : sub.customer?.id;
   const billingStatus = normalizeBillingStatus(sub.status);
+  const terminalSubscription = billingStatus === "canceled";
 
   const [practice] = await tx
     .update(practices)
     .set({
       ...(tier ? { subscriptionTier: tier } : {}),
       billingStatus,
-      stripeSubscriptionId: sub.id,
+      stripeSubscriptionId: terminalSubscription ? null : sub.id,
       ...(customerId ? { stripeCustomerId: customerId } : {}),
       trialEndsAt: sub.trial_end ? new Date(sub.trial_end * 1000) : null,
     })
-    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+    .where(
+      and(
+        eq(practices.id, practiceId),
+        isNull(practices.deletedAt),
+        or(
+          isNull(practices.stripeSubscriptionId),
+          eq(practices.stripeSubscriptionId, sub.id),
+        ),
+      ),
+    )
     .returning({ id: practices.id });
   if (!practice) {
+    const [currentPractice] = await tx
+      .select({ stripeSubscriptionId: practices.stripeSubscriptionId })
+      .from(practices)
+      .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+      .limit(1);
+    if (
+      currentPractice?.stripeSubscriptionId &&
+      currentPractice.stripeSubscriptionId !== sub.id
+    ) {
+      console.warn(
+        "[Stripe Subscription Webhook] ignored stale subscription identity:",
+        sub.id,
+        practiceId,
+      );
+      return null;
+    }
     console.warn(
       "[Stripe Subscription Webhook] subscription for missing/deleted practice:",
       sub.id,
@@ -349,11 +504,13 @@ async function applySubscription(
     );
     return null;
   }
-  await syncPracticeSubscriptionQuantities({
-    db: tx,
-    practiceId: practice.id,
-    subscriptionId: sub.id,
-  });
+  if (!terminalSubscription) {
+    await syncPracticeSubscriptionQuantities({
+      db: tx,
+      practiceId: practice.id,
+      subscriptionId: sub.id,
+    });
+  }
   return practice.id;
 }
 
@@ -494,14 +651,21 @@ function subscriptionIdForInvoice(inv: Stripe.Invoice): string | null {
     : (subscription?.id ?? null);
 }
 
+function stripeInvoiceCustomerId(inv: Stripe.Invoice): string | null {
+  return typeof inv.customer === "string"
+    ? inv.customer
+    : (inv.customer?.id ?? null);
+}
+
 /** Look up a practice's id / email / name by its Stripe customer id. */
 async function practiceForCustomer(tx: typeof db, customerId: string) {
-  const [p] = await tx
+  const matches = await tx
     .select({
       id: practices.id,
       email: practices.email,
       name: practices.name,
       timezone: practices.timezone,
+      billingStatus: practices.billingStatus,
     })
     .from(practices)
     .where(
@@ -510,21 +674,44 @@ async function practiceForCustomer(tx: typeof db, customerId: string) {
         isNull(practices.deletedAt),
       ),
     )
-    .limit(1);
-  return p ?? null;
+    .limit(2);
+  if (matches.length > 1) {
+    throw new Error(
+      `Stripe customer ${customerId} maps to multiple active practices.`,
+    );
+  }
+  return matches[0] ?? null;
 }
 
-/** Read billing contact details for an already-authoritatively resolved clinic. */
-async function practiceById(tx: typeof db, practiceId: string) {
+/**
+ * Read the clinic attached by the authoritative Stripe transaction. This is
+ * intentionally event-bound rather than a customer-id fallback: duplicate
+ * delivery may finish a post-commit email, but it may never loosen tenant
+ * attribution while doing so.
+ */
+async function practiceForLifecycleEvent(tx: typeof db, eventId: string) {
   const [practice] = await tx
     .select({
       id: practices.id,
       email: practices.email,
       name: practices.name,
       timezone: practices.timezone,
+      billingStatus: practices.billingStatus,
     })
-    .from(practices)
-    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+    .from(stripeEvents)
+    .innerJoin(
+      practices,
+      and(
+        eq(stripeEvents.practiceId, practices.id),
+        isNull(practices.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(stripeEvents.eventId, eventId),
+        eq(stripeEvents.endpoint, "subscription"),
+      ),
+    )
     .limit(1);
   return practice ?? null;
 }

--- a/apps/web/components/layout/trial-badge.tsx
+++ b/apps/web/components/layout/trial-badge.tsx
@@ -17,8 +17,7 @@ import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect";
  */
 export function TrialBadge() {
   const { data: session, status } = useSession();
-  const isAdmin =
-    status === "authenticated" && session?.user?.role === "admin";
+  const isAdmin = status === "authenticated" && session?.user?.role === "admin";
 
   const { data, isLoading, error } = trpc.subscription.get.useQuery(undefined, {
     enabled: isAdmin,
@@ -68,6 +67,30 @@ export function TrialBadge() {
     return null;
   }
 
+  if (data.billingStatus === "past_due") {
+    return (
+      <Link
+        href="/settings?tab=billing"
+        className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-100"
+      >
+        <AlertTriangle className="h-3.5 w-3.5" />
+        Payment retrying · Manage billing
+      </Link>
+    );
+  }
+
+  if (data.billingStatus === "unpaid" || data.billingStatus === "canceled") {
+    return (
+      <Link
+        href="/settings?tab=billing"
+        className="inline-flex items-center gap-1.5 rounded-full border border-destructive/30 bg-destructive/10 px-3 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/20"
+      >
+        <AlertTriangle className="h-3.5 w-3.5" />
+        Subscription inactive · Reactivate billing
+      </Link>
+    );
+  }
+
   // A Stripe subscription can legitimately remain `trialing` after Checkout
   // while the saved card waits for the free trial to end. Never offer another
   // Checkout in that state; it could create a duplicate subscription.
@@ -85,8 +108,7 @@ export function TrialBadge() {
 
   const trialing = data.billingStatus === "trialing" && data.trialEndsAt;
   if (trialing) {
-    const days =
-      trialCalendarDaysLeft(data.trialEndsAt, data.timezone) ?? 0;
+    const days = trialCalendarDaysLeft(data.trialEndsAt, data.timezone) ?? 0;
     const urgent = days <= 3;
     return (
       <button
@@ -98,7 +120,7 @@ export function TrialBadge() {
           "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-70",
           urgent
             ? "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100"
-            : "border-teal-200 bg-teal-50 text-teal-800 hover:bg-teal-100"
+            : "border-teal-200 bg-teal-50 text-teal-800 hover:bg-teal-100",
         )}
       >
         {checkout.isPending ? (
@@ -106,7 +128,9 @@ export function TrialBadge() {
         ) : (
           <Clock className="h-3.5 w-3.5" />
         )}
-        {days === 0 ? "Trial ends today" : `${days} day${days === 1 ? "" : "s"} left in trial`}
+        {days === 0
+          ? "Trial ends today"
+          : `${days} day${days === 1 ? "" : "s"} left in trial`}
         <span className="font-semibold">· Subscribe</span>
       </button>
     );

--- a/apps/web/lib/__tests__/email-lifecycle.test.ts
+++ b/apps/web/lib/__tests__/email-lifecycle.test.ts
@@ -244,11 +244,32 @@ describe("sendLifecycleEmail", () => {
     await expect(sendLifecycleEmail({ ...BASE_OPTS, send })).resolves.toEqual({
       sent: false,
       deduped: true,
+      dedupeState: "in_flight",
     });
 
     expect(send).not.toHaveBeenCalled();
     expect(mocks.deleteWhere).not.toHaveBeenCalled();
     expect(mocks.updateSet).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes a durably sent duplicate from an in-flight claim", async () => {
+    mocks.insertResults.push([]);
+    mocks.selectResults.push([
+      {
+        id: "comm-sent",
+        status: "sent",
+        createdAt: new Date(Date.now() - 5 * 60 * 1000),
+      },
+    ]);
+    const send = vi.fn(async () => ({ success: true, id: "email-1" }));
+
+    await expect(sendLifecycleEmail({ ...BASE_OPTS, send })).resolves.toEqual({
+      sent: false,
+      deduped: true,
+      dedupeState: "sent",
+    });
+
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("reclaims a stale pending claim before retrying the send", async () => {

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -634,15 +634,39 @@ describe("lifecycle email branding", () => {
         practiceName: "Neighborhood Veterinary",
         amount: "$79.00",
         periodLabel: "July 2026",
+        idempotencyKey: "lc:receipt:in_test",
       }),
     ).resolves.toEqual({ success: true, id: "email-1" });
 
-    const [payload] = mocks.resendSend.mock.calls[0] ?? [];
+    const [payload, options] = mocks.resendSend.mock.calls[0] ?? [];
     expect(payload).toEqual(
       expect.objectContaining({
         replyTo: "support@openvpm.com",
         to: "owner@example.com",
       }),
+    );
+    expect(options).toEqual(
+      expect.objectContaining({ idempotencyKey: "lc:receipt:in_test" }),
+    );
+  });
+
+  it("passes the lifecycle key to Resend for dunning retries", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    mocks.resendSend.mockResolvedValue({ data: { id: "email-1" } });
+    const { sendPaymentFailedEmail } = await loadEmail();
+
+    await expect(
+      sendPaymentFailedEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        amount: "$79.00",
+        idempotencyKey: "lc:dunning:in_test:2",
+      }),
+    ).resolves.toEqual({ success: true, id: "email-1" });
+
+    const [, options] = mocks.resendSend.mock.calls[0] ?? [];
+    expect(options).toEqual(
+      expect.objectContaining({ idempotencyKey: "lc:dunning:in_test:2" }),
     );
   });
 });

--- a/apps/web/lib/__tests__/trial-badge-ui.test.ts
+++ b/apps/web/lib/__tests__/trial-badge-ui.test.ts
@@ -19,13 +19,15 @@ describe("trial badge UI", () => {
     expect(source).toContain("Billing status unavailable");
     expect(source).toContain("if (error || !data)");
     expect(source.indexOf("if (isLoading)")).toBeLessThan(
-      source.indexOf("if (error || !data)")
+      source.indexOf("if (error || !data)"),
     );
     expect(source.indexOf("if (error || !data)")).toBeLessThan(
-      source.indexOf('if (!data.billingEnforced || data.billingStatus === "active")')
+      source.indexOf(
+        'if (!data.billingEnforced || data.billingStatus === "active")',
+      ),
     );
     expect(source).not.toContain(
-      'if (!data || !data.billingEnforced || data.billingStatus === "active")'
+      'if (!data || !data.billingEnforced || data.billingStatus === "active")',
     );
   });
 
@@ -53,12 +55,30 @@ describe("trial badge UI", () => {
     );
   });
 
+  it("distinguishes retrying payments from terminal read-only billing", () => {
+    expect(source).toContain('data.billingStatus === "past_due"');
+    expect(source).toContain("Payment retrying · Manage billing");
+    expect(source).toContain('data.billingStatus === "unpaid"');
+    expect(source).toContain("Subscription inactive · Reactivate billing");
+    expect(source.indexOf('data.billingStatus === "past_due"')).toBeLessThan(
+      source.indexOf("if (data.hasSubscription)"),
+    );
+    expect(source.indexOf('data.billingStatus === "unpaid"')).toBeLessThan(
+      source.indexOf("if (data.hasSubscription)"),
+    );
+    expect(settingsSource).toContain("Stripe is retrying it.");
+    expect(settingsSource).toContain("remains available; update your payment");
+    expect(settingsSource).not.toContain(
+      "Update your payment method to restore write access.",
+    );
+  });
+
   it("counts trial days from the practice timezone", () => {
     expect(source).toContain(
-      'import { trialCalendarDaysLeft } from "@/lib/billing/trial-days"'
+      'import { trialCalendarDaysLeft } from "@/lib/billing/trial-days"',
     );
     expect(source).toContain(
-      "trialCalendarDaysLeft(data.trialEndsAt, data.timezone)"
+      "trialCalendarDaysLeft(data.trialEndsAt, data.timezone)",
     );
     expect(source).not.toContain("getTime() - Date.now()");
     expect(source).not.toContain("24 * 60 * 60 * 1000");

--- a/apps/web/lib/billing/__tests__/plans.test.ts
+++ b/apps/web/lib/billing/__tests__/plans.test.ts
@@ -9,6 +9,7 @@ import {
   isTrialActive,
   effectiveTier,
   hasHostedFullAccess,
+  normalizeBillingStatus,
   billingEnforced,
   estimatedCloudBaseMonthlyUsd,
   tierForStripePrice,
@@ -102,15 +103,27 @@ describe("trials", () => {
   });
 });
 
+describe("Stripe subscription status normalization", () => {
+  it("preserves retrying and terminal dunning states separately", () => {
+    expect(normalizeBillingStatus("past_due")).toBe("past_due");
+    expect(normalizeBillingStatus("unpaid")).toBe("unpaid");
+  });
+
+  it("keeps terminal cancellation statuses on the canceled access path", () => {
+    expect(normalizeBillingStatus("canceled")).toBe("canceled");
+    expect(normalizeBillingStatus("incomplete_expired")).toBe("canceled");
+  });
+});
+
 describe("PLANS pricing", () => {
   it("uses flat per-location Cloud pricing, free self-host, and custom enterprise", () => {
     expect(PLANS.free.locationUnitPriceMonthlyUsd).toBe(0);
     expect(PLANS.free.seatUnitPriceMonthlyUsd).toBe(0);
     expect(PLANS.cloud.locationUnitPriceMonthlyUsd).toBe(
-      CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD
+      CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
     );
     expect(PLANS.cloud.seatUnitPriceMonthlyUsd).toBe(
-      CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD
+      CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
     );
     expect(PLANS.enterprise.locationUnitPriceMonthlyUsd).toBeNull();
     expect(PLANS.enterprise.seatUnitPriceMonthlyUsd).toBeNull();
@@ -139,18 +152,39 @@ describe("hosted full access", () => {
 
   it("self-host is fully writable regardless of billing state", () => {
     expect(hasHostedFullAccess("free", "none", null, now, false)).toBe(true);
+    expect(hasHostedFullAccess("free", "unpaid", null, now, false)).toBe(true);
   });
 
-  it("allows active trial and active paid subscription", () => {
-    expect(hasHostedFullAccess("free", "trialing", future, now, true)).toBe(true);
+  it("allows active trial, active paid subscription, and retrying Cloud dunning", () => {
+    expect(hasHostedFullAccess("free", "trialing", future, now, true)).toBe(
+      true,
+    );
     expect(hasHostedFullAccess("cloud", "active", past, now, true)).toBe(true);
+    expect(hasHostedFullAccess("cloud", "past_due", past, now, true)).toBe(
+      true,
+    );
   });
 
-  it("blocks expired trials, canceled, past due, and no subscription on hosted", () => {
-    expect(hasHostedFullAccess("free", "trialing", past, now, true)).toBe(false);
-    expect(hasHostedFullAccess("cloud", "past_due", future, now, true)).toBe(false);
-    expect(hasHostedFullAccess("cloud", "canceled", future, now, true)).toBe(false);
+  it("blocks expired trials and terminal subscription states on hosted", () => {
+    expect(hasHostedFullAccess("free", "trialing", past, now, true)).toBe(
+      false,
+    );
+    expect(hasHostedFullAccess("cloud", "unpaid", future, now, true)).toBe(
+      false,
+    );
+    expect(hasHostedFullAccess("cloud", "canceled", future, now, true)).toBe(
+      false,
+    );
+    expect(
+      hasHostedFullAccess("cloud", "incomplete_expired", future, now, true),
+    ).toBe(false);
     expect(hasHostedFullAccess("free", "none", null, now, true)).toBe(false);
+  });
+
+  it("does not grant retrying status access without a paid hosted tier", () => {
+    expect(hasHostedFullAccess("free", "past_due", future, now, true)).toBe(
+      false,
+    );
   });
 });
 
@@ -220,7 +254,9 @@ describe("Stripe price mapping", () => {
   it("returns undefined for blank Stripe price envs", () => {
     vi.stubEnv(STRIPE_PRICE_CLOUD_LOCATION_ENV, "   ");
 
-    expect(stripePriceIdFromEnv(STRIPE_PRICE_CLOUD_LOCATION_ENV)).toBeUndefined();
+    expect(
+      stripePriceIdFromEnv(STRIPE_PRICE_CLOUD_LOCATION_ENV),
+    ).toBeUndefined();
   });
 
   it("maps split Cloud prices and legacy Cloud price to the cloud tier", () => {

--- a/apps/web/lib/billing/plans.ts
+++ b/apps/web/lib/billing/plans.ts
@@ -111,7 +111,8 @@ export const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "Free (self-host)",
     locationUnitPriceMonthlyUsd: 0,
     seatUnitPriceMonthlyUsd: 0,
-    blurb: "Self-host OpenVPM on your own infrastructure. Free forever, no lock-in.",
+    blurb:
+      "Self-host OpenVPM on your own infrastructure. Free forever, no lock-in.",
     seatLimit: null,
     locationLimit: null,
     features: [],
@@ -166,7 +167,9 @@ export function getPlan(tier?: string | null): PlanDefinition {
 }
 
 /** Map a Stripe Price ID back to a plan tier (via the configured env vars). */
-export function tierForStripePrice(priceId: string | null | undefined): PlanTier | null {
+export function tierForStripePrice(
+  priceId: string | null | undefined,
+): PlanTier | null {
   const normalizedPriceId = nonBlank(priceId);
   if (!normalizedPriceId) return null;
   const cloudPriceEnvs = [
@@ -208,7 +211,7 @@ export function cloudMeteredPriceIds(): {
 
 export function estimatedCloudBaseMonthlyUsd(
   locationCount: number,
-  billableSeatCount: number
+  billableSeatCount: number,
 ): number {
   return (
     Math.max(1, locationCount) * CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD +
@@ -217,15 +220,18 @@ export function estimatedCloudBaseMonthlyUsd(
 }
 
 /** Normalize a Stripe subscription status to our billingStatus values. */
-export function normalizeBillingStatus(status: string | null | undefined): string {
+export function normalizeBillingStatus(
+  status: string | null | undefined,
+): string {
   switch (status) {
     case "trialing":
       return "trialing";
     case "active":
       return "active";
     case "past_due":
-    case "unpaid":
       return "past_due";
+    case "unpaid":
+      return "unpaid";
     case "canceled":
     case "incomplete_expired":
       return "canceled";
@@ -235,7 +241,10 @@ export function normalizeBillingStatus(status: string | null | undefined): strin
 }
 
 /** Pure: does this tier include this feature? (With parity, every paid tier does.) */
-export function planHasFeature(tier: string | null | undefined, feature: Feature): boolean {
+export function planHasFeature(
+  tier: string | null | undefined,
+  feature: Feature,
+): boolean {
   return getPlan(tier).features.includes(feature);
 }
 
@@ -263,23 +272,27 @@ export function trialEndsAtFrom(from: Date = new Date()): Date {
 export function isTrialActive(
   billingStatus: string | null | undefined,
   trialEndsAt: Date | string | null | undefined,
-  now: Date = new Date()
+  now: Date = new Date(),
 ): boolean {
   if (billingStatus !== "trialing" || !trialEndsAt) return false;
   return new Date(trialEndsAt).getTime() > now.getTime();
 }
 
-/** Hosted write access: active trial or active paid/custom subscription only. */
+/**
+ * Hosted write access: active trial, active paid/custom subscription, or a
+ * non-free subscription still inside Stripe's retrying `past_due` lifecycle.
+ * Terminal `unpaid` / canceled states remain read-only.
+ */
 export function hasHostedFullAccess(
   tier: string | null | undefined,
   billingStatus: string | null | undefined,
   trialEndsAt: Date | string | null | undefined,
   now: Date = new Date(),
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   if (isTrialActive(billingStatus, trialEndsAt, now)) return true;
-  if (billingStatus !== "active") return false;
+  if (billingStatus !== "active" && billingStatus !== "past_due") return false;
   return getPlan(tier).tier !== "free";
 }
 
@@ -291,12 +304,12 @@ export function effectiveTier(
   tier: string | null | undefined,
   billingStatus: string | null | undefined,
   trialEndsAt: Date | string | null | undefined,
-  now: Date = new Date()
+  now: Date = new Date(),
 ): PlanTier {
   if (isTrialActive(billingStatus, trialEndsAt, now)) return "cloud";
   const t = tier ?? "free";
   if (LEGACY_CLOUD_TIERS.has(t)) return "cloud";
-  return (PLANS[t as PlanTier] ? (t as PlanTier) : "free");
+  return PLANS[t as PlanTier] ? (t as PlanTier) : "free";
 }
 
 /**
@@ -314,7 +327,7 @@ export function billingEnforced(): boolean {
 export function isEntitled(
   tier: string | null | undefined,
   feature: Feature,
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   return planHasFeature(tier, feature);
@@ -324,7 +337,7 @@ export function isEntitled(
 export function withinSeatLimit(
   tier: string | null | undefined,
   currentSeats: number,
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   const limit = getPlan(tier).seatLimit;
@@ -335,7 +348,7 @@ export function withinSeatLimit(
 export function withinLocationLimit(
   tier: string | null | undefined,
   currentLocations: number,
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   const limit = getPlan(tier).locationLimit;

--- a/apps/web/lib/email-lifecycle.ts
+++ b/apps/web/lib/email-lifecycle.ts
@@ -13,6 +13,9 @@ import {
 
 type SendResult = { success: boolean; id?: string; error?: string };
 type ClaimedLifecycleEmail = { id: string };
+type LifecycleEmailClaim =
+  | { kind: "claimed"; row: ClaimedLifecycleEmail }
+  | { kind: "duplicate"; state: "sent" | "in_flight" | "failed" };
 type LifecycleEmailCategory = "transactional" | "marketing";
 
 type LifecycleEmailOptions = {
@@ -41,9 +44,12 @@ export const LIFECYCLE_EMAIL_PENDING_RECLAIM_MS = 30 * 60 * 1000;
  * we delete the claim so the next run retries; for webhook mail we keep it
  * (Stripe redelivers the event anyway) so customers never get duplicates.
  */
-export async function sendLifecycleEmail(
-  opts: LifecycleEmailOptions,
-): Promise<{ sent: boolean; deduped: boolean; suppressed?: boolean }> {
+export async function sendLifecycleEmail(opts: LifecycleEmailOptions): Promise<{
+  sent: boolean;
+  deduped: boolean;
+  suppressed?: boolean;
+  dedupeState?: "sent" | "in_flight" | "failed";
+}> {
   // Never throw into the caller (Stripe webhook / cron). Any infra error
   // (incl. a not-yet-migrated dedupe column) degrades to "not sent" + an alert.
   try {
@@ -68,10 +74,15 @@ export async function sendLifecycleEmail(
     // 1. Atomic claim. A fresh existing pending row means another worker is
     // sending right now; an old pending row means the previous worker likely
     // died before recording sent/failed, so it can be reclaimed.
-    const row = await claimLifecycleEmail(opts);
-    if (!row) {
-      return { sent: false, deduped: true };
+    const claim = await claimLifecycleEmail(opts);
+    if (claim.kind === "duplicate") {
+      return {
+        sent: false,
+        deduped: true,
+        dedupeState: claim.state,
+      };
     }
+    const row = claim.row;
 
     // 2. Send.
     let result: SendResult;
@@ -163,10 +174,10 @@ async function claimLifecycleEmail(opts: {
   practiceId: string;
   emailType: string;
   dedupeKey: string;
-}): Promise<ClaimedLifecycleEmail | null> {
+}): Promise<LifecycleEmailClaim> {
   const claimed = await insertLifecycleEmailClaim(opts);
   const row = claimed[0];
-  if (row) return row;
+  if (row) return { kind: "claimed", row };
 
   const [existing] = await withSystem(db, (tx) =>
     tx
@@ -179,11 +190,22 @@ async function claimLifecycleEmail(opts: {
       .where(eq(communications.dedupeKey, opts.dedupeKey))
       .limit(1),
   );
-  if (!existing || existing.status !== "pending") return null;
+  if (!existing) {
+    // The unique conflict disappeared between INSERT and SELECT. Treat the
+    // outcome as in-flight so webhook callers retry instead of acknowledging
+    // a delivery whose durable state cannot be proven.
+    return { kind: "duplicate", state: "in_flight" };
+  }
+  if (existing.status !== "pending") {
+    return {
+      kind: "duplicate",
+      state: existing.status === "sent" ? "sent" : "failed",
+    };
+  }
 
   const staleBefore = new Date(Date.now() - LIFECYCLE_EMAIL_PENDING_RECLAIM_MS);
   if (new Date(existing.createdAt).getTime() > staleBefore.getTime()) {
-    return null;
+    return { kind: "duplicate", state: "in_flight" };
   }
 
   const deleted = await withSystem(db, (tx) =>
@@ -198,9 +220,14 @@ async function claimLifecycleEmail(opts: {
       )
       .returning({ id: communications.id }),
   );
-  if (!deleted[0]) return null;
+  if (!deleted[0]) {
+    return { kind: "duplicate", state: "in_flight" };
+  }
 
-  return (await insertLifecycleEmailClaim(opts))[0] ?? null;
+  const reclaimed = (await insertLifecycleEmailClaim(opts))[0];
+  return reclaimed
+    ? { kind: "claimed", row: reclaimed }
+    : { kind: "duplicate", state: "in_flight" };
 }
 
 function insertLifecycleEmailClaim(opts: {

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -737,6 +737,7 @@ export async function sendPaymentReceiptEmail(data: {
   amount: string;
   periodLabel: string;
   invoiceUrl?: string;
+  idempotencyKey?: string;
 }): Promise<{ success: boolean; id?: string; error?: string }> {
   const brand = openvpmBrand();
   const { subject, html } = await renderPaymentReceiptEmail({
@@ -746,7 +747,13 @@ export async function sendPaymentReceiptEmail(data: {
     periodLabel: data.periodLabel,
     invoiceUrl: data.invoiceUrl,
   });
-  return sendEmail({ to: data.to, subject, html, replyTo: brand.supportEmail });
+  return sendEmail({
+    to: data.to,
+    subject,
+    html,
+    replyTo: brand.supportEmail,
+    ...(data.idempotencyKey ? { idempotencyKey: data.idempotencyKey } : {}),
+  });
 }
 
 /** Dunning email sent on a failed subscription payment. */
@@ -756,6 +763,7 @@ export async function sendPaymentFailedEmail(data: {
   amount: string;
   nextRetryDate?: string;
   billingUrl?: string;
+  idempotencyKey?: string;
 }): Promise<{ success: boolean; id?: string; error?: string }> {
   const brand = openvpmBrand();
   const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
@@ -766,5 +774,11 @@ export async function sendPaymentFailedEmail(data: {
     nextRetryDate: data.nextRetryDate,
     billingUrl,
   });
-  return sendEmail({ to: data.to, subject, html, replyTo: brand.supportEmail });
+  return sendEmail({
+    to: data.to,
+    subject,
+    html,
+    replyTo: brand.supportEmail,
+    ...(data.idempotencyKey ? { idempotencyKey: data.idempotencyKey } : {}),
+  });
 }

--- a/apps/web/server/__tests__/guards.test.ts
+++ b/apps/web/server/__tests__/guards.test.ts
@@ -50,7 +50,7 @@ describe("viewer read-only guard", () => {
   it("blocks mutations for a viewer with FORBIDDEN (before the resolver)", async () => {
     const caller = callerFor("viewer");
     await expect(
-      caller.clients.create({ firstName: "A", lastName: "B" })
+      caller.clients.create({ firstName: "A", lastName: "B" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
@@ -73,7 +73,7 @@ describe("viewer read-only guard", () => {
             limit: async () => [
               {
                 tier: "cloud",
-                billingStatus: "past_due",
+                billingStatus: "unpaid",
                 trialEndsAt: null,
               },
             ],
@@ -87,8 +87,51 @@ describe("viewer read-only guard", () => {
     };
     const caller = callerFor("front_desk", db);
     await expect(
-      caller.clients.create({ firstName: "A", lastName: "B" })
+      caller.clients.create({ firstName: "A", lastName: "B" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("allows a hosted Cloud practice to reach the resolver while Stripe is retrying", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const selectResults = [
+      [
+        {
+          tier: "cloud",
+          billingStatus: "past_due",
+          trialEndsAt: null,
+        },
+      ],
+      [],
+    ];
+    const select = vi.fn(() => {
+      const result = selectResults.shift() ?? [];
+      return {
+        from: () => ({
+          where: () => ({
+            limit: async () => result,
+          }),
+        }),
+      };
+    });
+    const tx: Record<string, unknown> = {
+      execute: async () => undefined,
+      select,
+    };
+    const db: Record<string, unknown> = {
+      transaction: async (fn: (t: unknown) => unknown) => fn(tx),
+      execute: async () => undefined,
+    };
+    const caller = callerFor("front_desk", db);
+
+    // The resolver's own active-practice check is the second lookup. Reaching
+    // its NOT_FOUND proves the hosted billing guard allowed retrying access.
+    await expect(
+      caller.clients.create({ firstName: "A", lastName: "B" }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Practice not found",
+    });
+    expect(select).toHaveBeenCalledTimes(2);
   });
 
   it("fails closed when hosted mutation guard cannot find the active practice", async () => {
@@ -110,7 +153,7 @@ describe("viewer read-only guard", () => {
     const caller = callerFor("front_desk", db);
 
     await expect(
-      caller.clients.create({ firstName: "A", lastName: "B" })
+      caller.clients.create({ firstName: "A", lastName: "B" }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -124,7 +167,7 @@ describe("viewer read-only guard", () => {
       [
         {
           tier: "cloud",
-          billingStatus: "past_due",
+          billingStatus: "unpaid",
           trialEndsAt: null,
         },
       ],
@@ -168,7 +211,7 @@ describe("viewer read-only guard", () => {
         contactEmail: "owner@example.com",
         confirmExportDownloaded: true,
         confirmManualReview: true,
-      })
+      }),
     ).resolves.toMatchObject({
       status: "requested",
       contactEmail: "owner@example.com",

--- a/apps/web/server/__tests__/subscription-checkout.test.ts
+++ b/apps/web/server/__tests__/subscription-checkout.test.ts
@@ -2,9 +2,11 @@ import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  createSubscriptionCheckoutSession: vi.fn(async () => ({
-    url: "https://stripe.example/subscription-checkout",
-  })),
+  createSubscriptionCheckoutSession: vi.fn(
+    async (_params: Record<string, unknown>) => ({
+      url: "https://stripe.example/subscription-checkout",
+    }),
+  ),
   createBillingPortalSession: vi.fn(async () => ({
     url: "https://stripe.example/billing-portal",
   })),
@@ -46,17 +48,19 @@ vi.mock("@/lib/tenant-db", () => ({
   withTenant: async (
     db: unknown,
     _practiceId: string,
-    fn: (tx: unknown) => Promise<unknown>
+    fn: (tx: unknown) => Promise<unknown>,
   ) => fn(db),
   withSystem: async (db: unknown, fn: (tx: unknown) => Promise<unknown>) =>
     fn(db),
 }));
 
-const { subscriptionRouter } = await import("../routers/subscription");
+const { subscriptionCheckoutTrialTerms, subscriptionRouter } =
+  await import("../routers/subscription");
 const { TRIAL_DAYS } = await import("@/lib/billing/plans");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
+const HOUR_MS = 60 * 60 * 1000;
 
 function callerWithDb(db: Record<string, unknown>) {
   const session = {
@@ -126,12 +130,72 @@ afterEach(() => {
 });
 
 describe("subscription checkout", () => {
+  it("derives mutually exclusive trial terms at Stripe's exact lead-time boundary", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z");
+    const safelyBeyondStripeMinimum = new Date(
+      now.getTime() + 48 * HOUR_MS + 5 * 60 * 1000,
+    );
+    const justInsideSafetyBoundary = new Date(
+      safelyBeyondStripeMinimum.getTime() - 1,
+    );
+
+    expect(
+      subscriptionCheckoutTrialTerms({
+        billingStatus: "trialing",
+        trialEndsAt: safelyBeyondStripeMinimum,
+        now,
+      }),
+    ).toEqual({
+      trialEnd: safelyBeyondStripeMinimum,
+      trialPeriodDays: undefined,
+    });
+    expect(
+      subscriptionCheckoutTrialTerms({
+        billingStatus: "trialing",
+        trialEndsAt: justInsideSafetyBoundary,
+        now,
+      }),
+    ).toEqual({
+      trialEnd: null,
+      trialPeriodDays: 3,
+    });
+
+    for (const terms of [
+      subscriptionCheckoutTrialTerms({
+        billingStatus: "trialing",
+        trialEndsAt: safelyBeyondStripeMinimum,
+        now,
+      }),
+      subscriptionCheckoutTrialTerms({
+        billingStatus: "trialing",
+        trialEndsAt: justInsideSafetyBoundary,
+        now,
+      }),
+      subscriptionCheckoutTrialTerms({
+        billingStatus: "trialing",
+        trialEndsAt: new Date(now.getTime() - 1),
+        now,
+      }),
+      subscriptionCheckoutTrialTerms({
+        billingStatus: "none",
+        trialEndsAt: null,
+        now,
+      }),
+    ]) {
+      expect(
+        Boolean(terms.trialEnd) && terms.trialPeriodDays !== undefined,
+      ).toBe(false);
+    }
+  });
+
   it("keeps active-practice invariants explicit after practice checks", () => {
     const source = readFileSync("server/routers/subscription.ts", "utf8");
 
     expect(source).toContain("throw practiceNotFound()");
     expect(source).toContain('tier: practice.tier ?? "free"');
-    expect(source).toContain("customerId: practice.stripeCustomerId ?? undefined");
+    expect(source).toContain(
+      "customerId: practice.stripeCustomerId ?? undefined",
+    );
     expect(source).toContain("if (!practice.stripeCustomerId)");
     expect(source).toContain("const checkoutUrl = result?.url");
     expect(source).toContain("if (!isSafeCheckoutRedirectUrl(checkoutUrl))");
@@ -208,7 +272,7 @@ describe("subscription checkout", () => {
     ]);
 
     await expect(
-      callerWithDb(db).createCheckout({ tier: "cloud" })
+      callerWithDb(db).createCheckout({ tier: "cloud" }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -246,7 +310,9 @@ describe("subscription checkout", () => {
       message: "Practice not found",
     });
 
-    await expect(caller.createCheckout({ tier: "cloud" })).rejects.toMatchObject({
+    await expect(
+      caller.createCheckout({ tier: "cloud" }),
+    ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
     });
@@ -268,7 +334,7 @@ describe("subscription checkout", () => {
     const db = createDb([[practice()]]);
 
     await expect(
-      callerWithDb(db).createCheckout({ tier: "cloud" })
+      callerWithDb(db).createCheckout({ tier: "cloud" }),
     ).resolves.toEqual({ url: "https://stripe.example/subscription-checkout" });
 
     expect(mocks.createSubscriptionCheckoutSession).toHaveBeenCalledWith(
@@ -279,10 +345,11 @@ describe("subscription checkout", () => {
         customerEmail: "practice@example.com",
         trialEnd: null,
         trialPeriodDays: TRIAL_DAYS,
-        successUrl: "https://app.example.com/settings?tab=billing&checkout=success",
+        successUrl:
+          "https://app.example.com/settings?tab=billing&checkout=success",
         cancelUrl:
           "https://app.example.com/settings?tab=billing&checkout=cancelled",
-      })
+      }),
     );
   });
 
@@ -314,13 +381,13 @@ describe("subscription checkout", () => {
       1,
       expect.objectContaining({
         customerEmail: "practice.owner@example.com",
-      })
+      }),
     );
     expect(mocks.createSubscriptionCheckoutSession).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         customerEmail: "admin@example.com",
-      })
+      }),
     );
   });
 
@@ -340,7 +407,7 @@ describe("subscription checkout", () => {
     ]);
 
     await expect(
-      callerWithDb(db).createCheckout({ tier: "cloud" })
+      callerWithDb(db).createCheckout({ tier: "cloud" }),
     ).resolves.toEqual({ url: "https://stripe.example/subscription-checkout" });
 
     expect(mocks.createSubscriptionCheckoutSession).toHaveBeenCalledWith(
@@ -348,7 +415,67 @@ describe("subscription checkout", () => {
         customerId: "cus_123",
         trialEnd: trialEndsAt,
         trialPeriodDays: undefined,
-      })
+      }),
+    );
+  });
+
+  it("uses stable three-day terms for repeated near-expiry Checkout attempts", async () => {
+    vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION", "price_location");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-27T12:00:00Z"));
+    const trialEndsAt = new Date("2026-06-29T11:00:00Z");
+    const nearExpiryPractice = practice({
+      billingStatus: "trialing",
+      trialEndsAt,
+      stripeCustomerId: "cus_123",
+    });
+    const db = createDb([[nearExpiryPractice], [nearExpiryPractice]]);
+    const caller = callerWithDb(db);
+
+    await expect(caller.createCheckout({ tier: "cloud" })).resolves.toEqual({
+      url: "https://stripe.example/subscription-checkout",
+    });
+    vi.setSystemTime(new Date("2026-06-27T13:00:00Z"));
+    await expect(caller.createCheckout({ tier: "cloud" })).resolves.toEqual({
+      url: "https://stripe.example/subscription-checkout",
+    });
+
+    const firstParams =
+      mocks.createSubscriptionCheckoutSession.mock.calls[0]?.[0];
+    const secondParams =
+      mocks.createSubscriptionCheckoutSession.mock.calls[1]?.[0];
+    expect(firstParams).toEqual(secondParams);
+    expect(firstParams).toEqual(
+      expect.objectContaining({
+        customerId: "cus_123",
+        trialEnd: null,
+        trialPeriodDays: 3,
+      }),
+    );
+  });
+
+  it("uses three-day terms when an active trial has one hour left", async () => {
+    vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION", "price_location");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-27T12:00:00Z"));
+    const db = createDb([
+      [
+        practice({
+          billingStatus: "trialing",
+          trialEndsAt: new Date("2026-06-27T13:00:00Z"),
+        }),
+      ],
+    ]);
+
+    await expect(
+      callerWithDb(db).createCheckout({ tier: "cloud" }),
+    ).resolves.toEqual({ url: "https://stripe.example/subscription-checkout" });
+
+    expect(mocks.createSubscriptionCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trialEnd: null,
+        trialPeriodDays: 3,
+      }),
     );
   });
 
@@ -366,14 +493,14 @@ describe("subscription checkout", () => {
     ]);
 
     await expect(
-      callerWithDb(db).createCheckout({ tier: "cloud" })
+      callerWithDb(db).createCheckout({ tier: "cloud" }),
     ).resolves.toEqual({ url: "https://stripe.example/subscription-checkout" });
 
     expect(mocks.createSubscriptionCheckoutSession).toHaveBeenCalledWith(
       expect.objectContaining({
         trialEnd: null,
         trialPeriodDays: undefined,
-      })
+      }),
     );
   });
 
@@ -385,7 +512,7 @@ describe("subscription checkout", () => {
     const db = createDb([[practice()]]);
 
     await expect(
-      callerWithDb(db).createCheckout({ tier: "cloud" })
+      callerWithDb(db).createCheckout({ tier: "cloud" }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Billing is not configured on this server.",
@@ -400,7 +527,7 @@ describe("subscription checkout", () => {
     const db = createDb([[practice()]]);
 
     await expect(
-      callerWithDb(db).createCheckout({ tier: "cloud" })
+      callerWithDb(db).createCheckout({ tier: "cloud" }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Billing is not configured on this server.",

--- a/apps/web/server/routers/subscription.ts
+++ b/apps/web/server/routers/subscription.ts
@@ -32,6 +32,57 @@ import { RECOVERY_HOLD_BLOCK_MESSAGE } from "@/lib/recovery-hold";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const STRIPE_TRIAL_END_MIN_LEAD_MS = 2 * DAY_MS;
+const STRIPE_TRIAL_END_SAFETY_BUFFER_MS = 5 * 60 * 1000;
+const LATE_TRIAL_CHECKOUT_GRACE_DAYS = 3;
+
+type CheckoutTrialTerms = {
+  trialEnd: Date | string | null;
+  trialPeriodDays: number | undefined;
+};
+
+/**
+ * Derive mutually exclusive Stripe Checkout trial terms from durable practice
+ * state. Checkout rejects a custom trial_end that is less than 48 hours away,
+ * so a still-active trial near that boundary receives a deterministic three-day
+ * grace. The grace is independent of the current instant, keeping repeated
+ * near-expiry Checkout attempts on identical provider parameters.
+ */
+export function subscriptionCheckoutTrialTerms(input: {
+  billingStatus: string | null | undefined;
+  trialEndsAt: Date | string | null | undefined;
+  now: Date;
+}): CheckoutTrialTerms {
+  const { billingStatus, trialEndsAt, now } = input;
+  if (billingStatus === "trialing" && trialEndsAt) {
+    const trialEndMs = new Date(trialEndsAt).getTime();
+    const remainingMs = trialEndMs - now.getTime();
+    if (
+      Number.isFinite(remainingMs) &&
+      remainingMs > 0 &&
+      remainingMs >=
+        STRIPE_TRIAL_END_MIN_LEAD_MS + STRIPE_TRIAL_END_SAFETY_BUFFER_MS
+    ) {
+      return { trialEnd: trialEndsAt, trialPeriodDays: undefined };
+    }
+    if (Number.isFinite(remainingMs) && remainingMs > 0) {
+      return {
+        trialEnd: null,
+        trialPeriodDays: LATE_TRIAL_CHECKOUT_GRACE_DAYS,
+      };
+    }
+  }
+
+  // Any stored end is historical trial evidence. Never grant another trial to
+  // an expired, canceled, or otherwise non-trialing practice.
+  if (trialEndsAt) {
+    return { trialEnd: null, trialPeriodDays: undefined };
+  }
+
+  return { trialEnd: null, trialPeriodDays: TRIAL_DAYS };
+}
+
 function activePracticeWhere(practiceId: string) {
   return and(eq(practices.id, practiceId), isNull(practices.deletedAt));
 }
@@ -71,7 +122,7 @@ export const subscriptionRouter = createRouter({
     let counts = await countBillableLocationsAndSeats(ctx.db, ctx.practiceId);
     let billingSync: BillingSyncState | null = await readBillingSyncState(
       ctx.db,
-      ctx.practiceId
+      ctx.practiceId,
     );
     const period = currentPeriodMonth();
     const [smsUsed, aiUsed] = enforced
@@ -92,7 +143,7 @@ export const subscriptionRouter = createRouter({
       hasFullAccess: hasHostedFullAccess(
         practice.tier,
         practice.billingStatus,
-        practice.trialEndsAt
+        practice.trialEndsAt,
       ),
       locationCount: counts.locationCount,
       billableSeatCount: counts.billableSeatCount,
@@ -100,7 +151,7 @@ export const subscriptionRouter = createRouter({
       seatUnitPriceMonthlyUsd: CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
       estimatedMonthlyBase: estimatedCloudBaseMonthlyUsd(
         counts.locationCount,
-        counts.billableSeatCount
+        counts.billableSeatCount,
       ),
       billingSyncStatus: billingSync,
       usage: { period, sms: smsUsed, aiRuns: aiUsed },
@@ -134,7 +185,7 @@ export const subscriptionRouter = createRouter({
         // Where Stripe sends the admin back: the billing page (default) or
         // the guided setup, which resumes where they left off.
         returnTo: z.enum(["settings", "setup"]).default("settings"),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const plan = PLANS[input.tier];
@@ -183,15 +234,17 @@ export const subscriptionRouter = createRouter({
         });
       }
 
-      const counts = await countBillableLocationsAndSeats(ctx.db, ctx.practiceId);
+      const counts = await countBillableLocationsAndSeats(
+        ctx.db,
+        ctx.practiceId,
+      );
 
       const base = appBaseUrl();
-      const activeTrialEnd =
-        practice.billingStatus === "trialing" &&
-        practice.trialEndsAt &&
-        new Date(practice.trialEndsAt).getTime() > Date.now()
-          ? practice.trialEndsAt
-          : null;
+      const trialTerms = subscriptionCheckoutTrialTerms({
+        billingStatus: practice.billingStatus,
+        trialEndsAt: practice.trialEndsAt,
+        now: new Date(),
+      });
       // Checkout carries only the per-location licensed item so the clinic
       // sees one clean product. The metered overage items (AI + SMS) are
       // attached to the subscription server-side after creation
@@ -209,8 +262,8 @@ export const subscriptionRouter = createRouter({
         practiceId: ctx.practiceId,
         customerId: practice.stripeCustomerId ?? undefined,
         customerEmail,
-        trialEnd: activeTrialEnd,
-        trialPeriodDays: activeTrialEnd || practice.trialEndsAt ? undefined : TRIAL_DAYS,
+        trialEnd: trialTerms.trialEnd,
+        trialPeriodDays: trialTerms.trialPeriodDays,
         successUrl:
           input.returnTo === "setup"
             ? `${base}/?setup=resume&checkout=success`

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -493,6 +493,21 @@ Subscribe to:
 
 Store this endpoint secret as `STRIPE_SUBSCRIPTION_WEBHOOK_SECRET`.
 
+### Subscription retry and access states
+
+Keep Stripe's retrying and terminal dunning states distinct. A Cloud
+subscription in `past_due` is still inside Stripe's retry lifecycle, so the
+clinic remains writable while staff update the payment method or Stripe retries
+the invoice. Continue showing the billing-recovery CTA and monitoring the retry;
+do not describe the clinic as already locked out.
+
+`unpaid`, `canceled`, and `incomplete_expired` are terminal for hosted access and
+must leave the clinic read-only until billing is reactivated. Do not normalize
+`unpaid` back to `past_due`, because that would grant retry-period access after
+Stripe has exhausted collection. An expired card-free trial remains read-only
+unless a subscription is activated. Self-host access is unchanged and never
+uses these hosted gates.
+
 `checkout.session.completed` is shared by the platform invoice and hosted
 subscription endpoints. OpenVPM de-duplicates it per endpoint, so both webhook
 endpoints must remain configured; each handler ignores sessions that belong to


### PR DESCRIPTION
## What changed

- Keep Stripe Checkout reliable near trial expiry: preserve a safe stored trial end, provide a deterministic three-day grace inside Stripe's 48-hour custom-end boundary, and never restart an expired trial.
- Reconcile subscription webhooks against current Stripe state and compare-and-set the stored subscription identity so stale or delayed events cannot reopen access or replace a newer subscription.
- Deliver receipts and dunning mail after the billing transaction commits, with durable lifecycle state, final eligibility checks, and provider idempotency keys.
- Keep retrying `past_due` clinics writable while making terminal `unpaid`, canceled, and expired subscriptions read-only; align the billing UI and production runbook with that contract.

## Why

The prior flow could reject Checkout for the highest-intent clinics late in their trial, self-block lifecycle email delivery on the practice row, lose or duplicate financial email outcomes, and let out-of-order Stripe events overwrite newer billing state. It also promised retry-period access while the entitlement guard disabled writes immediately.

## Validation

- Full `@openpims/web` suite: 374 files passed, 3 expected integration files skipped; 3,896 tests passed, 6 skipped.
- `pnpm --filter @openpims/web type-check`
- `git diff --check`
- Independent final review: no remaining concrete blocker.
- No schema migration, provider call, email send, or production mutation performed.

Stripe reference: https://docs.stripe.com/api/checkout/sessions/create