### PR TITLE
Add controlled SMS pilot activation preflight

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -79,6 +79,16 @@ const recoveryTrialStyles: Record<string, string> = {
   no_trial: "bg-gray-100 text-gray-600",
 };
 
+const smsPilotStageLabels: Record<string, string> = {
+  deferred: "Safely deferred",
+  blocked: "Blocked",
+  provisioning_prepared: "Provisioning prepared",
+  scope_prepared: "Scope prepared",
+  inbound_prepared: "Inbound prepared",
+  provider_ready: "Provider ready",
+  active: "Active",
+};
+
 function recoveryLabel(value: string) {
   return value.replaceAll("_", " ");
 }
@@ -116,8 +126,10 @@ export default function AdminPage() {
   );
   const { data: smsOperations, error: smsOperationsError } =
     trpc.admin.smsOperationsHealth.useQuery(undefined, { retry: false });
-  const { data: smsConfiguration, error: smsConfigurationError } =
-    trpc.admin.hostedSmsConfiguration.useQuery(undefined, { retry: false });
+  const { data: smsPilotPreflight, error: smsPilotPreflightError } =
+    trpc.admin.hostedSmsPilotActivationPreflight.useQuery(undefined, {
+      retry: false,
+    });
   const [extendTrialError, setExtendTrialError] = useState<string | null>(null);
   const [analyticsError, setAnalyticsError] = useState<string | null>(null);
   const [messagingError, setMessagingError] = useState<string | null>(null);
@@ -326,72 +338,154 @@ export default function AdminPage() {
             </span>
           ) : null}
         </div>
