### PR TITLE
Build a guided clinic activation and conversion funnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,10 @@ STRIPE_CONNECT_APPLICATION_FEE_BPS=
 # 14-day card-free trial, then bills $79/mo or $790/yr per active location,
 # unlimited staff. When enabled, both recurring Stripe prices below must be set.
 HOSTED_BILLING_ENABLED=
+# Prospective, default-off first-real-visit conversion email. Enable only with
+# an exact ISO timestamp so deployment cannot backfill historical closeouts.
+FIRST_CLINIC_WIN_ENABLED=false
+FIRST_CLINIC_WIN_ROLLOUT_AT=
 # Cloud recurring Prices. New checkout uses the per-location price; the per-user
 # price is legacy-only and not required for new checkout or hosted readiness.
 STRIPE_PRICE_CLOUD_LOCATION=
@@ -167,6 +171,7 @@ CRON_HEARTBEAT_BACKUP_URL=
 CRON_HEARTBEAT_FILE_REPLICAS_URL=
 CRON_HEARTBEAT_USAGE_RECONCILE_URL=
 CRON_HEARTBEAT_BILLING_LIFECYCLE_URL=
+CRON_HEARTBEAT_FIRST_CLINIC_WIN_URL=
 CRON_HEARTBEAT_SETUP_RECOVERY_URL=
 CRON_HEARTBEAT_WELLNESS_BILLING_URL=
 CRON_HEARTBEAT_RATE_LIMIT_CLEANUP_URL=

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -5,6 +5,7 @@ import { signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
+  ArrowLeft,
   ArrowRight,
   AlertTriangle,
   Bot,
@@ -47,8 +48,21 @@ import {
   type ClinicRegionCode,
 } from "@/lib/locale/clinic-regions";
 import { safeAuthNextPath } from "@/lib/auth-redirect";
+import { ClinicIntentBuilder } from "@/components/onboarding/clinic-intent-builder";
+import {
+  CLINIC_MODELS,
+  DEFAULT_CLINIC_MODEL,
+  DEFAULT_FIRST_GOAL,
+  FIRST_GOALS,
+  clinicModelOption,
+  type ClinicModel,
+  type FirstGoal,
+} from "@/lib/onboarding/clinic-profile";
 
 type RegistrationCountry = ClinicRegionCode | "OTHER" | "";
+type RegistrationStage = "profile" | "account";
+
+const REGISTRATION_PROFILE_STORAGE_KEY = "openvpm:registration-profile:v1";
 
 const selectClass =
   "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
@@ -73,6 +87,11 @@ function RegisterPageInner() {
   const cloudIntent = searchParams.get("intent") === "cloud";
   const nextPath = safeAuthNextPath(searchParams.get("next"), "/");
   const acquisition = acquisitionFromSearchParams(searchParams);
+  const [stage, setStage] = useState<RegistrationStage>("profile");
+  const [profileRestored, setProfileRestored] = useState(false);
+  const [clinicModel, setClinicModel] =
+    useState<ClinicModel>(DEFAULT_CLINIC_MODEL);
+  const [firstGoal, setFirstGoal] = useState<FirstGoal>(DEFAULT_FIRST_GOAL);
   const [practiceName, setPracticeName] = useState("");
   const [country, setCountry] = useState<RegistrationCountry>("");
   const [email, setEmail] = useState("");
@@ -90,8 +109,76 @@ function RegisterPageInner() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- signup attribution snapshot
   }, []);
 
+  useEffect(() => {
+    try {
+      const raw = window.sessionStorage.getItem(
+        REGISTRATION_PROFILE_STORAGE_KEY,
+      );
+      if (!raw) {
+        return;
+      }
+      const saved = JSON.parse(raw) as {
+        stage?: unknown;
+        clinicModel?: unknown;
+        firstGoal?: unknown;
+      };
+      if (
+        typeof saved.clinicModel === "string" &&
+        CLINIC_MODELS.includes(saved.clinicModel as ClinicModel)
+      ) {
+        setClinicModel(saved.clinicModel as ClinicModel);
+      }
+      if (
+        typeof saved.firstGoal === "string" &&
+        FIRST_GOALS.includes(saved.firstGoal as FirstGoal)
+      ) {
+        setFirstGoal(saved.firstGoal as FirstGoal);
+      }
+      if (saved.stage === "account") setStage("account");
+    } catch {
+      window.sessionStorage.removeItem(REGISTRATION_PROFILE_STORAGE_KEY);
+    } finally {
+      setProfileRestored(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!profileRestored) return;
+    try {
+      window.sessionStorage.setItem(
+        REGISTRATION_PROFILE_STORAGE_KEY,
+        JSON.stringify({ stage, clinicModel, firstGoal }),
+      );
+    } catch {
+      // Session continuity is helpful but must never block registration.
+    }
+  }, [profileRestored, stage, clinicModel, firstGoal]);
+
+  useEffect(() => {
+    if (!profileRestored) return;
+    trackFunnelEvent(
+      stage === "profile"
+        ? FUNNEL_EVENTS.signupProfileViewed
+        : FUNNEL_EVENTS.signupAccountViewed,
+      {
+        source: acquisition?.source ?? "none",
+        step: stage,
+      },
+    );
+  }, [acquisition?.source, profileRestored, stage]);
+
   const registerMutation = trpc.auth.register.useMutation({
     onSuccess: async (data) => {
+      trackFunnelEvent(FUNNEL_EVENTS.signupSucceeded, {
+        model: clinicModel,
+        goal: firstGoal,
+        step: "account",
+      });
+      try {
+        window.sessionStorage.removeItem(REGISTRATION_PROFILE_STORAGE_KEY);
+      } catch {
+        // The account is created even when storage is unavailable.
+      }
       if (data.checkoutUrl) {
         if (!isSafeCheckoutRedirectUrl(data.checkoutUrl)) {
           toast.error("Hosted checkout is unavailable. Please try again.");
@@ -164,6 +251,11 @@ function RegisterPageInner() {
     }
     setError("");
     setLoading(true);
+    trackFunnelEvent(FUNNEL_EVENTS.signupSubmitted, {
+      model: clinicModel,
+      goal: firstGoal,
+      step: "account",
+    });
     const registrationAcquisition = acquisitionWithFunnelVisitorId(
       acquisition,
       getFunnelVisitorId(),
@@ -173,41 +265,149 @@ function RegisterPageInner() {
       password,
       practiceName: practiceName.trim(),
       country: country as ClinicRegionCode,
+      onboardingDraft: { clinicModel, firstGoal },
       acquisition: registrationAcquisition,
     });
   }
 
+  function selectClinicModel(model: ClinicModel) {
+    const nextGoal =
+      model === "exploring" || firstGoal !== "self_host"
+        ? firstGoal
+        : "explore_sample";
+    setClinicModel(model);
+    setFirstGoal(nextGoal);
+    trackFunnelEvent(FUNNEL_EVENTS.onboardingModelSelected, {
+      model,
+      step: "profile",
+    });
+  }
+
+  function selectFirstGoal(goal: FirstGoal) {
+    setFirstGoal(goal);
+    trackFunnelEvent(FUNNEL_EVENTS.onboardingGoalSelected, {
+      model: clinicModel,
+      goal,
+      step: "profile",
+    });
+  }
+
+  function continueToAccount() {
+    trackFunnelEvent(FUNNEL_EVENTS.signupProfileCompleted, {
+      model: clinicModel,
+      goal: firstGoal,
+      step: "profile",
+    });
+    trackFunnelEvent(FUNNEL_EVENTS.onboardingPlanBuilt, {
+      model: clinicModel,
+      goal: firstGoal,
+      step: "profile",
+    });
+    setStage("account");
+  }
+
+  if (stage === "profile") {
+    return (
+      <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#fff7ed_0%,transparent_34%),radial-gradient(circle_at_top_right,#ede9fe_0%,transparent_36%),linear-gradient(180deg,#ffffff_0%,#f5fbf8_100%)] px-4 py-5 sm:px-6 sm:py-8">
+        <div className="mx-auto max-w-6xl overflow-hidden rounded-[28px] border border-white/80 bg-white/95 shadow-[0_30px_90px_-54px_rgba(15,23,42,0.48)] backdrop-blur">
+          <header className="flex items-center justify-between border-b border-slate-100 px-5 py-4 sm:px-9 sm:py-5">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-3 font-heading text-lg font-semibold tracking-tight text-slate-950 sm:text-xl"
+            >
+              <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
+                <PawMark className="h-5 w-5" />
+              </span>
+              OpenVPM
+            </Link>
+            <div className="flex items-center gap-3 text-xs font-medium text-slate-500 sm:text-sm">
+              <span>Step 1 of 2</span>
+              <span className="flex gap-1" aria-hidden="true">
+                <span className="h-1.5 w-10 rounded-full bg-primary" />
+                <span className="h-1.5 w-10 rounded-full bg-slate-200" />
+              </span>
+            </div>
+          </header>
+
+          <section className="px-5 py-7 sm:px-9 sm:py-10 lg:px-12">
+            <div className="mb-8 max-w-3xl">
+              <h1 className="font-heading text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
+                A platform truly built for your clinic.
+              </h1>
+              <p className="mt-3 text-sm leading-6 text-slate-600 sm:text-base">
+                Tell us what your team needs first. We’ll shape a useful first
+                day before asking you to create the workspace.
+              </p>
+            </div>
+
+            <ClinicIntentBuilder
+              clinicModel={clinicModel}
+              firstGoal={firstGoal}
+              onClinicModelChange={selectClinicModel}
+              onFirstGoalChange={selectFirstGoal}
+              intro="Two quick choices make the rest of setup feel like your clinic—not a generic software tour."
+            />
+          </section>
+
+          <footer className="flex flex-col-reverse gap-3 border-t border-slate-100 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-9">
+            <p className="text-center text-xs text-slate-500 sm:text-left">
+              No patient or client information belongs here.
+            </p>
+            <Button
+              type="button"
+              onClick={continueToAccount}
+              className="h-11 rounded-xl px-6 text-sm font-semibold shadow-[0_12px_28px_-16px_rgba(5,150,105,0.8)]"
+            >
+              Build my first day
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </footer>
+        </div>
+      </main>
+    );
+  }
+
   return (
-    <div className="grid min-h-screen lg:grid-cols-2">
+    <div className="grid min-h-screen min-w-0 overflow-x-hidden lg:grid-cols-2">
       {/* Left pane: the form, on clean white */}
-      <div className="flex items-center justify-center bg-white px-6 py-10 sm:px-10">
-        <div className="w-full max-w-md">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 hover:text-primary"
-          >
-            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-              <PawMark className="h-4 w-4" />
+      <div className="flex min-w-0 items-center justify-center bg-white px-6 py-10 sm:px-10">
+        <div className="min-w-0 w-full max-w-md">
+          <div className="flex items-center justify-between gap-4">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 hover:text-primary"
+            >
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+                <PawMark className="h-4 w-4" />
+              </span>
+              OpenVPM {cloudIntent ? "Cloud" : ""}
+            </Link>
+            <span className="text-xs font-medium text-slate-500">
+              Step 2 of 2
             </span>
-            OpenVPM {cloudIntent ? "Cloud" : ""}
-          </Link>
+          </div>
 
           <h1 className="mt-8 font-heading text-3xl font-bold tracking-tight text-slate-950">
-            Create your workspace
+            Make it yours.
           </h1>
           <p className="mt-2 text-sm leading-6 text-slate-600">
-            Start using OpenVPM in about a minute. You own your data, and smart
-            AI tools are built in.
+            Create the workspace for your{" "}
+            {clinicModelOption(clinicModel).shortLabel.toLowerCase()} team. Your
+            first-day plan will be waiting inside.
           </p>
 
-          <form onSubmit={handleSubmit} className="mt-8 grid gap-4">
+          <form onSubmit={handleSubmit} className="mt-8 grid min-w-0 gap-4">
             {error ? (
               <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
                 {error}
               </div>
             ) : null}
 
-            <FormField label="Practice name" htmlFor="practiceName">
+            <FormField
+              label="Practice name"
+              htmlFor="practiceName"
+              className="min-w-0"
+            >
               <Input
                 id="practiceName"
                 value={practiceName}
@@ -222,6 +422,7 @@ function RegisterPageInner() {
             <FormField
               label="Clinic country"
               htmlFor="country"
+              className="min-w-0"
               description="This sets your currency, tax defaults, time zone, and rollout eligibility."
             >
               <select
@@ -277,7 +478,7 @@ function RegisterPageInner() {
               </div>
             ) : null}
 
-            <FormField label="Work email" htmlFor="email">
+            <FormField label="Work email" htmlFor="email" className="min-w-0">
               <Input
                 id="email"
                 type="email"
@@ -292,6 +493,7 @@ function RegisterPageInner() {
             <FormField
               label="Password"
               htmlFor="password"
+              className="min-w-0"
               description={`At least ${AUTH_PASSWORD_MIN_LENGTH} characters.`}
             >
               <Input
@@ -328,6 +530,15 @@ function RegisterPageInner() {
               <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
               Free for 14 days. No credit card required.
             </p>
+
+            <button
+              type="button"
+              onClick={() => setStage("profile")}
+              className="mx-auto inline-flex items-center gap-1.5 text-xs font-medium text-slate-500 transition hover:text-primary"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              Change first-day plan
+            </button>
 
             <p className="text-center text-xs text-slate-500">
               <Link
@@ -374,11 +585,13 @@ function RegisterPageInner() {
       <div className="relative hidden overflow-hidden bg-[linear-gradient(135deg,#fff7ed_0%,#fdf2f8_45%,#ecfdf5_100%)] lg:block">
         <div className="relative z-10 px-12 pt-16">
           <h2 className="max-w-md font-heading text-3xl font-bold tracking-tight text-slate-950">
-            The practice system you own.
+            Your first day, already taking shape.
           </h2>
           <p className="mt-3 max-w-md text-sm leading-6 text-slate-600">
-            Run your day, keep clean records, and send bills. Smart AI tools are
-            built in, and your data stays yours to export any time.
+            Built around{" "}
+            {clinicModelOption(clinicModel).shortLabel.toLowerCase()} care and
+            the first outcome you chose. You can change any of it once you’re
+            inside.
           </p>
         </div>
 

--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -1122,14 +1122,34 @@ export default function AdminPage() {
         </div>
         {journey ? (
           <>
-            <div className="mt-3 grid gap-4 sm:grid-cols-3 xl:grid-cols-6">
+            <div className="mt-3 grid gap-4 sm:grid-cols-3 xl:grid-cols-5">
               {[
                 ["Visit", journey.totals.visitors, null],
                 ["Demo", journey.totals.demos, journey.totals.demoRate],
                 [
+                  "Plan started",
+                  journey.totals.signupProfileViewed,
+                  journey.totals.profileViewRate,
+                ],
+                [
+                  "Plan built",
+                  journey.totals.signupProfileCompleted,
+                  journey.totals.profileCompletionRate,
+                ],
+                [
+                  "Account form",
+                  journey.totals.signupAccountViewed,
+                  journey.totals.accountViewRate,
+                ],
+                [
+                  "Signup submitted",
+                  journey.totals.signupSubmitted,
+                  journey.totals.signupSubmitRate,
+                ],
+                [
                   "Registered",
                   journey.totals.registrations,
-                  journey.totals.registrationRate,
+                  journey.totals.signupSuccessRate,
                 ],
                 [
                   "Activated",
@@ -1343,6 +1363,52 @@ export default function AdminPage() {
               payment. Currently active is current billing state, not a
               historical conversion milestone.
             </p>
+
+            <div className="mt-4 rounded-lg border border-primary/15 bg-primary/5 p-4">
+              <p className="text-sm font-medium">
+                First real visit → billing setup
+              </p>
+              <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                <div>
+                  <p className="text-xs text-muted-foreground">
+                    Conversion opportunities
+                  </p>
+                  <p className="mt-1 font-heading text-xl font-bold tabular-nums">
+                    {funnel.firstVisitBillingConversion.opportunities}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Within 24h</p>
+                  <p className="mt-1 font-heading text-xl font-bold tabular-nums">
+                    {funnel.firstVisitBillingConversion.convertedWithin24Hours}
+                    <span className="ml-2 text-sm font-normal text-muted-foreground">
+                      {formatPct(
+                        funnel.firstVisitBillingConversion
+                          .conversionWithin24HoursRate,
+                      )}
+                    </span>
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Within 72h</p>
+                  <p className="mt-1 font-heading text-xl font-bold tabular-nums">
+                    {funnel.firstVisitBillingConversion.convertedWithin72Hours}
+                    <span className="ml-2 text-sm font-normal text-muted-foreground">
+                      {formatPct(
+                        funnel.firstVisitBillingConversion
+                          .conversionWithin72HoursRate,
+                      )}
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Uses only first real visits at least 72 hours old. Clinics that
+                connected billing before that visit are reported separately (
+                {funnel.firstVisitBillingConversion.alreadyConnectedAtVisit})
+                and are not in the opportunity denominator.
+              </p>
+            </div>
             <div className="mt-4 rounded-md border border-amber-300/60 bg-amber-50/50 p-3 text-xs text-muted-foreground dark:bg-amber-950/10">
               <p className="font-medium text-foreground">
                 Conversion evidence quality

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1578,6 +1578,17 @@ function BillingTab() {
             </div>
           ) : null}
 
+          {data.billingStatus === "past_due" ? (
+            <div className="mb-5 flex gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>
+                Stripe is retrying this payment. Your clinic remains writable
+                during the retry window; review billing to avoid an unpaid,
+                read-only account.
+              </p>
+            </div>
+          ) : null}
+
           {firstActivation ? (
             <>
               <CloudBillingCadencePicker

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -100,6 +100,15 @@ function funnel(
       confirmedNonUs: jurisdictionTotals(1, 0),
       unknown: jurisdictionTotals(1, 0),
     },
+    firstVisitBillingConversion: {
+      maturedFirstVisits: 1,
+      alreadyConnectedAtVisit: 0,
+      opportunities: 1,
+      convertedWithin24Hours: 0,
+      convertedWithin72Hours: 1,
+      conversionWithin24HoursRate: 0,
+      conversionWithin72HoursRate: 1,
+    },
     dataQuality: {
       confirmedUsSignups: 3,
       confirmedNonUsSignups: 1,
@@ -122,6 +131,10 @@ function journey(days: number): JourneyFunnel {
     totals: {
       visitors: 20,
       demos: 8,
+      signupProfileViewed: 6,
+      signupProfileCompleted: 5,
+      signupAccountViewed: 5,
+      signupSubmitted: 5,
       registrations: 5,
       activated: 2,
       paymentMethodCollected: 1,
@@ -136,6 +149,11 @@ function journey(days: number): JourneyFunnel {
       repairableAttributionGaps: 0,
       clientErrors: 2,
       demoRate: 0.4,
+      profileViewRate: 0.3,
+      profileCompletionRate: 5 / 6,
+      accountViewRate: 1,
+      signupSubmitRate: 1,
+      signupSuccessRate: 1,
       registrationRate: 0.25,
       activationRate: 0.4,
       paymentMethodRate: 0.5,
@@ -257,9 +275,7 @@ describe("activation digest cron", () => {
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
-        html: expect.stringContaining(
-          "its rate is measured from activated clinics",
-        ),
+        html: expect.stringContaining("its rate is measured from signups"),
       }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -135,6 +135,7 @@ function funnelSection(title: string, funnel: ActivationFunnel): string {
   </tr>
 </table>
 <p style="margin:8px 0 0;color:#374151;font-size:13px;line-height:1.5;"><strong>Jurisdiction cohorts:</strong> US ${funnel.jurisdictionCohorts.confirmedUs.signups} signup(s) → ${funnel.jurisdictionCohorts.confirmedUs.activated} activated (${pct(funnel.jurisdictionCohorts.confirmedUs.activationRate)}) · non-US ${funnel.jurisdictionCohorts.confirmedNonUs.signups} → ${funnel.jurisdictionCohorts.confirmedNonUs.activated} (${pct(funnel.jurisdictionCohorts.confirmedNonUs.activationRate)}) · historical unknown ${funnel.jurisdictionCohorts.unknown.signups} → ${funnel.jurisdictionCohorts.unknown.activated} (${pct(funnel.jurisdictionCohorts.unknown.activationRate)}).</p>
+<p style="margin:8px 0 0;color:#374151;font-size:13px;line-height:1.5;"><strong>First real visit → billing setup:</strong> ${funnel.firstVisitBillingConversion.convertedWithin24Hours}/${funnel.firstVisitBillingConversion.opportunities} within 24h (${pct(funnel.firstVisitBillingConversion.conversionWithin24HoursRate)}) · ${funnel.firstVisitBillingConversion.convertedWithin72Hours}/${funnel.firstVisitBillingConversion.opportunities} within 72h (${pct(funnel.firstVisitBillingConversion.conversionWithin72HoursRate)}) · ${funnel.firstVisitBillingConversion.alreadyConnectedAtVisit} already connected at first visit. Only first visits at least 72 hours old are included.</p>
 <p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Evidence quality: ${funnel.dataQuality.legacyBusinessStageRows} excluded legacy stage row(s) · ${funnel.dataQuality.unknownPaymentMethodPractices} clinic(s) with unknown payment-method evidence · ${funnel.dataQuality.unknownPositivePaymentPractices} clinic(s) with unknown positive-payment evidence · ${funnel.dataQuality.missingRegistrationMilestones} missing registration projection(s) · ${funnel.dataQuality.missingActivationMilestones} missing activation projection(s) · ${funnel.dataQuality.unprojectedStripeEvidence} unprojected Stripe evidence row(s) · ${funnel.dataQuality.unmappedStripeEvidence} unmapped Stripe evidence row(s). Unknown is not zero and receives no synthetic date.</p>`;
 }
 
@@ -142,6 +143,10 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
   const {
     visitors,
     demos,
+    signupProfileViewed,
+    signupProfileCompleted,
+    signupAccountViewed,
+    signupSubmitted,
     registrations,
     activated,
     paymentMethodCollected,
@@ -171,6 +176,7 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
     <td style="padding:2px 0;">${firstPositivePayment} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(positivePaymentRate)}</span></td>
   </tr>
 </table>
+<p style="margin:8px 0 0;color:#374151;font-size:13px;line-height:1.5;"><strong>Signup path:</strong> ${signupProfileViewed} plan start(s) → ${signupProfileCompleted} plan(s) built → ${signupAccountViewed} account form(s) → ${signupSubmitted} submission(s) → ${registrations} registered.</p>
 <p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Left before trying: ${funnel.totals.leftBeforeTrying} · Demo without signup: ${funnel.totals.demoAbandoned} · Signup without activation: ${funnel.totals.registrationAbandoned} · Activated without payment method: ${funnel.totals.activationAbandoned} · Payment method without positive payment after trial: ${funnel.totals.paymentAbandoned} · Client errors: ${funnel.totals.clientErrors}</p>
 <p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>`;
 }
@@ -221,7 +227,7 @@ function digestHtml(
               ${funnelSection("Past 7 days", week)}
               ${funnelSection("Past 30 days", month)}
               ${pilotSection(pilots)}
-              <p style="margin:24px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Activated = added a real client and booked a real visit. First visit done = completed the clinical and billing closeout; its rate is measured from activated clinics. Payment method = signed subscription Checkout completion with collection required. First positive payment = signed positive subscription invoice payment. Currently active is current billing state, not a historical milestone. Legacy business-stage rows are excluded; demo data never counts.</p>
+              <p style="margin:24px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Activated = added a real client and booked a real visit. First visit done = completed the clinical and billing closeout; its rate is measured from signups. Payment method = signed subscription Checkout completion with collection required and is also measured from signups because billing can be connected before activation. First positive payment = signed positive subscription invoice payment. Currently active is current billing state, not a historical milestone. Legacy business-stage rows are excluded; demo data never counts.</p>
             </td>
           </tr>
           <tr>

--- a/apps/web/app/api/cron/billing-lifecycle/route.test.ts
+++ b/apps/web/app/api/cron/billing-lifecycle/route.test.ts
@@ -98,6 +98,8 @@ function practice(overrides: Record<string, unknown> = {}) {
     email: "owner@example.com",
     timezone: "America/New_York",
     trialEndsAt: new Date("2026-07-04T15:00:00Z"),
+    stripeSubscriptionId: null,
+    billingSetupRecorded: false,
     ...overrides,
   };
 }
@@ -194,6 +196,8 @@ describe("billing lifecycle cron", () => {
       daysLeft: 3,
       trialEndDate: "July 4, 2026",
       monthlyPrice: "$79",
+      billingConnected: false,
+      idempotencyKey: `lc:trial-ending:${PRACTICE_ID}:2026-07-04:t-3`,
     });
     expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
       job: "billing-lifecycle",
@@ -266,6 +270,49 @@ describe("billing lifecycle cron", () => {
         to: "owner@example.com",
       }),
     );
+  });
+
+  it("reassures a signed billing-connected trial instead of asking for a card", async () => {
+    mocks.selectResults.push([
+      practice({
+        stripeSubscriptionId: "sub_connected",
+        billingSetupRecorded: true,
+      }),
+    ]);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/billing-lifecycle"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      sent: 1,
+      skipped: 0,
+    });
+    expect(mocks.sendTrialEndingEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        billingConnected: true,
+        idempotencyKey: `lc:trial-ending:${PRACTICE_ID}:2026-07-04:t-3`,
+      }),
+    );
+  });
+
+  it("suppresses contradictory subscription and signed milestone evidence", async () => {
+    mocks.selectResults.push([
+      practice({
+        stripeSubscriptionId: "sub_unprojected",
+        billingSetupRecorded: false,
+      }),
+    ]);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/billing-lifecycle"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      sent: 0,
+      skipped: 1,
+    });
+    expect(mocks.sendOptionalPlatformEmail).not.toHaveBeenCalled();
   });
 
   it("skips non-milestone trials and practices without billing email", async () => {

--- a/apps/web/app/api/cron/billing-lifecycle/route.ts
+++ b/apps/web/app/api/cron/billing-lifecycle/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { and, eq, gte, isNotNull, isNull, lte } from "drizzle-orm";
-import { db } from "@openpims/db/client";
+import { and, eq, gte, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import { db, type Database } from "@openpims/db/client";
 import { practices } from "@openpims/db";
 import {
   billingEnforced,
@@ -65,6 +65,13 @@ export async function GET(request: Request) {
           email: practices.email,
           timezone: practices.timezone,
           trialEndsAt: practices.trialEndsAt,
+          stripeSubscriptionId: practices.stripeSubscriptionId,
+          billingSetupRecorded: sql<boolean>`exists (
+            select 1
+            from practice_conversion_milestones pcm
+            where pcm.practice_id = ${practices.id}
+              and pcm.milestone = 'payment_method_collected'
+          )`,
         })
         .from(practices)
         .where(
@@ -99,17 +106,38 @@ export async function GET(request: Request) {
         continue;
       }
 
+      const billingConnected =
+        Boolean(practice.stripeSubscriptionId) &&
+        practice.billingSetupRecorded === true;
+      const needsBilling =
+        !practice.stripeSubscriptionId &&
+        practice.billingSetupRecorded !== true;
+      if (!billingConnected && !needsBilling) {
+        // Conflicting local evidence is an operator reconciliation case. Do
+        // not guess whether the clinic needs a card or is already connected.
+        skipped++;
+        continue;
+      }
+
+      const dedupeKey = [
+        "lc:trial-ending",
+        practice.id,
+        formatDateKey(trialEndsAt, practice.timezone ?? undefined),
+        `t-${daysLeft}`,
+      ].join(":");
       const result = await sendOptionalPlatformEmail({
         practiceId: practice.id,
         to,
         emailType: "trial-ending",
-        dedupeKey: [
-          "lc:trial-ending",
-          practice.id,
-          formatDateKey(trialEndsAt, practice.timezone ?? undefined),
-          `t-${daysLeft}`,
-        ].join(":"),
+        dedupeKey,
         retryOnFail: true,
+        stillEligible: (tx) =>
+          trialReminderStillEligible(tx, {
+            practiceId: practice.id,
+            to,
+            trialEndsAt,
+            billingConnected,
+          }),
         send: () =>
           sendTrialEndingEmail({
             to,
@@ -120,6 +148,8 @@ export async function GET(request: Request) {
               practice.timezone ?? undefined,
             ),
             monthlyPrice: `$${CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD}`,
+            billingConnected,
+            idempotencyKey: dedupeKey,
           }),
       });
 
@@ -162,6 +192,52 @@ export async function GET(request: Request) {
       { status: 500 },
     );
   }
+}
+
+async function trialReminderStillEligible(
+  tx: Database,
+  input: {
+    practiceId: string;
+    to: string;
+    trialEndsAt: Date;
+    billingConnected: boolean;
+  },
+): Promise<boolean> {
+  const [practice] = await tx
+    .select({
+      email: practices.email,
+      stripeSubscriptionId: practices.stripeSubscriptionId,
+      billingStatus: practices.billingStatus,
+      trialEndsAt: practices.trialEndsAt,
+      billingSetupRecorded: sql<boolean>`exists (
+        select 1
+        from practice_conversion_milestones pcm
+        where pcm.practice_id = ${practices.id}
+          and pcm.milestone = 'payment_method_collected'
+      )`,
+    })
+    .from(practices)
+    .where(
+      and(
+        eq(practices.id, input.practiceId),
+        isNull(practices.deletedAt),
+        eq(practices.recoveryHold, false),
+      ),
+    )
+    .limit(1);
+  if (
+    !practice ||
+    practice.billingStatus !== "trialing" ||
+    !practice.trialEndsAt ||
+    new Date(practice.trialEndsAt).getTime() !== input.trialEndsAt.getTime() ||
+    billingContactEmail(practice.email) !== input.to
+  ) {
+    return false;
+  }
+  return input.billingConnected
+    ? Boolean(practice.stripeSubscriptionId) &&
+        practice.billingSetupRecorded === true
+    : !practice.stripeSubscriptionId && practice.billingSetupRecorded !== true;
 }
 
 function calendarDaysUntil(end: Date, now: Date, timeZone?: string): number {

--- a/apps/web/app/api/cron/first-clinic-win/route.test.ts
+++ b/apps/web/app/api/cron/first-clinic-win/route.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const ROUTE_SOURCE = readFileSync(
+  fileURLToPath(new URL("./route.ts", import.meta.url)),
+  "utf8",
+);
+
+const mocks = vi.hoisted(() => {
+  const selectResults: unknown[][] = [];
+  const select = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const builder: Record<string, unknown> = {};
+    builder.from = vi.fn(() => builder);
+    builder.where = vi.fn(() => builder);
+    builder.orderBy = vi.fn(() => builder);
+    builder.limit = vi.fn(async () => result);
+    return builder;
+  });
+  const db = { select };
+  return {
+    db,
+    selectResults,
+    billingEnforced: vi.fn(() => true),
+    cronAuthError: vi.fn(() => null),
+    reportCronHeartbeat: vi.fn(async () => undefined),
+    alertOps: vi.fn(async () => undefined),
+    sendFirstClinicWinEmail: vi.fn(async () => ({
+      success: true,
+      id: "email-first-win",
+    })),
+    sendOptionalPlatformEmail: vi.fn(
+      async (opts: {
+        stillEligible?: (tx: unknown) => Promise<boolean>;
+        send: () => Promise<{ success: boolean }>;
+      }) => {
+        if (opts.stillEligible && !(await opts.stillEligible(db))) {
+          return { sent: false, deduped: false, suppressed: true };
+        }
+        const result = await opts.send();
+        return result.success
+          ? { sent: true, deduped: false }
+          : { sent: false, deduped: false };
+      },
+    ),
+    withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
+      fn(db),
+    ),
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({ db: mocks.db }));
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
+vi.mock("@/lib/billing/plans", () => ({
+  billingEnforced: mocks.billingEnforced,
+}));
+vi.mock("@/lib/cron-auth", () => ({ cronAuthError: mocks.cronAuthError }));
+vi.mock("@/lib/cron-heartbeat", () => ({
+  reportCronHeartbeat: mocks.reportCronHeartbeat,
+}));
+vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
+vi.mock("@/lib/email", () => ({
+  sendFirstClinicWinEmail: mocks.sendFirstClinicWinEmail,
+}));
+vi.mock("@/lib/email-lifecycle", () => ({
+  sendOptionalPlatformEmail: mocks.sendOptionalPlatformEmail,
+}));
+
+const { GET } = await import("./route");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+
+function candidate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: PRACTICE_ID,
+    name: "Neighborhood Veterinary",
+    email: "owner@example.com",
+    timezone: "America/New_York",
+    trialEndsAt: new Date("2026-08-28T04:00:00Z"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-15T15:00:00Z"));
+  vi.stubEnv("FIRST_CLINIC_WIN_ENABLED", "true");
+  vi.stubEnv("FIRST_CLINIC_WIN_ROLLOUT_AT", "2026-08-15T12:00:00Z");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  mocks.selectResults.length = 0;
+});
+
+describe("first clinic win cron", () => {
+  it("requires cron authorization before reading clinic state", async () => {
+    mocks.cronAuthError.mockReturnValueOnce(
+      new Response("Unauthorized", { status: 401 }) as never,
+    );
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/first-clinic-win"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.db.select).not.toHaveBeenCalled();
+  });
+
+  it("is default-off without an explicit prospective rollout boundary", async () => {
+    vi.stubEnv("FIRST_CLINIC_WIN_ENABLED", "false");
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/first-clinic-win"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      disabled: true,
+      reason: "disabled",
+      sent: 0,
+    });
+    expect(mocks.db.select).not.toHaveBeenCalled();
+  });
+
+  it("sends one PHI-free, exact-once message after final eligibility", async () => {
+    mocks.selectResults.push(
+      [candidate()],
+      [{ id: PRACTICE_ID, email: "owner@example.com" }],
+    );
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/first-clinic-win"),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      sent: 1,
+      deduped: 0,
+      suppressed: 0,
+      failed: 0,
+    });
+    expect(mocks.sendOptionalPlatformEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        to: "owner@example.com",
+        emailType: "first-clinic-win",
+        dedupeKey: `lc:first-clinic-win:v1:${PRACTICE_ID}`,
+        retryOnFail: true,
+        stillEligible: expect.any(Function),
+      }),
+    );
+    expect(mocks.sendFirstClinicWinEmail).toHaveBeenCalledWith({
+      to: "owner@example.com",
+      practiceName: "Neighborhood Veterinary",
+      trialEndDate: "August 28, 2026",
+      idempotencyKey: `lc:first-clinic-win:v1:${PRACTICE_ID}`,
+    });
+  });
+
+  it("suppresses a stale candidate before the provider call", async () => {
+    mocks.selectResults.push([candidate()], []);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/first-clinic-win"),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      sent: 0,
+      suppressed: 1,
+    });
+    expect(mocks.sendFirstClinicWinEmail).not.toHaveBeenCalled();
+  });
+
+  it("requires verified admin contact, a post-rollout real closeout, and no card", () => {
+    expect(ROUTE_SOURCE).toContain("u.email_verified_at is not null");
+    expect(ROUTE_SOURCE).toContain("lower(btrim(u.email))");
+    expect(ROUTE_SOURCE).toContain("vc.completed_at >= ${rolloutAt}");
+    expect(ROUTE_SOURCE).toContain("a.status = 'checked_out'");
+    expect(ROUTE_SOURCE).toContain("demoData");
+    expect(ROUTE_SOURCE).toContain("payment_method_collected");
+    expect(ROUTE_SOURCE).toContain("isNull(practices.stripeSubscriptionId)");
+    expect(ROUTE_SOURCE).not.toContain("clientName");
+    expect(ROUTE_SOURCE).not.toContain("patientName");
+  });
+});

--- a/apps/web/app/api/cron/first-clinic-win/route.test.ts
+++ b/apps/web/app/api/cron/first-clinic-win/route.test.ts
@@ -181,6 +181,8 @@ describe("first clinic win cron", () => {
     expect(ROUTE_SOURCE).toContain("demoData");
     expect(ROUTE_SOURCE).toContain("payment_method_collected");
     expect(ROUTE_SOURCE).toContain("isNull(practices.stripeSubscriptionId)");
+    expect(ROUTE_SOURCE).toContain("c.dedupe_key = 'lc:first-clinic-win:v1:'");
+    expect(ROUTE_SOURCE).toContain("c.status <> 'pending'::comm_status");
     expect(ROUTE_SOURCE).not.toContain("clientName");
     expect(ROUTE_SOURCE).not.toContain("patientName");
   });

--- a/apps/web/app/api/cron/first-clinic-win/route.ts
+++ b/apps/web/app/api/cron/first-clinic-win/route.ts
@@ -1,0 +1,237 @@
+import { NextResponse } from "next/server";
+import { and, eq, gt, isNotNull, isNull, sql, type SQL } from "drizzle-orm";
+import { db, type Database } from "@openpims/db/client";
+import { practices } from "@openpims/db";
+import { billingEnforced } from "@/lib/billing/plans";
+import { billingContactEmail } from "@/lib/billing/contact";
+import { firstClinicWinConfig } from "@/lib/billing/first-clinic-win";
+import { cronAuthError } from "@/lib/cron-auth";
+import { reportCronHeartbeat } from "@/lib/cron-heartbeat";
+import { sendFirstClinicWinEmail } from "@/lib/email";
+import { sendOptionalPlatformEmail } from "@/lib/email-lifecycle";
+import { alertOps } from "@/lib/alerts";
+import { withSystem } from "@/lib/tenant-db";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const CANDIDATE_LIMIT = 100;
+
+type Candidate = {
+  id: string;
+  name: string;
+  email: string | null;
+  timezone: string | null;
+  trialEndsAt: Date | null;
+};
+
+export async function GET(request: Request) {
+  const authError = cronAuthError(request);
+  if (authError) return authError;
+
+  const config = firstClinicWinConfig();
+  const hostedBillingEnabled = billingEnforced();
+  if (!hostedBillingEnabled) {
+    const reason = "billing_disabled";
+    await reportCronHeartbeat({
+      job: "first-clinic-win",
+      status: "ok",
+      detail: `Campaign disabled: ${reason}`,
+      metrics: { sent: 0, deduped: 0, suppressed: 0, failed: 0, reason },
+    });
+    return NextResponse.json({
+      sent: 0,
+      deduped: 0,
+      suppressed: 0,
+      failed: 0,
+      disabled: true,
+      reason,
+    });
+  }
+  if (!config.enabled) {
+    const reason = config.reason;
+    await reportCronHeartbeat({
+      job: "first-clinic-win",
+      status: "ok",
+      detail: `Campaign disabled: ${reason}`,
+      metrics: { sent: 0, deduped: 0, suppressed: 0, failed: 0, reason },
+    });
+    return NextResponse.json({
+      sent: 0,
+      deduped: 0,
+      suppressed: 0,
+      failed: 0,
+      disabled: true,
+      reason,
+    });
+  }
+
+  try {
+    const now = new Date();
+    const candidates = await withSystem(db, (tx) =>
+      tx
+        .select({
+          id: practices.id,
+          name: practices.name,
+          email: practices.email,
+          timezone: practices.timezone,
+          trialEndsAt: practices.trialEndsAt,
+        })
+        .from(practices)
+        .where(firstClinicWinEligibility(config.rolloutAt, now))
+        .orderBy(practices.id)
+        .limit(CANDIDATE_LIMIT),
+    );
+
+    let sent = 0;
+    let deduped = 0;
+    let suppressed = 0;
+    let failed = 0;
+
+    for (const candidate of candidates as Candidate[]) {
+      const to = billingContactEmail(candidate.email);
+      const trialEndsAt = candidate.trialEndsAt
+        ? new Date(candidate.trialEndsAt)
+        : null;
+      if (!to || !trialEndsAt) {
+        suppressed++;
+        continue;
+      }
+
+      const dedupeKey = `lc:first-clinic-win:v1:${candidate.id}`;
+      const result = await sendOptionalPlatformEmail({
+        practiceId: candidate.id,
+        to,
+        emailType: "first-clinic-win",
+        dedupeKey,
+        retryOnFail: true,
+        stillEligible: (tx) =>
+          firstClinicWinStillEligible(tx, {
+            practiceId: candidate.id,
+            to,
+            rolloutAt: config.rolloutAt,
+          }),
+        send: () =>
+          sendFirstClinicWinEmail({
+            to,
+            practiceName: candidate.name,
+            trialEndDate: formatTrialEndDate(
+              trialEndsAt,
+              candidate.timezone ?? undefined,
+            ),
+            idempotencyKey: dedupeKey,
+          }),
+      });
+
+      if (result.sent) sent++;
+      else if (result.suppressed) suppressed++;
+      else if (result.deduped) deduped++;
+      else failed++;
+    }
+
+    const status = failed > 0 ? "degraded" : "ok";
+    await reportCronHeartbeat({
+      job: "first-clinic-win",
+      status,
+      detail: `${sent} sent, ${deduped} deduped, ${suppressed} suppressed, ${failed} failed`,
+      metrics: {
+        candidates: candidates.length,
+        sent,
+        deduped,
+        suppressed,
+        failed,
+        candidateLimit: CANDIDATE_LIMIT,
+      },
+    });
+    return NextResponse.json({ sent, deduped, suppressed, failed });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await alertOps("First clinic win cron failed", message);
+    await reportCronHeartbeat({
+      job: "first-clinic-win",
+      status: "failed",
+      detail: message,
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+function firstClinicWinEligibility(rolloutAt: Date, now: Date): SQL {
+  return and(
+    eq(practices.billingStatus, "trialing"),
+    gt(practices.trialEndsAt, now),
+    isNotNull(practices.trialEndsAt),
+    isNull(practices.stripeSubscriptionId),
+    eq(practices.recoveryHold, false),
+    isNull(practices.deletedAt),
+    sql`${practices.settings} ->> 'analyticsExcluded' is distinct from 'true'`,
+    sql`exists (
+      select 1
+      from users u
+      where u.practice_id = ${practices.id}
+        and u.role = 'admin'
+        and u.deleted_at is null
+        and u.email_verified_at is not null
+        and lower(btrim(u.email)) = lower(btrim(${practices.email}))
+    )`,
+    sql`not exists (
+      select 1
+      from practice_conversion_milestones pcm
+      where pcm.practice_id = ${practices.id}
+        and pcm.milestone = 'payment_method_collected'
+    )`,
+    sql`exists (
+      select 1
+      from visit_closeouts vc
+      join appointments a
+        on a.id = vc.appointment_id
+       and a.practice_id = ${practices.id}
+       and a.deleted_at is null
+       and a.status = 'checked_out'
+      where vc.practice_id = ${practices.id}
+        and vc.status = 'completed'
+        and vc.deleted_at is null
+        and vc.completed_at >= ${rolloutAt}
+        and not (
+          coalesce(${practices.settings} -> 'demoData' -> 'appointmentIds', '[]'::jsonb)
+            @> to_jsonb(a.id::text)
+        )
+    )`,
+  )!;
+}
+
+async function firstClinicWinStillEligible(
+  tx: Database,
+  input: { practiceId: string; to: string; rolloutAt: Date },
+): Promise<boolean> {
+  const [practice] = await tx
+    .select({ id: practices.id, email: practices.email })
+    .from(practices)
+    .where(
+      and(
+        eq(practices.id, input.practiceId),
+        firstClinicWinEligibility(input.rolloutAt, new Date()),
+      ),
+    )
+    .limit(1);
+  return billingContactEmail(practice?.email) === input.to;
+}
+
+function formatTrialEndDate(date: Date, timeZone?: string): string {
+  const options: Intl.DateTimeFormatOptions = {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  };
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      ...options,
+      ...(timeZone ? { timeZone } : {}),
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat("en-US", options).format(date);
+  }
+}

--- a/apps/web/app/api/cron/first-clinic-win/route.ts
+++ b/apps/web/app/api/cron/first-clinic-win/route.ts
@@ -183,6 +183,16 @@ function firstClinicWinEligibility(rolloutAt: Date, now: Date): SQL {
       where pcm.practice_id = ${practices.id}
         and pcm.milestone = 'payment_method_collected'
     )`,
+    // Keep the bounded sweep moving forward. A terminal claim means this
+    // practice has already been handled; a pending claim remains eligible so
+    // sendLifecycleEmail can either observe the in-flight worker or reclaim a
+    // stale attempt after its bounded recovery window.
+    sql`not exists (
+      select 1
+      from communications c
+      where c.dedupe_key = 'lc:first-clinic-win:v1:' || ${practices.id}::text
+        and c.status <> 'pending'::comm_status
+    )`,
     sql`exists (
       select 1
       from visit_closeouts vc

--- a/apps/web/app/api/funnel-event/route.test.ts
+++ b/apps/web/app/api/funnel-event/route.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   tx: {},
   insertFunnelEvent: vi.fn(async () => true),
   withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-    fn({})
+    fn({}),
   ),
   rateLimit: vi.fn(async () => ({
     success: true,
@@ -67,7 +67,7 @@ describe("/api/funnel-event", () => {
 
     expect(response.status).toBe(202);
     expect(response.headers.get("access-control-allow-origin")).toBe(
-      "https://openvpm.com"
+      "https://openvpm.com",
     );
     expect(mocks.rateLimit).toHaveBeenCalledWith({
       key: "funnel-event:ip:203.0.113.10",
@@ -86,7 +86,7 @@ describe("/api/funnel-event", () => {
         metadata: {
           placement: "hero",
         },
-      })
+      }),
     );
   });
 
@@ -108,11 +108,11 @@ describe("/api/funnel-event", () => {
       new Request("https://app.openvpm.com/api/funnel-event", {
         method: "OPTIONS",
         headers: { origin: "https://openvpm.com" },
-      })
+      }),
     );
     expect(response.status).toBe(204);
     expect(response.headers.get("access-control-allow-origin")).toBe(
-      "https://openvpm.com"
+      "https://openvpm.com",
     );
   });
 
@@ -125,13 +125,13 @@ describe("/api/funnel-event", () => {
           path: "/login",
           source: undefined,
         },
-        "https://demo.openvpm.com"
-      )
+        "https://demo.openvpm.com",
+      ),
     );
 
     expect(response.status).toBe(202);
     expect(response.headers.get("access-control-allow-origin")).toBe(
-      "https://demo.openvpm.com"
+      "https://demo.openvpm.com",
     );
     expect(mocks.insertFunnelEvent).toHaveBeenCalledWith(
       {},
@@ -139,7 +139,87 @@ describe("/api/funnel-event", () => {
         eventName: "demo_gate_viewed",
         origin: "https://demo.openvpm.com",
         path: "/login",
-      })
+      }),
+    );
+  });
+
+  it("accepts only coarse onboarding dimensions", async () => {
+    const response = await POST(
+      request({
+        ...validEvent,
+        name: "onboarding_plan_built",
+        path: "/",
+        props: {
+          model: "mobile",
+          goal: "run_visit",
+          step: "workspace",
+          practiceName: "must not persist",
+          clientName: "must not persist",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(mocks.insertFunnelEvent).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        eventName: "onboarding_plan_built",
+        metadata: {
+          model: "mobile",
+          goal: "run_visit",
+          step: "workspace",
+        },
+      }),
+    );
+  });
+
+  it("accepts the pre-account and in-app journey transitions", async () => {
+    for (const [name, step] of [
+      ["signup_profile_completed", "profile"],
+      ["onboarding_step_viewed", "basics"],
+      ["onboarding_step_completed", "data"],
+      ["onboarding_completed", "allSet"],
+      ["first_action_selected", "first_action"],
+    ] as const) {
+      mocks.insertFunnelEvent.mockClear();
+      const response = await POST(
+        request({
+          ...validEvent,
+          eventId: crypto.randomUUID(),
+          name,
+          props: { model: "mobile", goal: "run_visit", step },
+        }),
+      );
+
+      expect(response.status).toBe(202);
+      expect(mocks.insertFunnelEvent).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          eventName: name,
+          metadata: { model: "mobile", goal: "run_visit", step },
+        }),
+      );
+    }
+  });
+
+  it("drops invented onboarding dimensions instead of storing free text", async () => {
+    const response = await POST(
+      request({
+        ...validEvent,
+        name: "onboarding_plan_built",
+        path: "/",
+        props: {
+          model: "clinic name must not persist",
+          goal: "patient detail must not persist",
+          step: "custom free text",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(mocks.insertFunnelEvent).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ metadata: {} }),
     );
   });
 });