-        {smsConfiguration ? (
+        {smsPilotPreflight ? (
           <div className="mt-4 rounded-md border border-border bg-muted/20 p-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <p className="text-sm font-medium">Hosted SMS configuration</p>
-              <span className="text-xs text-muted-foreground">
-                {smsConfiguration.rolloutIntended
-                  ? smsConfiguration.providerIsTelnyx &&
-                    smsConfiguration.apiKeyShapeValid &&
-                    smsConfiguration.webhookPublicKeyShapeValid &&
-                    smsConfiguration.registrationEncryptionKeyShapeValid &&
-                    smsConfiguration.provisioningScopeExact &&
-                    smsConfiguration.sendingScopeExact &&
-                    smsConfiguration.inboundEnabled
-                    ? "Rollout configured"
-                    : "Needs attention"
-                  : "Safely deferred"}
+              <p className="text-sm font-medium">
+                Hosted SMS pilot activation preflight
+              </p>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  smsPilotPreflight.stage === "blocked"
+                    ? "bg-red-100 text-red-800"
+                    : smsPilotPreflight.stage === "active"
+                      ? "bg-green-100 text-green-800"
+                      : smsPilotPreflight.stage === "deferred"
+                        ? "bg-gray-100 text-gray-700"
+                        : "bg-amber-100 text-amber-800"
+                }`}
+              >
+                {smsPilotStageLabels[smsPilotPreflight.stage] ??
+                  smsPilotPreflight.stage}
               </span>
             </div>
-            <div className="mt-2 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
+            <p className="mt-2 text-sm">{smsPilotPreflight.detail}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Next: {smsPilotPreflight.nextAction}
+            </p>
+            <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
               {[
-                ["Telnyx provider", smsConfiguration.providerIsTelnyx],
-                ["API key shape", smsConfiguration.apiKeyShapeValid],
-                [
-                  "Webhook key shape",
-                  smsConfiguration.webhookPublicKeyShapeValid,
-                ],
-                [
-                  "Registration key shape",
-                  smsConfiguration.registrationEncryptionKeyShapeValid,
-                ],
-                [
-                  "Provisioning scope exact",
-                  smsConfiguration.provisioningScopeExact,
-                ],
-                ["Sending scope exact", smsConfiguration.sendingScopeExact],
-                ["Inbound gate enabled", smsConfiguration.inboundEnabled],
-              ].map(([label, valid]) => (
-                <div
-                  key={String(label)}
-                  className="flex items-center justify-between rounded border border-border bg-background px-2 py-1.5"
-                >
-                  <span>{label}</span>
-                  <span
-                    className={
-                      valid
-                        ? "font-medium text-green-700"
-                        : "font-medium text-red-700"
-                    }
+                {
+                  label: "Telnyx provider",
+                  value: smsPilotPreflight.configuration.providerIsTelnyx,
+                  falseLabel: "Fix",
+                },
+                {
+                  label: "Credential shapes",
+                  value: smsPilotPreflight.checks.credentialsValid,
+                  falseLabel: "Fix",
+                },
+                {
+                  label: "Provisioning scope",
+                  value: smsPilotPreflight.checks.provisioningScopeExact,
+                  falseLabel: "Fix",
+                },
+                {
+                  label: "Sending scope",
+                  value: smsPilotPreflight.checks.sendingScopeExact,
+                  falseLabel: "Fix",
+                },
+                {
+                  label: "Scopes match",
+                  value: smsPilotPreflight.checks.scopesMatch,
+                  falseLabel: "Fix",
+                },
+                {
+                  label: "Practice active",
+                  value: smsPilotPreflight.checks.practiceActive,
+                  falseLabel: "Blocked",
+                },
+                {
+                  label: "Recovery clear",
+                  value: smsPilotPreflight.checks.recoveryClear,
+                  falseLabel: "Blocked",
+                },
+                {
+                  label: "Carrier identity",
+                  value: smsPilotPreflight.checks.carrierIdentityReady,
+                  falseLabel: "Blocked",
+                },
+                {
+                  label: "Provider events",
+                  value: smsPilotPreflight.checks.providerEventsClear,
+                  falseLabel: "Blocked",
+                },
+                {
+                  label: "Heartbeat delivery",
+                  value: smsPilotPreflight.checks.heartbeatDeliveryConfigured,
+                  falseLabel: "Fix",
+                },
+                {
+                  label: "Inbound gate",
+                  value: smsPilotPreflight.configuration.inboundEnabled,
+                  falseLabel: "Pending",
+                },
+                {
+                  label: "Provider profile",
+                  value: smsPilotPreflight.checks.providerProfileReady,
+                  falseLabel: "Pending",
+                },
+                {
+                  label: "Sending gate",
+                  value: smsPilotPreflight.configuration.sendingEnabled,
+                  falseLabel: "Pending",
+                },
+              ].map((check) => {
+                const ready = check.value === true;
+                const notStaged = check.value === null;
+                return (
+                  <div
+                    key={check.label}
+                    className="flex items-center justify-between rounded border border-border bg-background px-2 py-1.5"
                   >
-                    {valid ? "Valid" : "Fix"}
-                  </span>
-                </div>
-              ))}
+                    <span>{check.label}</span>
+                    <span
+                      className={
+                        ready
+                          ? "font-medium text-green-700"
+                          : notStaged
+                            ? "font-medium text-muted-foreground"
+                            : check.falseLabel === "Pending"
+                              ? "font-medium text-amber-700"
+                              : "font-medium text-red-700"
+                      }
+                    >
+                      {ready
+                        ? "Ready"
+                        : notStaged
+                          ? "Not staged"
+                          : check.falseLabel}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
             <p className="mt-2 text-xs text-muted-foreground">
-              Provisioning {smsConfiguration.provisioningEnabled ? "on" : "off"}
-              {" · "}sending {smsConfiguration.sendingEnabled ? "on" : "off"}
-              {" · "}scopes {smsConfiguration.provisioningPracticeScopeCount}/
-              {smsConfiguration.sendingPracticeScopeCount}/
-              {smsConfiguration.sendingLocationScopeCount} (provisioning /
-              sending practice / sending location). No secret values are shown.
+              Provisioning{" "}
+              {smsPilotPreflight.configuration.provisioningEnabled
+                ? "on"
+                : "off"}
+              {" · "}inbound{" "}
+              {smsPilotPreflight.configuration.inboundEnabled ? "on" : "off"}
+              {" · "}sending{" "}
+              {smsPilotPreflight.configuration.sendingEnabled ? "on" : "off"}
+              {" · "}scopes{" "}
+              {smsPilotPreflight.configuration.provisioningPracticeScopeCount}/
+              {smsPilotPreflight.configuration.sendingPracticeScopeCount}/
+              {smsPilotPreflight.configuration.sendingLocationScopeCount}
+              {" · "}blocking provider events{" "}
+              {smsPilotPreflight.providerEventBlocking ?? "not checked"}. No
+              secret, phone, clinic, or provider identifier is returned.
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Configured heartbeat delivery is necessary but does not prove a
+              fresh external receipt. Verify both SMS heartbeats in the monitor
+              before changing a launch flag.
             </p>
           </div>
-        ) : smsConfigurationError ? (
+        ) : smsPilotPreflightError ? (
           <p className="mt-3 text-sm text-red-700">
-            Could not load hosted SMS configuration diagnostics.
+            Could not load the hosted SMS pilot activation preflight.
           </p>
         ) : null}
         {smsOperations ? (

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  dbExecute: vi.fn(async () => [{ ok: 1, scopeValid: true }]),
+  dbExecute: vi.fn(async () => [
+    {
+      ok: 1,
+      practiceActive: true,
+      recoveryClear: true,
+      carrierIdentityReady: true,
+      providerProfileReady: true,
+      clinicSenderEnabled: false,
+    },
+  ]),
   withSystem: vi.fn(
     async (
       database: { execute: typeof mocks.dbExecute },
@@ -177,10 +186,25 @@ function stubHostedSmsInboundGate() {
   vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
 }
 
+function stubHostedSmsProvisioningScope(
+  practiceId = "00000000-0000-4000-8000-0000000000aa",
+) {
+  vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", practiceId);
+}
+
 afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
-  mocks.dbExecute.mockResolvedValue([{ ok: 1, scopeValid: true }]);
+  mocks.dbExecute.mockResolvedValue([
+    {
+      ok: 1,
+      practiceActive: true,
+      recoveryClear: true,
+      carrierIdentityReady: true,
+      providerProfileReady: true,
+      clinicSenderEnabled: false,
+    },
+  ]);
   mocks.withSystem.mockImplementation(async (database, fn) => fn(database));
   mocks.billingEnforced.mockReturnValue(false);
   mocks.replicaStorageReadiness.mockReturnValue({
@@ -398,7 +422,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "3 required hosted SMS configuration issues detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
     expect(JSON.stringify(json)).not.toContain("TELNYX_API_KEY");
     expect(JSON.stringify(json)).not.toContain(
@@ -422,11 +446,71 @@ describe("health route", () => {
     });
   });
 
+  it("keeps health green while an exact carrier-ready scope is staged with both live gates off", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    stubHostedSmsProvisioningScope();
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.checks.hostedSms).toEqual({
+      ok: true,
+      detail: "Hosted SMS pilot scope prepared; inbound and sending remain off",
+    });
+  });
+
+  it("keeps health green after inbound enablement while provider activation is pending", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    stubValidTelnyxEnvs();
+    stubHostedSmsInboundGate();
+    stubHostedSmsProvisioningScope();
+    vi.stubEnv(
+      "MESSAGING_SENDING_PRACTICE_IDS",
+      "00000000-0000-4000-8000-0000000000aa",
+    );
+    vi.stubEnv(
+      "MESSAGING_SENDING_LOCATION_IDS",
+      "00000000-0000-4000-8000-000000000002",
+    );
+    mocks.dbExecute.mockResolvedValue([
+      {
+        ok: 1,
+        practiceActive: true,
+        recoveryClear: true,
+        carrierIdentityReady: true,
+        providerProfileReady: false,
+        clinicSenderEnabled: false,
+      },
+    ]);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.checks.hostedSms).toEqual({
+      ok: true,
+      detail: "Hosted SMS inbound projection prepared; sending remains off",
+    });
+  });
+
   it("rejects an incomplete live hosted SMS pilot scope", async () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
     stubHostedSmsInboundGate();
+    stubHostedSmsProvisioningScope();
     vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
     vi.stubEnv(
       "MESSAGING_SENDING_PRACTICE_IDS",
@@ -439,7 +523,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -448,6 +532,7 @@ describe("health route", () => {
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
     stubHostedSmsInboundGate();
+    stubHostedSmsProvisioningScope();
     vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
     vi.stubEnv(
       "MESSAGING_SENDING_PRACTICE_IDS",
@@ -466,7 +551,7 @@ describe("health route", () => {
       ok: true,
       detail: "Hosted SMS pilot configuration active",
     });
-    expect(mocks.withSystem).toHaveBeenCalledTimes(2);
+    expect(mocks.withSystem).toHaveBeenCalledTimes(1);
   });
 
   it("rejects different provisioning and sending clinic scopes", async () => {
@@ -493,7 +578,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -502,6 +587,7 @@ describe("health route", () => {
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
     stubHostedSmsInboundGate();
+    stubHostedSmsProvisioningScope();
     vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
     vi.stubEnv(
       "MESSAGING_SENDING_PRACTICE_IDS",
@@ -511,9 +597,16 @@ describe("health route", () => {
       "MESSAGING_SENDING_LOCATION_IDS",
       "00000000-0000-4000-8000-000000000002",
     );
-    mocks.dbExecute
-      .mockResolvedValueOnce([{ ok: 1, scopeValid: true }])
-      .mockResolvedValueOnce([{ ok: 1, scopeValid: false }]);
+    mocks.dbExecute.mockResolvedValue([
+      {
+        ok: 1,
+        practiceActive: true,
+        recoveryClear: true,
+        carrierIdentityReady: false,
+        providerProfileReady: false,
+        clinicSenderEnabled: false,
+      },
+    ]);
 
     const response = await GET();
     const json = await response.json();
@@ -521,8 +614,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail:
-        "Hosted SMS pilot scope does not match an active, carrier-ready clinic location",
+      detail: "2 hosted SMS pilot readiness issues detected",
     });
   });
 
@@ -531,6 +623,7 @@ describe("health route", () => {
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
     stubHostedSmsInboundGate();
+    stubHostedSmsProvisioningScope();
     vi.stubEnv("MESSAGING_PROVIDER", "twilio");
     vi.stubEnv(
       "MESSAGING_SENDING_PRACTICE_IDS",
@@ -547,7 +640,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -556,6 +649,7 @@ describe("health route", () => {
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
     stubHostedSmsInboundGate();
+    stubHostedSmsProvisioningScope();
     vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", "not-a-practice-id");
     vi.stubEnv(
       "MESSAGING_SENDING_LOCATION_IDS",
@@ -568,7 +662,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -577,6 +671,7 @@ describe("health route", () => {
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
     stubHostedSmsInboundGate();
+    stubHostedSmsProvisioningScope();
     vi.stubEnv(
       "MESSAGING_SENDING_PRACTICE_IDS",
       "00000000-0000-0000-0000-0000000000aa",
@@ -592,7 +687,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -615,7 +710,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "3 required hosted SMS configuration issues detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
     expect(JSON.stringify(json)).not.toContain("test-api-key");
     expect(JSON.stringify(json)).not.toContain("test-public-key");

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -17,7 +17,6 @@ import {
 } from "@/lib/rls-assertion";
 import { cronHeartbeatConfigured } from "@/lib/cron-heartbeat";
 import { envFlagEnabled } from "@/lib/env-bool";
-import { loadSmsProviderEventGateSummaryInTransaction } from "@/lib/messaging/sms-provider-event-operations";
 import {
   checkObjectStorageHealth,
   checkReplicaStorageHealth,
@@ -28,8 +27,6 @@ import {
 import { getFileReplicaCoverage } from "@/lib/file-replication";
 import { normalizeAppBaseUrl } from "@/lib/app-url";
 import { platformAdminEmails } from "@/lib/platform-admin";
-import { rowsFromExecute } from "@/lib/db/execute-rows";
-import { withSystem } from "@/lib/tenant-db";
 import {
   CANONICAL_EMAIL_PREFERENCE_BASE_URL,
   isValidEmailPreferencePreviousSecrets,
@@ -38,6 +35,10 @@ import {
 } from "@/lib/email-preferences";
 import { platformEmailIdentityConfigurationReady } from "@/lib/platform-email-preferences";
 import { hostedSmsCredentialIssueCount } from "@/lib/messaging/hosted-sms-readiness";
+import {
+  hostedSmsRolloutIntended,
+  loadHostedSmsPilotActivationPreflight,
+} from "@/lib/messaging/hosted-sms-pilot-preflight";
 
 export const dynamic = "force-dynamic";
 
@@ -89,10 +90,6 @@ const HOSTED_EMAIL_ENV_NAMES = [
   "EMAIL_SUPPORT_ADDRESS",
   "EMAIL_COMPANY_ADDRESS",
 ];
-const HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV =
-  "MESSAGING_PROVISIONING_PRACTICE_IDS";
-const HOSTED_SMS_SENDING_PRACTICE_IDS_ENV = "MESSAGING_SENDING_PRACTICE_IDS";
-const HOSTED_SMS_SENDING_LOCATION_IDS_ENV = "MESSAGING_SENDING_LOCATION_IDS";
 const HOSTED_GOOGLE_AI_ENV_NAMES = [
   "GOOGLE_API_KEY",
   "GOOGLE_GENERATIVE_AI_API_KEY",
@@ -258,23 +255,6 @@ function hostedSubscriptionTaxCheck(): { ok: boolean; detail: string } {
   };
 }
 
-function commaSeparatedValues(name: string): string[] {
-  return (process.env[name] ?? "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-}
-
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-    value,
-  );
-}
-
-function isExactPilotScope(values: string[]): boolean {
-  return values.length === 1 && isUuid(values[0]!);
-}
-
 function hostedTelnyxCredentialCheck(): { ok: boolean; detail: string } {
   const issueCount = hostedSmsCredentialIssueCount();
   return issueCount > 0
@@ -288,164 +268,6 @@ function hostedTelnyxCredentialCheck(): { ok: boolean; detail: string } {
         ok: true,
         detail: "Hosted Telnyx credentials are structurally valid",
       };
-}
-
-function hostedSmsRolloutIntended(): boolean {
-  return (
-    envFlagEnabled("MESSAGING_PROVISIONING_ENABLED") ||
-    envFlagEnabled("MESSAGING_SENDING_ENABLED") ||
-    envFlagEnabled("MESSAGING_INBOUND_ENABLED") ||
-    commaSeparatedValues(HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV).length > 0 ||
-    commaSeparatedValues(HOSTED_SMS_SENDING_PRACTICE_IDS_ENV).length > 0 ||
-    commaSeparatedValues(HOSTED_SMS_SENDING_LOCATION_IDS_ENV).length > 0
-  );
-}
-
-async function hostedSmsRolloutCheck(): Promise<{
-  ok: boolean;
-  detail: string;
-}> {
-  const credentialIssues = hostedSmsCredentialIssueCount();
-  const provisioningEnabled = envFlagEnabled("MESSAGING_PROVISIONING_ENABLED");
-  const sendingEnabled = envFlagEnabled("MESSAGING_SENDING_ENABLED");
-  const inboundEnabled = envFlagEnabled("MESSAGING_INBOUND_ENABLED");
-  const provisioningPracticeIds = commaSeparatedValues(
-    HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV,
-  );
-  const sendingPracticeIds = commaSeparatedValues(
-    HOSTED_SMS_SENDING_PRACTICE_IDS_ENV,
-  );
-  const sendingLocationIds = commaSeparatedValues(
-    HOSTED_SMS_SENDING_LOCATION_IDS_ENV,
-  );
-  const provisioningScopePrepared = provisioningPracticeIds.length > 0;
-  const sendingScopePrepared =
-    sendingPracticeIds.length > 0 || sendingLocationIds.length > 0;
-
-  let configurationIssues = 0;
-  if (envValue("MESSAGING_PROVIDER")?.toLowerCase() !== "telnyx") {
-    configurationIssues += 1;
-  }
-  if (
-    (provisioningEnabled || provisioningScopePrepared) &&
-    !isExactPilotScope(provisioningPracticeIds)
-  ) {
-    configurationIssues += 1;
-  }
-  if (
-    (sendingEnabled || sendingScopePrepared) &&
-    (!isExactPilotScope(sendingPracticeIds) ||
-      !isExactPilotScope(sendingLocationIds))
-  ) {
-    configurationIssues += 1;
-  }
-  if (
-    (sendingEnabled || sendingScopePrepared || inboundEnabled) &&
-    !inboundEnabled
-  ) {
-    configurationIssues += 1;
-  }
-  if (inboundEnabled && !sendingScopePrepared) {
-    configurationIssues += 1;
-  }
-  if (
-    provisioningScopePrepared &&
-    sendingScopePrepared &&
-    provisioningPracticeIds[0] !== sendingPracticeIds[0]
-  ) {
-    configurationIssues += 1;
-  }
-
-  const issueCount = credentialIssues + configurationIssues;
-  if (issueCount > 0) {
-    return {
-      ok: false,
-      detail: `${issueCount} required hosted SMS configuration ${
-        issueCount === 1 ? "issue" : "issues"
-      } detected`,
-    };
-  }
-
-  const pilotPracticeId = sendingPracticeIds[0] ?? provisioningPracticeIds[0]!;
-  const sendingLocationId = sendingLocationIds[0] ?? null;
-  try {
-    // Health has no tenant identity. Verify the explicitly configured rollout
-    // scope in system context so hosted RLS does not hide a valid pilot clinic.
-    const result = await withSystem(db, (tx) =>
-      tx.execute(sql`
-        select (
-          exists (
-            select 1
-            from practices as practice
-            where practice.id = ${pilotPracticeId}::uuid
-              and practice.deleted_at is null
-          )
-          and ${
-            sendingLocationId
-              ? sql`exists (
-                  select 1
-                  from locations as location
-                  join location_messaging as sender
-                    on sender.practice_id = location.practice_id
-                    and sender.location_id = location.id
-                    and sender.deleted_at is null
-                  join messaging_registrations as registration
-                    on registration.practice_id = location.practice_id
-                    and registration.deleted_at is null
-                  where location.id = ${sendingLocationId}::uuid
-                    and location.practice_id = ${pilotPracticeId}::uuid
-                    and location.deleted_at is null
-                    and sender.provider = 'telnyx'
-                    and sender.registration_status = 'active'
-                    and nullif(btrim(sender.sender_e164), '') is not null
-                    and nullif(btrim(sender.messaging_profile_id), '') is not null
-                    and sender.provider_profile_ready = true
-                    and sender.provider_profile_synced_at is not null
-                    and registration.provider = 'telnyx'
-                    and registration.status = 'active'
-                    and sender.a2p_brand_id = registration.provider_brand_id
-                    and sender.a2p_campaign_id = registration.provider_campaign_id
-                )`
-              : sql`true`
-          }
-        ) as "scopeValid"
-      `),
-    );
-    const scopeValid =
-      rowsFromExecute<{ scopeValid: boolean }>(result)[0]?.scopeValid === true;
-    if (!scopeValid) {
-      return {
-        ok: false,
-        detail:
-          "Hosted SMS pilot scope does not match an active, carrier-ready clinic location",
-      };
-    }
-    const providerEventGate = await withSystem(db, (tx) =>
-      loadSmsProviderEventGateSummaryInTransaction(tx, {
-        practiceId: pilotPracticeId,
-        locationId: sendingLocationId ?? undefined,
-      }),
-    );
-    if (providerEventGate.total > 0) {
-      return {
-        ok: false,
-        detail:
-          "Hosted SMS pilot has unresolved provider-event projection evidence",
-      };
-    }
-  } catch {
-    return {
-      ok: false,
-      detail: "Hosted SMS pilot scope verification failed",
-    };
-  }
-
-  return {
-    ok: true,
-    detail: sendingEnabled
-      ? "Hosted SMS pilot configuration active"
-      : "Hosted SMS pilot configuration prepared and sending gated off",
-  };
 }
 
 export async function GET() {
@@ -578,13 +400,20 @@ export async function GET() {
     // configuration release-blocking. This prevents a production health 200
     // while provisioning or sending is nominally enabled without credentials,
     // webhook verification, encrypted registration storage, or exact pilot
-    // scope. Missing/partial launch state still fails closed at every send.
-    checks.hostedSms = hostedSmsRolloutIntended()
-      ? await hostedSmsRolloutCheck()
-      : {
-          ...hostedTelnyxCredentialCheck(),
-          advisory: true,
-        };
+    // scope. Missing/partial launch state still fails closed at both inbound
+    // projection and outbound sending boundaries.
+    if (hostedSmsRolloutIntended()) {
+      const smsPreflight = await loadHostedSmsPilotActivationPreflight(db);
+      checks.hostedSms = {
+        ok: smsPreflight.ok,
+        detail: smsPreflight.detail,
+      };
+    } else {
+      checks.hostedSms = {
+        ...hostedTelnyxCredentialCheck(),
+        advisory: true,
+      };
+    }
     checks.hostedOpsAlerting = {
       ...hostedEnvCheck(
         HOSTED_OPS_ALERTING_ENV_NAMES,

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -138,13 +138,26 @@ describe("admin UI", () => {
     expect(source).not.toContain("sender.senderE164");
   });
 
-  it("shows secret-free hosted SMS scope diagnostics instead of count-only readiness", () => {
-    expect(source).toContain("Hosted SMS configuration");
-    expect(source).toContain("Provisioning scope exact");
-    expect(source).toContain("smsConfiguration.provisioningScopeExact");
-    expect(source).toContain("Sending scope exact");
-    expect(source).toContain("smsConfiguration.sendingScopeExact");
-    expect(source).toContain('"Needs attention"');
+  it("shows a sequenced, secret-free hosted SMS pilot activation preflight", () => {
+    expect(source).toContain(
+      "trpc.admin.hostedSmsPilotActivationPreflight.useQuery",
+    );
+    expect(source).toContain("Hosted SMS pilot activation preflight");
+    expect(source).toContain('scope_prepared: "Scope prepared"');
+    expect(source).toContain('inbound_prepared: "Inbound prepared"');
+    expect(source).toContain('provider_ready: "Provider ready"');
+    expect(source).toContain("smsPilotPreflight.checks.provisioningScopeExact");
+    expect(source).toContain("smsPilotPreflight.checks.sendingScopeExact");
+    expect(source).toContain("smsPilotPreflight.checks.providerEventsClear");
+    expect(source).toContain(
+      "smsPilotPreflight.checks.heartbeatDeliveryConfigured",
+    );
+    expect(source).toContain(
+      "Configured heartbeat delivery is necessary but does not prove a",
+    );
+    expect(compactSource).toContain(
+      "No secret, phone, clinic, or provider identifier is returned",
+    );
   });
 
   it("shows bounded read-only redacted carrier lifecycle history", () => {

--- a/apps/web/lib/messaging/__tests__/hosted-sms-pilot-preflight.test.ts
+++ b/apps/web/lib/messaging/__tests__/hosted-sms-pilot-preflight.test.ts
@@ -1,0 +1,289 @@
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const execute = vi.fn();
+  const database = { execute };
+  return {
+    execute,
+    database,
+    withSystem: vi.fn(
+      async (
+        db: typeof database,
+        action: (tx: typeof database) => Promise<unknown>,
+      ) => action(db),
+    ),
+    heartbeatConfigured: vi.fn(() => ({
+      ok: true,
+      detail: "Job-specific cron heartbeat URLs configured",
+    })),
+    loadGate: vi.fn(async () => ({ total: 0 })),
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({ db: mocks.database }));
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
+vi.mock("@/lib/cron-heartbeat", () => ({
+  cronHeartbeatConfigured: mocks.heartbeatConfigured,
+}));
+vi.mock("../sms-provider-event-operations", () => ({
+  loadSmsProviderEventGateSummaryInTransaction: mocks.loadGate,
+}));
+
+const { loadHostedSmsPilotActivationPreflight } =
+  await import("../hosted-sms-pilot-preflight");
+
+const PRACTICE_ID = "00000000-0000-4000-8000-0000000000aa";
+const OTHER_PRACTICE_ID = "00000000-0000-4000-8000-0000000000bb";
+const LOCATION_ID = "00000000-0000-4000-8000-000000000002";
+const SOURCE = readFileSync(
+  "lib/messaging/hosted-sms-pilot-preflight.ts",
+  "utf8",
+);
+
+function stubValidCredentials() {
+  vi.stubEnv("MESSAGING_PROVIDER", "telnyx");
+  vi.stubEnv("TELNYX_API_KEY", "KEY_abcdefghijklmnopqrstuvwxyz");
+  vi.stubEnv("TELNYX_PUBLIC_KEY", Buffer.alloc(32, 1).toString("base64"));
+  vi.stubEnv(
+    "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
+    Buffer.alloc(32, 2).toString("base64"),
+  );
+}
+
+function stubExactPilotScope() {
+  vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", PRACTICE_ID);
+  vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
+  vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", LOCATION_ID);
+}
+
+function scopeRow(
+  overrides: Partial<{
+    practiceActive: boolean;
+    recoveryClear: boolean;
+    carrierIdentityReady: boolean;
+    providerProfileReady: boolean;
+    clinicSenderEnabled: boolean;
+  }> = {},
+) {
+  return {
+    practiceActive: true,
+    recoveryClear: true,
+    carrierIdentityReady: true,
+    providerProfileReady: false,
+    clinicSenderEnabled: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.execute.mockResolvedValue([scopeRow()]);
+  mocks.heartbeatConfigured.mockReturnValue({
+    ok: true,
+    detail: "Job-specific cron heartbeat URLs configured",
+  });
+  mocks.loadGate.mockResolvedValue({ total: 0 });
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("hosted SMS pilot activation preflight", () => {
+  it("keeps an unstaged rollout advisory and performs no database or provider work", async () => {
+    stubValidCredentials();
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+      new Date("2026-08-11T12:00:00.000Z"),
+    );
+
+    expect(result).toMatchObject({
+      stage: "deferred",
+      ok: true,
+      readyForInboundEnable: false,
+      providerEventBlocking: null,
+    });
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.execute).not.toHaveBeenCalled();
+    expect(SOURCE).not.toContain("telnyx-provisioning");
+    expect(SOURCE).not.toContain("updateMessagingProfileEnabled");
+    expect(SOURCE).not.toContain("sendSms");
+  });
+
+  it("accepts an exact carrier-ready scope while inbound and sending remain off", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "scope_prepared",
+      ok: true,
+      blockers: [],
+      readyForInboundEnable: true,
+      readyForProviderActivation: false,
+      readyForSendingEnable: false,
+      checks: {
+        carrierIdentityReady: true,
+        providerProfileReady: false,
+        providerEventsClear: true,
+      },
+    });
+    expect(mocks.withSystem).toHaveBeenCalledTimes(1);
+    expect(mocks.loadGate).toHaveBeenCalledWith(mocks.database, {
+      practiceId: PRACTICE_ID,
+      locationId: LOCATION_ID,
+    });
+  });
+
+  it("keeps health prepared between inbound enablement and provider activation", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "inbound_prepared",
+      ok: true,
+      readyForInboundEnable: false,
+      readyForProviderActivation: true,
+      readyForSendingEnable: false,
+    });
+  });
+
+  it("allows sending enablement only after the provider profile is ready", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    mocks.execute.mockResolvedValue([scopeRow({ providerProfileReady: true })]);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "provider_ready",
+      ok: true,
+      readyForSendingEnable: true,
+    });
+  });
+
+  it("fails closed when sending is on before the provider profile is ready", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "blocked",
+      ok: false,
+      readyForSendingEnable: false,
+    });
+    expect(result.blockers).toContain("provider_profile_not_ready");
+  });
+
+  it("reports an active exact pilot after every global gate is ready", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    mocks.execute.mockResolvedValue([
+      scopeRow({ providerProfileReady: true, clinicSenderEnabled: true }),
+    ]);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "active",
+      ok: true,
+      detail: "Hosted SMS pilot configuration active",
+    });
+    expect(result.nextAction).toContain("live SMS validation drill");
+  });
+
+  it("requires the exact same provisioning and sending practice", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", OTHER_PRACTICE_ID);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({ stage: "blocked", ok: false });
+    expect(result.blockers).toEqual(["scope_mismatch"]);
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+  });
+
+  it("blocks unresolved provider evidence without returning scoped identifiers", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    mocks.loadGate.mockResolvedValue({ total: 2 });
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+    const serialized = JSON.stringify(result);
+
+    expect(result).toMatchObject({
+      stage: "blocked",
+      ok: false,
+      providerEventBlocking: 2,
+      checks: { providerEventsClear: false },
+    });
+    expect(result.blockers).toContain("provider_event_backlog");
+    expect(serialized).not.toContain(PRACTICE_ID);
+    expect(serialized).not.toContain(LOCATION_ID);
+  });
+
+  it("blocks a held practice and missing heartbeat delivery configuration", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    mocks.execute.mockResolvedValue([scopeRow({ recoveryClear: false })]);
+    mocks.heartbeatConfigured.mockReturnValue({
+      ok: false,
+      detail: "Missing cron heartbeat URLs",
+    });
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result.blockers).toEqual([
+      "practice_recovery_hold",
+      "heartbeat_not_configured",
+    ]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("supports a provisioning-only preparation stage without inventing location readiness", async () => {
+    stubValidCredentials();
+    vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", PRACTICE_ID);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "provisioning_prepared",
+      ok: true,
+      checks: {
+        provisioningScopeExact: true,
+        sendingScopeExact: null,
+        carrierIdentityReady: null,
+        providerProfileReady: null,
+      },
+    });
+  });
+});

--- a/apps/web/lib/messaging/__tests__/launch-gate.test.ts
+++ b/apps/web/lib/messaging/__tests__/launch-gate.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  hostedMessagingInboundProjectionDecision,
   hostedMessagingLaunchDecision,
+  MESSAGING_INBOUND_ENABLED_ENV,
   MESSAGING_SENDING_ENABLED_ENV,
   MESSAGING_SENDING_LOCATION_IDS_ENV,
   MESSAGING_SENDING_PRACTICE_IDS_ENV,
@@ -23,7 +25,7 @@ describe("hostedMessagingLaunchDecision", () => {
       hostedMessagingLaunchDecision({
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
-      })
+      }),
     ).toEqual({ allowed: false, reason: "platform_disabled" });
   });
 
@@ -46,7 +48,7 @@ describe("hostedMessagingLaunchDecision", () => {
       hostedMessagingLaunchDecision({
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
-      })
+      }),
     ).toEqual({ allowed: false, reason: "practice_not_allowed" });
 
     vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, PRACTICE_ID);
@@ -55,19 +57,93 @@ describe("hostedMessagingLaunchDecision", () => {
       hostedMessagingLaunchDecision({
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
-      })
+      }),
     ).toEqual({ allowed: false, reason: "location_not_allowed" });
   });
 
-  it("trims comma-separated allowlist entries", () => {
+  it("trims the exact allowlist entries", () => {
     vi.stubEnv(MESSAGING_SENDING_ENABLED_ENV, "true");
-    vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, ` other, ${PRACTICE_ID} `);
-    vi.stubEnv(MESSAGING_SENDING_LOCATION_IDS_ENV, ` other, ${LOCATION_ID} `);
+    vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, ` ${PRACTICE_ID} `);
+    vi.stubEnv(MESSAGING_SENDING_LOCATION_IDS_ENV, ` ${LOCATION_ID} `);
     expect(
       hostedMessagingLaunchDecision({
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
-      })
+      }),
     ).toEqual({ allowed: true });
+  });
+
+  it("fails closed when a hosted rollout contains multiple clinics", () => {
+    enablePilot();
+    vi.stubEnv(
+      MESSAGING_SENDING_PRACTICE_IDS_ENV,
+      `${PRACTICE_ID},another-practice`,
+    );
+    expect(
+      hostedMessagingLaunchDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      }),
+    ).toEqual({ allowed: false, reason: "missing_scope" });
+  });
+});
+
+describe("hostedMessagingInboundProjectionDecision", () => {
+  it("preserves self-host provider behavior", () => {
+    expect(
+      hostedMessagingInboundProjectionDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      }),
+    ).toEqual({ allowed: true });
+  });
+
+  it("is independently default-off for hosted deployments", () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, PRACTICE_ID);
+    vi.stubEnv(MESSAGING_SENDING_LOCATION_IDS_ENV, LOCATION_ID);
+    expect(
+      hostedMessagingInboundProjectionDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      }),
+    ).toEqual({ allowed: false, reason: "platform_disabled" });
+  });
+
+  it("requires the exact hosted pilot practice and location", () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    vi.stubEnv(MESSAGING_INBOUND_ENABLED_ENV, "true");
+    vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, PRACTICE_ID);
+    vi.stubEnv(MESSAGING_SENDING_LOCATION_IDS_ENV, LOCATION_ID);
+
+    expect(
+      hostedMessagingInboundProjectionDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      hostedMessagingInboundProjectionDecision({
+        practiceId: "another-practice",
+        locationId: LOCATION_ID,
+      }),
+    ).toEqual({ allowed: false, reason: "practice_not_allowed" });
+    expect(
+      hostedMessagingInboundProjectionDecision({
+        practiceId: PRACTICE_ID,
+        locationId: "another-location",
+      }),
+    ).toEqual({ allowed: false, reason: "location_not_allowed" });
+
+    vi.stubEnv(
+      MESSAGING_SENDING_PRACTICE_IDS_ENV,
+      `${PRACTICE_ID},another-practice`,
+    );
+    expect(
+      hostedMessagingInboundProjectionDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      }),
+    ).toEqual({ allowed: false, reason: "missing_scope" });
   });
 });

--- a/apps/web/lib/messaging/__tests__/sms-provider-events.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-provider-events.test.ts
@@ -201,8 +201,9 @@ describe("SMS provider event durability contracts", () => {
       "allowDisabledInbound: Boolean(options.lockedPracticeId && options.force)",
     );
     expect(SERVICE_SOURCE).toContain(
-      "!options.allowDisabledInbound && !hostedInboundProjectionEnabled()",
+      "hostedMessagingInboundProjectionDecision({",
     );
+    expect(SERVICE_SOURCE).toContain("inbound_projection_outside_pilot_scope");
   });
 
   it("revalidates exact A2P identities in the registration compare-and-set", () => {
@@ -233,6 +234,7 @@ describe("SMS provider event durability contracts", () => {
       'if (event.kind === "delivery")',
     );
     expect(inbound).toContain("inbound_projection_disabled");
+    expect(inbound).toContain("inbound_projection_outside_pilot_scope");
     expect(inbound).toContain("exhaustible: false");
   });
 

--- a/apps/web/lib/messaging/hosted-sms-pilot-preflight.ts
+++ b/apps/web/lib/messaging/hosted-sms-pilot-preflight.ts
@@ -1,0 +1,439 @@
+import { sql } from "drizzle-orm";
+import { db } from "@openpims/db/client";
+import type { Database } from "@openpims/db/client";
+import { cronHeartbeatConfigured } from "@/lib/cron-heartbeat";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import { withSystem } from "@/lib/tenant-db";
+import { loadSmsProviderEventGateSummaryInTransaction } from "./sms-provider-event-operations";
+import { hostedSmsConfigurationDiagnostics } from "./hosted-sms-readiness";
+
+const PROVISIONING_PRACTICE_IDS_ENV = "MESSAGING_PROVISIONING_PRACTICE_IDS";
+const SENDING_PRACTICE_IDS_ENV = "MESSAGING_SENDING_PRACTICE_IDS";
+const SENDING_LOCATION_IDS_ENV = "MESSAGING_SENDING_LOCATION_IDS";
+const PILOT_HEARTBEAT_JOBS = ["sms-provider-events", "sms-operations"] as const;
+
+export type HostedSmsPilotStage =
+  | "deferred"
+  | "blocked"
+  | "provisioning_prepared"
+  | "scope_prepared"
+  | "inbound_prepared"
+  | "provider_ready"
+  | "active";
+
+export type HostedSmsPilotBlocker =
+  | "provider_not_telnyx"
+  | "credential_shape_invalid"
+  | "provisioning_scope_invalid"
+  | "sending_scope_invalid"
+  | "scope_mismatch"
+  | "inbound_disabled_while_sending"
+  | "pilot_practice_unavailable"
+  | "practice_recovery_hold"
+  | "carrier_identity_not_ready"
+  | "provider_event_backlog"
+  | "heartbeat_not_configured"
+  | "provider_profile_not_ready"
+  | "readiness_check_failed";
+
+export interface HostedSmsPilotActivationPreflight {
+  generatedAt: string;
+  stage: HostedSmsPilotStage;
+  ok: boolean;
+  detail: string;
+  nextAction: string;
+  blockers: HostedSmsPilotBlocker[];
+  configuration: ReturnType<typeof hostedSmsConfigurationDiagnostics>;
+  checks: {
+    credentialsValid: boolean;
+    provisioningScopeExact: boolean | null;
+    sendingScopeExact: boolean | null;
+    scopesMatch: boolean | null;
+    practiceActive: boolean | null;
+    recoveryClear: boolean | null;
+    carrierIdentityReady: boolean | null;
+    providerProfileReady: boolean | null;
+    providerEventsClear: boolean | null;
+    heartbeatDeliveryConfigured: boolean;
+  };
+  providerEventBlocking: number | null;
+  readyForInboundEnable: boolean;
+  readyForProviderActivation: boolean;
+  readyForSendingEnable: boolean;
+}
+
+interface PilotScopeRow {
+  practiceActive: boolean;
+  recoveryClear: boolean;
+  carrierIdentityReady: boolean;
+  providerProfileReady: boolean;
+  clinicSenderEnabled: boolean;
+}
+
+function commaSeparatedValues(name: string): string[] {
+  return (process.env[name] ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+function exactUuidScope(values: string[]): boolean {
+  return values.length === 1 && isUuid(values[0]!);
+}
+
+function uniqueBlockers(
+  values: readonly HostedSmsPilotBlocker[],
+): HostedSmsPilotBlocker[] {
+  return [...new Set(values)];
+}
+
+function nextActionForBlocker(blocker: HostedSmsPilotBlocker): string {
+  switch (blocker) {
+    case "provider_not_telnyx":
+      return "Select Telnyx as the hosted messaging provider.";
+    case "credential_shape_invalid":
+      return "Fix the secret-safe Telnyx credential checks before staging a clinic.";
+    case "provisioning_scope_invalid":
+      return "Stage exactly one approved provisioning practice UUID.";
+    case "sending_scope_invalid":
+      return "Stage exactly one sending practice and its exact location while sending remains off.";
+    case "scope_mismatch":
+      return "Make the provisioning and sending practice scopes name the same clinic.";
+    case "inbound_disabled_while_sending":
+      return "Turn sending off until the inbound gate and provider profile are ready.";
+    case "pilot_practice_unavailable":
+      return "Select one active, non-deleted pilot practice.";
+    case "practice_recovery_hold":
+      return "Finish or safely release the clinic recovery hold before SMS activation.";
+    case "carrier_identity_not_ready":
+      return "Reconcile the exact Telnyx registration, campaign assignment, sender number, and messaging profile.";
+    case "provider_event_backlog":
+      return "Project or reconcile every blocking provider event before activation.";
+    case "heartbeat_not_configured":
+      return "Configure both SMS heartbeat destinations, then verify fresh receipts in the external monitor.";
+    case "provider_profile_not_ready":
+      return "Keep sending off and enable/read back the exact provider profile first.";
+    case "readiness_check_failed":
+      return "Retry the read-only preflight and investigate database readiness if it fails again.";
+  }
+}
+
+function blockedPreflight(
+  base: Omit<
+    HostedSmsPilotActivationPreflight,
+    | "stage"
+    | "ok"
+    | "detail"
+    | "nextAction"
+    | "readyForInboundEnable"
+    | "readyForProviderActivation"
+    | "readyForSendingEnable"
+  >,
+): HostedSmsPilotActivationPreflight {
+  const blockers = uniqueBlockers(base.blockers);
+  const first = blockers[0] ?? "readiness_check_failed";
+  return {
+    ...base,
+    blockers,
+    stage: "blocked",
+    ok: false,
+    detail: `${blockers.length} hosted SMS pilot readiness ${
+      blockers.length === 1 ? "issue" : "issues"
+    } detected`,
+    nextAction: nextActionForBlocker(first),
+    readyForInboundEnable: false,
+    readyForProviderActivation: false,
+    readyForSendingEnable: false,
+  };
+}
+
+export function hostedSmsRolloutIntended(): boolean {
+  return hostedSmsConfigurationDiagnostics().rolloutIntended;
+}
+
+/**
+ * Secret- and PHI-free hosted SMS activation preflight. This performs no
+ * provider I/O and no mutation. The exact configured UUIDs are used only as
+ * bounded internal lookup keys and are never returned to the caller.
+ */
+export async function loadHostedSmsPilotActivationPreflight(
+  database: Database = db,
+  now: Date = new Date(),
+): Promise<HostedSmsPilotActivationPreflight> {
+  const configuration = hostedSmsConfigurationDiagnostics();
+  const provisioningPracticeIds = commaSeparatedValues(
+    PROVISIONING_PRACTICE_IDS_ENV,
+  );
+  const sendingPracticeIds = commaSeparatedValues(SENDING_PRACTICE_IDS_ENV);
+  const sendingLocationIds = commaSeparatedValues(SENDING_LOCATION_IDS_ENV);
+  const sendingSignal =
+    configuration.sendingEnabled ||
+    configuration.inboundEnabled ||
+    sendingPracticeIds.length > 0 ||
+    sendingLocationIds.length > 0;
+  const provisioningSignal =
+    configuration.provisioningEnabled ||
+    provisioningPracticeIds.length > 0 ||
+    sendingSignal;
+  const credentialsValid =
+    configuration.apiKeyShapeValid &&
+    configuration.webhookPublicKeyShapeValid &&
+    configuration.registrationEncryptionKeyShapeValid;
+  const provisioningScopeExact = provisioningSignal
+    ? exactUuidScope(provisioningPracticeIds)
+    : null;
+  const sendingScopeExact = sendingSignal
+    ? exactUuidScope(sendingPracticeIds) && exactUuidScope(sendingLocationIds)
+    : null;
+  const scopesMatch =
+    provisioningScopeExact === true && sendingScopeExact === true
+      ? provisioningPracticeIds[0] === sendingPracticeIds[0]
+      : null;
+  const heartbeat = cronHeartbeatConfigured(PILOT_HEARTBEAT_JOBS);
+  const checks: HostedSmsPilotActivationPreflight["checks"] = {
+    credentialsValid,
+    provisioningScopeExact,
+    sendingScopeExact,
+    scopesMatch,
+    practiceActive: null,
+    recoveryClear: null,
+    carrierIdentityReady: null,
+    providerProfileReady: null,
+    providerEventsClear: null,
+    heartbeatDeliveryConfigured: heartbeat.ok,
+  };
+  const base: Parameters<typeof blockedPreflight>[0] = {
+    generatedAt: now.toISOString(),
+    configuration,
+    checks,
+    providerEventBlocking: null,
+    blockers: [] as HostedSmsPilotBlocker[],
+  };
+
+  if (!configuration.rolloutIntended) {
+    return {
+      ...base,
+      stage: "deferred",
+      ok: true,
+      detail: "Hosted SMS pilot is safely deferred",
+      nextAction:
+        "Fix any credential-shape issue, then stage one approved provisioning practice with all launch flags off.",
+      readyForInboundEnable: false,
+      readyForProviderActivation: false,
+      readyForSendingEnable: false,
+    };
+  }
+
+  if (!configuration.providerIsTelnyx) {
+    base.blockers.push("provider_not_telnyx");
+  }
+  if (!credentialsValid) base.blockers.push("credential_shape_invalid");
+  if (provisioningScopeExact !== true) {
+    base.blockers.push("provisioning_scope_invalid");
+  }
+  if (sendingSignal && sendingScopeExact !== true) {
+    base.blockers.push("sending_scope_invalid");
+  }
+  if (scopesMatch === false) base.blockers.push("scope_mismatch");
+  if (configuration.sendingEnabled && !configuration.inboundEnabled) {
+    base.blockers.push("inbound_disabled_while_sending");
+  }
+  if (base.blockers.length > 0) return blockedPreflight(base);
+
+  const practiceId = provisioningPracticeIds[0]!;
+  const locationId = sendingSignal ? sendingLocationIds[0]! : null;
+
+  try {
+    const result = await withSystem(database, async (tx) => {
+      const scopeResult = await tx.execute(sql`
+        select
+          exists (
+            select 1
+            from practices practice
+            where practice.id = ${practiceId}::uuid
+              and practice.deleted_at is null
+          ) as "practiceActive",
+          exists (
+            select 1
+            from practices practice
+            where practice.id = ${practiceId}::uuid
+              and practice.deleted_at is null
+              and practice.recovery_hold = false
+          ) as "recoveryClear",
+          ${
+            locationId
+              ? sql`exists (
+                  select 1
+                  from locations location
+                  join location_messaging sender
+                    on sender.practice_id = location.practice_id
+                    and sender.location_id = location.id
+                    and sender.deleted_at is null
+                  join messaging_registrations registration
+                    on registration.practice_id = location.practice_id
+                    and registration.deleted_at is null
+                  where location.id = ${locationId}::uuid
+                    and location.practice_id = ${practiceId}::uuid
+                    and location.deleted_at is null
+                    and sender.provider = 'telnyx'
+                    and sender.registration_status = 'active'
+                    and nullif(btrim(sender.sender_e164), '') is not null
+                    and nullif(btrim(sender.messaging_profile_id), '') is not null
+                    and registration.provider = 'telnyx'
+                    and registration.status = 'active'
+                    and sender.a2p_brand_id = registration.provider_brand_id
+                    and sender.a2p_campaign_id = registration.provider_campaign_id
+                )`
+              : sql`false`
+          } as "carrierIdentityReady",
+          ${
+            locationId
+              ? sql`exists (
+                  select 1
+                  from location_messaging sender
+                  where sender.practice_id = ${practiceId}::uuid
+                    and sender.location_id = ${locationId}::uuid
+                    and sender.deleted_at is null
+                    and sender.provider = 'telnyx'
+                    and sender.provider_profile_ready = true
+                    and sender.provider_profile_synced_at is not null
+                )`
+              : sql`false`
+          } as "providerProfileReady",
+          ${
+            locationId
+              ? sql`exists (
+                  select 1
+                  from location_messaging sender
+                  where sender.practice_id = ${practiceId}::uuid
+                    and sender.location_id = ${locationId}::uuid
+                    and sender.deleted_at is null
+                    and sender.enabled = true
+                )`
+              : sql`false`
+          } as "clinicSenderEnabled"
+      `);
+      const scope = rowsFromExecute<PilotScopeRow>(scopeResult)[0];
+      if (!scope?.practiceActive) {
+        return { scope: null, providerEventBlocking: null };
+      }
+      const gate = await loadSmsProviderEventGateSummaryInTransaction(tx, {
+        practiceId,
+        ...(locationId ? { locationId } : {}),
+      });
+      return { scope, providerEventBlocking: gate.total };
+    });
+
+    checks.practiceActive = result.scope?.practiceActive ?? false;
+    checks.recoveryClear = result.scope?.recoveryClear ?? false;
+    checks.carrierIdentityReady = locationId
+      ? (result.scope?.carrierIdentityReady ?? false)
+      : null;
+    checks.providerProfileReady = locationId
+      ? (result.scope?.providerProfileReady ?? false)
+      : null;
+    checks.providerEventsClear =
+      result.providerEventBlocking === null
+        ? null
+        : result.providerEventBlocking === 0;
+    base.providerEventBlocking = result.providerEventBlocking;
+
+    if (!checks.practiceActive)
+      base.blockers.push("pilot_practice_unavailable");
+    if (checks.practiceActive && !checks.recoveryClear) {
+      base.blockers.push("practice_recovery_hold");
+    }
+    if (locationId && !checks.carrierIdentityReady) {
+      base.blockers.push("carrier_identity_not_ready");
+    }
+    if (checks.providerEventsClear === false) {
+      base.blockers.push("provider_event_backlog");
+    }
+    if (!checks.heartbeatDeliveryConfigured) {
+      base.blockers.push("heartbeat_not_configured");
+    }
+    if (configuration.sendingEnabled && checks.providerProfileReady !== true) {
+      base.blockers.push("provider_profile_not_ready");
+    }
+    if (base.blockers.length > 0) return blockedPreflight(base);
+
+    if (!locationId) {
+      return {
+        ...base,
+        stage: "provisioning_prepared",
+        ok: true,
+        detail: "Hosted SMS provisioning scope prepared; sending remains off",
+        nextAction:
+          "Complete carrier registration, then stage the exact sending practice and location with sending off.",
+        readyForInboundEnable: false,
+        readyForProviderActivation: false,
+        readyForSendingEnable: false,
+      };
+    }
+
+    if (configuration.sendingEnabled) {
+      return {
+        ...base,
+        stage: "active",
+        ok: true,
+        detail: "Hosted SMS pilot configuration active",
+        nextAction: result.scope?.clinicSenderEnabled
+          ? "Run and record the consented live SMS validation drill."
+          : "Have the clinic admin enable the exact approved sender, then run the live validation drill.",
+        readyForInboundEnable: false,
+        readyForProviderActivation: false,
+        readyForSendingEnable: false,
+      };
+    }
+
+    if (!configuration.inboundEnabled) {
+      return {
+        ...base,
+        stage: "scope_prepared",
+        ok: true,
+        detail:
+          "Hosted SMS pilot scope prepared; inbound and sending remain off",
+        nextAction:
+          "Verify fresh provider-event and SMS-operations heartbeat receipts, then enable inbound projection while sending stays off.",
+        readyForInboundEnable: true,
+        readyForProviderActivation: false,
+        readyForSendingEnable: false,
+      };
+    }
+
+    if (checks.providerProfileReady !== true) {
+      return {
+        ...base,
+        stage: "inbound_prepared",
+        ok: true,
+        detail: "Hosted SMS inbound projection prepared; sending remains off",
+        nextAction:
+          "Enable and read back the exact provider profile in the platform-admin queue.",
+        readyForInboundEnable: false,
+        readyForProviderActivation: true,
+        readyForSendingEnable: false,
+      };
+    }
+
+    return {
+      ...base,
+      stage: "provider_ready",
+      ok: true,
+      detail: "Hosted SMS provider profile ready; sending remains off",
+      nextAction:
+        "Enable the exact sending allowlist flag, redeploy, and confirm health before clinic enablement.",
+      readyForInboundEnable: false,
+      readyForProviderActivation: false,
+      readyForSendingEnable: true,
+    };
+  } catch {
+    base.blockers.push("readiness_check_failed");
+    return blockedPreflight(base);
+  }
+}

--- a/apps/web/lib/messaging/launch-gate.ts
+++ b/apps/web/lib/messaging/launch-gate.ts
@@ -1,6 +1,7 @@
 import { envFlagEnabled } from "@/lib/env-bool";
 
 export const MESSAGING_SENDING_ENABLED_ENV = "MESSAGING_SENDING_ENABLED";
+export const MESSAGING_INBOUND_ENABLED_ENV = "MESSAGING_INBOUND_ENABLED";
 export const MESSAGING_SENDING_PRACTICE_IDS_ENV =
   "MESSAGING_SENDING_PRACTICE_IDS";
 export const MESSAGING_SENDING_LOCATION_IDS_ENV =
@@ -21,7 +22,7 @@ function allowlist(name: string): ReadonlySet<string> {
     (process.env[name] ?? "")
       .split(",")
       .map((value) => value.trim())
-      .filter(Boolean)
+      .filter(Boolean),
   );
 }
 
@@ -43,17 +44,58 @@ export function hostedMessagingLaunchDecision(opts: {
   if (!opts.practiceId?.trim() || !opts.locationId?.trim()) {
     return { allowed: false, reason: "missing_scope" };
   }
-  if (!allowlist(MESSAGING_SENDING_PRACTICE_IDS_ENV).has(opts.practiceId)) {
+  const practiceAllowlist = allowlist(MESSAGING_SENDING_PRACTICE_IDS_ENV);
+  const locationAllowlist = allowlist(MESSAGING_SENDING_LOCATION_IDS_ENV);
+  if (practiceAllowlist.size !== 1 || locationAllowlist.size !== 1) {
+    return { allowed: false, reason: "missing_scope" };
+  }
+  if (!practiceAllowlist.has(opts.practiceId)) {
     return { allowed: false, reason: "practice_not_allowed" };
   }
-  if (!allowlist(MESSAGING_SENDING_LOCATION_IDS_ENV).has(opts.locationId)) {
+  if (!locationAllowlist.has(opts.locationId)) {
+    return { allowed: false, reason: "location_not_allowed" };
+  }
+  return { allowed: true };
+}
+
+/**
+ * Hosted inbound projection is independently default-off, but uses the same
+ * exact practice and location scope as outbound sending. This keeps signed
+ * callbacks durable while preventing historical or out-of-pilot sender
+ * identities from mutating clinic records during a controlled rollout.
+ *
+ * Self-host deployments do not use the hosted rollout flags and retain their
+ * configured provider behavior.
+ */
+export function hostedMessagingInboundProjectionDecision(opts: {
+  practiceId?: string;
+  locationId?: string;
+}): HostedMessagingLaunchDecision {
+  if (!envFlagEnabled("HOSTED_BILLING_ENABLED")) {
+    return { allowed: true };
+  }
+  if (!envFlagEnabled(MESSAGING_INBOUND_ENABLED_ENV)) {
+    return { allowed: false, reason: "platform_disabled" };
+  }
+  if (!opts.practiceId?.trim() || !opts.locationId?.trim()) {
+    return { allowed: false, reason: "missing_scope" };
+  }
+  const practiceAllowlist = allowlist(MESSAGING_SENDING_PRACTICE_IDS_ENV);
+  const locationAllowlist = allowlist(MESSAGING_SENDING_LOCATION_IDS_ENV);
+  if (practiceAllowlist.size !== 1 || locationAllowlist.size !== 1) {
+    return { allowed: false, reason: "missing_scope" };
+  }
+  if (!practiceAllowlist.has(opts.practiceId)) {
+    return { allowed: false, reason: "practice_not_allowed" };
+  }
+  if (!locationAllowlist.has(opts.locationId)) {
     return { allowed: false, reason: "location_not_allowed" };
   }
   return { allowed: true };
 }
 
 export function hostedMessagingLaunchBlockMessage(
-  reason: HostedMessagingLaunchBlock
+  reason: HostedMessagingLaunchBlock,
 ): string {
   if (reason === "missing_scope") {
     return "Hosted SMS requires an explicit clinic practice and location.";

--- a/apps/web/lib/messaging/sms-provider-events.ts
+++ b/apps/web/lib/messaging/sms-provider-events.ts
@@ -11,10 +11,10 @@ import {
   smsSendAttempts,
 } from "@openpims/db";
 import { db, type Database } from "@openpims/db/client";
-import { envFlagEnabled } from "@/lib/env-bool";
 import { rowsFromExecute } from "@/lib/db/execute-rows";
 import { withSystem } from "@/lib/tenant-db";
 import { mergeRegistrationStatus } from "./a2p-lifecycle";
+import { hostedMessagingInboundProjectionDecision } from "./launch-gate";
 import {
   findMessagingLocationCandidatesForWebhookInTransaction,
   lockMessagingLocationIdentityInTransaction,
@@ -681,13 +681,6 @@ export type LockedSmsProviderEventRemediation = {
   inboundRecipientLockHeld: boolean;
 };
 
-function hostedInboundProjectionEnabled(): boolean {
-  return (
-    !envFlagEnabled("HOSTED_BILLING_ENABLED") ||
-    envFlagEnabled("MESSAGING_INBOUND_ENABLED")
-  );
-}
-
 async function lockPracticeStatesInTransaction(
   tx: Database,
   practiceIds: string[],
@@ -1219,15 +1212,6 @@ async function projectLockedEventInTransaction(
     : resolution.attribution;
 
   if (event.kind === "inbound") {
-    if (!options.allowDisabledInbound && !hostedInboundProjectionEnabled()) {
-      const outcome = await markRetryInTransaction(tx, event, {
-        ...attribution,
-        code: "inbound_projection_disabled",
-        detail: "Inbound SMS projection is disabled for this deployment.",
-        exhaustible: false,
-      });
-      return { outcome };
-    }
     if (
       !attribution?.locationId ||
       !event.fromE164 ||
@@ -1240,6 +1224,26 @@ async function projectLockedEventInTransaction(
         detail: "Inbound SMS is waiting for exact sender attribution.",
       });
       return { outcome };
+    }
+    if (!options.allowDisabledInbound) {
+      const inboundLaunch = hostedMessagingInboundProjectionDecision({
+        practiceId: attribution.practiceId,
+        locationId: attribution.locationId,
+      });
+      if (!inboundLaunch.allowed) {
+        const globallyDisabled = inboundLaunch.reason === "platform_disabled";
+        const outcome = await markRetryInTransaction(tx, event, {
+          ...attribution,
+          code: globallyDisabled
+            ? "inbound_projection_disabled"
+            : "inbound_projection_outside_pilot_scope",
+          detail: globallyDisabled
+            ? "Inbound SMS projection is disabled for this deployment."
+            : "Inbound SMS projection is outside the configured pilot scope.",
+          exhaustible: false,
+        });
+        return { outcome };
+      }
     }
     const { projectInboundSmsReplyInTransaction } = await import("./inbound");
     await projectInboundSmsReplyInTransaction(tx, {

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -82,6 +82,13 @@ const mocks = vi.hoisted(() => {
       duplicate: false,
     })),
     loadSmsProviderEventResolutionHistory: vi.fn(),
+    loadHostedSmsPilotActivationPreflight: vi.fn(async () => ({
+      stage: "scope_prepared",
+      ok: true,
+      detail: "Hosted SMS pilot scope prepared; inbound and sending remain off",
+      nextAction: "Verify fresh heartbeats, then enable inbound projection.",
+      blockers: [],
+    })),
     MockTelnyxError,
     withTenant: vi.fn(
       async (
@@ -114,6 +121,10 @@ vi.mock("@/lib/messaging/sms-provider-event-remediation", () => ({
   resolveSmsProviderEventInTransaction: mocks.resolveSmsProviderEvent,
   loadSmsProviderEventResolutionHistory:
     mocks.loadSmsProviderEventResolutionHistory,
+}));
+vi.mock("@/lib/messaging/hosted-sms-pilot-preflight", () => ({
+  loadHostedSmsPilotActivationPreflight:
+    mocks.loadHostedSmsPilotActivationPreflight,
 }));
 vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   createA2pBrand: mocks.createA2pBrand,
@@ -223,6 +234,13 @@ afterEach(() => {
     events: [],
     truncated: false,
   });
+  mocks.loadHostedSmsPilotActivationPreflight.mockResolvedValue({
+    stage: "scope_prepared",
+    ok: true,
+    detail: "Hosted SMS pilot scope prepared; inbound and sending remain off",
+    nextAction: "Verify fresh heartbeats, then enable inbound projection.",
+    blockers: [],
+  });
 });
 
 describe("platform messaging operations", () => {
@@ -307,6 +325,24 @@ describe("platform messaging operations", () => {
     });
     expect(JSON.stringify(result)).not.toContain("legacy-sensitive-value");
     expect(mocks.noStore).toHaveBeenCalled();
+  });
+
+  it("returns the read-only SMS pilot activation preflight only to platform admins", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(caller().hostedSmsPilotActivationPreflight()).resolves.toEqual(
+      expect.objectContaining({ stage: "scope_prepared", ok: true }),
+    );
+    expect(mocks.loadHostedSmsPilotActivationPreflight).toHaveBeenCalledWith(
+      mocks.db,
+    );
+    expect(mocks.noStore).toHaveBeenCalled();
+
+    mocks.loadHostedSmsPilotActivationPreflight.mockClear();
+    await expect(
+      caller("clinic@example.com").hostedSmsPilotActivationPreflight(),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.loadHostedSmsPilotActivationPreflight).not.toHaveBeenCalled();
   });
 
   it("returns bounded newest-first PHI-free registration history", async () => {

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -113,6 +113,7 @@ import {
   RECOVERY_HOLD_BLOCK_MESSAGE,
 } from "@/lib/recovery-hold";
 import { hostedSmsConfigurationDiagnostics } from "@/lib/messaging/hosted-sms-readiness";
+import { loadHostedSmsPilotActivationPreflight } from "@/lib/messaging/hosted-sms-pilot-preflight";
 import { envFlagEnabled } from "@/lib/env-bool";
 
 /**
@@ -1518,6 +1519,12 @@ export const adminRouter = createRouter({
   hostedSmsConfiguration: platformAdminProcedure.query(() => {
     noStore();
     return hostedSmsConfigurationDiagnostics();
+  }),
+
+  /** Read-only, secret-free activation sequence for the exact staged pilot. */
+  hostedSmsPilotActivationPreflight: platformAdminProcedure.query(() => {
+    noStore();
+    return loadHostedSmsPilotActivationPreflight(db);
   }),
 
   /** Newest-first, PHI-free carrier lifecycle evidence for one exact clinic. */

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -192,11 +192,12 @@ below.
 Provider profiles are created disabled. Never enable one during number
 purchase or carrier submission. Use the platform admin queue in this order:
 
-> **Current release gate:** keep `MESSAGING_INBOUND_ENABLED=false`. Signed
-> hosted callbacks are acknowledged without tenant projection, and provider
-> profile activation is blocked, until the durable recovery-aware inbound event
-> inbox is deployed. Provisioning and carrier review may be prepared, but do
-> not proceed to provider activation or live SMS in this release.
+> The durable recovery-aware provider-event inbox, audited remediation ledger,
+> and provider-free concurrency drill are part of this release. Activation is
+> still default-off: keep inbound and sending disabled until the protected
+> **Hosted SMS pilot activation preflight** proves the exact staged clinic is
+> ready. Loading the preflight is read-only and never contacts Telnyx, changes a
+> provider profile, claims an event, or sends a message.
 
 1. Reconcile the brand as `VERIFIED` or `VETTED_VERIFIED`, the campaign as
    `ACTIVE` or `MNO_PROVISIONED`, and the exact number assignment as `ASSIGNED`.
@@ -205,26 +206,39 @@ purchase or carrier submission. Use the platform admin queue in this order:
    webhook, a US-only destination allowlist, smart encoding, and the enforced
    `$10.00` daily cap. A new profile may still report its clinic-specific
    auto-response rules as missing at this read-only step.
-3. After the durable inbound-event release is deployed and its recovery drill
-   passes, confirm the every-five-minute `sms-provider-events` writer heartbeat,
-   an empty redacted provider-event queue, and a healthy read-only
-   `sms-operations` heartbeat. Then set `MESSAGING_INBOUND_ENABLED=true`, select
-   **Enable provider profile**, and confirm the provider mutation. OpenVPM
-   first installs and reads back the exact clinic-branded US START, STOP, and
-   HELP rules using the registered clinic name and support phone. Missing,
-   duplicate, wildcard, paginated, or changed rules block activation. OpenVPM
-   then reads every provider prerequisite back after the update and deliberately
-   leaves the clinic database sender off. Provider activation remains blocked
-   if exact or identity-matched pending, retry, recovery-blocked, quarantined,
-   or unreviewed identity-conflict evidence exists.
-4. Add exactly one practice and location to the sending allowlists and set
-   `MESSAGING_SENDING_ENABLED=true`.
-5. Within 15 minutes of the provider readback, have the clinic admin enable the
+3. Turn fee-bearing provisioning back off. With
+   `MESSAGING_INBOUND_ENABLED=false` and `MESSAGING_SENDING_ENABLED=false`,
+   stage exactly one provisioning practice, the same sending practice, and its
+   exact location in the three pilot allowlists. Redeploy. Health must remain
+   `200`; the protected preflight must report **Scope prepared**, carrier
+   identity ready, recovery clear, and zero blocking provider events. A staged
+   scope no longer requires the provider profile to be active while sending is
+   safely off. Hosted inbound projection and outbound sending both enforce this
+   exact single-practice, single-location scope at runtime; a multi-clinic or
+   partial allowlist fails closed even if a deployment bypasses health checks.
+4. Confirm a fresh every-five-minute `sms-provider-events` writer heartbeat and
+   a fresh, healthy read-only `sms-operations` heartbeat in the external
+   monitor. A configured heartbeat destination is not proof of a fresh receipt.
+   Then set `MESSAGING_INBOUND_ENABLED=true`, keep sending off, and redeploy.
+   Health must remain `200` and the preflight must report **Inbound prepared**.
+5. Select **Enable provider profile** and confirm the provider mutation.
+   OpenVPM first installs and reads back the exact clinic-branded US START,
+   STOP, and HELP rules using the registered clinic name and support phone.
+   Missing, duplicate, wildcard, paginated, or changed rules block activation.
+   OpenVPM then reads every provider prerequisite back after the update and
+   deliberately leaves the clinic database sender off. Provider activation
+   remains blocked if exact or identity-matched pending, retry,
+   recovery-blocked, quarantined, or unreviewed identity-conflict evidence
+   exists. The preflight must advance to **Provider ready**.
+6. Set `MESSAGING_SENDING_ENABLED=true`, redeploy, and require health `200` plus
+   preflight state **Active**. A live sending flag with inbound disabled or a
+   provider profile that is not ready is release-blocking.
+7. Within 15 minutes of the provider readback, have the clinic admin enable the
    location sender. This transaction takes the practice row before reading the
    event queue and refuses to enable while relevant evidence remains. An expired
    or failed attestation blocks the database switch; inspect the profile again
    instead of bypassing the gate.
-6. Validate only with a current, consented client workflow. Confirm outbound
+8. Validate only with a current, consented client workflow. Confirm outbound
    accepted-to-delivered evidence, an ordinary inbound reply, HELP, STOP plus a
    blocked resend, START plus restored consent, one reminder, usage metering,
    and empty reconciliation queues.


### PR DESCRIPTION
## What changed

- add a read-only, secret-free hosted SMS pilot activation preflight with explicit deferred, staged, provider-ready, and active states
- surface the sequenced preflight in public health and the platform-admin console without returning clinic, phone, provider, or secret identifiers
- enforce one exact hosted pilot practice and location at both inbound projection and outbound send boundaries
- keep out-of-scope signed inbound evidence durable and non-exhaustingly retryable instead of projecting it
- replace the obsolete runbook release gate with the tested activation and kill sequence

## Why

The previous health contract created a circular activation deadlock: staging the sending scope with inbound off failed health, while provider profile activation required inbound on. It also gated inbound projection only with a global flag, so historical or out-of-pilot sender identities could project during a controlled rollout.

This release makes safe intermediate rollout states health-green while sending remains off, and aligns health, operator guidance, inbound projection, and outbound sending on the same exact single-clinic scope.

## Safety

- no Telnyx/provider calls or mutations
- no SMS sends
- no production or environment changes
- no schema migration
- self-host messaging behavior is preserved
- loading the preflight is read-only

## Validation

- changed-area SMS/health/admin suite: 290 tests passed
- full web suite: 375 files passed, 3 skipped; 3,892 tests passed, 6 integration tests skipped by existing guards
- `pnpm type-check`
- `pnpm build`
- Prettier and `git diff --check`