--- a/apps/web/app/api/funnel-event/route.ts
+++ b/apps/web/app/api/funnel-event/route.ts
@@ -25,6 +25,34 @@ const ALLOWED_PROP_KEYS = new Set([
   "placement",
   "role",
   "tool",
+  "model",
+  "goal",
+  "step",
+]);
+const ALLOWED_CLINIC_MODELS = new Set([
+  "companion",
+  "mobile",
+  "equine",
+  "specialty",
+  "shelter",
+  "exploring",
+]);
+const ALLOWED_FIRST_GOALS = new Set([
+  "run_visit",
+  "import_records",
+  "start_fresh",
+  "explore_sample",
+  "self_host",
+]);
+const ALLOWED_ONBOARDING_STEPS = new Set([
+  "profile",
+  "account",
+  "workspace",
+  "intent",
+  "basics",
+  "data",
+  "allSet",
+  "first_action",
 ]);
 const UUID_PATH_SEGMENT_RE =
   /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
@@ -42,6 +70,18 @@ const eventSchema = z
       "demo_tool_opened",
       "demo_cta_start_clinic",
       "signup_land",
+      "signup_profile_viewed",
+      "signup_profile_completed",
+      "signup_account_viewed",
+      "signup_submitted",
+      "signup_succeeded",
+      "onboarding_model_selected",
+      "onboarding_goal_selected",
+      "onboarding_plan_built",
+      "onboarding_step_viewed",
+      "onboarding_step_completed",
+      "onboarding_completed",
+      "first_action_selected",
     ]),
     source: z
       .string()
@@ -75,7 +115,7 @@ function corsHeaders(origin: string | null): HeadersInit {
 function json(
   request: Request,
   body: Record<string, unknown>,
-  init?: ResponseInit
+  init?: ResponseInit,
 ) {
   return NextResponse.json(body, {
     ...init,
@@ -87,12 +127,21 @@ function json(
 }
 
 function cleanProps(
-  props: Record<string, string | number | boolean> | undefined
+  props: Record<string, string | number | boolean> | undefined,
 ): Record<string, string | number | boolean> {
   if (!props) return {};
   const entries = Object.entries(props)
     .filter(([key, value]) => {
       if (!ALLOWED_PROP_KEYS.has(key)) return false;
+      if (key === "model") {
+        return typeof value === "string" && ALLOWED_CLINIC_MODELS.has(value);
+      }
+      if (key === "goal") {
+        return typeof value === "string" && ALLOWED_FIRST_GOALS.has(value);
+      }
+      if (key === "step") {
+        return typeof value === "string" && ALLOWED_ONBOARDING_STEPS.has(value);
+      }
       return typeof value !== "string" || value.length <= 200;
     })
     .slice(0, 20);
@@ -134,10 +183,14 @@ export async function POST(request: Request) {
     return json(request, { ok: false }, { status: 429 });
   }
   if (!limit.success) {
-    return json(request, { ok: false }, {
-      status: 429,
-      headers: rateLimitResponseHeaders(EVENT_LIMIT, limit),
-    });
+    return json(
+      request,
+      { ok: false },
+      {
+        status: 429,
+        headers: rateLimitResponseHeaders(EVENT_LIMIT, limit),
+      },
+    );
   }
 
   const body = await readJsonRequestBody(request);
@@ -145,7 +198,7 @@ export async function POST(request: Request) {
     return json(
       request,
       { ok: false },
-      { status: body.reason === "too_large" ? 413 : 400 }
+      { status: body.reason === "too_large" ? 413 : 400 },
     );
   }
   const parsed = eventSchema.safeParse(body.data);
@@ -163,7 +216,7 @@ export async function POST(request: Request) {
         path: cleanPath(parsed.data.path),
         origin: requestOrigin,
         metadata: cleanProps(parsed.data.props),
-      })
+      }),
     );
     return json(request, { ok: true }, { status: 202 });
   } catch (error) {

--- a/apps/web/app/api/webhooks/stripe-subscription/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe-subscription/route.test.ts
@@ -156,7 +156,7 @@ function checkoutCompletedEvent() {
 }
 
 function stripeSubscription(
-  status: "trialing" | "active" = "active",
+  status: "trialing" | "active" | "past_due" | "unpaid" | "canceled" = "active",
   metadata: Record<string, string> = { practiceId: PRACTICE_ID },
 ) {
   return {
@@ -228,6 +228,14 @@ function invoicePaymentFailedEvent() {
         next_payment_attempt: Math.floor(
           Date.parse("2026-07-01T02:00:00.000Z") / 1000,
         ),
+        parent: {
+          type: "subscription_details",
+          quote_details: null,
+          subscription_details: {
+            metadata: { practiceId: PRACTICE_ID },
+            subscription: SUBSCRIPTION_ID,
+          },
+        },
       },
     },
   };
@@ -235,7 +243,11 @@ function invoicePaymentFailedEvent() {
 
 function invokeLifecycleSendOnce() {
   mocks.sendLifecycleEmail.mockImplementationOnce(
-    async (opts: { send: () => Promise<unknown> }) => {
+    async (opts: {
+      stillEligible?: (tx: unknown) => Promise<boolean>;
+      send: () => Promise<unknown>;
+    }) => {
+      if (opts.stillEligible && !(await opts.stillEligible(mocks.db))) return;
       await opts.send();
     },
   );
@@ -528,6 +540,9 @@ describe("Stripe subscription webhook", () => {
     const event = subscriptionUpdatedEvent();
     event.data.object.metadata = {};
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(event);
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("active", {}),
+    );
     mocks.selectResults.push([
       { id: PRACTICE_ID, stripeSubscriptionId: SUBSCRIPTION_ID },
       {
@@ -578,7 +593,40 @@ describe("Stripe subscription webhook", () => {
       amount: "$79.00",
       periodLabel: "June 30, 2026 – July 31, 2026",
       invoiceUrl: "https://billing.stripe.test/in_paid",
+      idempotencyKey: "lc:receipt:in_paid",
     });
+  });
+
+  it("does not call the email provider until the billing transaction commits", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentSucceededEvent(),
+    );
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: "owner@example.com",
+        name: "Westside Vet",
+        timezone: "UTC",
+      },
+    ]);
+    let transactionOpen = false;
+    mocks.withSystem.mockImplementationOnce(async (_db, fn) => {
+      transactionOpen = true;
+      try {
+        return await fn(mocks.db);
+      } finally {
+        transactionOpen = false;
+      }
+    });
+    mocks.sendLifecycleEmail.mockImplementationOnce(async (opts) => {
+      expect(transactionOpen).toBe(false);
+      await opts.send();
+    });
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.sendPaymentReceiptEmail).toHaveBeenCalledOnce();
   });
 
   it("self-heals subscription state from a positive paid invoice", async () => {
@@ -658,6 +706,18 @@ describe("Stripe subscription webhook", () => {
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
       invoicePaymentFailedEvent(),
     );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("past_due"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: " Owner@Example.COM ",
+        name: "Westside Vet",
+        timezone: "America/Los_Angeles",
+      },
+    ]);
     mocks.selectResults.push([
       {
         id: PRACTICE_ID,
@@ -671,9 +731,9 @@ describe("Stripe subscription webhook", () => {
     const response = await POST(stripeRequest());
 
     await expect(response.json()).resolves.toEqual({ received: true });
-    expect(mocks.updateSet).toHaveBeenCalledWith({
-      billingStatus: "past_due",
-    });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "past_due" }),
+    );
     expect(mocks.sendLifecycleEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: PRACTICE_ID,
@@ -687,6 +747,7 @@ describe("Stripe subscription webhook", () => {
       practiceName: "Westside Vet",
       amount: "$79.00",
       nextRetryDate: "June 30, 2026",
+      idempotencyKey: "lc:dunning:in_failed:2",
     });
   });
 
@@ -694,6 +755,10 @@ describe("Stripe subscription webhook", () => {
     mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
       invoicePaymentFailedEvent(),
     );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("past_due"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
     mocks.selectResults.push([
       {
         id: PRACTICE_ID,
@@ -706,10 +771,64 @@ describe("Stripe subscription webhook", () => {
     const response = await POST(stripeRequest());
 
     await expect(response.json()).resolves.toEqual({ received: true });
-    expect(mocks.updateSet).toHaveBeenCalledWith({
-      billingStatus: "past_due",
-    });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "past_due" }),
+    );
     expect(mocks.sendLifecycleEmail).not.toHaveBeenCalled();
+    expect(mocks.sendPaymentFailedEmail).not.toHaveBeenCalled();
+  });
+
+  it("does not let a delayed failed invoice overwrite terminal unpaid state", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentFailedEvent(),
+    );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("unpaid"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: "owner@example.com",
+        name: "Westside Vet",
+        timezone: "UTC",
+      },
+    ]);
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ billingStatus: "unpaid" }),
+    );
+    expect(mocks.sendLifecycleEmail).not.toHaveBeenCalled();
+  });
+
+  it("suppresses stale dunning after billing status changes under the send lock", async () => {
+    mocks.constructSubscriptionWebhookEvent.mockResolvedValue(
+      invoicePaymentFailedEvent(),
+    );
+    mocks.retrieveSubscription.mockResolvedValueOnce(
+      stripeSubscription("past_due"),
+    );
+    mocks.updateReturns.push([{ id: PRACTICE_ID }]);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        email: "owner@example.com",
+        name: "Westside Vet",
+        timezone: "UTC",
+      },
+    ]);
+    mocks.selectResults.push([]);
+    invokeLifecycleSendOnce();
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(200);
+    expect(mocks.sendLifecycleEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ stillEligible: expect.any(Function) }),
+    );
     expect(mocks.sendPaymentFailedEmail).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/api/webhooks/stripe-subscription/route.ts
+++ b/apps/web/app/api/webhooks/stripe-subscription/route.ts
@@ -77,6 +77,7 @@ export async function POST(req: NextRequest) {
   }
 
   const conversionEvidence = conversionEvidenceForEvent(event);
+  const postCommitEffects: Array<() => Promise<unknown>> = [];
   try {
     await withSystem(db, async (tx) => {
       const claimed = await claimStripeEvent(tx, {
@@ -98,15 +99,29 @@ export async function POST(req: NextRequest) {
               : (s.subscription?.id ?? null);
           let activePracticeId: string | null = null;
           if (practiceId && s.customer) {
+            const customerId =
+              typeof s.customer === "string" ? s.customer : s.customer.id;
             const [practice] = await tx
               .update(practices)
               .set({
-                stripeCustomerId:
-                  typeof s.customer === "string" ? s.customer : s.customer!.id,
+                stripeCustomerId: customerId,
                 stripeSubscriptionId: subscriptionId,
               })
               .where(
-                and(eq(practices.id, practiceId), isNull(practices.deletedAt)),
+                and(
+                  eq(practices.id, practiceId),
+                  isNull(practices.deletedAt),
+                  or(
+                    isNull(practices.stripeCustomerId),
+                    eq(practices.stripeCustomerId, customerId),
+                  ),
+                  subscriptionId
+                    ? or(
+                        isNull(practices.stripeSubscriptionId),
+                        eq(practices.stripeSubscriptionId, subscriptionId),
+                      )
+                    : isNull(practices.stripeSubscriptionId),
+                ),
               )
               .returning({ id: practices.id });
             activePracticeId = practice?.id ?? null;
@@ -145,7 +160,16 @@ export async function POST(req: NextRequest) {
 
         case "customer.subscription.created":
         case "customer.subscription.updated": {
-          await applySubscription(tx, event.data.object as Stripe.Subscription);
+          if (!stripe) {
+            throw new Error(
+              "Stripe is unavailable while reconciling a subscription event.",
+            );
+          }
+          const eventSubscription = event.data.object as Stripe.Subscription;
+          const currentSubscription = await stripe.subscriptions.retrieve(
+            eventSubscription.id,
+          );
+          await applySubscription(tx, currentSubscription);
           break;
         }
 
@@ -211,21 +235,25 @@ export async function POST(req: NextRequest) {
             const to = billingContactEmail(practice?.email);
             if (practice && to) {
               const practiceName = practice.name ?? "your practice";
-              await sendLifecycleEmail({
-                practiceId: practice.id,
-                to,
-                emailType: "receipt",
-                dedupeKey: `lc:receipt:${inv.id}`,
-                category: "transactional",
-                send: () =>
-                  sendPaymentReceiptEmail({
-                    to,
-                    practiceName,
-                    amount: formatMoney(inv.amount_paid, inv.currency),
-                    periodLabel: invoicePeriodLabel(inv, practice.timezone),
-                    invoiceUrl: inv.hosted_invoice_url ?? undefined,
-                  }),
-              });
+              const dedupeKey = `lc:receipt:${inv.id}`;
+              postCommitEffects.push(() =>
+                sendLifecycleEmail({
+                  practiceId: practice.id,
+                  to,
+                  emailType: "receipt",
+                  dedupeKey,
+                  category: "transactional",
+                  send: () =>
+                    sendPaymentReceiptEmail({
+                      to,
+                      practiceName,
+                      amount: formatMoney(inv.amount_paid, inv.currency),
+                      periodLabel: invoicePeriodLabel(inv, practice.timezone),
+                      invoiceUrl: inv.hosted_invoice_url ?? undefined,
+                      idempotencyKey: dedupeKey,
+                    }),
+                }),
+              );
             }
           }
           break;
@@ -233,44 +261,61 @@ export async function POST(req: NextRequest) {
 
         case "invoice.payment_failed": {
           const inv = event.data.object as Stripe.Invoice;
-          const customerId =
-            typeof inv.customer === "string" ? inv.customer : inv.customer?.id;
-          if (customerId) {
-            await tx
-              .update(practices)
-              .set({ billingStatus: "past_due" })
-              .where(
-                and(
-                  eq(practices.stripeCustomerId, customerId),
-                  isNull(practices.deletedAt),
-                ),
+          const subscriptionId = subscriptionIdForInvoice(inv);
+          if (subscriptionId) {
+            if (!stripe) {
+              throw new Error(
+                "Stripe is unavailable while reconciling a failed invoice.",
               );
-            await alertOps(
-              "Subscription payment failed",
-              `Stripe customer ${customerId} had a failed subscription payment; marked past_due.`,
+            }
+            const subscription =
+              await stripe.subscriptions.retrieve(subscriptionId);
+            const authoritativeStatus = normalizeBillingStatus(
+              subscription.status,
             );
-            const practice = await practiceForCustomer(tx, customerId);
+            const practiceId = await applySubscription(tx, subscription);
+            const practice = practiceId
+              ? await practiceById(tx, practiceId)
+              : null;
             const to = billingContactEmail(practice?.email);
-            if (practice && to) {
+            if (practice && to && authoritativeStatus === "past_due") {
               const practiceName = practice.name ?? "your practice";
-              await sendLifecycleEmail({
-                practiceId: practice.id,
-                to,
-                emailType: "dunning",
-                // One dunning email per Stripe retry attempt.
-                dedupeKey: `lc:dunning:${inv.id}:${inv.attempt_count ?? 0}`,
-                category: "transactional",
-                send: () =>
-                  sendPaymentFailedEmail({
-                    to,
-                    practiceName,
-                    amount: formatMoney(inv.amount_due, inv.currency),
-                    nextRetryDate: formatUnixDate(
-                      inv.next_payment_attempt,
-                      practice.timezone,
-                    ),
-                  }),
-              });
+              const dedupeKey = `lc:dunning:${inv.id}:${inv.attempt_count ?? 0}`;
+              postCommitEffects.push(() =>
+                sendLifecycleEmail({
+                  practiceId: practice.id,
+                  to,
+                  emailType: "dunning",
+                  dedupeKey,
+                  category: "transactional",
+                  stillEligible: async (emailTx) => {
+                    const [current] = await emailTx
+                      .select({ id: practices.id })
+                      .from(practices)
+                      .where(
+                        and(
+                          eq(practices.id, practice.id),
+                          eq(practices.billingStatus, "past_due"),
+                          eq(practices.stripeSubscriptionId, subscriptionId),
+                          isNull(practices.deletedAt),
+                        ),
+                      )
+                      .limit(1);
+                    return Boolean(current);
+                  },
+                  send: () =>
+                    sendPaymentFailedEmail({
+                      to,
+                      practiceName,
+                      amount: formatMoney(inv.amount_due, inv.currency),
+                      nextRetryDate: formatUnixDate(
+                        inv.next_payment_attempt,
+                        practice.timezone,
+                      ),
+                      idempotencyKey: dedupeKey,
+                    }),
+                }),
+              );
             }
           }
           break;
@@ -281,6 +326,9 @@ export async function POST(req: NextRequest) {
           break;
       }
     });
+    for (const effect of postCommitEffects) {
+      await effect();
+    }
   } catch (err) {
     console.error("[Stripe Subscription Webhook] handler error:", err);
     await alertOps(
@@ -329,17 +377,27 @@ async function applySubscription(
   const customerId =
     typeof sub.customer === "string" ? sub.customer : sub.customer?.id;
   const billingStatus = normalizeBillingStatus(sub.status);
+  const terminalWithoutSubscriptionIdentity = billingStatus === "canceled";
 
   const [practice] = await tx
     .update(practices)
     .set({
       ...(tier ? { subscriptionTier: tier } : {}),
       billingStatus,
-      stripeSubscriptionId: sub.id,
+      stripeSubscriptionId: terminalWithoutSubscriptionIdentity ? null : sub.id,
       ...(customerId ? { stripeCustomerId: customerId } : {}),
       trialEndsAt: sub.trial_end ? new Date(sub.trial_end * 1000) : null,
     })
-    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+    .where(
+      and(
+        eq(practices.id, practiceId),
+        isNull(practices.deletedAt),
+        or(
+          isNull(practices.stripeSubscriptionId),
+          eq(practices.stripeSubscriptionId, sub.id),
+        ),
+      ),
+    )
     .returning({ id: practices.id });
   if (!practice) {
     console.warn(
@@ -349,11 +407,13 @@ async function applySubscription(
     );
     return null;
   }
-  await syncPracticeSubscriptionQuantities({
-    db: tx,
-    practiceId: practice.id,
-    subscriptionId: sub.id,
-  });
+  if (!terminalWithoutSubscriptionIdentity) {
+    await syncPracticeSubscriptionQuantities({
+      db: tx,
+      practiceId: practice.id,
+      subscriptionId: sub.id,
+    });
+  }
   return practice.id;
 }
 

--- a/apps/web/components/layout/trial-badge.tsx
+++ b/apps/web/components/layout/trial-badge.tsx
@@ -15,8 +15,7 @@ import { trialCalendarDaysLeft } from "@/lib/billing/trial-days";
  */
 export function TrialBadge() {
   const { data: session, status } = useSession();
-  const isAdmin =
-    status === "authenticated" && session?.user?.role === "admin";
+  const isAdmin = status === "authenticated" && session?.user?.role === "admin";
 
   const { data, isLoading, error } = trpc.subscription.get.useQuery(undefined, {
     enabled: isAdmin,
@@ -55,6 +54,30 @@ export function TrialBadge() {
     return null;
   }
 
+  if (data.billingStatus === "past_due") {
+    return (
+      <Link
+        href="/settings?tab=billing"
+        className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-100"
+      >
+        <CreditCard className="h-3.5 w-3.5" />
+        Payment retrying · Review billing
+      </Link>
+    );
+  }
+
+  if (data.billingStatus === "unpaid") {
+    return (
+      <Link
+        href="/settings?tab=billing"
+        className="inline-flex items-center gap-1.5 rounded-full border border-destructive/30 bg-destructive/10 px-3 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/20"
+      >
+        <CreditCard className="h-3.5 w-3.5" />
+        Payment unpaid · Read only
+      </Link>
+    );
+  }
+
   // A Stripe subscription can legitimately remain `trialing` after Checkout
   // while the saved card waits for the free trial to end. Never offer another
   // Checkout in that state; it could create a duplicate subscription.
@@ -65,15 +88,14 @@ export function TrialBadge() {
         className="inline-flex items-center gap-1.5 rounded-full border border-teal-200 bg-teal-50 px-3 py-1 text-xs font-medium text-teal-800 transition-colors hover:bg-teal-100"
       >
         <CreditCard className="h-3.5 w-3.5" />
-        Card on file · Manage billing
+        Billing connected · Manage billing
       </Link>
     );
   }
 
   const trialing = data.billingStatus === "trialing" && data.trialEndsAt;
   if (trialing) {
-    const days =
-      trialCalendarDaysLeft(data.trialEndsAt, data.timezone) ?? 0;
+    const days = trialCalendarDaysLeft(data.trialEndsAt, data.timezone) ?? 0;
     const urgent = days <= 3;
     return (
       <Link
@@ -83,11 +105,13 @@ export function TrialBadge() {
           "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
           urgent
             ? "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100"
-            : "border-teal-200 bg-teal-50 text-teal-800 hover:bg-teal-100"
+            : "border-teal-200 bg-teal-50 text-teal-800 hover:bg-teal-100",
         )}
       >
         <Clock className="h-3.5 w-3.5" />
-        {days === 0 ? "Trial ends today" : `${days} day${days === 1 ? "" : "s"} left in trial`}
+        {days === 0
+          ? "Trial ends today"
+          : `${days} day${days === 1 ? "" : "s"} left in trial`}
         <span className="font-semibold">· Activate account</span>
       </Link>
     );

--- a/apps/web/components/onboarding/clinic-intent-builder.tsx
+++ b/apps/web/components/onboarding/clinic-intent-builder.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import {
+  Building2,
+  CalendarCheck2,
+  Check,
+  ClipboardCheck,
+  Compass,
+  Dog,
+  FilePlus2,
+  Files,
+  FlaskConical,
+  HeartPulse,
+  Home,
+  Leaf,
+  PawPrint,
+  ShieldCheck,
+  Sparkles,
+  Stethoscope,
+  Truck,
+  UserRoundPlus,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  CLINIC_MODEL_OPTIONS,
+  FIRST_GOAL_OPTIONS,
+  SELF_HOST_GOAL,
+  clinicModelOption,
+  firstDayTasks,
+  type ClinicModel,
+  type FirstGoal,
+} from "@/lib/onboarding/clinic-profile";
+
+const modelIcons = {
+  companion: Dog,
+  mobile: Truck,
+  equine: Leaf,
+  specialty: HeartPulse,
+  shelter: Home,
+  exploring: Compass,
+} satisfies Record<ClinicModel, typeof Dog>;
+
+const goalIcons = {
+  run_visit: CalendarCheck2,
+  import_records: Files,
+  start_fresh: FilePlus2,
+  explore_sample: FlaskConical,
+  self_host: Building2,
+} satisfies Record<FirstGoal, typeof CalendarCheck2>;
+
+const taskIcons = [
+  CalendarCheck2,
+  UserRoundPlus,
+  Stethoscope,
+  ClipboardCheck,
+] as const;
+
+const toneClasses = {
+  emerald: "bg-emerald-50 text-emerald-700",
+  coral: "bg-orange-50 text-orange-700",
+  lavender: "bg-violet-50 text-violet-700",
+  blue: "bg-sky-50 text-sky-700",
+  rose: "bg-rose-50 text-rose-700",
+  amber: "bg-amber-50 text-amber-700",
+} as const;
+
+export function ClinicIntentBuilder({
+  clinicModel,
+  firstGoal,
+  onClinicModelChange,
+  onFirstGoalChange,
+  intro = "Start with one useful workflow. We’ll shape OpenVPM around the way your team works—and you stay in control.",
+}: {
+  clinicModel: ClinicModel;
+  firstGoal: FirstGoal;
+  onClinicModelChange: (model: ClinicModel) => void;
+  onFirstGoalChange: (goal: FirstGoal) => void;
+  intro?: string;
+}) {
+  const selectedModel = clinicModelOption(clinicModel);
+  const tasks = firstDayTasks(clinicModel, firstGoal);
+  const goalOptions =
+    clinicModel === "exploring"
+      ? [...FIRST_GOAL_OPTIONS, SELF_HOST_GOAL]
+      : FIRST_GOAL_OPTIONS;
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,1.28fr)_minmax(340px,0.72fr)] lg:gap-12">
+      <div className="min-w-0">
+        <p className="max-w-2xl text-[15px] leading-7 text-slate-600 sm:text-base">
+          {intro}
+        </p>
+
+        <fieldset className="mt-7">
+          <legend className="text-sm font-semibold text-slate-950 sm:text-base">
+            What kind of care do you provide?
+          </legend>
+          <div className="mt-3 grid grid-cols-2 gap-2.5 sm:grid-cols-3 sm:gap-3">
+            {CLINIC_MODEL_OPTIONS.map((option) => {
+              const Icon = modelIcons[option.value];
+              const active = clinicModel === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => onClinicModelChange(option.value)}
+                  className={cn(
+                    "group relative min-h-[104px] rounded-2xl border bg-white p-3 text-left transition duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 sm:min-h-[118px] sm:p-4",
+                    active
+                      ? "-translate-y-0.5 border-primary bg-primary/5 shadow-[0_12px_30px_-18px_rgba(5,150,105,0.65)]"
+                      : "border-slate-200 hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-[0_10px_24px_-20px_rgba(15,23,42,0.45)]",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-10 w-10 items-center justify-center rounded-xl transition-transform duration-200 group-hover:scale-105",
+                      toneClasses[option.tone],
+                    )}
+                  >
+                    <Icon className="h-5 w-5" strokeWidth={1.8} />
+                  </span>
+                  <span className="mt-2.5 block max-w-[10rem] text-[13px] font-semibold leading-[1.3] text-slate-900 sm:text-sm">
+                    {option.label}
+                  </span>
+                  {active ? (
+                    <span className="absolute right-2.5 top-2.5 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm">
+                      <Check className="h-3.5 w-3.5" strokeWidth={2.5} />
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <fieldset className="mt-7">
+          <legend className="text-sm font-semibold text-slate-950 sm:text-base">
+            What would feel useful first?
+          </legend>
+          <div className="mt-3 grid gap-2.5 sm:grid-cols-2">
+            {goalOptions.map((option) => {
+              const Icon = goalIcons[option.value];
+              const active = firstGoal === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => onFirstGoalChange(option.value)}
+                  className={cn(
+                    "flex min-h-14 items-center gap-3 rounded-xl border px-3.5 py-3 text-left transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                    active
+                      ? "border-primary bg-primary/5 shadow-[0_8px_24px_-20px_rgba(5,150,105,0.7)]"
+                      : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/70",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+                      active
+                        ? "bg-primary/10 text-primary"
+                        : "bg-violet-50 text-violet-700",
+                    )}
+                  >
+                    <Icon className="h-[18px] w-[18px]" strokeWidth={1.8} />
+                  </span>
+                  <span className="min-w-0 flex-1 text-[13px] font-medium leading-5 text-slate-800 sm:text-sm">
+                    {option.label}
+                  </span>
+                  <span
+                    className={cn(
+                      "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border",
+                      active
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-slate-300 bg-white text-transparent",
+                    )}
+                  >
+                    <Check className="h-3 w-3" strokeWidth={2.5} />
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+      </div>
+
+      <aside
+        aria-live="polite"
+        className="relative overflow-hidden rounded-[24px] border border-primary/15 bg-[linear-gradient(155deg,#ffffff_0%,#f5fbf8_72%,#f7f5ff_100%)] px-5 py-6 shadow-[0_24px_60px_-42px_rgba(5,150,105,0.55)] sm:px-7 sm:py-8 lg:min-h-[570px]"
+      >
+        <div
+          aria-hidden="true"
+          className="absolute -right-10 -top-10 h-32 w-32 rounded-full border border-violet-100/80"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute -right-4 top-6 h-20 w-20 rounded-full border border-rose-100"
+        />
+        <div className="relative">
+          <div className="flex items-center gap-3 lg:justify-center">
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary lg:hidden">
+              <Sparkles className="h-5 w-5" strokeWidth={1.8} />
+            </span>
+            <div>
+              <h3 className="font-heading text-lg font-semibold text-slate-950 sm:text-xl">
+                Your first OpenVPM day
+              </h3>
+              <p className="mt-0.5 text-xs text-slate-500 lg:text-center">
+                Shaped for {selectedModel.shortLabel.toLowerCase()} care
+              </p>
+            </div>
+          </div>
+
+          <ol key={`${clinicModel}-${firstGoal}`} className="mt-6 space-y-3">
+            {tasks.map((task, index) => {
+              const Icon = taskIcons[index] ?? PawPrint;
+              return (
+                <li
+                  key={task}
+                  style={{ animationDelay: `${index * 90}ms` }}
+                  className="onboarding-task-in relative flex items-center gap-3 rounded-2xl border border-white bg-white/90 p-3 shadow-[0_12px_30px_-22px_rgba(15,23,42,0.4)] sm:p-4"
+                >
+                  <span className="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-[11px] font-bold text-primary-foreground shadow-sm">
+                    {index + 1}
+                  </span>
+                  <span className="ml-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                    <Icon className="h-5 w-5" strokeWidth={1.8} />
+                  </span>
+                  <span className="text-sm font-medium leading-5 text-slate-800">
+                    {task}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+
+          {selectedModel.readiness === "design_partner" ? (
+            <div className="mt-5 flex gap-3 rounded-xl border border-violet-100 bg-white/75 p-3.5">
+              <HeartPulse className="mt-0.5 h-4 w-4 shrink-0 text-violet-600" />
+              <p className="text-xs leading-5 text-slate-600">
+                We’ll validate one real workflow with you and be clear about
+                anything that isn’t ready yet.
+              </p>
+            </div>
+          ) : null}
+
+          <div className="mt-6 flex items-center gap-2 text-xs text-primary">
+            <ShieldCheck className="h-4 w-4" strokeWidth={1.8} />
+            <span>Nothing moves until you review it.</span>
+          </div>
+        </div>
+        <style>{`
+          @keyframes onboarding-task-in {
+            from { opacity: 0; transform: translateY(7px); }
+            to { opacity: 1; transform: translateY(0); }
+          }
+          .onboarding-task-in { animation: onboarding-task-in 320ms ease-out backwards; }
+          @media (prefers-reduced-motion: reduce) { .onboarding-task-in { animation: none; } }
+        `}</style>
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -12,16 +12,25 @@ import {
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { ArrowLeft, ArrowRight, Loader2, PawPrint } from "lucide-react";
+import { ArrowLeft, ArrowRight, Loader2, ShieldCheck } from "lucide-react";
 import { trpc } from "@/lib/trpc";
+import { BrandBadge } from "@/components/brand/paw-mark";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { firstRunMode } from "@/lib/welcome/first-run";
+import { FUNNEL_EVENTS } from "@/lib/funnel-analytics";
+import { trackFunnelEvent } from "@/lib/track-funnel-event";
 import {
   DEFAULT_ONBOARDING_INTENT,
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
+import {
+  DEFAULT_CLINIC_MODEL,
+  DEFAULT_FIRST_GOAL,
+  type ClinicModel,
+  type FirstGoal,
+} from "@/lib/onboarding/clinic-profile";
 import type { JourneyState, StepHandle } from "./journey-types";
 import {
   ONBOARDING_JOURNEY_STEPS,
@@ -117,8 +126,8 @@ export function OnboardingJourneyProvider({
     if (opened.current || index !== null || !isAdmin) return;
     // In "welcome" first-run mode the Polaroid guide surface owns the
     // greeting; the wizard opens on demand (welcome footer, first-win
-    // offer, activation checklist). NEXT_PUBLIC_FIRST_RUN_MODE=wizard
-    // restores this auto-open exactly.
+    // offer, activation checklist). The personalized builder is the default;
+    // NEXT_PUBLIC_FIRST_RUN_MODE=welcome remains the rollback path.
     if (firstRunMode() === "welcome") return;
     // Wait until the setup state is loaded so the resume point is stable.
     if (!onboardingStatus.data || !onboardingState.data) {
@@ -152,6 +161,14 @@ export function OnboardingJourneyProvider({
           index={index!}
           setIndex={setIndex}
           initialIntent={onboardingIntent ?? DEFAULT_ONBOARDING_INTENT}
+          initialClinicModel={
+            (onboardingState.data?.clinicModel as ClinicModel | null) ??
+            DEFAULT_CLINIC_MODEL
+          }
+          initialFirstGoal={
+            (onboardingState.data?.firstGoal as FirstGoal | null) ??
+            DEFAULT_FIRST_GOAL
+          }
           initialMigrationHasCommittedChanges={
             onboardingState.data?.migrationHasCommittedChanges === true
           }
@@ -177,6 +194,8 @@ function JourneyShell({
   index,
   setIndex,
   initialIntent,
+  initialClinicModel,
+  initialFirstGoal,
   initialMigrationHasCommittedChanges,
   initialMigrationSource,
   initialMigrationSourceHasCommittedChanges,
@@ -186,6 +205,8 @@ function JourneyShell({
   index: number;
   setIndex: (i: number | null) => void;
   initialIntent: OnboardingIntent;
+  initialClinicModel: ClinicModel;
+  initialFirstGoal: FirstGoal;
   initialMigrationHasCommittedChanges: boolean;
   initialMigrationSource: JourneyState["migrationSource"];
   initialMigrationSourceHasCommittedChanges: boolean;
@@ -202,6 +223,8 @@ function JourneyShell({
   // Shared step state. Real imports replace sample data; otherwise the clinic
   // can keep the sample records while it adds its first real client.
   const [state, setStateRaw] = useState<JourneyState>({
+    clinicModel: initialClinicModel,
+    firstGoal: initialFirstGoal,
     onboardingIntent: initialIntent,
     keepSampleData: !initialMigrationHasCommittedChanges,
     hasPartialImport: false,
@@ -231,6 +254,14 @@ function JourneyShell({
   const total = steps.length;
   const step = steps[index]!;
   const isLast = index >= total - 1;
+
+  useEffect(() => {
+    trackFunnelEvent(FUNNEL_EVENTS.onboardingStepViewed, {
+      model: state.clinicModel,
+      goal: state.firstGoal,
+      step: step.id,
+    });
+  }, [state.clinicModel, state.firstGoal, step.id]);
 
   // Do not advance or close until the server accepts the cursor. A local-only
   // optimistic cursor can strand a clinic at an earlier step after a reload.
@@ -265,6 +296,16 @@ function JourneyShell({
       utils.settings.onboardingStatus.invalidate(),
       utils.settings.getOnboardingState.invalidate(),
     ]);
+    trackFunnelEvent(FUNNEL_EVENTS.onboardingCompleted, {
+      model: state.clinicModel,
+      goal: state.firstGoal,
+      step: "allSet",
+    });
+    trackFunnelEvent(FUNNEL_EVENTS.firstActionSelected, {
+      goal: state.firstGoal,
+      placement: state.hasImportedData ? "schedule" : "client",
+      step: "first_action",
+    });
     setIndex(null);
     router.push(
       state.hasImportedData
@@ -274,6 +315,8 @@ function JourneyShell({
   }, [
     completeOnboarding,
     clearDemoData,
+    state.clinicModel,
+    state.firstGoal,
     state.keepSampleData,
     state.hasImportedData,
     utils,
@@ -289,6 +332,11 @@ function JourneyShell({
         ? await handleRef.current.onContinue()
         : true;
       if (!advance) return;
+      trackFunnelEvent(FUNNEL_EVENTS.onboardingStepCompleted, {
+        model: state.clinicModel,
+        goal: state.firstGoal,
+        step: step.id,
+      });
       if (isLast) {
         await finish();
       } else {
@@ -312,6 +360,9 @@ function JourneyShell({
     isLast,
     finish,
     index,
+    state.clinicModel,
+    state.firstGoal,
+    step.id,
     steps,
     persistCursor,
     setIndex,
@@ -383,9 +434,9 @@ function JourneyShell({
       }}
     >
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-[80] bg-[linear-gradient(135deg,#fff7ed_0%,#fdf2f8_45%,#ecfdf5_100%)]" />
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[80] bg-[linear-gradient(135deg,#fff8f5_0%,#f7f5ff_42%,#f2fbf7_100%)]" />
         <DialogPrimitive.Content
-          className="fixed inset-0 z-[80] overflow-y-auto p-4 text-slate-950 outline-none sm:p-6"
+          className="fixed inset-0 z-[80] overflow-y-auto text-slate-950 outline-none sm:p-4 lg:p-6"
           onInteractOutside={(event) => event.preventDefault()}
           onPointerDownOutside={(event) => event.preventDefault()}
         >
@@ -393,120 +444,154 @@ function JourneyShell({
             Guided setup for your OpenVPM clinic.
           </DialogPrimitive.Description>
           <div className="flex min-h-full items-center justify-center">
-            <div className="w-full max-w-2xl rounded-2xl border border-white/80 bg-white p-6 shadow-xl shadow-rose-200/30 sm:p-8">
-              {/* Brand mark + progress */}
-              <div className="flex items-center justify-between gap-4">
-                <div className="inline-flex items-center gap-2 text-sm font-medium text-emerald-700">
-                  <PawPrint className="h-4 w-4" />
-                  Make it yours
+            <div
+              className={cn(
+                "flex min-h-full w-full flex-col overflow-hidden bg-white shadow-[0_30px_90px_-38px_rgba(30,41,59,0.38)] sm:min-h-0 sm:rounded-[24px] sm:border sm:border-white/90",
+                step.id === "intent"
+                  ? "max-w-[1440px]"
+                  : step.id === "allSet"
+                    ? "max-w-5xl"
+                    : "max-w-3xl",
+              )}
+            >
+              <header className="flex items-center justify-between gap-5 border-b border-slate-100 px-5 py-4 sm:px-8 sm:py-5 lg:px-12">
+                <div className="inline-flex items-center gap-2.5 text-slate-950">
+                  <BrandBadge
+                    className="h-9 w-9 rounded-xl"
+                    pawClassName="h-5 w-5"
+                  />
+                  <span className="font-heading text-lg font-semibold tracking-tight">
+                    OpenVPM
+                  </span>
                 </div>
-                <span className="text-xs font-medium text-slate-500">
-                  Step {index + 1} of {total}
-                </span>
-              </div>
+                <div className="flex min-w-[132px] items-center gap-3 sm:min-w-[230px]">
+                  <span className="shrink-0 text-xs font-medium text-slate-500">
+                    Step {index + 1} of {total}
+                  </span>
+                  <div className="flex flex-1 gap-1.5" aria-hidden="true">
+                    {steps.map((s, i) => (
+                      <span
+                        key={s.id}
+                        className={cn(
+                          "h-1.5 flex-1 rounded-full transition-colors duration-300",
+                          i <= index ? "bg-primary" : "bg-slate-200",
+                        )}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </header>
 
-              <div className="mt-3 flex gap-1.5" aria-hidden="true">
-                {steps.map((s, i) => (
-                  <span
-                    key={s.id}
+              <div
+                className={cn(
+                  "flex-1 px-5 py-7 sm:px-8 sm:py-9",
+                  step.id === "intent" || step.id === "allSet"
+                    ? "lg:px-12 lg:py-10"
+                    : "lg:px-10",
+                )}
+              >
+                <DialogPrimitive.Title asChild>
+                  <h2
                     className={cn(
-                      "h-1.5 flex-1 rounded-full transition-colors",
-                      i <= index ? "bg-emerald-500" : "bg-slate-200",
+                      "max-w-3xl tracking-[-0.035em] text-slate-950",
+                      step.id === "intent"
+                        ? "font-heading text-[2.15rem] font-bold leading-[1.08] sm:text-[2.65rem] lg:text-[3rem]"
+                        : "font-heading text-2xl font-bold sm:text-3xl",
                     )}
-                  />
-                ))}
+                  >
+                    {step.title}
+                  </h2>
+                </DialogPrimitive.Title>
+
+                <div className={step.id === "intent" ? "mt-3" : "mt-6"}>
+                  {step.id === "intent" ? (
+                    <ChoosePathStep
+                      register={register}
+                      state={state}
+                      setState={setState}
+                    />
+                  ) : null}
+                  {step.id === "basics" ? (
+                    <PracticeBasicsStep register={register} />
+                  ) : null}
+                  {step.id === "data" ? (
+                    <BringDataStep
+                      register={register}
+                      state={state}
+                      setState={setState}
+                    />
+                  ) : null}
+                  {step.id === "allSet" ? (
+                    <AllSetStep register={register} state={state} />
+                  ) : null}
+                </div>
               </div>
 
-              {/* Title */}
-              <DialogPrimitive.Title asChild>
-                <h2 className="mt-6 font-heading text-2xl font-bold tracking-tight text-slate-950">
-                  {step.title}
-                </h2>
-              </DialogPrimitive.Title>
-
-              {/* Active step */}
-              <div className="mt-5">
-                {step.id === "intent" ? (
-                  <ChoosePathStep
-                    register={register}
-                    state={state}
-                    setState={setState}
-                  />
-                ) : null}
-                {step.id === "basics" ? (
-                  <PracticeBasicsStep register={register} />
-                ) : null}
-                {step.id === "data" ? (
-                  <BringDataStep
-                    register={register}
-                    state={state}
-                    setState={setState}
-                  />
-                ) : null}
-                {step.id === "allSet" ? (
-                  <AllSetStep register={register} state={state} />
-                ) : null}
-              </div>
-
-              {/* Footer */}
-              <div className="mt-8 flex flex-col-reverse items-stretch gap-4 border-t border-slate-100 pt-5 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex flex-col gap-2">
-                  <div className="flex items-center justify-between gap-3 sm:justify-start">
-                    {index > 0 ? (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        onClick={handleBack}
-                        disabled={
-                          busy || continueDisabled || state.hasPartialImport
-                        }
-                        aria-describedby={
-                          state.hasPartialImport
-                            ? "onboarding-back-disabled-reason"
-                            : undefined
-                        }
+              <footer className="border-t border-slate-100 bg-white px-5 py-4 sm:px-8 sm:py-5 lg:px-12">
+                <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex min-w-0 flex-col gap-2">
+                    <div className="flex items-center justify-between gap-3 sm:justify-start">
+                      {index > 0 ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={handleBack}
+                          disabled={
+                            busy || continueDisabled || state.hasPartialImport
+                          }
+                          aria-describedby={
+                            state.hasPartialImport
+                              ? "onboarding-back-disabled-reason"
+                              : undefined
+                          }
+                        >
+                          <ArrowLeft className="mr-1.5 h-4 w-4" />
+                          Back
+                        </Button>
+                      ) : (
+                        <span className="hidden items-center gap-2 text-xs text-slate-500 sm:flex">
+                          <ShieldCheck className="h-4 w-4 text-primary" />
+                          You can change this later.
+                        </span>
+                      )}
+                      {!isLast ? (
+                        <button
+                          type="button"
+                          onClick={handleFinishLater}
+                          disabled={busy || continueDisabled}
+                          className="min-h-10 rounded-lg px-2 text-sm font-medium text-slate-500 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50"
+                        >
+                          {state.hasPartialImport
+                            ? "Finish remaining import later"
+                            : "I'll finish later"}
+                        </button>
+                      ) : null}
+                    </div>
+                    {state.hasPartialImport ? (
+                      <p
+                        id="onboarding-back-disabled-reason"
+                        className="max-w-sm text-xs leading-5 text-slate-500"
                       >
-                        <ArrowLeft className="mr-1.5 h-4 w-4" />
-                        Back
-                      </Button>
-                    ) : null}
-                    {!isLast ? (
-                      <button
-                        type="button"
-                        onClick={handleFinishLater}
-                        disabled={busy || continueDisabled}
-                        className="text-sm font-medium text-slate-500 hover:text-slate-700 disabled:opacity-50"
-                      >
-                        {state.hasPartialImport
-                          ? "Finish remaining import later"
-                          : "I'll finish later"}
-                      </button>
+                        Back is unavailable after records are saved. Finish the
+                        remaining import now or continue it later.
+                      </p>
                     ) : null}
                   </div>
-                  {state.hasPartialImport ? (
-                    <p
-                      id="onboarding-back-disabled-reason"
-                      className="max-w-sm text-xs leading-5 text-slate-500"
-                    >
-                      Back is unavailable after records are saved. Finish the
-                      remaining import now or continue it later.
-                    </p>
-                  ) : null}
-                </div>
 
-                <Button
-                  type="button"
-                  onClick={handleContinue}
-                  disabled={busy || continueDisabled}
-                  className="h-auto min-h-10 w-full whitespace-normal py-2 text-center sm:w-auto"
-                >
-                  {busy ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : null}
-                  {continueLabel ?? (isLast ? "Finish" : "Continue")}
-                  {!busy ? <ArrowRight className="ml-2 h-4 w-4" /> : null}
-                </Button>
-              </div>
+                  <Button
+                    type="button"
+                    onClick={handleContinue}
+                    disabled={busy || continueDisabled}
+                    className="h-auto min-h-12 w-full whitespace-normal rounded-xl bg-primary px-6 py-3 text-center text-sm font-semibold shadow-[0_12px_24px_-14px_rgba(4,120,87,0.8)] transition hover:-translate-y-0.5 hover:bg-primary/90 sm:w-auto"
+                  >
+                    {busy ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : null}
+                    {continueLabel ?? (isLast ? "Finish" : "Continue")}
+                    {!busy ? <ArrowRight className="ml-2 h-4 w-4" /> : null}
+                  </Button>
+                </div>
+              </footer>
             </div>
           </div>
         </DialogPrimitive.Content>

--- a/apps/web/components/onboarding/journey-types.ts
+++ b/apps/web/components/onboarding/journey-types.ts
@@ -1,9 +1,14 @@
 /** Shared collected state and the per-step contract for the onboarding journey. */
 
 import type { OnboardingIntent } from "@/lib/onboarding/intent";
+import type { ClinicModel, FirstGoal } from "@/lib/onboarding/clinic-profile";
 import type { MigrationImportMode } from "@/lib/import/sources";
 
 export interface JourneyState {
+  /** Care model used to personalize the setup language and first-day plan. */
+  clinicModel: ClinicModel;
+  /** The concrete outcome the clinic wants from its first OpenVPM session. */
+  firstGoal: FirstGoal;
   /** The adoption path selected on the first setup step. */
   onboardingIntent: OnboardingIntent;
   /** When true, the seeded sample data stays put instead of being cleared at finish. */

--- a/apps/web/components/onboarding/steps/all-set.tsx
+++ b/apps/web/components/onboarding/steps/all-set.tsx
@@ -1,8 +1,90 @@
 "use client";
 
 import { useEffect } from "react";
-import { CalendarPlus, UserPlus } from "lucide-react";
+import {
+  CalendarCheck2,
+  CalendarPlus,
+  Check,
+  CreditCard,
+  Globe2,
+  PawPrint,
+  ReceiptText,
+  UserPlus,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { JourneyState, StepHandle } from "../journey-types";
+
+type RecommendationTone = "primary" | "violet" | "coral";
+
+const RECOMMENDATION_TONES: Record<
+  RecommendationTone,
+  { picture: string; icon: string; tag: string }
+> = {
+  primary: {
+    picture: "from-emerald-50 to-teal-50",
+    icon: "bg-primary/10 text-primary",
+    tag: "bg-primary/10 text-primary",
+  },
+  violet: {
+    picture: "from-violet-50 to-sky-50",
+    icon: "bg-violet-100 text-violet-700",
+    tag: "bg-violet-100 text-violet-700",
+  },
+  coral: {
+    picture: "from-orange-50 to-rose-50",
+    icon: "bg-orange-100 text-orange-700",
+    tag: "bg-orange-100 text-orange-700",
+  },
+};
+
+function RecommendationCard({
+  title,
+  body,
+  tag,
+  tone,
+  tilt,
+  children,
+}: {
+  title: string;
+  body: string;
+  tag: string;
+  tone: RecommendationTone;
+  tilt: string;
+  children: React.ReactNode;
+}) {
+  const palette = RECOMMENDATION_TONES[tone];
+  return (
+    <li
+      className={cn(
+        "group flex min-w-0 flex-col rounded-sm bg-white p-3 pb-4 shadow-[0_18px_40px_-24px_rgba(15,23,42,0.55)] ring-1 ring-black/5",
+        "transition duration-300 ease-out hover:z-10 hover:rotate-0 hover:-translate-y-1.5 hover:shadow-xl",
+        "motion-reduce:transform-none motion-reduce:transition-none",
+        tilt,
+      )}
+    >
+      <div
+        className={cn(
+          "flex min-h-32 flex-col justify-between overflow-hidden rounded-[3px] bg-gradient-to-br p-4",
+          palette.picture,
+        )}
+      >
+        {children}
+      </div>
+      <h4 className="mt-3 font-heading text-base font-semibold leading-snug text-slate-950">
+        {title}
+      </h4>
+      <p className="mt-1 text-xs leading-5 text-slate-600">{body}</p>
+      <span
+        className={cn(
+          "mt-3 w-fit rounded-full px-2.5 py-1 text-[10px] font-semibold",
+          palette.tag,
+        )}
+      >
+        {tag}
+      </span>
+    </li>
+  );
+}
 
 /**
  * Closing step: turn setup momentum into the first real clinic action. The
@@ -28,32 +110,112 @@ export function AllSetStep({
   const Icon = hasImportedData ? CalendarPlus : UserPlus;
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-7">
       <div className="flex items-center gap-3">
-        <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
+        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
           <Icon className="h-5 w-5" />
         </span>
-        <p className="text-sm leading-6 text-slate-600">
+        <p className="max-w-3xl text-sm leading-6 text-slate-600">
           {hasImportedData
-            ? "Your reviewed records are saved. Book one real appointment next, then run that visit from check-in through checkout before changing your clinic's live workflow."
-            : "Your clinic basics are saved. Add one real client and pet next. Your current PIMS can stay in place while you validate the complete visit with your team."}
+            ? "Your reviewed records are saved. Start with one real appointment, then decide what deserves a larger rollout."
+            : "Your clinic basics are saved. Start with one real client and visit while your current PIMS stays safely in place."}
         </p>
       </div>
 
-      <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800">
-          What happens next
-        </p>
-        <p className="mt-1 text-sm font-semibold text-slate-950">
-          {hasImportedData
-            ? "Choose a pet and put the first visit on the schedule."
-            : "Create one owner, add their pet, and book the first visit."}
-        </p>
-        <p className="mt-1 text-xs leading-5 text-slate-600">
-          Branding, teammates, AI, texting, and billing remain in your dashboard
-          checklist. None of them blocks this first clinic test.
-        </p>
-      </div>
+      <section aria-labelledby="first-day-recommendations-heading">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+          <div>
+            <h3
+              id="first-day-recommendations-heading"
+              className="font-heading text-xl font-semibold text-slate-950"
+            >
+              Here’s what I think will help first.
+            </h3>
+            <p className="mt-1 text-sm text-slate-500">
+              Pick one useful win. The rest will still be here when you’re
+              ready.
+            </p>
+          </div>
+          <p className="text-xs text-slate-500">Nothing here blocks launch.</p>
+        </div>
+
+        <ul className="mt-6 grid gap-6 sm:grid-cols-3 sm:gap-5">
+          <RecommendationCard
+            title={
+              hasImportedData
+                ? "Book one real appointment"
+                : "Run one real visit"
+            }
+            body={
+              hasImportedData
+                ? "Choose a patient from your reviewed records and put one visit on the schedule."
+                : "Add one owner and pet, then work from check-in through the client handoff."
+            }
+            tag="Best next step"
+            tone="primary"
+            tilt="sm:-rotate-1"
+          >
+            <span className="flex items-center gap-2 text-xs font-semibold text-primary">
+              <CalendarCheck2 className="h-4 w-4" /> Your clinic day
+            </span>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 rounded-lg bg-white/90 px-3 py-2 text-xs text-slate-700 shadow-sm">
+                <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <PawPrint className="h-3.5 w-3.5" />
+                </span>
+                <span>{hasImportedData ? "First visit" : "New patient"}</span>
+                <Check className="ml-auto h-3.5 w-3.5 text-primary" />
+              </div>
+            </div>
+          </RecommendationCard>
+
+          <RecommendationCard
+            title="Make getting paid easy"
+            body="Send an online invoice and let clients pay by card from their private link."
+            tag="Get paid faster"
+            tone="violet"
+            tilt="sm:rotate-1"
+          >
+            <span className="flex items-center gap-2 text-xs font-semibold text-violet-700">
+              <ReceiptText className="h-4 w-4" /> Client billing
+            </span>
+            <div className="rounded-lg bg-white/90 px-3 py-2.5 shadow-sm">
+              <div className="flex items-center justify-between text-xs text-slate-500">
+                <span>Invoice total</span>
+                <span className="font-semibold text-slate-900">$68.00</span>
+              </div>
+              <div className="mt-2 flex items-center gap-1.5 text-[11px] font-medium text-violet-700">
+                <CreditCard className="h-3.5 w-3.5" /> Pay securely online
+              </div>
+            </div>
+          </RecommendationCard>
+
+          <RecommendationCard
+            title="Give clients one simple place"
+            body="Share visits, vaccine history, and bills through a private client portal."
+            tag="Fewer status calls"
+            tone="coral"
+            tilt="sm:-rotate-1"
+          >
+            <span className="flex items-center gap-2 text-xs font-semibold text-orange-700">
+              <Globe2 className="h-4 w-4" /> Client portal
+            </span>
+            <div className="flex items-center gap-2 rounded-lg bg-white/90 px-3 py-2.5 shadow-sm">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-orange-100 text-orange-700">
+                <PawPrint className="h-4 w-4" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-xs font-semibold text-slate-900">
+                  Everything in one link
+                </p>
+                <p className="text-[10px] text-slate-500">
+                  Visits · Vaccines · Bills
+                </p>
+              </div>
+            </div>
+          </RecommendationCard>
+        </ul>
+      </section>
     </div>
   );
 }

--- a/apps/web/components/onboarding/steps/choose-path.tsx
+++ b/apps/web/components/onboarding/steps/choose-path.tsx
@@ -1,191 +1,89 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
+import { ClinicIntentBuilder } from "@/components/onboarding/clinic-intent-builder";
+import { FUNNEL_EVENTS } from "@/lib/funnel-analytics";
 import {
-  Check,
-  Compass,
-  RefreshCcw,
-  Rocket,
-  Server,
-  ShieldCheck,
-} from "lucide-react";
+  onboardingIntentForGoal,
+  type ClinicModel,
+  type FirstGoal,
+} from "@/lib/onboarding/clinic-profile";
+import { trackFunnelEvent } from "@/lib/track-funnel-event";
 import { trpc } from "@/lib/trpc";
-import { cn } from "@/lib/utils";
-import {
-  getOnboardingIntentOption,
-  HOSTED_CLINIC_PILOT,
-  ONBOARDING_INTENT_OPTIONS,
-  type OnboardingIntent,
-} from "@/lib/onboarding/intent";
 import type { StepProps } from "../journey-types";
 
-const intentIcons = {
-  alongside: RefreshCcw,
-  replace: Rocket,
-  explore: Compass,
-  self_host: Server,
-} satisfies Record<OnboardingIntent, typeof Compass>;
-
 /**
- * The first setup question is intentionally about the customer's job, not
- * product configuration. The answer is stored with onboarding progress so the
- * checklist and platform funnel can keep the same pathway context.
+ * Personalize the workspace around a coarse care model and first outcome.
+ * Neither value contains patient, client, or clinical information.
  */
 export function ChoosePathStep({ register, state, setState }: StepProps) {
   const utils = trpc.useUtils();
   const saveIntent = trpc.settings.setOnboardingIntent.useMutation();
-  const selected = getOnboardingIntentOption(state.onboardingIntent);
 
   useEffect(() => {
     register({
+      continueLabel: "Build my first day",
       async onContinue() {
-        await saveIntent.mutateAsync({ intent: state.onboardingIntent });
-        // The journey provider derives its same-session resume point from this
-        // cache. Keep it aligned with the successful server write so pausing
-        // and reopening does not return to the path question.
+        await saveIntent.mutateAsync({
+          intent: state.onboardingIntent,
+          clinicModel: state.clinicModel,
+          firstGoal: state.firstGoal,
+        });
         utils.settings.getOnboardingState.setData(undefined, (prev) =>
           prev
             ? {
                 ...prev,
                 onboardingIntent: state.onboardingIntent,
+                clinicModel: state.clinicModel,
+                firstGoal: state.firstGoal,
                 journeyDismissed: false,
               }
             : prev,
         );
+        trackFunnelEvent(FUNNEL_EVENTS.onboardingPlanBuilt, {
+          model: state.clinicModel,
+          goal: state.firstGoal,
+          step: "workspace",
+        });
         return true;
       },
     });
-  }, [register, saveIntent, state.onboardingIntent, utils]);
+  }, [register, saveIntent, state, utils]);
+
+  function selectModel(model: ClinicModel) {
+    const nextGoal =
+      model === "exploring" || state.firstGoal !== "self_host"
+        ? state.firstGoal
+        : "explore_sample";
+    setState({
+      clinicModel: model,
+      firstGoal: nextGoal,
+      onboardingIntent: onboardingIntentForGoal(nextGoal),
+    });
+    trackFunnelEvent(FUNNEL_EVENTS.onboardingModelSelected, {
+      model,
+      step: "workspace",
+    });
+  }
+
+  function selectGoal(goal: FirstGoal) {
+    setState({
+      firstGoal: goal,
+      onboardingIntent: onboardingIntentForGoal(goal),
+    });
+    trackFunnelEvent(FUNNEL_EVENTS.onboardingGoalSelected, {
+      model: state.clinicModel,
+      goal,
+      step: "workspace",
+    });
+  }
 
   return (
-    <div className="space-y-5">
-      <p className="text-sm leading-6 text-slate-600">
-        There is no all-or-nothing decision today. Pick the path that best fits
-        how you want to get value from OpenVPM first.
-      </p>
-
-      <div className="grid gap-3 sm:grid-cols-2">
-        {ONBOARDING_INTENT_OPTIONS.map((option) => {
-          const Icon = intentIcons[option.value];
-          const active = option.value === state.onboardingIntent;
-          return (
-            <button
-              key={option.value}
-              type="button"
-              aria-pressed={active}
-              onClick={() => setState({ onboardingIntent: option.value })}
-              className={cn(
-                "relative rounded-xl border bg-white p-4 text-left transition-colors",
-                active
-                  ? "border-emerald-400 bg-emerald-50/60 ring-1 ring-emerald-400"
-                  : "border-slate-200 hover:border-slate-300",
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <span
-                  className={cn(
-                    "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-                    active
-                      ? "bg-emerald-100 text-emerald-700"
-                      : "bg-slate-100 text-slate-600",
-                  )}
-                >
-                  <Icon className="h-5 w-5" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-semibold text-slate-950">
-                      {option.label}
-                    </span>
-                    {option.recommended ? (
-                      <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-800">
-                        Recommended
-                      </span>
-                    ) : null}
-                  </span>
-                  <span className="mt-1 block text-xs leading-5 text-slate-500">
-                    {option.description}
-                  </span>
-                </span>
-                {active ? (
-                  <Check className="h-5 w-5 shrink-0 text-emerald-600" />
-                ) : null}
-              </div>
-            </button>
-          );
-        })}
-      </div>
-
-      <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
-        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800">
-          Your first win
-        </p>
-        <p className="mt-1 text-sm font-semibold text-slate-950">
-          {selected.firstWin}
-        </p>
-        <p className="mt-1 text-xs leading-5 text-slate-600">
-          {selected.firstWinHint}
-        </p>
-      </div>
-
-      {state.onboardingIntent !== "self_host" ? (
-        <section
-          aria-labelledby="clinic-pilot-fit-heading"
-          className="rounded-xl border border-slate-200 bg-slate-50 p-4"
-        >
-          <div className="flex items-start gap-3">
-            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white text-slate-700 shadow-sm ring-1 ring-slate-200">
-              <ShieldCheck className="h-5 w-5" aria-hidden="true" />
-            </span>
-            <div className="min-w-0">
-              <p
-                id="clinic-pilot-fit-heading"
-                className="text-sm font-semibold text-slate-950"
-              >
-                Clinic pilot fit
-              </p>
-              <p className="mt-1 text-xs leading-5 text-slate-600">
-                {HOSTED_CLINIC_PILOT.recommendedFit}
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-3 rounded-lg border border-emerald-200 bg-white p-3">
-            <p className="text-xs font-semibold text-emerald-800">
-              First useful day target
-            </p>
-            <p className="mt-1 text-xs leading-5 text-slate-600">
-              {HOSTED_CLINIC_PILOT.firstUsefulDay}
-            </p>
-          </div>
-
-          <div className="mt-3">
-            <p className="text-xs font-semibold text-slate-700">
-              Know before you pilot
-            </p>
-            <ul className="mt-2 space-y-1.5 text-xs leading-5 text-slate-600">
-              {HOSTED_CLINIC_PILOT.guardrails.map((guardrail) => (
-                <li key={guardrail} className="flex gap-2">
-                  <span
-                    aria-hidden="true"
-                    className="mt-2 h-1 w-1 shrink-0 rounded-full bg-slate-400"
-                  />
-                  <span>{guardrail}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <Link
-            href="/clinic-fit"
-            target="_blank"
-            rel="noreferrer"
-            className="mt-3 inline-flex text-xs font-semibold text-emerald-700 underline underline-offset-2"
-          >
-            Review the full capability boundary
-          </Link>
-        </section>
-      ) : null}
-    </div>
+    <ClinicIntentBuilder
+      clinicModel={state.clinicModel}
+      firstGoal={state.firstGoal}
+      onClinicModelChange={selectModel}
+      onFirstGoalChange={selectGoal}
+    />
   );
 }

--- a/apps/web/components/tour/tour-provider.tsx
+++ b/apps/web/components/tour/tour-provider.tsx
@@ -113,6 +113,10 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
         ...prev,
         onboardingIntent: prev?.onboardingIntent ?? null,
         onboardingIntentSelectedAt: prev?.onboardingIntentSelectedAt ?? null,
+        clinicModel: prev?.clinicModel ?? null,
+        clinicModelSelectedAt: prev?.clinicModelSelectedAt ?? null,
+        firstGoal: prev?.firstGoal ?? null,
+        firstGoalSelectedAt: prev?.firstGoalSelectedAt ?? null,
         migrationHasCommittedChanges:
           prev?.migrationHasCommittedChanges ?? false,
         migrationLastCommittedAt: prev?.migrationLastCommittedAt ?? null,

--- a/apps/web/lib/__tests__/cron-schedule.test.ts
+++ b/apps/web/lib/__tests__/cron-schedule.test.ts
@@ -15,6 +15,7 @@ describe("Vercel cron schedule", () => {
         "/api/cron/file-replicas",
         "/api/cron/usage-reconcile",
         "/api/cron/billing-lifecycle",
+        "/api/cron/first-clinic-win",
         "/api/cron/setup-recovery",
         "/api/cron/wellness-billing",
         "/api/cron/rate-limit-cleanup",
@@ -36,6 +37,11 @@ describe("Vercel cron schedule", () => {
       config.crons?.find((cron) => cron.path === "/api/cron/setup-recovery")
         ?.schedule,
     ).toBe("0 15 * * *");
+
+    expect(
+      config.crons?.find((cron) => cron.path === "/api/cron/first-clinic-win")
+        ?.schedule,
+    ).toBe("17 * * * *");
 
     expect(
       config.crons?.find((cron) => cron.path === "/api/cron/sms-operations")

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -171,7 +171,7 @@ describe("dashboard onboarding UI states", () => {
     expect(settingsRouter).toContain("clearDemoData: adminProcedure.mutation");
     expect(settingsRouter).toContain("setOnboardingIntent: adminProcedure");
     expect(journeyPlanSource).toContain(
-      '{ id: "data", title: "Bring your clinic records." }',
+      '{ id: "data", title: "Bring your history with confidence." }',
     );
     expect(journeyProviderSource).toContain(
       "router.push(\n      state.hasImportedData",
@@ -179,6 +179,18 @@ describe("dashboard onboarding UI states", () => {
     expect(journeyProviderSource).toContain('"/clients/new?setup=first-visit"');
     expect(journeyProviderSource).not.toContain("<SetUpTextingStep");
     expect(journeyProviderSource).not.toContain("<AddACardStep");
+    expect(journeyProviderSource).toContain(
+      "FUNNEL_EVENTS.onboardingStepViewed",
+    );
+    expect(journeyProviderSource).toContain(
+      "FUNNEL_EVENTS.onboardingStepCompleted",
+    );
+    expect(journeyProviderSource).toContain(
+      "FUNNEL_EVENTS.onboardingCompleted",
+    );
+    expect(journeyProviderSource).toContain(
+      "FUNNEL_EVENTS.firstActionSelected",
+    );
   });
 
   it("uses the selected pathway to put a tailored first win first", () => {

--- a/apps/web/lib/__tests__/demo-conversion-ui.test.ts
+++ b/apps/web/lib/__tests__/demo-conversion-ui.test.ts
@@ -9,7 +9,7 @@ describe("demo conversion bridge UI", () => {
   const bar = readFileSync("components/demo/demo-conversion-bar.tsx", "utf8");
   const tracker = readFileSync(
     "components/demo/demo-funnel-tracker.tsx",
-    "utf8"
+    "utf8",
   );
 
   it("instruments the email gate and start-clinic CTA", () => {
@@ -17,7 +17,7 @@ describe("demo conversion bridge UI", () => {
     expect(login).toContain("FUNNEL_EVENTS.demoGateViewed");
     expect(login).toContain("anonymousId: visitorId ?? getFunnelVisitorId()");
     expect(login).not.toContain(
-      "trackFunnelEvent(FUNNEL_EVENTS.demoGateSubmitted)"
+      "trackFunnelEvent(FUNNEL_EVENTS.demoGateSubmitted)",
     );
     expect(demoAccessRoute).toContain('name: "demo_gate_submitted"');
     expect(demoAccessRoute).toContain("await recordAcceptedDemoGate");
@@ -36,6 +36,24 @@ describe("demo conversion bridge UI", () => {
     expect(register).toContain("acquisitionWithFunnelVisitorId");
     expect(register).toContain("getFunnelVisitorId()");
     expect(register).toContain("acquisition: registrationAcquisition");
+  });
+
+  it("continues from clinic intent into account creation without repeating the profile", () => {
+    expect(register).toContain("A platform truly built for your clinic.");
+    expect(register).toContain("<ClinicIntentBuilder");
+    expect(register).toContain(
+      'type RegistrationStage = "profile" | "account"',
+    );
+    expect(register).toContain("REGISTRATION_PROFILE_STORAGE_KEY");
+    expect(register).toContain("if (!profileRestored) return;");
+    expect(register).toContain("setProfileRestored(true)");
+    expect(register).toContain("onboardingDraft: { clinicModel, firstGoal }");
+    expect(register).toContain("FUNNEL_EVENTS.signupProfileCompleted");
+    expect(register).toContain("FUNNEL_EVENTS.signupSubmitted");
+    expect(register).toContain("FUNNEL_EVENTS.signupSucceeded");
+    expect(register).toContain(
+      "No patient or client information belongs here.",
+    );
   });
 
   it("mounts the demo bar and path tracker in the dashboard shell", () => {

--- a/apps/web/lib/__tests__/email-lifecycle.test.ts
+++ b/apps/web/lib/__tests__/email-lifecycle.test.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => {
     updateSet,
     alertOps: vi.fn(async () => undefined),
     marketingEmailEnabledForRecipient: vi.fn(async () => true),
+    lockAndCheckMarketingEmailEnabled: vi.fn(async () => true),
     practiceAllowsExternalSideEffects: vi.fn(async () => true),
     lockPracticeForExternalSideEffects: vi.fn(async () => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -59,6 +60,11 @@ vi.mock("@/lib/alerts", () => ({
 
 vi.mock("@/lib/platform-email-preferences", () => ({
   marketingEmailEnabledForRecipient: mocks.marketingEmailEnabledForRecipient,
+  lockAndCheckMarketingEmailEnabled: mocks.lockAndCheckMarketingEmailEnabled,
+}));
+
+vi.mock("@/lib/email-preferences", () => ({
+  emailPreferenceRecipientHash: vi.fn(() => "a".repeat(64)),
 }));
 
 vi.mock("@/lib/recovery-hold", () => ({
@@ -83,6 +89,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-06-28T12:00:00Z"));
   mocks.marketingEmailEnabledForRecipient.mockResolvedValue(true);
+  mocks.lockAndCheckMarketingEmailEnabled.mockResolvedValue(true);
   mocks.practiceAllowsExternalSideEffects.mockResolvedValue(true);
   mocks.lockPracticeForExternalSideEffects.mockResolvedValue(true);
 });
@@ -197,7 +204,28 @@ describe("sendLifecycleEmail", () => {
     ).resolves.toEqual({ sent: true, deduped: false });
 
     expect(mocks.insertValues).toHaveBeenCalledTimes(1);
+    expect(mocks.lockAndCheckMarketingEmailEnabled).toHaveBeenCalledWith(
+      mocks.db,
+      "owner@example.com",
+    );
     expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a safe claim when the recipient opts out before provider send", async () => {
+    mocks.insertResults.push([{ id: "comm-consent-race" }]);
+    mocks.lockAndCheckMarketingEmailEnabled.mockResolvedValueOnce(false);
+    const send = vi.fn(async () => ({ success: true, id: "email-1" }));
+
+    await expect(
+      sendLifecycleEmail({ ...BASE_OPTS, category: "marketing", send }),
+    ).resolves.toEqual({
+      sent: false,
+      deduped: false,
+      suppressed: true,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mocks.deleteWhere).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed when optional-email preference lookup fails", async () => {
@@ -293,7 +321,10 @@ describe("sendLifecycleEmail", () => {
 
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Lifecycle email failed",
-      "trial-ending \u2192 owner@example.com: provider down",
+      `trial-ending practice=${PRACTICE_ID} recipient=${"a".repeat(12)}: provider down`,
+    );
+    expect(mocks.alertOps.mock.calls.flat().join(" ")).not.toContain(
+      "owner@example.com",
     );
     expect(mocks.deleteWhere).not.toHaveBeenCalled();
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "failed" });

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -540,10 +540,12 @@ describe("lifecycle email branding", () => {
         practiceName: "Neighborhood Veterinary",
         daysLeft: 3,
         trialEndDate: "August 12, 2026",
+        billingConnected: true,
+        idempotencyKey: "lc:trial-ending:practice:t-3",
       }),
     ).resolves.toEqual({ success: true, id: "email-1" });
 
-    const [payload] = mocks.resendSend.mock.calls[0] ?? [];
+    const [payload, providerOptions] = mocks.resendSend.mock.calls[0] ?? [];
     expect(payload.headers).toMatchObject({
       "List-Unsubscribe": expect.stringMatching(
         /^<https:\/\/app\.openvpm\.com\/api\/email-preferences\/unsubscribe\?token=.+>$/,
@@ -554,9 +556,58 @@ describe("lifecycle email branding", () => {
     expect(payload.html).toContain(
       "This address is the OpenVPM billing contact for Neighborhood Veterinary.",
     );
+    expect(payload.html).toContain("Review billing");
+    expect(payload.html).toContain("no need to add it again");
+    expect(payload.html).not.toContain(">Add billing<");
+    expect(providerOptions).toMatchObject({
+      idempotencyKey: "lc:trial-ending:practice:t-3",
+    });
     expect(payload.html).not.toContain(
       'href="https://app.openvpm.com/settings?tab=billing">Manage email preferences',
     );
+  });
+
+  it("sends the PHI-free first-clinic-win campaign with provider idempotency", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv(
+      "EMAIL_PREFERENCE_IDENTITY_SECRET",
+      "stable-identity-secret-at-least-32-bytes",
+    );
+    vi.stubEnv(
+      "EMAIL_PREFERENCE_SIGNING_SECRET",
+      "stable-signing-secret-at-least-32-bytes",
+    );
+    vi.stubEnv("EMAIL_PREFERENCE_BASE_URL", "https://app.openvpm.com");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    mocks.resendSend.mockResolvedValue({ data: { id: "email-first-win" } });
+    const { sendFirstClinicWinEmail } = await loadEmail();
+
+    await expect(
+      sendFirstClinicWinEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        trialEndDate: "August 28, 2026",
+        idempotencyKey: "lc:first-clinic-win:v1:practice",
+      }),
+    ).resolves.toEqual({ success: true, id: "email-first-win" });
+
+    const [payload, providerOptions] = mocks.resendSend.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({
+      to: "owner@example.com",
+      subject: "Your first real OpenVPM visit is complete",
+      headers: {
+        "List-Unsubscribe": expect.stringContaining(
+          "https://app.openvpm.com/api/email-preferences/unsubscribe?token=",
+        ),
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
+    });
+    expect(providerOptions).toMatchObject({
+      idempotencyKey: "lc:first-clinic-win:v1:practice",
+    });
+    expect(payload.html).toContain("You ran your first real visit");
+    expect(payload.html).toContain("A card is not required");
+    expect(payload.html).not.toMatch(/patient|client name|invoice amount/i);
   });
 
   it("does not send optional mail without a dedicated preference secret", async () => {

--- a/apps/web/lib/__tests__/funnel-analytics.test.ts
+++ b/apps/web/lib/__tests__/funnel-analytics.test.ts
@@ -151,5 +151,25 @@ describe("FUNNEL_EVENTS", () => {
     expect(FUNNEL_EVENTS.demoToolOpened).toBe("demo_tool_opened");
     expect(FUNNEL_EVENTS.demoCtaStartClinic).toBe("demo_cta_start_clinic");
     expect(FUNNEL_EVENTS.signupLand).toBe("signup_land");
+    expect(FUNNEL_EVENTS.signupProfileViewed).toBe("signup_profile_viewed");
+    expect(FUNNEL_EVENTS.signupProfileCompleted).toBe(
+      "signup_profile_completed",
+    );
+    expect(FUNNEL_EVENTS.signupAccountViewed).toBe("signup_account_viewed");
+    expect(FUNNEL_EVENTS.signupSubmitted).toBe("signup_submitted");
+    expect(FUNNEL_EVENTS.signupSucceeded).toBe("signup_succeeded");
+    expect(FUNNEL_EVENTS.onboardingModelSelected).toBe(
+      "onboarding_model_selected",
+    );
+    expect(FUNNEL_EVENTS.onboardingGoalSelected).toBe(
+      "onboarding_goal_selected",
+    );
+    expect(FUNNEL_EVENTS.onboardingPlanBuilt).toBe("onboarding_plan_built");
+    expect(FUNNEL_EVENTS.onboardingStepViewed).toBe("onboarding_step_viewed");
+    expect(FUNNEL_EVENTS.onboardingStepCompleted).toBe(
+      "onboarding_step_completed",
+    );
+    expect(FUNNEL_EVENTS.onboardingCompleted).toBe("onboarding_completed");
+    expect(FUNNEL_EVENTS.firstActionSelected).toBe("first_action_selected");
   });
 });

--- a/apps/web/lib/__tests__/journey-funnel.test.ts
+++ b/apps/web/lib/__tests__/journey-funnel.test.ts
@@ -5,7 +5,9 @@ import { PgDialect } from "drizzle-orm/pg-core";
 
 const mocks = vi.hoisted(() => {
   const executeResults: unknown[][] = [];
-  const execute = vi.fn(async (_query: unknown) => executeResults.shift() ?? []);
+  const execute = vi.fn(
+    async (_query: unknown) => executeResults.shift() ?? [],
+  );
   const db = { execute };
   return {
     db,
@@ -13,7 +15,7 @@ const mocks = vi.hoisted(() => {
     executeResults,
     withSystem: vi.fn(
       async (database: unknown, fn: (tx: unknown) => Promise<unknown>) =>
-        fn(database)
+        fn(database),
     ),
   };
 });
@@ -35,6 +37,10 @@ describe("computeJourneyFunnel", () => {
           weekStart: "2026-07-27",
           visitors: "20",
           demos: "8",
+          signupProfileViewed: "6",
+          signupProfileCompleted: "5",
+          signupAccountViewed: "5",
+          signupSubmitted: "5",
           registrations: "5",
           activated: "2",
           paymentMethodCollected: "1",
@@ -47,7 +53,7 @@ describe("computeJourneyFunnel", () => {
         },
       ],
       [{ historicalUnknown: "2", repairableGap: "1" }],
-      [{ count: "4" }]
+      [{ count: "4" }],
     );
 
     const result = await computeJourneyFunnel(mocks.db as never, 30);
@@ -57,6 +63,10 @@ describe("computeJourneyFunnel", () => {
         weekStart: "2026-07-27",
         visitors: 20,
         demos: 8,
+        signupProfileViewed: 6,
+        signupProfileCompleted: 5,
+        signupAccountViewed: 5,
+        signupSubmitted: 5,
         registrations: 5,
         activated: 2,
         paymentMethodCollected: 1,
@@ -66,6 +76,10 @@ describe("computeJourneyFunnel", () => {
     expect(result.totals).toMatchObject({
       visitors: 20,
       demos: 8,
+      signupProfileViewed: 6,
+      signupProfileCompleted: 5,
+      signupAccountViewed: 5,
+      signupSubmitted: 5,
       registrations: 5,
       activated: 2,
       paymentMethodCollected: 1,
@@ -80,9 +94,14 @@ describe("computeJourneyFunnel", () => {
       repairableAttributionGaps: 1,
       clientErrors: 4,
       demoRate: 0.4,
+      profileViewRate: 0.3,
+      profileCompletionRate: 5 / 6,
+      accountViewRate: 1,
+      signupSubmitRate: 1,
+      signupSuccessRate: 1,
       registrationRate: 0.25,
       activationRate: 0.4,
-      paymentMethodRate: 0.5,
+      paymentMethodRate: 0.2,
       positivePaymentRate: 1,
     });
     expect(mocks.execute).toHaveBeenCalledTimes(3);
@@ -101,12 +120,21 @@ describe("computeJourneyFunnel", () => {
     expect(result.totals).toMatchObject({
       visitors: 0,
       demos: 0,
+      signupProfileViewed: 0,
+      signupProfileCompleted: 0,
+      signupAccountViewed: 0,
+      signupSubmitted: 0,
       registrations: 0,
       activated: 0,
       paymentMethodCollected: 0,
       firstPositivePayment: 0,
       clientErrors: 0,
       demoRate: 0,
+      profileViewRate: 0,
+      profileCompletionRate: 0,
+      accountViewRate: 0,
+      signupSubmitRate: 0,
+      signupSuccessRate: 0,
       registrationRate: 0,
       activationRate: 0,
       paymentMethodRate: 0,
@@ -119,25 +147,32 @@ describe("computeJourneyFunnel", () => {
 
     expect(source).toContain("export const ABANDONMENT_GRACE_DAYS = 7");
     expect(source).toContain("with first_touch_all_time as (");
-    expect(source).toMatch(
-      /first_touch_all_time[\s\S]*'demo_gate_submitted'/,
-    );
+    expect(source).toMatch(/first_touch_all_time[\s\S]*'demo_gate_submitted'/);
     expect(source).not.toContain(
       "fe.created_at >= ${windowStart}::timestamptz",
     );
-    expect(source).toContain(
-      "where cohort_at >= ${windowStart}::timestamptz",
-    );
+    expect(source).toContain("where cohort_at >= ${windowStart}::timestamptz");
     expect(source).toContain("select min(demo.created_at) as demo_at");
     expect(source).toContain("demo.created_at >= ft.cohort_at");
     expect(source).toContain("s.cohort_at < ${abandonedBefore}::timestamptz");
     expect(source).toContain("s.demo_at < ${abandonedBefore}::timestamptz");
-    expect(source).toContain("s.registered_at < ${abandonedBefore}::timestamptz");
-    expect(source).toContain("s.activation_at < ${abandonedBefore}::timestamptz");
-    expect(source).toContain("s.payment_method_at < ${abandonedBefore}::timestamptz");
+    expect(source).toContain(
+      "s.registered_at < ${abandonedBefore}::timestamptz",
+    );
+    expect(source).toContain(
+      "s.activation_at < ${abandonedBefore}::timestamptz",
+    );
+    expect(source).toContain(
+      "s.payment_method_at < ${abandonedBefore}::timestamptz",
+    );
     expect(source).toContain("s.stripe_subscription_id is not null");
     expect(source).toContain("s.billing_status = 'trialing'");
-    expect(source).toContain("s.trial_ends_at > ${now.toISOString()}::timestamptz");
+    expect(source).toContain(
+      "s.trial_ends_at > ${now.toISOString()}::timestamptz",
+    );
+    expect(source).toContain(
+      "paymentMethodRate: funnelRate(paymentMethodCollected, registrations)",
+    );
   });
 
   it("keeps the client-error aggregate as one valid select statement", () => {
@@ -147,7 +182,9 @@ describe("computeJourneyFunnel", () => {
     )?.[1];
 
     expect(errorQuery).toBeDefined();
-    expect(errorQuery?.match(/select count\(\*\)::int as count/g)).toHaveLength(1);
+    expect(errorQuery?.match(/select count\(\*\)::int as count/g)).toHaveLength(
+      1,
+    );
     expect(errorQuery).toMatch(
       /select count\(\*\)::int as count\s+from funnel_events\s+where event_name = 'client_error'/,
     );

--- a/apps/web/lib/__tests__/onboarding-import-ui.test.ts
+++ b/apps/web/lib/__tests__/onboarding-import-ui.test.ts
@@ -50,7 +50,9 @@ describe("onboarding import UI", () => {
     expect(source).toContain(
       "History attaches only to a safely matched real patient",
     );
-    expect(journeyPlanSource).toContain('title: "Bring your clinic records."');
+    expect(journeyPlanSource).toContain(
+      'title: "Bring your history with confidence."',
+    );
     expect(journeyPlanSource).not.toContain(
       'title: "Add your real clients and pets."',
     );

--- a/apps/web/lib/__tests__/onboarding-ui-states.test.ts
+++ b/apps/web/lib/__tests__/onboarding-ui-states.test.ts
@@ -34,6 +34,10 @@ describe("onboarding UI states", () => {
     "components/onboarding/steps/choose-path.tsx",
     "utf8",
   );
+  const clinicIntentBuilder = readFileSync(
+    "components/onboarding/clinic-intent-builder.tsx",
+    "utf8",
+  );
   const onboardingIntent = readFileSync("lib/onboarding/intent.ts", "utf8");
   const journeyOverlay = readFileSync(
     "components/onboarding/journey-overlay.tsx",
@@ -72,32 +76,48 @@ describe("onboarding UI states", () => {
     );
   });
 
-  it("starts with a persisted adoption pathway and recommends running alongside", () => {
+  it("starts with a persisted clinic model, first outcome, and adoption pathway", () => {
     expect(journeyPlan).toContain(
-      '{ id: "intent", title: "How do you want to start?" }',
+      '{ id: "intent", title: "A platform truly built for your clinic." }',
     );
     expect(journeyOverlay).toContain(
       "initialIntent={onboardingIntent ?? DEFAULT_ONBOARDING_INTENT}",
     );
+    expect(journeyOverlay).toContain("initialClinicModel={");
+    expect(journeyOverlay).toContain("initialFirstGoal={");
     expect(onboardingIntent).toContain(
       'label: "Run alongside my current PIMS"',
     );
-    expect(choosePath).toContain("Recommended");
-    expect(choosePath).toContain(
-      "saveIntent.mutateAsync({ intent: state.onboardingIntent })",
-    );
-    expect(choosePath).toContain("onboardingIntent: state.onboardingIntent");
+    expect(choosePath).toContain("clinicModel: state.clinicModel");
+    expect(choosePath).toContain("firstGoal: state.firstGoal");
+    expect(choosePath).toContain("Build my first day");
+    expect(clinicIntentBuilder).toContain("Your first OpenVPM day");
     expect(choosePath).toContain("journeyDismissed: false");
     expect(settingsRouter).toContain("onboardingIntentSelectedAt");
+    expect(settingsRouter).toContain("clinicModelSelectedAt");
+    expect(settingsRouter).toContain("firstGoalSelectedAt");
   });
 
-  it("shows honest hosted-pilot qualification after signup", () => {
-    expect(choosePath).toContain("HOSTED_CLINIC_PILOT");
-    expect(choosePath).toContain('state.onboardingIntent !== "self_host"');
-    expect(choosePath).toContain("Clinic pilot fit");
-    expect(choosePath).toContain("First useful day target");
-    expect(choosePath).toContain("HOSTED_CLINIC_PILOT.guardrails.map");
-    expect(choosePath).toContain('href="/clinic-fit"');
+  it("personalizes new care models without overstating pilot readiness", () => {
+    expect(clinicIntentBuilder).toContain(
+      'selectedModel.readiness === "design_partner"',
+    );
+    expect(clinicIntentBuilder).toContain("one real workflow");
+    expect(clinicIntentBuilder).toContain("anything that isn’t ready yet");
+    expect(clinicIntentBuilder).toContain("Nothing moves until you review it.");
+    expect(choosePath).toContain("FUNNEL_EVENTS.onboardingModelSelected");
+    expect(choosePath).toContain("FUNNEL_EVENTS.onboardingGoalSelected");
+    expect(choosePath).toContain("FUNNEL_EVENTS.onboardingPlanBuilt");
+  });
+
+  it("uses the canonical OpenVPM mark, typography, and primary color tokens", () => {
+    expect(journeyOverlay).toContain("import { BrandBadge }");
+    expect(journeyOverlay).toContain("<BrandBadge");
+    expect(journeyOverlay).toContain("font-heading text-[2.15rem]");
+    expect(journeyOverlay).not.toContain("[font-family:Georgia,serif]");
+    expect(journeyOverlay).not.toContain("<PawPrint");
+    expect(journeyOverlay).toContain('i <= index ? "bg-primary"');
+    expect(clinicIntentBuilder).toContain("focus-visible:ring-primary");
   });
 
   it("keeps imported-real-data cleanup sticky across setup resumes", () => {
@@ -135,9 +155,8 @@ describe("onboarding UI states", () => {
     expect(journeyOverlay).toContain(
       "onInteractOutside={(event) => event.preventDefault()}",
     );
-    expect(journeyOverlay).toContain(
-      "aria-describedby={\n                          state.hasPartialImport",
-    );
+    expect(journeyOverlay).toContain("aria-describedby={");
+    expect(journeyOverlay).toContain("state.hasPartialImport");
     expect(journeyOverlay).toContain('id="onboarding-back-disabled-reason"');
     expect(journeyOverlay).toContain("whitespace-normal");
     expect(journeyOverlay).toContain('"I\'ll finish later"');

--- a/apps/web/lib/__tests__/request-only-booking-ui.test.ts
+++ b/apps/web/lib/__tests__/request-only-booking-ui.test.ts
@@ -5,16 +5,16 @@ describe("request-only booking UI", () => {
   const publicPage = readFileSync("app/book/[slug]/page.tsx", "utf8");
   const settingsTab = readFileSync(
     "components/settings/booking-tab.tsx",
-    "utf8"
+    "utf8",
   );
   const portalPage = readFileSync("app/portal/[token]/book/page.tsx", "utf8");
   const activationChecklist = readFileSync(
     "components/dashboard/activation-checklist.tsx",
-    "utf8"
+    "utf8",
   );
   const allSetStep = readFileSync(
     "components/onboarding/steps/all-set.tsx",
-    "utf8"
+    "utf8",
   );
 
   it("describes every public submission as a request that the clinic confirms", () => {
@@ -29,7 +29,9 @@ describe("request-only booking UI", () => {
 
   it("removes auto-confirm from settings and explains the staff handoff", () => {
     expect(settingsTab).toContain("Online appointment requests");
-    expect(settingsTab).toContain("Requests are never confirmed automatically.");
+    expect(settingsTab).toContain(
+      "Requests are never confirmed automatically.",
+    );
     expect(settingsTab).toContain("assigns a doctor and room as needed");
     expect(settingsTab).not.toContain("Confirm bookings automatically");
     expect(settingsTab).not.toContain("config.autoConfirm");
@@ -107,7 +109,7 @@ describe("request-only booking UI", () => {
   it("blocks misleading publication and explains how to resolve it", () => {
     expect(settingsTab).toContain("nextPublished && bookableSet.size === 0");
     expect(settingsTab).toContain(
-      "Select at least one active visit type before publishing"
+      "Select at least one active visit type before publishing",
     );
     expect(settingsTab).toContain('role="alert"');
   });
@@ -115,17 +117,17 @@ describe("request-only booking UI", () => {
   it("fails closed until saved booking settings are available", () => {
     expect(settingsTab).toContain("pageSettingsUnavailable");
     expect(settingsTab).toContain(
-      "Appointment request settings could not be loaded"
+      "Appointment request settings could not be loaded",
     );
     expect(settingsTab).toContain(
-      "Nothing can be changed until the saved settings are available."
+      "Nothing can be changed until the saved settings are available.",
     );
     expect(settingsTab).toContain("onClick={() => void myPage.refetch()}");
     expect(settingsTab).toContain("Retry loading settings");
     expect(settingsTab).toContain("appointmentTypesUnavailable");
     expect(settingsTab).toContain("Active visit types could not be loaded");
     expect(settingsTab).toContain(
-      "Publishing and editing are unavailable so saved selections are"
+      "Publishing and editing are unavailable so saved selections are",
     );
     expect(settingsTab).toContain("onClick={() => void types.refetch()}");
     expect(settingsTab).toContain("Retry loading visit types");
@@ -135,19 +137,22 @@ describe("request-only booking UI", () => {
     expect(activationChecklist).toContain("Guided setup checks complete");
     expect(activationChecklist).toContain("Configure appointment requests");
     expect(activationChecklist).toContain(
-      "Choose which visit types and times clients can request, then publish the page."
+      "Choose which visit types and times clients can request, then publish the page.",
     );
     expect(activationChecklist).toContain(
-      "Keep validating real clinic workflows with your team before"
+      "Keep validating real clinic workflows with your team before",
     );
     expect(activationChecklist).not.toContain("is ready to run");
     expect(allSetStep).toContain("Add the first real client");
     expect(allSetStep).toContain(
-      "before changing your clinic's live workflow"
+      "Start with one real appointment, then decide what deserves a larger rollout.",
     );
-    expect(allSetStep).toContain(
-      "None of them blocks this first clinic test."
-    );
+    expect(allSetStep).toContain("Here’s what I think will help first.");
+    expect(allSetStep).toContain("Make getting paid easy");
+    expect(allSetStep).toContain("Get paid faster");
+    expect(allSetStep).not.toContain("Useful for every clinic");
+    expect(allSetStep).toContain("pay by card from their private link");
+    expect(allSetStep).not.toContain("ACH");
     expect(allSetStep).not.toContain("Your workspace is ready");
   });
 });

--- a/apps/web/lib/__tests__/trial-badge-ui.test.ts
+++ b/apps/web/lib/__tests__/trial-badge-ui.test.ts
@@ -19,13 +19,15 @@ describe("trial badge UI", () => {
     expect(source).toContain("Billing status unavailable");
     expect(source).toContain("if (error || !data)");
     expect(source.indexOf("if (isLoading)")).toBeLessThan(
-      source.indexOf("if (error || !data)")
+      source.indexOf("if (error || !data)"),
     );
     expect(source.indexOf("if (error || !data)")).toBeLessThan(
-      source.indexOf('if (!data.billingEnforced || data.billingStatus === "active")')
+      source.indexOf(
+        'if (!data.billingEnforced || data.billingStatus === "active")',
+      ),
     );
     expect(source).not.toContain(
-      'if (!data || !data.billingEnforced || data.billingStatus === "active")'
+      'if (!data || !data.billingEnforced || data.billingStatus === "active")',
     );
   });
 
@@ -40,7 +42,9 @@ describe("trial badge UI", () => {
   it("routes card-on-file trialing accounts to billing instead of another Checkout", () => {
     expect(source).toContain("if (data.hasSubscription)");
     expect(source).toContain('href="/settings?tab=billing"');
-    expect(source).toContain("Card on file · Manage billing");
+    expect(source).toContain("Billing connected · Manage billing");
+    expect(source).toContain("Payment retrying · Review billing");
+    expect(source).toContain("Payment unpaid · Read only");
     expect(source.indexOf("if (data.hasSubscription)")).toBeLessThan(
       source.indexOf("const trialing ="),
     );
@@ -54,10 +58,10 @@ describe("trial badge UI", () => {
 
   it("counts trial days from the practice timezone", () => {
     expect(source).toContain(
-      'import { trialCalendarDaysLeft } from "@/lib/billing/trial-days"'
+      'import { trialCalendarDaysLeft } from "@/lib/billing/trial-days"',
     );
     expect(source).toContain(
-      "trialCalendarDaysLeft(data.trialEndsAt, data.timezone)"
+      "trialCalendarDaysLeft(data.trialEndsAt, data.timezone)",
     );
     expect(source).not.toContain("getTime() - Date.now()");
     expect(source).not.toContain("24 * 60 * 60 * 1000");

--- a/apps/web/lib/admin/activation-funnel.ts
+++ b/apps/web/lib/admin/activation-funnel.ts
@@ -49,6 +49,19 @@ export interface ActivationFunnelDataQuality {
   unmappedStripeEvidence: number;
 }
 
+export interface FirstVisitBillingConversion {
+  /** First real visits in the window that are at least 72 hours old. */
+  maturedFirstVisits: number;
+  /** Billing was already connected at or before the first real visit. */
+  alreadyConnectedAtVisit: number;
+  /** Matured first visits where billing was not connected at visit time. */
+  opportunities: number;
+  convertedWithin24Hours: number;
+  convertedWithin72Hours: number;
+  conversionWithin24HoursRate: number;
+  conversionWithin72HoursRate: number;
+}
+
 export interface ActivationFunnelTotals {
   signups: number;
   setupStarted: number;
@@ -64,9 +77,9 @@ export interface ActivationFunnelTotals {
   setupCompletionRate: number;
   /** activated / signups; 0 when there are no signups. */
   activationRate: number;
-  /** firstVisitCompleted / activated; 0 when there are no activated clinics. */
+  /** firstVisitCompleted / signups; 0 when there are no signups. */
   firstVisitCompletionRate: number;
-  /** paymentMethodCollected / activated; 0 when there are no activations. */
+  /** paymentMethodCollected / signups; billing may be connected before product activation. */
   paymentMethodRate: number;
   /** firstPositivePayment / paymentMethodCollected. */
   positivePaymentRate: number;
@@ -88,6 +101,7 @@ export interface ActivationFunnel {
     ActivationFunnelTotals
   >;
   dataQuality: ActivationFunnelDataQuality;
+  firstVisitBillingConversion: FirstVisitBillingConversion;
 }
 
 /** Rate guarded against divide-by-zero: no signups means a 0 rate, not NaN. */
@@ -116,6 +130,14 @@ interface DataQualityRow {
   missingActivationMilestones: number | string;
   unprojectedStripeEvidence: number | string;
   unmappedStripeEvidence: number | string;
+}
+
+interface FirstVisitBillingRow {
+  maturedFirstVisits: number | string;
+  alreadyConnectedAtVisit: number | string;
+  opportunities: number | string;
+  convertedWithin24Hours: number | string;
+  convertedWithin72Hours: number | string;
 }
 
 function rowsFromExecute<T>(result: unknown): T[] {
@@ -174,8 +196,8 @@ function summarizeWeeks(weeks: ActivationFunnelWeek[]): ActivationFunnelTotals {
     setupStartRate: funnelRate(setupStarted, signups),
     setupCompletionRate: funnelRate(setupCompleted, signups),
     activationRate: funnelRate(activated, signups),
-    firstVisitCompletionRate: funnelRate(firstVisitCompleted, activated),
-    paymentMethodRate: funnelRate(paymentMethodCollected, activated),
+    firstVisitCompletionRate: funnelRate(firstVisitCompleted, signups),
+    paymentMethodRate: funnelRate(paymentMethodCollected, signups),
     positivePaymentRate: funnelRate(
       firstPositivePayment,
       paymentMethodCollected,
@@ -193,14 +215,15 @@ function jurisdictionCohort(
 
 export async function computeActivationFunnel(
   db: Database,
-  days: number
+  days: number,
 ): Promise<ActivationFunnel> {
   const windowStart = new Date(Date.now() - days * DAY_MS).toISOString();
 
   // Cross-tenant read → system context (RLS bypass), same as the admin
   // overview. One grouped aggregate query — no per-practice N+1.
-  const { cohortResult, qualityResult } = await withSystem(db, async (tx) => {
-    const cohortResult = await tx.execute(sql`
+  const { cohortResult, qualityResult, firstVisitBillingResult } =
+    await withSystem(db, async (tx) => {
+      const cohortResult = await tx.execute(sql`
       with signups as (
         select
           p.id,
@@ -275,7 +298,6 @@ export async function computeActivationFunnel(
         )::int as "activated",
         count(*) filter (
           where mt.registered_at is not null
-            and mt.activated_at is not null
             and exists (
             select 1
             from visit_closeouts vc
@@ -295,13 +317,10 @@ export async function computeActivationFunnel(
         )::int as "firstVisitCompleted",
         count(*) filter (
           where mt.registered_at is not null
-            and mt.activated_at is not null
             and mt.payment_method_at is not null
         )::int as "paymentMethodCollected",
         count(*) filter (
           where mt.registered_at is not null
-            and mt.activated_at is not null
-            and mt.payment_method_at is not null
             and mt.positive_payment_at is not null
         )::int as "firstPositivePayment",
         count(*) filter (
@@ -313,7 +332,7 @@ export async function computeActivationFunnel(
       order by s.week_start, s.jurisdiction_cohort
     `);
 
-    const qualityResult = await tx.execute(sql`
+      const qualityResult = await tx.execute(sql`
       with cohort as (
         select p.*
         from practices p
@@ -412,8 +431,66 @@ export async function computeActivationFunnel(
             and se.practice_id is null
         )::int as "unmappedStripeEvidence"
     `);
-    return { cohortResult, qualityResult };
-  });
+      const firstVisitBillingResult = await tx.execute(sql`
+      with eligible_practices as (
+        select p.id, p.settings
+        from practices p
+        where p.deleted_at is null
+          and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+      ), first_real_visits as (
+        select
+          p.id as practice_id,
+          min(vc.completed_at) as first_visit_at
+        from eligible_practices p
+        join visit_closeouts vc
+          on vc.practice_id = p.id
+         and vc.status = 'completed'
+         and vc.deleted_at is null
+        join appointments a
+          on a.id = vc.appointment_id
+         and a.practice_id = p.id
+         and a.status = 'checked_out'
+         and a.deleted_at is null
+        where not (
+          coalesce(p.settings -> 'demoData' -> 'appointmentIds', '[]'::jsonb)
+            @> to_jsonb(a.id::text)
+        )
+        group by p.id
+      ), first_payment_methods as (
+        select
+          pcm.practice_id,
+          min(pcm.occurred_at) as payment_method_at
+        from practice_conversion_milestones pcm
+        where pcm.milestone = 'payment_method_collected'
+        group by pcm.practice_id
+      ), mature_cohort as (
+        select frv.practice_id, frv.first_visit_at, fpm.payment_method_at
+        from first_real_visits frv
+        left join first_payment_methods fpm on fpm.practice_id = frv.practice_id
+        where frv.first_visit_at >= ${windowStart}::timestamptz
+          and frv.first_visit_at <= now() - interval '72 hours'
+      )
+      select
+        count(*)::int as "maturedFirstVisits",
+        count(*) filter (
+          where payment_method_at is not null
+            and payment_method_at <= first_visit_at
+        )::int as "alreadyConnectedAtVisit",
+        count(*) filter (
+          where payment_method_at is null or payment_method_at > first_visit_at
+        )::int as "opportunities",
+        count(*) filter (
+          where payment_method_at > first_visit_at
+            and payment_method_at <= first_visit_at + interval '24 hours'
+        )::int as "convertedWithin24Hours",
+        count(*) filter (
+          where payment_method_at > first_visit_at
+            and payment_method_at <= first_visit_at + interval '72 hours'
+        )::int as "convertedWithin72Hours"
+      from mature_cohort
+    `);
+      return { cohortResult, qualityResult, firstVisitBillingResult };
+    });
 
   const rawWeeks = rowsFromExecute<FunnelRow>(cohortResult).map((row) => ({
     ...emptyWeek(String(row.weekStart)),
@@ -459,6 +536,10 @@ export async function computeActivationFunnel(
       ] as const,
   );
   const quality = rowsFromExecute<DataQualityRow>(qualityResult)[0];
+  const firstVisitBilling = rowsFromExecute<FirstVisitBillingRow>(
+    firstVisitBillingResult,
+  )[0];
+  const opportunities = Number(firstVisitBilling?.opportunities) || 0;
   const jurisdictionCohorts = Object.fromEntries(
     cohortWeeks.map(([cohort, rows]) => [cohort, summarizeWeeks(rows)]),
   ) as Record<ActivationFunnelJurisdictionCohort, ActivationFunnelTotals>;
@@ -468,6 +549,24 @@ export async function computeActivationFunnel(
     weeks,
     totals: summarizeWeeks(weeks),
     jurisdictionCohorts,
+    firstVisitBillingConversion: {
+      maturedFirstVisits: Number(firstVisitBilling?.maturedFirstVisits) || 0,
+      alreadyConnectedAtVisit:
+        Number(firstVisitBilling?.alreadyConnectedAtVisit) || 0,
+      opportunities,
+      convertedWithin24Hours:
+        Number(firstVisitBilling?.convertedWithin24Hours) || 0,
+      convertedWithin72Hours:
+        Number(firstVisitBilling?.convertedWithin72Hours) || 0,
+      conversionWithin24HoursRate: funnelRate(
+        Number(firstVisitBilling?.convertedWithin24Hours) || 0,
+        opportunities,
+      ),
+      conversionWithin72HoursRate: funnelRate(
+        Number(firstVisitBilling?.convertedWithin72Hours) || 0,
+        opportunities,
+      ),
+    },
     dataQuality: {
       confirmedUsSignups: jurisdictionCohorts.confirmedUs.signups,
       confirmedNonUsSignups: jurisdictionCohorts.confirmedNonUs.signups,

--- a/apps/web/lib/admin/journey-funnel.ts
+++ b/apps/web/lib/admin/journey-funnel.ts
@@ -10,6 +10,10 @@ export interface JourneyFunnelWeek {
   weekStart: string;
   visitors: number;
   demos: number;
+  signupProfileViewed: number;
+  signupProfileCompleted: number;
+  signupAccountViewed: number;
+  signupSubmitted: number;
   registrations: number;
   activated: number;
   paymentMethodCollected: number;
@@ -19,6 +23,10 @@ export interface JourneyFunnelWeek {
 export interface JourneyFunnelTotals {
   visitors: number;
   demos: number;
+  signupProfileViewed: number;
+  signupProfileCompleted: number;
+  signupAccountViewed: number;
+  signupSubmitted: number;
   registrations: number;
   activated: number;
   paymentMethodCollected: number;
@@ -33,6 +41,11 @@ export interface JourneyFunnelTotals {
   repairableAttributionGaps: number;
   clientErrors: number;
   demoRate: number;
+  profileViewRate: number;
+  profileCompletionRate: number;
+  accountViewRate: number;
+  signupSubmitRate: number;
+  signupSuccessRate: number;
   registrationRate: number;
   activationRate: number;
   paymentMethodRate: number;
@@ -49,6 +62,10 @@ interface JourneyRow {
   weekStart: string;
   visitors: number | string;
   demos: number | string;
+  signupProfileViewed: number | string;
+  signupProfileCompleted: number | string;
+  signupAccountViewed: number | string;
+  signupSubmitted: number | string;
   registrations: number | string;
   activated: number | string;
   paymentMethodCollected: number | string;
@@ -69,15 +86,17 @@ function rowsFromExecute<T>(result: unknown): T[] {
 export async function computeJourneyFunnel(
   db: Database,
   days: number,
-  now: Date = new Date()
+  now: Date = new Date(),
 ): Promise<JourneyFunnel> {
   const windowStart = new Date(now.getTime() - days * DAY_MS).toISOString();
   const abandonedBefore = new Date(
-    now.getTime() - ABANDONMENT_GRACE_DAYS * DAY_MS
+    now.getTime() - ABANDONMENT_GRACE_DAYS * DAY_MS,
   ).toISOString();
 
-  const { weeklyResult, unattributedResult, errorsResult } = await withSystem(db, async (tx) => {
-    const weeklyResult = await tx.execute(sql`
+  const { weeklyResult, unattributedResult, errorsResult } = await withSystem(
+    db,
+    async (tx) => {
+      const weeklyResult = await tx.execute(sql`
       with first_touch_all_time as (
         select
           fe.anonymous_id,
@@ -94,16 +113,47 @@ export async function computeJourneyFunnel(
         select anonymous_id, cohort_at
         from first_touch_all_time
         where cohort_at >= ${windowStart}::timestamptz
+      ), signup_event_times as (
+        select
+          ft.anonymous_id,
+          min(fe.created_at) filter (
+            where fe.event_name = 'signup_profile_viewed'
+          ) as signup_profile_viewed_at,
+          min(fe.created_at) filter (
+            where fe.event_name = 'signup_profile_completed'
+          ) as signup_profile_completed_at,
+          min(fe.created_at) filter (
+            where fe.event_name = 'signup_account_viewed'
+          ) as signup_account_viewed_at,
+          min(fe.created_at) filter (
+            where fe.event_name = 'signup_submitted'
+          ) as signup_submitted_at
+        from first_touch ft
+        left join funnel_events fe
+          on fe.anonymous_id = ft.anonymous_id
+         and fe.deleted_at is null
+         and fe.created_at >= ft.cohort_at
+         and fe.event_name in (
+           'signup_profile_viewed', 'signup_profile_completed',
+           'signup_account_viewed', 'signup_submitted'
+         )
+        group by ft.anonymous_id
       ), journeys as (
         select
           ft.anonymous_id,
           ft.cohort_at,
           date_trunc('week', ft.cohort_at) as week_start,
+          signup.signup_profile_viewed_at,
+          signup.signup_profile_completed_at,
+          signup.signup_account_viewed_at,
+          signup.signup_submitted_at,
           demo.demo_at,
           demo.demo_at is not null as tried_demo,
           registration.practice_id,
           registration.registered_at
         from first_touch ft
+        left join signup_event_times signup
+          on signup.anonymous_id = ft.anonymous_id
         left join lateral (
           select min(demo.created_at) as demo_at
           from funnel_events demo
@@ -157,15 +207,25 @@ export async function computeJourneyFunnel(
         to_char(s.week_start, 'YYYY-MM-DD') as "weekStart",
         count(*)::int as "visitors",
         count(*) filter (where s.tried_demo)::int as "demos",
+        count(*) filter (
+          where s.signup_profile_viewed_at is not null
+        )::int as "signupProfileViewed",
+        count(*) filter (
+          where s.signup_profile_completed_at is not null
+        )::int as "signupProfileCompleted",
+        count(*) filter (
+          where s.signup_account_viewed_at is not null
+        )::int as "signupAccountViewed",
+        count(*) filter (
+          where s.signup_submitted_at is not null
+        )::int as "signupSubmitted",
         count(*) filter (where s.practice_id is not null)::int as "registrations",
         count(*) filter (where s.activation_at is not null)::int as "activated",
         count(*) filter (
-          where s.activation_at is not null and s.payment_method_at is not null
+          where s.payment_method_at is not null
         )::int as "paymentMethodCollected",
         count(*) filter (
-          where s.activation_at is not null
-            and s.payment_method_at is not null
-            and s.positive_payment_at is not null
+          where s.positive_payment_at is not null
         )::int as "firstPositivePayment",
         count(*) filter (
           where not s.tried_demo
@@ -202,7 +262,7 @@ export async function computeJourneyFunnel(
       order by s.week_start
     `);
 
-    const unattributedResult = await tx.execute(sql`
+      const unattributedResult = await tx.execute(sql`
       select
         count(*) filter (
           where not (
@@ -231,21 +291,26 @@ export async function computeJourneyFunnel(
         and p.deleted_at is null
         and p.settings ->> 'analyticsExcluded' is distinct from 'true'
     `);
-    const errorsResult = await tx.execute(sql`
+      const errorsResult = await tx.execute(sql`
       select count(*)::int as count
       from funnel_events
       where event_name = 'client_error'
         and deleted_at is null
         and created_at >= ${windowStart}::timestamptz
     `);
-    return { weeklyResult, unattributedResult, errorsResult };
-  });
+      return { weeklyResult, unattributedResult, errorsResult };
+    },
+  );
 
   const rawWeeks = rowsFromExecute<JourneyRow>(weeklyResult);
   const weeks = rawWeeks.map((row) => ({
     weekStart: String(row.weekStart),
     visitors: Number(row.visitors) || 0,
     demos: Number(row.demos) || 0,
+    signupProfileViewed: Number(row.signupProfileViewed) || 0,
+    signupProfileCompleted: Number(row.signupProfileCompleted) || 0,
+    signupAccountViewed: Number(row.signupAccountViewed) || 0,
+    signupSubmitted: Number(row.signupSubmitted) || 0,
     registrations: Number(row.registrations) || 0,
     activated: Number(row.activated) || 0,
     paymentMethodCollected: Number(row.paymentMethodCollected) || 0,
@@ -256,6 +321,10 @@ export async function computeJourneyFunnel(
     rawWeeks.reduce((total, week) => total + (Number(week[key]) || 0), 0);
   const visitors = sum("visitors");
   const demos = sum("demos");
+  const signupProfileViewed = sum("signupProfileViewed");
+  const signupProfileCompleted = sum("signupProfileCompleted");
+  const signupAccountViewed = sum("signupAccountViewed");
+  const signupSubmitted = sum("signupSubmitted");
   const registrations = sum("registrations");
   const activated = sum("activated");
   const paymentMethodCollected = sum("paymentMethodCollected");
@@ -276,6 +345,10 @@ export async function computeJourneyFunnel(
     totals: {
       visitors,
       demos,
+      signupProfileViewed,
+      signupProfileCompleted,
+      signupAccountViewed,
+      signupSubmitted,
       registrations,
       activated,
       paymentMethodCollected,
@@ -291,9 +364,17 @@ export async function computeJourneyFunnel(
       repairableAttributionGaps,
       clientErrors: Number(errorRows[0]?.count) || 0,
       demoRate: funnelRate(demos, visitors),
+      profileViewRate: funnelRate(signupProfileViewed, visitors),
+      profileCompletionRate: funnelRate(
+        signupProfileCompleted,
+        signupProfileViewed,
+      ),
+      accountViewRate: funnelRate(signupAccountViewed, signupProfileCompleted),
+      signupSubmitRate: funnelRate(signupSubmitted, signupAccountViewed),
+      signupSuccessRate: funnelRate(registrations, signupSubmitted),
       registrationRate: funnelRate(registrations, visitors),
       activationRate: funnelRate(activated, registrations),
-      paymentMethodRate: funnelRate(paymentMethodCollected, activated),
+      paymentMethodRate: funnelRate(paymentMethodCollected, registrations),
       positivePaymentRate: funnelRate(
         firstPositivePayment,
         paymentMethodCollected,

--- a/apps/web/lib/billing/__tests__/first-clinic-win.test.ts
+++ b/apps/web/lib/billing/__tests__/first-clinic-win.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FIRST_CLINIC_WIN_ENABLED_ENV,
+  FIRST_CLINIC_WIN_ROLLOUT_AT_ENV,
+  firstClinicWinConfig,
+} from "../first-clinic-win";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("first clinic win rollout", () => {
+  it("is default-off", () => {
+    expect(firstClinicWinConfig()).toEqual({
+      enabled: false,
+      reason: "disabled",
+    });
+  });
+
+  it("fails closed without an exact prospective launch timestamp", () => {
+    vi.stubEnv(FIRST_CLINIC_WIN_ENABLED_ENV, "true");
+    vi.stubEnv(FIRST_CLINIC_WIN_ROLLOUT_AT_ENV, "not-a-date");
+
+    expect(firstClinicWinConfig()).toEqual({
+      enabled: false,
+      reason: "rollout_at_invalid",
+    });
+  });
+
+  it("returns the configured prospective launch boundary", () => {
+    vi.stubEnv(FIRST_CLINIC_WIN_ENABLED_ENV, "true");
+    vi.stubEnv(FIRST_CLINIC_WIN_ROLLOUT_AT_ENV, "2026-08-15T12:00:00Z");
+
+    expect(firstClinicWinConfig()).toEqual({
+      enabled: true,
+      rolloutAt: new Date("2026-08-15T12:00:00Z"),
+    });
+  });
+});

--- a/apps/web/lib/billing/__tests__/plans.test.ts
+++ b/apps/web/lib/billing/__tests__/plans.test.ts
@@ -9,6 +9,7 @@ import {
   isTrialActive,
   effectiveTier,
   hasHostedFullAccess,
+  normalizeBillingStatus,
   billingEnforced,
   estimatedCloudBaseMonthlyUsd,
   estimatedCloudBaseAnnualUsd,
@@ -111,10 +112,10 @@ describe("PLANS pricing", () => {
     expect(PLANS.free.locationUnitPriceMonthlyUsd).toBe(0);
     expect(PLANS.free.seatUnitPriceMonthlyUsd).toBe(0);
     expect(PLANS.cloud.locationUnitPriceMonthlyUsd).toBe(
-      CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD
+      CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
     );
     expect(PLANS.cloud.seatUnitPriceMonthlyUsd).toBe(
-      CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD
+      CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
     );
     expect(PLANS.enterprise.locationUnitPriceMonthlyUsd).toBeNull();
     expect(PLANS.enterprise.seatUnitPriceMonthlyUsd).toBeNull();
@@ -148,15 +149,31 @@ describe("hosted full access", () => {
   });
 
   it("allows active trial and active paid subscription", () => {
-    expect(hasHostedFullAccess("free", "trialing", future, now, true)).toBe(true);
+    expect(hasHostedFullAccess("free", "trialing", future, now, true)).toBe(
+      true,
+    );
     expect(hasHostedFullAccess("cloud", "active", past, now, true)).toBe(true);
   });
 
-  it("blocks expired trials, canceled, past due, and no subscription on hosted", () => {
-    expect(hasHostedFullAccess("free", "trialing", past, now, true)).toBe(false);
-    expect(hasHostedFullAccess("cloud", "past_due", future, now, true)).toBe(false);
-    expect(hasHostedFullAccess("cloud", "canceled", future, now, true)).toBe(false);
+  it("keeps retrying paid subscriptions writable but blocks terminal billing states", () => {
+    expect(hasHostedFullAccess("free", "trialing", past, now, true)).toBe(
+      false,
+    );
+    expect(hasHostedFullAccess("cloud", "past_due", future, now, true)).toBe(
+      true,
+    );
+    expect(hasHostedFullAccess("cloud", "unpaid", future, now, true)).toBe(
+      false,
+    );
+    expect(hasHostedFullAccess("cloud", "canceled", future, now, true)).toBe(
+      false,
+    );
     expect(hasHostedFullAccess("free", "none", null, now, true)).toBe(false);
+  });
+
+  it("preserves retrying and terminal Stripe statuses distinctly", () => {
+    expect(normalizeBillingStatus("past_due")).toBe("past_due");
+    expect(normalizeBillingStatus("unpaid")).toBe("unpaid");
   });
 });
 
@@ -236,7 +253,9 @@ describe("Stripe price mapping", () => {
   it("returns undefined for blank Stripe price envs", () => {
     vi.stubEnv(STRIPE_PRICE_CLOUD_LOCATION_ENV, "   ");
 
-    expect(stripePriceIdFromEnv(STRIPE_PRICE_CLOUD_LOCATION_ENV)).toBeUndefined();
+    expect(
+      stripePriceIdFromEnv(STRIPE_PRICE_CLOUD_LOCATION_ENV),
+    ).toBeUndefined();
   });
 
   it("maps split Cloud prices and legacy Cloud price to the cloud tier", () => {

--- a/apps/web/lib/billing/first-clinic-win.ts
+++ b/apps/web/lib/billing/first-clinic-win.ts
@@ -1,0 +1,26 @@
+export const FIRST_CLINIC_WIN_ENABLED_ENV = "FIRST_CLINIC_WIN_ENABLED";
+export const FIRST_CLINIC_WIN_ROLLOUT_AT_ENV = "FIRST_CLINIC_WIN_ROLLOUT_AT";
+
+export type FirstClinicWinConfig =
+  | { enabled: false; reason: "disabled" | "rollout_at_invalid" }
+  | { enabled: true; rolloutAt: Date };
+
+/**
+ * Prospective-only campaign gate. A launch timestamp is mandatory so a new
+ * deployment cannot unexpectedly email every historical trial clinic.
+ */
+export function firstClinicWinConfig(): FirstClinicWinConfig {
+  if (
+    process.env[FIRST_CLINIC_WIN_ENABLED_ENV]?.trim().toLowerCase() !== "true"
+  ) {
+    return { enabled: false, reason: "disabled" };
+  }
+
+  const rolloutAt = new Date(
+    process.env[FIRST_CLINIC_WIN_ROLLOUT_AT_ENV]?.trim() ?? "",
+  );
+  if (Number.isNaN(rolloutAt.getTime())) {
+    return { enabled: false, reason: "rollout_at_invalid" };
+  }
+  return { enabled: true, rolloutAt };
+}

--- a/apps/web/lib/billing/plans.ts
+++ b/apps/web/lib/billing/plans.ts
@@ -121,7 +121,8 @@ export const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "Free (self-host)",
     locationUnitPriceMonthlyUsd: 0,
     seatUnitPriceMonthlyUsd: 0,
-    blurb: "Self-host OpenVPM on your own infrastructure. Free forever, no lock-in.",
+    blurb:
+      "Self-host OpenVPM on your own infrastructure. Free forever, no lock-in.",
     seatLimit: null,
     locationLimit: null,
     features: [],
@@ -176,7 +177,9 @@ export function getPlan(tier?: string | null): PlanDefinition {
 }
 
 /** Map a Stripe Price ID back to a plan tier (via the configured env vars). */
-export function tierForStripePrice(priceId: string | null | undefined): PlanTier | null {
+export function tierForStripePrice(
+  priceId: string | null | undefined,
+): PlanTier | null {
   const normalizedPriceId = nonBlank(priceId);
   if (!normalizedPriceId) return null;
   const cloudPriceEnvs = [
@@ -191,9 +194,7 @@ export function tierForStripePrice(priceId: string | null | undefined): PlanTier
   return null;
 }
 
-export function cloudCheckoutPriceIds(
-  cadence: BillingCadence = "month",
-): {
+export function cloudCheckoutPriceIds(cadence: BillingCadence = "month"): {
   locationPriceId?: string;
   seatPriceId?: string;
 } {
@@ -248,7 +249,7 @@ export function cloudMeteredPriceIds(): {
 
 export function estimatedCloudBaseMonthlyUsd(
   locationCount: number,
-  billableSeatCount: number
+  billableSeatCount: number,
 ): number {
   return (
     Math.max(1, locationCount) * CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD +
@@ -267,15 +268,18 @@ export function estimatedCloudBaseAnnualUsd(
 }
 
 /** Normalize a Stripe subscription status to our billingStatus values. */
-export function normalizeBillingStatus(status: string | null | undefined): string {
+export function normalizeBillingStatus(
+  status: string | null | undefined,
+): string {
   switch (status) {
     case "trialing":
       return "trialing";
     case "active":
       return "active";
     case "past_due":
-    case "unpaid":
       return "past_due";
+    case "unpaid":
+      return "unpaid";
     case "canceled":
     case "incomplete_expired":
       return "canceled";
@@ -285,7 +289,10 @@ export function normalizeBillingStatus(status: string | null | undefined): strin
 }
 
 /** Pure: does this tier include this feature? (With parity, every paid tier does.) */
-export function planHasFeature(tier: string | null | undefined, feature: Feature): boolean {
+export function planHasFeature(
+  tier: string | null | undefined,
+  feature: Feature,
+): boolean {
   return getPlan(tier).features.includes(feature);
 }
 
@@ -313,23 +320,27 @@ export function trialEndsAtFrom(from: Date = new Date()): Date {
 export function isTrialActive(
   billingStatus: string | null | undefined,
   trialEndsAt: Date | string | null | undefined,
-  now: Date = new Date()
+  now: Date = new Date(),
 ): boolean {
   if (billingStatus !== "trialing" || !trialEndsAt) return false;
   return new Date(trialEndsAt).getTime() > now.getTime();
 }
 
-/** Hosted write access: active trial or active paid/custom subscription only. */
+/**
+ * Hosted write access: active trial, active paid/custom subscription, or a
+ * paid/custom subscription in Stripe's retrying `past_due` state. Stripe's
+ * terminal `unpaid` state remains read-only.
+ */
 export function hasHostedFullAccess(
   tier: string | null | undefined,
   billingStatus: string | null | undefined,
   trialEndsAt: Date | string | null | undefined,
   now: Date = new Date(),
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   if (isTrialActive(billingStatus, trialEndsAt, now)) return true;
-  if (billingStatus !== "active") return false;
+  if (billingStatus !== "active" && billingStatus !== "past_due") return false;
   return getPlan(tier).tier !== "free";
 }
 
@@ -341,12 +352,12 @@ export function effectiveTier(
   tier: string | null | undefined,
   billingStatus: string | null | undefined,
   trialEndsAt: Date | string | null | undefined,
-  now: Date = new Date()
+  now: Date = new Date(),
 ): PlanTier {
   if (isTrialActive(billingStatus, trialEndsAt, now)) return "cloud";
   const t = tier ?? "free";
   if (LEGACY_CLOUD_TIERS.has(t)) return "cloud";
-  return (PLANS[t as PlanTier] ? (t as PlanTier) : "free");
+  return PLANS[t as PlanTier] ? (t as PlanTier) : "free";
 }
 
 /**
@@ -364,7 +375,7 @@ export function billingEnforced(): boolean {
 export function isEntitled(
   tier: string | null | undefined,
   feature: Feature,
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   return planHasFeature(tier, feature);
@@ -374,7 +385,7 @@ export function isEntitled(
 export function withinSeatLimit(
   tier: string | null | undefined,
   currentSeats: number,
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   const limit = getPlan(tier).seatLimit;
@@ -385,7 +396,7 @@ export function withinSeatLimit(
 export function withinLocationLimit(
   tier: string | null | undefined,
   currentLocations: number,
-  enforced: boolean = billingEnforced()
+  enforced: boolean = billingEnforced(),
 ): boolean {
   if (!enforced) return true;
   const limit = getPlan(tier).locationLimit;

--- a/apps/web/lib/cron-heartbeat.ts
+++ b/apps/web/lib/cron-heartbeat.ts
@@ -9,6 +9,7 @@ export const CRON_HEARTBEAT_JOBS = [
   "file-replicas",
   "usage-reconcile",
   "billing-lifecycle",
+  "first-clinic-win",
   "setup-recovery",
   "wellness-billing",
   "rate-limit-cleanup",

--- a/apps/web/lib/email-lifecycle.ts
+++ b/apps/web/lib/email-lifecycle.ts
@@ -4,7 +4,11 @@ import type { Database } from "@openpims/db/client";
 import { communications } from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
 import { alertOps } from "@/lib/alerts";
-import { marketingEmailEnabledForRecipient } from "@/lib/platform-email-preferences";
+import { emailPreferenceRecipientHash } from "@/lib/email-preferences";
+import {
+  lockAndCheckMarketingEmailEnabled,
+  marketingEmailEnabledForRecipient,
+} from "@/lib/platform-email-preferences";
 import {
   lockPracticeForExternalSideEffects,
   practiceAllowsExternalSideEffects,
@@ -83,6 +87,12 @@ export async function sendLifecycleEmail(
         if (opts.stillEligible && !(await opts.stillEligible(tx))) {
           return { blocked: true as const };
         }
+        if (
+          opts.category === "marketing" &&
+          !(await lockAndCheckMarketingEmailEnabled(tx, opts.to))
+        ) {
+          return { blocked: true as const };
+        }
         return { blocked: false as const, result: await opts.send() };
       });
       if (delivery.blocked) {
@@ -122,7 +132,7 @@ export async function sendLifecycleEmail(
 
     await alertOps(
       "Lifecycle email failed",
-      `${opts.emailType} → ${opts.to}: ${result.error ?? "unknown error"}`,
+      `${opts.emailType} practice=${opts.practiceId} recipient=${recipientReference(opts.to)}: ${result.error ?? "unknown error"}`,
     );
 
     if (opts.retryOnFail) {
@@ -142,10 +152,14 @@ export async function sendLifecycleEmail(
   } catch (err) {
     await alertOps(
       "Lifecycle email error",
-      `${opts.emailType} → ${opts.to}: ${err instanceof Error ? err.message : String(err)}`,
+      `${opts.emailType} practice=${opts.practiceId} recipient=${recipientReference(opts.to)}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return { sent: false, deduped: false };
   }
+}
+
+function recipientReference(email: string): string {
+  return emailPreferenceRecipientHash(email)?.slice(0, 12) ?? "unavailable";
 }
 
 /**

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -6,6 +6,7 @@ import {
   renderTrialEndingEmail,
   renderPaymentReceiptEmail,
   renderPaymentFailedEmail,
+  renderFirstClinicWinEmail,
 } from "@openpims/email";
 import {
   createEmailPreferenceLinks,
@@ -689,6 +690,8 @@ export async function sendTrialEndingEmail(data: {
   trialEndDate: string;
   monthlyPrice?: string;
   billingUrl?: string;
+  billingConnected?: boolean;
+  idempotencyKey?: string;
 }): Promise<{ success: boolean; id?: string; error?: string }> {
   const brand = openvpmBrand();
   const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
@@ -716,6 +719,7 @@ export async function sendTrialEndingEmail(data: {
     trialEndDate: data.trialEndDate,
     monthlyPrice: data.monthlyPrice ?? "$79",
     billingUrl,
+    billingConnected: data.billingConnected,
     unsubscribeUrl: preferenceLinks.preferencesUrl,
   });
   return sendEmail({
@@ -727,6 +731,54 @@ export async function sendTrialEndingEmail(data: {
       "List-Unsubscribe": `<${preferenceLinks.oneClickUrl}>`,
       "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
     },
+    idempotencyKey: data.idempotencyKey,
+  });
+}
+
+/** First-real-visit celebration and optional billing handoff. */
+export async function sendFirstClinicWinEmail(data: {
+  to: string;
+  practiceName: string;
+  trialEndDate: string;
+  billingUrl?: string;
+  idempotencyKey: string;
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  const brand = openvpmBrand();
+  const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
+  const recipientHash = emailPreferenceRecipientHash(data.to);
+  if (!recipientHash) {
+    return {
+      success: false,
+      error: "Email preference signing is not configured.",
+    };
+  }
+  const preferenceLinks = createEmailPreferenceLinks({
+    kind: "recipient",
+    id: recipientHash,
+  });
+  if (!preferenceLinks) {
+    return {
+      success: false,
+      error: "Email preference signing is not configured.",
+    };
+  }
+  const { subject, html } = await renderFirstClinicWinEmail({
+    brand,
+    practiceName: data.practiceName,
+    trialEndDate: data.trialEndDate,
+    billingUrl,
+    unsubscribeUrl: preferenceLinks.preferencesUrl,
+  });
+  return sendEmail({
+    to: data.to,
+    subject,
+    html,
+    replyTo: brand.supportEmail,
+    headers: {
+      "List-Unsubscribe": `<${preferenceLinks.oneClickUrl}>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    },
+    idempotencyKey: data.idempotencyKey,
   });
 }
 
@@ -737,6 +789,7 @@ export async function sendPaymentReceiptEmail(data: {
   amount: string;
   periodLabel: string;
   invoiceUrl?: string;
+  idempotencyKey?: string;
 }): Promise<{ success: boolean; id?: string; error?: string }> {
   const brand = openvpmBrand();
   const { subject, html } = await renderPaymentReceiptEmail({
@@ -746,7 +799,13 @@ export async function sendPaymentReceiptEmail(data: {
     periodLabel: data.periodLabel,
     invoiceUrl: data.invoiceUrl,
   });
-  return sendEmail({ to: data.to, subject, html, replyTo: brand.supportEmail });
+  return sendEmail({
+    to: data.to,
+    subject,
+    html,
+    replyTo: brand.supportEmail,
+    idempotencyKey: data.idempotencyKey,
+  });
 }
 
 /** Dunning email sent on a failed subscription payment. */
@@ -756,6 +815,7 @@ export async function sendPaymentFailedEmail(data: {
   amount: string;
   nextRetryDate?: string;
   billingUrl?: string;
+  idempotencyKey?: string;
 }): Promise<{ success: boolean; id?: string; error?: string }> {
   const brand = openvpmBrand();
   const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
@@ -766,5 +826,11 @@ export async function sendPaymentFailedEmail(data: {
     nextRetryDate: data.nextRetryDate,
     billingUrl,
   });
-  return sendEmail({ to: data.to, subject, html, replyTo: brand.supportEmail });
+  return sendEmail({
+    to: data.to,
+    subject,
+    html,
+    replyTo: brand.supportEmail,
+    idempotencyKey: data.idempotencyKey,
+  });
 }

--- a/apps/web/lib/funnel-analytics.ts
+++ b/apps/web/lib/funnel-analytics.ts
@@ -15,6 +15,18 @@ export const FUNNEL_EVENTS = {
   demoToolOpened: "demo_tool_opened",
   demoCtaStartClinic: "demo_cta_start_clinic",
   signupLand: "signup_land",
+  signupProfileViewed: "signup_profile_viewed",
+  signupProfileCompleted: "signup_profile_completed",
+  signupAccountViewed: "signup_account_viewed",
+  signupSubmitted: "signup_submitted",
+  signupSucceeded: "signup_succeeded",
+  onboardingModelSelected: "onboarding_model_selected",
+  onboardingGoalSelected: "onboarding_goal_selected",
+  onboardingPlanBuilt: "onboarding_plan_built",
+  onboardingStepViewed: "onboarding_step_viewed",
+  onboardingStepCompleted: "onboarding_step_completed",
+  onboardingCompleted: "onboarding_completed",
+  firstActionSelected: "first_action_selected",
 } as const;
 
 export type FunnelEventName =

--- a/apps/web/lib/onboarding/__tests__/clinic-profile.test.ts
+++ b/apps/web/lib/onboarding/__tests__/clinic-profile.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLINIC_MODEL_OPTIONS,
+  FIRST_GOAL_OPTIONS,
+  firstDayTasks,
+  onboardingIntentForGoal,
+} from "../clinic-profile";
+
+describe("clinic onboarding profile", () => {
+  it("keeps every first-day choice stable and coarse", () => {
+    expect(CLINIC_MODEL_OPTIONS.map((option) => option.value)).toEqual([
+      "companion",
+      "mobile",
+      "equine",
+      "specialty",
+      "shelter",
+      "exploring",
+    ]);
+    expect(FIRST_GOAL_OPTIONS.map((option) => option.value)).toEqual([
+      "run_visit",
+      "import_records",
+      "start_fresh",
+      "explore_sample",
+    ]);
+  });
+
+  it("maps outcomes onto the existing safe adoption paths", () => {
+    expect(onboardingIntentForGoal("run_visit")).toBe("alongside");
+    expect(onboardingIntentForGoal("start_fresh")).toBe("alongside");
+    expect(onboardingIntentForGoal("import_records")).toBe("replace");
+    expect(onboardingIntentForGoal("explore_sample")).toBe("explore");
+    expect(onboardingIntentForGoal("self_host")).toBe("self_host");
+  });
+
+  it("uses migration tasks when migration is the chosen first value", () => {
+    expect(firstDayTasks("equine", "import_records")).toEqual([
+      "Inventory your current export",
+      "Preview supported record counts",
+      "Review a representative chart",
+      "Plan your first live visit",
+    ]);
+  });
+
+  it("uses honest care-model tasks for a field practice", () => {
+    expect(firstDayTasks("mobile", "run_visit")).toEqual([
+      "Map one house-call workflow",
+      "Add a real client and patient",
+      "Test a visit from your phone",
+      "Review the field handoff",
+    ]);
+  });
+});

--- a/apps/web/lib/onboarding/clinic-profile.ts
+++ b/apps/web/lib/onboarding/clinic-profile.ts
@@ -1,0 +1,202 @@
+import type { OnboardingIntent } from "@/lib/onboarding/intent";
+
+export const CLINIC_MODELS = [
+  "companion",
+  "mobile",
+  "equine",
+  "specialty",
+  "shelter",
+  "exploring",
+] as const;
+
+export type ClinicModel = (typeof CLINIC_MODELS)[number];
+
+export const DEFAULT_CLINIC_MODEL: ClinicModel = "companion";
+
+export const FIRST_GOALS = [
+  "run_visit",
+  "import_records",
+  "start_fresh",
+  "explore_sample",
+  "self_host",
+] as const;
+
+export type FirstGoal = (typeof FIRST_GOALS)[number];
+
+export const DEFAULT_FIRST_GOAL: FirstGoal = "run_visit";
+
+export type ClinicModelOption = {
+  value: ClinicModel;
+  label: string;
+  shortLabel: string;
+  tone: "emerald" | "coral" | "lavender" | "blue" | "rose" | "amber";
+  readiness: "pilot" | "design_partner" | "explore";
+};
+
+export const CLINIC_MODEL_OPTIONS: readonly ClinicModelOption[] = [
+  {
+    value: "companion",
+    label: "Companion animal clinic",
+    shortLabel: "Companion animal",
+    tone: "emerald",
+    readiness: "pilot",
+  },
+  {
+    value: "mobile",
+    label: "Mobile or house-call practice",
+    shortLabel: "Mobile or house-call",
+    tone: "coral",
+    readiness: "design_partner",
+  },
+  {
+    value: "equine",
+    label: "Equine or farm practice",
+    shortLabel: "Equine or farm",
+    tone: "lavender",
+    readiness: "design_partner",
+  },
+  {
+    value: "specialty",
+    label: "Specialty or wellness",
+    shortLabel: "Specialty or wellness",
+    tone: "blue",
+    readiness: "design_partner",
+  },
+  {
+    value: "shelter",
+    label: "Shelter or nonprofit",
+    shortLabel: "Shelter or nonprofit",
+    tone: "rose",
+    readiness: "design_partner",
+  },
+  {
+    value: "exploring",
+    label: "I’m exploring",
+    shortLabel: "Exploring",
+    tone: "amber",
+    readiness: "explore",
+  },
+];
+
+export type FirstGoalOption = {
+  value: FirstGoal;
+  label: string;
+  onboardingIntent: OnboardingIntent;
+};
+
+export const FIRST_GOAL_OPTIONS: readonly FirstGoalOption[] = [
+  {
+    value: "run_visit",
+    label: "Run one real visit",
+    onboardingIntent: "alongside",
+  },
+  {
+    value: "import_records",
+    label: "Bring records from my current PIMS",
+    onboardingIntent: "replace",
+  },
+  {
+    value: "start_fresh",
+    label: "Start fresh",
+    onboardingIntent: "alongside",
+  },
+  {
+    value: "explore_sample",
+    label: "Explore with sample data",
+    onboardingIntent: "explore",
+  },
+];
+
+export const SELF_HOST_GOAL: FirstGoalOption = {
+  value: "self_host",
+  label: "Evaluate self-hosting",
+  onboardingIntent: "self_host",
+};
+
+export function onboardingIntentForGoal(goal: FirstGoal): OnboardingIntent {
+  if (goal === "self_host") return "self_host";
+  return (
+    FIRST_GOAL_OPTIONS.find((option) => option.value === goal)
+      ?.onboardingIntent ?? "alongside"
+  );
+}
+
+const MODEL_FIRST_DAY_TASKS: Record<ClinicModel, readonly string[]> = {
+  companion: [
+    "Review today’s schedule",
+    "Add your first real client",
+    "Complete one visit",
+    "Review the client handoff",
+  ],
+  mobile: [
+    "Map one house-call workflow",
+    "Add a real client and patient",
+    "Test a visit from your phone",
+    "Review the field handoff",
+  ],
+  equine: [
+    "Map one farm-call workflow",
+    "Add an owner, animal, and location",
+    "Test one low-risk visit",
+    "Review the ambulatory gaps together",
+  ],
+  specialty: [
+    "Choose your first consult type",
+    "Capture the history you rely on",
+    "Complete one specialty visit",
+    "Plan the next follow-up",
+  ],
+  shelter: [
+    "Map one intake workflow",
+    "Add a real animal record",
+    "Complete one care handoff",
+    "Review team access together",
+  ],
+  exploring: [
+    "Meet the sample clinic",
+    "Open a patient timeline",
+    "Walk through one visit",
+    "Choose what to make yours",
+  ],
+};
+
+const GOAL_FIRST_DAY_TASKS: Partial<Record<FirstGoal, readonly string[]>> = {
+  import_records: [
+    "Inventory your current export",
+    "Preview supported record counts",
+    "Review a representative chart",
+    "Plan your first live visit",
+  ],
+  start_fresh: [
+    "Set your clinic basics",
+    "Add your first real client",
+    "Book the first appointment",
+    "Review the client handoff",
+  ],
+  explore_sample: [
+    "Meet the sample clinic",
+    "Review today’s schedule",
+    "Open a patient timeline",
+    "Choose what to make yours",
+  ],
+  self_host: [
+    "Confirm your deployment path",
+    "Make the workspace yours",
+    "Review data ownership controls",
+    "Plan your first local workflow",
+  ],
+};
+
+export function firstDayTasks(
+  model: ClinicModel,
+  goal: FirstGoal,
+): readonly string[] {
+  return GOAL_FIRST_DAY_TASKS[goal] ?? MODEL_FIRST_DAY_TASKS[model];
+}
+
+export function clinicModelOption(value: ClinicModel): ClinicModelOption {
+  return (
+    CLINIC_MODEL_OPTIONS.find((option) => option.value === value) ??
+    CLINIC_MODEL_OPTIONS[0]!
+  );
+}

--- a/apps/web/lib/onboarding/journey-plan.ts
+++ b/apps/web/lib/onboarding/journey-plan.ts
@@ -11,10 +11,10 @@ export interface OnboardingJourneyStep {
  * they do not stand between signup and a real client or appointment.
  */
 export const ONBOARDING_JOURNEY_STEPS: readonly OnboardingJourneyStep[] = [
-  { id: "intent", title: "How do you want to start?" },
-  { id: "basics", title: "Tell us about your clinic." },
-  { id: "data", title: "Bring your clinic records." },
-  { id: "allSet", title: "Start your first clinic day." },
+  { id: "intent", title: "A platform truly built for your clinic." },
+  { id: "basics", title: "Make it feel like your clinic." },
+  { id: "data", title: "Bring your history with confidence." },
+  { id: "allSet", title: "Your first day is ready." },
 ];
 
 const retiredStepIds = new Set([

--- a/apps/web/lib/platform-email-preferences.ts
+++ b/apps/web/lib/platform-email-preferences.ts
@@ -247,17 +247,28 @@ async function updateProjection(
 export async function marketingEmailEnabledForRecipient(
   email: string,
 ): Promise<boolean> {
+  return withSystem(db, (tx) => lockAndCheckMarketingEmailEnabled(tx, email));
+}
+
+/**
+ * Serialize a marketing send with preference changes for this recipient and
+ * re-read the current preference in the caller's provider-call transaction.
+ * The lock order is practice row first, then recipient advisory lock.
+ */
+export async function lockAndCheckMarketingEmailEnabled(
+  tx: Database,
+  email: string,
+): Promise<boolean> {
   const identity = configuredIdentity();
   const emailHash = identity.emailHashFor(email);
-  return withSystem(db, async (tx) => {
-    await assertPersistedIdentityKey(tx, identity.fingerprint);
-    const preference = await currentPreference(
-      tx,
-      emailHash,
-      identity.fingerprint,
-    );
-    return preference?.marketingEnabled !== false;
-  });
+  await assertPersistedIdentityKey(tx, identity.fingerprint);
+  await lockRecipient(tx, emailHash);
+  const preference = await currentPreference(
+    tx,
+    emailHash,
+    identity.fingerprint,
+  );
+  return preference?.marketingEnabled !== false;
 }
 
 export async function setMarketingEmailPreferenceForRecipient(input: {

--- a/apps/web/lib/welcome/first-run.ts
+++ b/apps/web/lib/welcome/first-run.ts
@@ -1,17 +1,17 @@
 /**
- * Which experience greets a brand-new practice. "welcome" (default) is the
- * value-first Polaroid guide surface; "wizard" restores the previous
- * behavior exactly (the Make-it-yours wizard auto-opens), giving hosted a
- * one-env-var rollback with no code change.
+ * Which experience greets a brand-new practice. The personalized workspace
+ * builder is the default; "welcome" remains an explicit one-env-var rollback
+ * to the Polaroid guide surface. Guides stay available from Settings either
+ * way after the clinic has shaped its first useful day.
  *
  * NEXT_PUBLIC_ vars are inlined at build time, so this must stay a direct
  * property access.
  */
 export function firstRunMode(): "welcome" | "wizard" {
   return process.env.NEXT_PUBLIC_FIRST_RUN_MODE?.trim().toLowerCase() ===
-    "wizard"
-    ? "wizard"
-    : "welcome";
+    "welcome"
+    ? "welcome"
+    : "wizard";
 }
 
 /** Keep conversion deep links focused; Guides still opens the welcome manually. */

--- a/apps/web/server/__tests__/admin-activation-funnel.test.ts
+++ b/apps/web/server/__tests__/admin-activation-funnel.test.ts
@@ -113,6 +113,15 @@ describe("admin activation funnel", () => {
           unknownPaymentMethodPractices: 2,
         },
       ],
+      [
+        {
+          maturedFirstVisits: 8,
+          alreadyConnectedAtVisit: 2,
+          opportunities: 6,
+          convertedWithin24Hours: 2,
+          convertedWithin72Hours: 3,
+        },
+      ],
     );
 
     const result = await caller().activationFunnel({ days: 30 });
@@ -154,8 +163,8 @@ describe("admin activation funnel", () => {
       setupStartRate: 0.7,
       setupCompletionRate: 0.3,
       activationRate: 0.5,
-      firstVisitCompletionRate: 0.6,
-      paymentMethodRate: 1,
+      firstVisitCompletionRate: 0.3,
+      paymentMethodRate: 0.5,
       positivePaymentRate: 0.6,
       currentlyActiveRate: 0.3,
     });
@@ -176,6 +185,15 @@ describe("admin activation funnel", () => {
       unknownJurisdictionSignups: 0,
       legacyBusinessStageRows: 9,
       unknownPaymentMethodPractices: 2,
+    });
+    expect(result.firstVisitBillingConversion).toEqual({
+      maturedFirstVisits: 8,
+      alreadyConnectedAtVisit: 2,
+      opportunities: 6,
+      convertedWithin24Hours: 2,
+      convertedWithin72Hours: 3,
+      conversionWithin24HoursRate: 1 / 3,
+      conversionWithin72HoursRate: 0.5,
     });
     expect(mocks.withSystem).toHaveBeenCalledWith(
       mocks.db,
@@ -287,7 +305,7 @@ describe("admin activation funnel", () => {
     expect(result.totals.signups).toBe(2);
     expect(result.totals.activated).toBe(1);
     expect(result.totals.firstVisitCompleted).toBe(1);
-    expect(result.totals.firstVisitCompletionRate).toBe(1);
+    expect(result.totals.firstVisitCompletionRate).toBe(0.5);
     expect(result.totals.paymentMethodCollected).toBe(1);
     expect(result.totals.activationRate).toBe(0.5);
   });
@@ -308,6 +326,16 @@ describe("admin activation funnel", () => {
     expect(source).toContain("pcm.milestone = 'payment_method_collected'");
     expect(source).toContain("pcm.milestone = 'first_positive_payment'");
     expect(source).toContain("onboardingIntentSelectedAt");
+    expect(source).toContain(
+      "paymentMethodRate: funnelRate(paymentMethodCollected, signups)",
+    );
+    expect(source).toContain(
+      "firstVisitCompletionRate: funnelRate(firstVisitCompleted, signups)",
+    );
+    expect(source).toContain(
+      "frv.first_visit_at <= now() - interval '72 hours'",
+    );
+    expect(source).toContain("payment_method_at > first_visit_at");
 
     // First-visit completion requires a completed, tenant-owned closeout for a
     // real appointment and uses the same post-signup/demo exclusions.

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -302,6 +302,29 @@ describe("auth router input validation", () => {
     await expect(
       caller.register({
         email: "owner@example.com",
+        password: "password123",
+        practiceName: "Neighborhood Veterinary",
+        country: "US",
+        onboardingDraft: { clinicModel: "mobile" },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    await expect(
+      caller.register({
+        email: "owner@example.com",
+        password: "password123",
+        practiceName: "Neighborhood Veterinary",
+        country: "US",
+        onboardingDraft: {
+          clinicModel: "companion",
+          firstGoal: "self_host",
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    await expect(
+      caller.register({
+        email: "owner@example.com",
         password: "p".repeat(129),
         practiceName: "Neighborhood Veterinary",
         country: "US",
@@ -380,6 +403,8 @@ describe("auth router input validation", () => {
         onboardingDraft: {
           logoName: "  Neighborhood  ",
           brandColor: "#AABBCC",
+          clinicModel: "mobile",
+          firstGoal: "run_visit",
           teamMembers: [
             {
               name: "  Tech One  ",
@@ -434,6 +459,15 @@ describe("auth router input validation", () => {
           jurisdictionCountry: "IE",
           jurisdictionSelectedAt: expect.any(String),
           jurisdictionSource: "registration",
+          onboardingIntent: "alongside",
+          onboardingIntentSelectedAt: expect.any(String),
+          clinicModel: "mobile",
+          clinicModelSelectedAt: expect.any(String),
+          firstGoal: "run_visit",
+          firstGoalSelectedAt: expect.any(String),
+          journeyStepId: "basics",
+          journeyLastProgressAt: expect.any(String),
+          journeyDismissed: false,
         },
         acquisition: {
           source: "homepage_hero",
@@ -444,6 +478,8 @@ describe("auth router input validation", () => {
         onboardingDraft: {
           logoName: "Neighborhood",
           brandColor: "#aabbcc",
+          clinicModel: "mobile",
+          firstGoal: "run_visit",
           teamMembers: [
             {
               name: "Tech One",

--- a/apps/web/server/__tests__/guards.test.ts
+++ b/apps/web/server/__tests__/guards.test.ts
@@ -50,7 +50,7 @@ describe("viewer read-only guard", () => {
   it("blocks mutations for a viewer with FORBIDDEN (before the resolver)", async () => {
     const caller = callerFor("viewer");
     await expect(
-      caller.clients.create({ firstName: "A", lastName: "B" })
+      caller.clients.create({ firstName: "A", lastName: "B" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
@@ -60,7 +60,7 @@ describe("viewer read-only guard", () => {
     expect(res.drugs.length).toBeGreaterThan(0);
   });
 
-  it("blocks hosted lapsed accounts from protected mutations before resolver writes", async () => {
+  it("blocks hosted terminal-unpaid accounts from protected mutations before resolver writes", async () => {
     vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
     // The read-only guard now runs inside withTenant (a transaction) so the
     // practice lookup is RLS-scoped. The tx exposes execute() (for the
@@ -73,7 +73,7 @@ describe("viewer read-only guard", () => {
             limit: async () => [
               {
                 tier: "cloud",
-                billingStatus: "past_due",
+                billingStatus: "unpaid",
                 trialEndsAt: null,
               },
             ],
@@ -87,7 +87,7 @@ describe("viewer read-only guard", () => {
     };
     const caller = callerFor("front_desk", db);
     await expect(
-      caller.clients.create({ firstName: "A", lastName: "B" })
+      caller.clients.create({ firstName: "A", lastName: "B" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
@@ -110,7 +110,7 @@ describe("viewer read-only guard", () => {
     const caller = callerFor("front_desk", db);
 
     await expect(
-      caller.clients.create({ firstName: "A", lastName: "B" })
+      caller.clients.create({ firstName: "A", lastName: "B" }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -168,7 +168,7 @@ describe("viewer read-only guard", () => {
         contactEmail: "owner@example.com",
         confirmExportDownloaded: true,
         confirmManualReview: true,
-      })
+      }),
     ).resolves.toMatchObject({
       status: "requested",
       contactEmail: "owner@example.com",

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -36,8 +36,7 @@ vi.mock("@/lib/billing/subscription-sync", () => ({
 
 vi.mock("@/lib/recovery-hold", () => ({
   RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
-  lockPracticeForExternalSideEffects:
-    mocks.lockPracticeForExternalSideEffects,
+  lockPracticeForExternalSideEffects: mocks.lockPracticeForExternalSideEffects,
 }));
 
 const { settingsRouter } = await import("../routers/settings");
@@ -222,6 +221,20 @@ describe("settings admin stale target safety", () => {
       callerWithDb(db).setOnboardingIntent({ intent: "unknown" as never }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
+    await expect(
+      callerWithDb(db).setOnboardingIntent({
+        intent: "alongside",
+        clinicModel: "unknown" as never,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    await expect(
+      callerWithDb(db).setOnboardingIntent({
+        intent: "alongside",
+        firstGoal: "unknown" as never,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
     expect(updateSet).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -232,24 +245,36 @@ describe("settings admin stale target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).setOnboardingIntent({ intent: "alongside" }),
+      callerWithDb(db).setOnboardingIntent({
+        intent: "alongside",
+        clinicModel: "mobile",
+        firstGoal: "run_visit",
+      }),
     ).resolves.toEqual({ ok: true });
 
     expect(updateSet).toHaveBeenCalledTimes(1);
     expect(SETTINGS_SOURCE).toContain(
-      "onboardingIntentStatePatch(input.intent, now)",
+      "onboardingProfileStatePatch({ ...input, now })",
     );
-    expect(SETTINGS_SOURCE).toContain("'onboardingIntent', ${intent}");
+    expect(SETTINGS_SOURCE).toContain(
+      "'onboardingIntent', ${input.intent}::text",
+    );
+    expect(SETTINGS_SOURCE).toContain("${input.clinicModel ?? null}::text");
+    expect(SETTINGS_SOURCE).toContain("${input.firstGoal ?? null}::text");
+    expect(SETTINGS_SOURCE).toContain("${input.now}::text");
     expect(SETTINGS_SOURCE).toContain("onboardingIntentSelectedAt");
+    expect(SETTINGS_SOURCE).toContain("clinicModelSelectedAt");
+    expect(SETTINGS_SOURCE).toContain("firstGoalSelectedAt");
     expect(SETTINGS_SOURCE).toContain("journeyLastProgressAt");
   });
 
   it("keeps setup start and completion cohort timestamps first-write-wins", () => {
-    expect(SETTINGS_SOURCE).toContain("function onboardingIntentStatePatch");
+    expect(SETTINGS_SOURCE).toContain("function onboardingProfileStatePatch");
     expect(SETTINGS_SOURCE).toContain(
       "nullif(${practices.settings}->'onboardingState'->>'onboardingIntentSelectedAt', '')",
     );
     expect(SETTINGS_SOURCE).toContain("function onboardingCompletionPatch");
+    expect(SETTINGS_SOURCE).toContain("${now}::text");
     expect(SETTINGS_SOURCE).toContain(
       "nullif(${practices.settings}->>'onboardingCompletedAt', '')",
     );

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -43,6 +43,11 @@ import {
   CLINIC_REGION_CODES,
   explicitJurisdictionState,
 } from "@/lib/locale/clinic-regions";
+import {
+  CLINIC_MODELS,
+  FIRST_GOALS,
+  onboardingIntentForGoal,
+} from "@/lib/onboarding/clinic-profile";
 
 /** Display name from explicit input, else derived from the email local-part. */
 function deriveName(name: string | undefined, email: string): string {
@@ -102,21 +107,41 @@ const onboardingTeamMemberSchema = z.object({
   name: authTextInput(
     "Team member name",
     1,
-    AUTH_ONBOARDING_TEAM_MEMBER_NAME_MAX_LENGTH
+    AUTH_ONBOARDING_TEAM_MEMBER_NAME_MAX_LENGTH,
   ),
   email: authEmailInput,
   role: z.enum(["veterinarian", "technician", "front_desk", "viewer"]),
 });
 
-const onboardingDraftSchema = z.object({
-  logoName: authTextInput(
-    "Logo name",
-    1,
-    AUTH_ONBOARDING_LOGO_NAME_MAX_LENGTH,
-  ).optional(),
-  brandColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-  teamMembers: z.array(onboardingTeamMemberSchema).max(8).optional(),
-});
+const onboardingDraftSchema = z
+  .object({
+    logoName: authTextInput(
+      "Logo name",
+      1,
+      AUTH_ONBOARDING_LOGO_NAME_MAX_LENGTH,
+    ).optional(),
+    brandColor: z
+      .string()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
+    teamMembers: z.array(onboardingTeamMemberSchema).max(8).optional(),
+    clinicModel: z.enum(CLINIC_MODELS).optional(),
+    firstGoal: z.enum(FIRST_GOALS).optional(),
+  })
+  .superRefine((draft, ctx) => {
+    if (Boolean(draft.clinicModel) !== Boolean(draft.firstGoal)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Clinic model and first goal must be selected together.",
+      });
+    }
+    if (draft.firstGoal === "self_host" && draft.clinicModel !== "exploring") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Self-hosting evaluation is available from the explore path.",
+      });
+    }
+  });
 
 const acquisitionValueSchema = z
   .string()
@@ -139,13 +164,17 @@ const authTokenSchema = z
   .regex(/^[a-f0-9]{64}$/i, "Invalid or expired link.");
 
 function cleanOnboardingDraft(
-  draft: z.infer<typeof onboardingDraftSchema> | undefined
+  draft: z.infer<typeof onboardingDraftSchema> | undefined,
 ): Record<string, unknown> | undefined {
   if (!draft) return undefined;
 
   const clean: Record<string, unknown> = {};
   if (draft.logoName?.trim()) clean.logoName = draft.logoName.trim();
   if (draft.brandColor) clean.brandColor = draft.brandColor.toLowerCase();
+  if (draft.clinicModel && draft.firstGoal) {
+    clean.clinicModel = draft.clinicModel;
+    clean.firstGoal = draft.firstGoal;
+  }
   const teamMembers = draft.teamMembers
     ?.map((member) => ({
       name: member.name.trim(),
@@ -170,17 +199,17 @@ export const authRouter = createRouter({
         practiceName: authTextInput(
           "Practice name",
           2,
-          AUTH_PRACTICE_NAME_MAX_LENGTH
+          AUTH_PRACTICE_NAME_MAX_LENGTH,
         ),
         country: z.enum(CLINIC_REGION_CODES),
         locationName: authTextInput(
           "Location name",
           2,
-          AUTH_LOCATION_NAME_MAX_LENGTH
+          AUTH_LOCATION_NAME_MAX_LENGTH,
         ).optional(),
         onboardingDraft: onboardingDraftSchema.optional(),
         acquisition: signupAcquisitionSchema.optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const email = normalizeAuthEmail(input.email);
@@ -208,6 +237,13 @@ export const authRouter = createRouter({
       }
 
       const onboardingDraft = cleanOnboardingDraft(input.onboardingDraft);
+      const registrationProfile =
+        input.onboardingDraft?.clinicModel && input.onboardingDraft.firstGoal
+          ? {
+              clinicModel: input.onboardingDraft.clinicModel,
+              firstGoal: input.onboardingDraft.firstGoal,
+            }
+          : null;
       const hostedBilling = billingEnforced();
       // Card-free trial: skip the Stripe Checkout wall at signup and grant a
       // `trialing` window directly, so the clinic lands in the product and only
@@ -242,13 +278,29 @@ export const authRouter = createRouter({
       const passwordHash = await hash(input.password, PASSWORD_HASH_COST);
       const registeredAt = new Date().toISOString();
       const defaults = regionDefaults(input.country);
-      const practiceSettings: Record<string, unknown> = {
-        onboardingState: explicitJurisdictionState(
+      const onboardingState: Record<string, unknown> = {
+        ...explicitJurisdictionState(
           input.country,
           "registration",
           registeredAt,
         ),
       };
+      if (registrationProfile) {
+        Object.assign(onboardingState, {
+          onboardingIntent: onboardingIntentForGoal(
+            registrationProfile.firstGoal,
+          ),
+          onboardingIntentSelectedAt: registeredAt,
+          clinicModel: registrationProfile.clinicModel,
+          clinicModelSelectedAt: registeredAt,
+          firstGoal: registrationProfile.firstGoal,
+          firstGoalSelectedAt: registeredAt,
+          journeyStepId: "basics",
+          journeyLastProgressAt: registeredAt,
+          journeyDismissed: false,
+        });
+      }
+      const practiceSettings: Record<string, unknown> = { onboardingState };
       if (input.acquisition) {
         practiceSettings.acquisition = {
           ...input.acquisition,
@@ -262,8 +314,8 @@ export const authRouter = createRouter({
         practiceSettings.onboardingCompletedAt = null;
       }
 
-      const { practice, user, checkoutUrl } =
-        await ctx.db.transaction(async (tx) => {
+      const { practice, user, checkoutUrl } = await ctx.db.transaction(
+        async (tx) => {
           const [createdPractice] = await tx
             .insert(practices)
             .values({
@@ -396,14 +448,18 @@ export const authRouter = createRouter({
             user: createdUser,
             checkoutUrl: createdCheckoutUrl,
           };
-        });
+        },
+      );
 
       // Durable, privacy-safe registration stage. Non-fatal so telemetry can
       // never turn a successful account creation into a failed signup.
       try {
         await recordRegistration(ctx.db, practice.id);
       } catch (err) {
-        console.error("[register] conversion milestone projection failed:", err);
+        console.error(
+          "[register] conversion milestone projection failed:",
+          err,
+        );
       }
 
       // On the hosted service, request email verification without blocking the
@@ -473,7 +529,9 @@ export const authRouter = createRouter({
           } catch {
             // Signup is already committed. Keep verification soft and do not
             // log the auth link or recipient embedded in the closure.
-            console.error("[register] post-commit verification dispatch failed");
+            console.error(
+              "[register] post-commit verification dispatch failed",
+            );
           }
         });
       }
@@ -550,8 +608,8 @@ export const authRouter = createRouter({
         and(
           eq(users.id, ctx.user.id),
           eq(users.practiceId, ctx.practiceId),
-          isNull(users.deletedAt)
-        )
+          isNull(users.deletedAt),
+        ),
       )
       .limit(1);
 
@@ -689,7 +747,7 @@ export const authRouter = createRouter({
       z.object({
         token: authTokenSchema,
         password: authPasswordInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await consumeAuthToken(input.token, "password_reset", {
@@ -722,7 +780,7 @@ export const authRouter = createRouter({
       z.object({
         token: authTokenSchema,
         password: authPasswordInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await consumeAuthToken(input.token, "invite", {

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -81,6 +81,12 @@ import {
   ONBOARDING_INTENTS,
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
+import {
+  CLINIC_MODELS,
+  FIRST_GOALS,
+  type ClinicModel,
+  type FirstGoal,
+} from "@/lib/onboarding/clinic-profile";
 import { isValidMigrationSource } from "@/lib/import/sources";
 import { parseBookingPageConfig } from "@/lib/booking/page-config";
 import { takeAppointmentSchedulingLock } from "@/lib/scheduling/location";
@@ -257,6 +263,8 @@ const journeyStepIdInput = z
   .max(64, "Journey step must be at most 64 characters")
   .nullish();
 const onboardingIntentInput = z.enum(ONBOARDING_INTENTS);
+const clinicModelInput = z.enum(CLINIC_MODELS);
+const firstGoalInput = z.enum(FIRST_GOALS);
 const migrationHelpSourceInput = z
   .string()
   .trim()
@@ -303,18 +311,47 @@ function settingsAndOnboardingStateMergePatch(
  * first time setup actually began. That timestamp is cohort evidence, not a
  * last-updated field.
  */
-function onboardingIntentStatePatch(intent: OnboardingIntent, now: string) {
+function onboardingProfileStatePatch(input: {
+  intent: OnboardingIntent;
+  clinicModel?: ClinicModel;
+  firstGoal?: FirstGoal;
+  now: string;
+}) {
   return sql`jsonb_set(
     coalesce(${practices.settings}, '{}'::jsonb),
     '{onboardingState}',
-    coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) ||
+      coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) ||
       jsonb_build_object(
-        'onboardingIntent', ${intent},
+        'onboardingIntent', ${input.intent}::text,
         'onboardingIntentSelectedAt', coalesce(
           nullif(${practices.settings}->'onboardingState'->>'onboardingIntentSelectedAt', ''),
-          ${now}
+          ${input.now}::text
         ),
-        'journeyLastProgressAt', ${now},
+        'clinicModel', coalesce(
+          ${input.clinicModel ?? null}::text,
+          nullif(${practices.settings}->'onboardingState'->>'clinicModel', '')
+        ),
+        'clinicModelSelectedAt', case
+          when ${input.clinicModel ?? null}::text is null then
+            nullif(${practices.settings}->'onboardingState'->>'clinicModelSelectedAt', '')
+          else coalesce(
+            nullif(${practices.settings}->'onboardingState'->>'clinicModelSelectedAt', ''),
+            ${input.now}::text
+          )
+        end,
+        'firstGoal', coalesce(
+          ${input.firstGoal ?? null}::text,
+          nullif(${practices.settings}->'onboardingState'->>'firstGoal', '')
+        ),
+        'firstGoalSelectedAt', case
+          when ${input.firstGoal ?? null}::text is null then
+            nullif(${practices.settings}->'onboardingState'->>'firstGoalSelectedAt', '')
+          else coalesce(
+            nullif(${practices.settings}->'onboardingState'->>'firstGoalSelectedAt', ''),
+            ${input.now}::text
+          )
+        end,
+        'journeyLastProgressAt', ${input.now}::text,
         'journeyDismissed', false
       )
   )`;
@@ -328,12 +365,12 @@ function onboardingCompletionPatch(now: string) {
       '{onboardingCompletedAt}',
       to_jsonb(coalesce(
         nullif(${practices.settings}->>'onboardingCompletedAt', ''),
-        ${now}
+        ${now}::text
       )::text)
     ),
     '{onboardingState}',
     coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) ||
-      jsonb_build_object('journeyLastProgressAt', ${now})
+      jsonb_build_object('journeyLastProgressAt', ${now}::text)
   )`;
 }
 
@@ -508,6 +545,11 @@ interface PracticeSettings {
     /** Adoption pathway selected on the first guided-setup step. */
     onboardingIntent?: OnboardingIntent;
     onboardingIntentSelectedAt?: string;
+    /** Coarse, non-clinical personalization selected during setup. */
+    clinicModel?: ClinicModel;
+    clinicModelSelectedAt?: string;
+    firstGoal?: FirstGoal;
+    firstGoalSelectedAt?: string;
     /** Resume cursor for the "Make it yours" setup wizard (step id, not index). */
     journeyStepId?: string | null;
     /** Last successfully persisted journey action, used for stall recovery. */
@@ -1658,6 +1700,10 @@ export const settingsRouter = createRouter({
       setupDismissed: false,
       onboardingIntent: null,
       onboardingIntentSelectedAt: null,
+      clinicModel: null,
+      clinicModelSelectedAt: null,
+      firstGoal: null,
+      firstGoalSelectedAt: null,
       journeyStepId: null,
       journeyLastProgressAt: null,
       journeyDismissed: false,
@@ -1713,13 +1759,19 @@ export const settingsRouter = createRouter({
 
   /** Persist the selected adoption path for tailored setup and funnel review. */
   setOnboardingIntent: adminProcedure
-    .input(z.object({ intent: onboardingIntentInput }))
+    .input(
+      z.object({
+        intent: onboardingIntentInput,
+        clinicModel: clinicModelInput.optional(),
+        firstGoal: firstGoalInput.optional(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       const now = new Date().toISOString();
       const [updated] = await ctx.db
         .update(practices)
         .set({
-          settings: onboardingIntentStatePatch(input.intent, now),
+          settings: onboardingProfileStatePatch({ ...input, now }),
         })
         .where(activePracticeWhere(ctx.practiceId))
         .returning({ id: practices.id });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -27,6 +27,10 @@
       "schedule": "0 14 * * *"
     },
     {
+      "path": "/api/cron/first-clinic-win",
+      "schedule": "17 * * * *"
+    },
+    {
       "path": "/api/cron/setup-recovery",
       "schedule": "0 15 * * *"
     },

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -69,6 +69,10 @@ Set these on the hosted app deployment:
 
 ```env
 HOSTED_BILLING_ENABLED=true
+# Default-off. Set both only after reviewing the verified-admin recipient
+# cohort; the timestamp is the prospective closeout eligibility boundary.
+FIRST_CLINIC_WIN_ENABLED=false
+FIRST_CLINIC_WIN_ROLLOUT_AT=
 NEXTAUTH_URL=https://app.openvpm.com
 NEXT_PUBLIC_APP_URL=https://app.openvpm.com
 NEXTAUTH_SECRET=...
@@ -522,6 +526,7 @@ one global `CRON_HEARTBEAT_URL` to receive every cron completion as POST JSON, o
 set job-specific URLs (`CRON_HEARTBEAT_REMINDERS_URL`,
 `CRON_HEARTBEAT_BACKUP_URL`, `CRON_HEARTBEAT_USAGE_RECONCILE_URL`,
 `CRON_HEARTBEAT_BILLING_LIFECYCLE_URL`,
+`CRON_HEARTBEAT_FIRST_CLINIC_WIN_URL`,
 `CRON_HEARTBEAT_SETUP_RECOVERY_URL`,
 `CRON_HEARTBEAT_WELLNESS_BILLING_URL`,
 `CRON_HEARTBEAT_RATE_LIMIT_CLEANUP_URL`,

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -9,3 +9,4 @@ export type { TrialEndingEmailProps } from "./src/templates/TrialEndingEmail";
 export type { SetupRecoveryEmailProps } from "./src/templates/SetupRecoveryEmail";
 export type { PaymentReceiptEmailProps } from "./src/templates/PaymentReceiptEmail";
 export type { PaymentFailedEmailProps } from "./src/templates/PaymentFailedEmail";
+export type { FirstClinicWinEmailProps } from "./src/templates/FirstClinicWinEmail";

--- a/packages/email/preview.tsx
+++ b/packages/email/preview.tsx
@@ -37,6 +37,7 @@ async function main() {
       trialEndDate: "July 10, 2026",
       monthlyPrice: "$79",
       billingUrl,
+      billingConnected: false,
       unsubscribeUrl: `${brand.appUrl}/email-preferences?token=preview`,
     }),
     receipt: await renderPaymentReceiptEmail({

--- a/packages/email/src/render.tsx
+++ b/packages/email/src/render.tsx
@@ -17,6 +17,10 @@ import {
   PaymentFailedEmail,
   type PaymentFailedEmailProps,
 } from "./templates/PaymentFailedEmail";
+import {
+  FirstClinicWinEmail,
+  type FirstClinicWinEmailProps,
+} from "./templates/FirstClinicWinEmail";
 
 export interface RenderedEmail {
   subject: string;
@@ -69,5 +73,14 @@ export async function renderPaymentFailedEmail(
   return {
     subject: "Action needed: your OpenVPM payment didn't go through",
     html: await render(<PaymentFailedEmail {...p} />),
+  };
+}
+
+export async function renderFirstClinicWinEmail(
+  p: FirstClinicWinEmailProps,
+): Promise<RenderedEmail> {
+  return {
+    subject: "Your first real OpenVPM visit is complete",
+    html: await render(<FirstClinicWinEmail {...p} />),
   };
 }

--- a/packages/email/src/templates/FirstClinicWinEmail.tsx
+++ b/packages/email/src/templates/FirstClinicWinEmail.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { Button } from "../components/Button";
+import { InfoCard } from "../components/InfoCard";
+import { Heading, Label, Paragraph, Stat } from "../components/Typography";
+import type { Brand } from "../brand";
+
+export interface FirstClinicWinEmailProps {
+  brand: Brand;
+  practiceName: string;
+  trialEndDate: string;
+  billingUrl: string;
+  unsubscribeUrl?: string;
+}
+
+/** A PHI-free celebration sent only after the first completed real visit. */
+export function FirstClinicWinEmail({
+  brand,
+  practiceName,
+  trialEndDate,
+  billingUrl,
+  unsubscribeUrl,
+}: FirstClinicWinEmailProps) {
+  return (
+    <EmailLayout
+      brand={brand}
+      preview="Your team completed its first real visit in OpenVPM."
+      unsubscribeUrl={unsubscribeUrl}
+      recipientReason={`This is the verified OpenVPM administrator address saved for ${practiceName}.`}
+    >
+      <Heading>You ran your first real visit.</Heading>
+      <Paragraph>
+        Your team just took OpenVPM through a real clinic workflow—not a demo or
+        a setup checklist. That&apos;s a meaningful first win.
+      </Paragraph>
+
+      <InfoCard tone="success">
+        <Label>Your supported trial</Label>
+        <Stat>Runs through {trialEndDate}</Stat>
+        <Paragraph muted>
+          Keep validating the workflow with your team. A card is not required
+          during this supported trial.
+        </Paragraph>
+      </InfoCard>
+
+      <Paragraph>
+        When the clinic is ready, add billing once and the workspace can keep
+        moving without an interruption at the end of the trial.
+      </Paragraph>
+
+      <Section style={{ margin: "8px 0" }}>
+        <Button href={billingUrl}>Review billing</Button>
+      </Section>
+
+      <Paragraph muted>
+        Questions or something that did not fit the way your clinic works? Reply
+        and tell us. We&apos;re building this with clinics like yours.
+      </Paragraph>
+    </EmailLayout>
+  );
+}

--- a/packages/email/src/templates/TrialEndingEmail.tsx
+++ b/packages/email/src/templates/TrialEndingEmail.tsx
@@ -13,6 +13,7 @@ export interface TrialEndingEmailProps {
   trialEndDate: string; // e.g. "July 10, 2026"
   monthlyPrice: string; // e.g. "$79"
   billingUrl: string;
+  billingConnected?: boolean;
   unsubscribeUrl?: string;
 }
 
@@ -23,23 +24,30 @@ export function TrialEndingEmail({
   trialEndDate,
   monthlyPrice,
   billingUrl,
+  billingConnected = false,
   unsubscribeUrl,
 }: TrialEndingEmailProps) {
-  const whenLabel =
-    daysLeft <= 1 ? "tomorrow" : `in ${daysLeft} days`;
+  const whenLabel = daysLeft <= 1 ? "tomorrow" : `in ${daysLeft} days`;
   return (
     <EmailLayout
       brand={brand}
-      preview={`Your OpenVPM trial ends ${whenLabel}. Add a card and nothing changes.`}
+      preview={
+        billingConnected
+          ? `Your OpenVPM trial ends ${whenLabel}. Your billing setup is connected.`
+          : `Your OpenVPM trial ends ${whenLabel}. Add billing and nothing changes.`
+      }
       unsubscribeUrl={unsubscribeUrl}
       recipientReason={`This address is the OpenVPM billing contact for ${practiceName}.`}
     >
       <Heading>Your trial ends {whenLabel}</Heading>
       <Paragraph>
         Hi {practiceName}, your OpenVPM trial ends on{" "}
-        <strong>{trialEndDate}</strong>. Add a card now and nothing changes.
-        Your schedule, your records, and everything you&apos;ve set up stay
-        exactly as they are.
+        <strong>{trialEndDate}</strong>.{" "}
+        {billingConnected
+          ? "You already completed billing setup, so there is no need to add it again."
+          : "Add billing now and nothing changes."}{" "}
+        Your schedule, records, and everything you&apos;ve set up stay exactly
+        as they are.
       </Paragraph>
 
       <InfoCard tone="warning">
@@ -51,7 +59,9 @@ export function TrialEndingEmail({
       </InfoCard>
 
       <Section style={{ margin: "8px 0" }}>
-        <Button href={billingUrl}>Add billing</Button>
+        <Button href={billingUrl}>
+          {billingConnected ? "Review billing" : "Add billing"}
+        </Button>
       </Section>
 
       <Paragraph muted>


### PR DESCRIPTION
## What changed

- replaces the generic signup handoff with a branded, clinic-specific intent builder and a simpler guided first-day journey
- records durable onboarding and funnel milestones without collecting patient or clinical data
- adds first-real-visit to billing-setup reporting at 24-hour and 72-hour windows
- adds a default-off, prospective first-clinic-win campaign for exact verified clinic admins
- segments trial-ending email copy so clinics with billing already connected do not receive an Add billing prompt
- hardens subscription webhooks against stale event ordering and moves receipt/dunning email delivery outside the billing transaction
- preserves write access during Stripe's past-due retry window while keeping terminal unpaid accounts read-only
- adds final marketing-consent locking, PHI-free alerting, and stable provider idempotency

## Why

OpenVPM's early funnel should feel like the product is being built around the clinic, move a new team toward one real workflow quickly, and measure where clinics need help. The previous flow mixed generic setup tasks with billing language and did not provide a clean first-visit to billing conversion view.

## Safety and rollout

- the first-clinic-win campaign remains disabled unless both `FIRST_CLINIC_WIN_ENABLED=true` and a valid prospective `FIRST_CLINIC_WIN_ROLLOUT_AT` are configured
- recipients must exactly match an active, verified clinic admin
- campaign copy and metrics contain no patient/client identifiers or clinical data
- eligibility, recovery hold, subscription state, consent, and email identity are rechecked at the final provider boundary
- no email, charge, provider mutation, production mutation, or deployment was performed while building this change

## Validation

- full web suite: 4,014 passed / 6 expected skips
- web type-check passed
- diff integrity passed
- desktop and mobile billing walkthrough passed with no console errors or horizontal overflow
- production health remained green for database, schema, RLS, billing, storage, email, and operations

## Follow-up

Receipt and dunning delivery is now post-commit and idempotent. A durable transactional email outbox would provide stronger recovery from a process crash between commit and dispatch.