### PR TITLE
Polish the trial onboarding walkthrough

### DIFF
--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -68,6 +68,15 @@ const REGISTRATION_PROFILE_STORAGE_KEY = "openvpm:registration-profile:v1";
 const selectClass =
   "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
 
+const onboardingStageMainClass =
+  "min-h-screen bg-[radial-gradient(circle_at_top_left,#fff7ed_0%,transparent_34%),radial-gradient(circle_at_top_right,#ede9fe_0%,transparent_36%),linear-gradient(180deg,#ffffff_0%,#f5fbf8_100%)] px-4 py-4 sm:px-6 sm:py-6";
+const onboardingStageFrameClass =
+  "mx-auto flex max-w-6xl flex-col overflow-hidden rounded-[28px] border border-white/80 bg-white/95 shadow-[0_30px_90px_-54px_rgba(15,23,42,0.48)] backdrop-blur sm:min-h-[650px] lg:h-[calc(100dvh-5rem)] lg:min-h-[680px] lg:max-h-[730px]";
+const onboardingStageHeaderClass =
+  "flex shrink-0 items-center justify-between border-b border-slate-100 px-5 py-4 sm:px-9";
+const onboardingStageFooterClass =
+  "relative flex shrink-0 flex-col-reverse gap-3 border-t border-slate-100 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-9";
+
 export default function RegisterPage() {
   return (
     <Suspense
@@ -348,9 +357,9 @@ function RegisterPageInner() {
 
   if (stage === "profile") {
     return (
-      <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#fff7ed_0%,transparent_34%),radial-gradient(circle_at_top_right,#ede9fe_0%,transparent_36%),linear-gradient(180deg,#ffffff_0%,#f5fbf8_100%)] px-4 py-5 sm:px-6 sm:py-8">
-        <div className="mx-auto max-w-6xl overflow-hidden rounded-[28px] border border-white/80 bg-white/95 shadow-[0_30px_90px_-54px_rgba(15,23,42,0.48)] backdrop-blur">
-          <header className="flex items-center justify-between border-b border-slate-100 px-5 py-4 sm:px-9 sm:py-5">
+      <main className={onboardingStageMainClass}>
+        <div className={onboardingStageFrameClass}>
+          <header className={onboardingStageHeaderClass}>
             <Link
               href="/"
               className="inline-flex items-center gap-3 font-heading text-lg font-semibold tracking-tight text-slate-950 sm:text-xl"
@@ -371,7 +380,7 @@ function RegisterPageInner() {
             </div>
           </header>
 
-          <section className="px-5 py-7 sm:px-9 sm:py-10 lg:px-12">
+          <section className="flex-1 px-5 py-7 sm:px-9 sm:py-10 lg:px-12">
             <div className="mb-8 max-w-3xl">
               <h1 className="font-heading text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
                 A platform truly built for your clinic.
@@ -392,10 +401,7 @@ function RegisterPageInner() {
             />
           </section>
 
-          <footer className="flex flex-col-reverse gap-3 border-t border-slate-100 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-9">
-            <p className="text-center text-xs text-slate-500 sm:text-left">
-              No patient or client information belongs here.
-            </p>
+          <footer className={cn(onboardingStageFooterClass, "sm:justify-end")}>
             <Button
               type="button"
               onClick={continueToWorkflow}
@@ -412,9 +418,9 @@ function RegisterPageInner() {
 
   if (stage === "workflow") {
     return (
-      <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#fff7ed_0%,transparent_34%),radial-gradient(circle_at_top_right,#ede9fe_0%,transparent_36%),linear-gradient(180deg,#ffffff_0%,#f5fbf8_100%)] px-4 py-5 sm:px-6 sm:py-8">
-        <div className="mx-auto max-w-6xl overflow-hidden rounded-[28px] border border-white/80 bg-white/95 shadow-[0_30px_90px_-54px_rgba(15,23,42,0.48)] backdrop-blur">
-          <header className="flex items-center justify-between border-b border-slate-100 px-5 py-4 sm:px-9 sm:py-5">
+      <main className={onboardingStageMainClass}>
+        <div className={onboardingStageFrameClass}>
+          <header className={onboardingStageHeaderClass}>
             <Link
               href="/"
               className="inline-flex items-center gap-3 font-heading text-lg font-semibold tracking-tight text-slate-950 sm:text-xl"
@@ -435,17 +441,7 @@ function RegisterPageInner() {
             </div>
           </header>
 
-          <section className="px-5 py-7 sm:px-9 sm:py-10 lg:px-12">
-            <div className="mb-8 max-w-3xl">
-              <h1 className="font-heading text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
-                What would you like to see?
-              </h1>
-              <p className="mt-3 text-sm leading-6 text-slate-600 sm:text-base">
-                Here are some useful workflows for your practice. Pick one and
-                we’ll shape the first day around it.
-              </p>
-            </div>
-
+          <section className="flex-1 px-5 py-6 sm:px-9 sm:py-7 lg:px-10">
             <ClinicIntentBuilder
               clinicModel={clinicModel}
               firstGoal={firstGoal}
@@ -454,13 +450,21 @@ function RegisterPageInner() {
               intro={null}
               showClinicModel={false}
               goalLegend="Choose your first useful workflow"
+              beforeChoices={
+                <div className="max-w-3xl">
+                  <h1 className="font-heading text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
+                    What would you like to see?
+                  </h1>
+                  <p className="mt-2 text-sm leading-6 text-slate-600 sm:text-base">
+                    Pick one useful workflow and we’ll shape your first day
+                    around it.
+                  </p>
+                </div>
+              }
               afterChoices={
-                <div className="mt-8 border-t border-slate-100 pt-7">
+                <div className="mt-5 border-t border-slate-100 pt-5">
                   <p className="text-sm font-semibold text-slate-950 sm:text-base">
                     Start your workspace
-                  </p>
-                  <p className="mt-1 text-sm leading-6 text-slate-600">
-                    Just your practice name and work email for now.
                   </p>
 
                   {error ? (
@@ -469,7 +473,7 @@ function RegisterPageInner() {
                     </div>
                   ) : null}
 
-                  <div className="mt-5 grid gap-4 sm:grid-cols-2">
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
                     <FormField label="Practice name" htmlFor="practiceName">
                       <Input
                         id="practiceName"
@@ -508,7 +512,7 @@ function RegisterPageInner() {
             />
           </section>
 
-          <footer className="flex flex-col-reverse gap-3 border-t border-slate-100 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-9">
+          <footer className={onboardingStageFooterClass}>
             <button
               type="button"
               onClick={() => {
@@ -536,9 +540,9 @@ function RegisterPageInner() {
 
   if (stage === "preview") {
     return (
-      <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#fff7ed_0%,transparent_34%),radial-gradient(circle_at_top_right,#ede9fe_0%,transparent_36%),linear-gradient(180deg,#ffffff_0%,#f5fbf8_100%)] px-4 py-5 sm:px-6 sm:py-8">
-        <div className="mx-auto max-w-6xl overflow-hidden rounded-[28px] border border-white/80 bg-white/95 shadow-[0_30px_90px_-54px_rgba(15,23,42,0.48)] backdrop-blur">
-          <header className="flex items-center justify-between border-b border-slate-100 px-5 py-4 sm:px-9 sm:py-5">
+      <main className={onboardingStageMainClass}>
+        <div className={onboardingStageFrameClass}>
+          <header className={onboardingStageHeaderClass}>
             <Link
               href="/"
               className="inline-flex items-center gap-3 font-heading text-lg font-semibold tracking-tight text-slate-950 sm:text-xl"
@@ -559,8 +563,8 @@ function RegisterPageInner() {
             </div>
           </header>
 
-          <section className="px-5 py-7 sm:px-9 sm:py-10 lg:px-12">
-            <div className="mb-9 max-w-3xl">
+          <section className="flex-1 px-5 py-6 sm:px-9 sm:py-7 lg:px-10">
+            <div className="mb-6 max-w-3xl">
               <h1 className="font-heading text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
                 Your first day is ready.
               </h1>
@@ -573,7 +577,7 @@ function RegisterPageInner() {
             <FirstDayRecommendations primaryGoal={firstGoal} />
           </section>
 
-          <footer className="flex flex-col-reverse gap-3 border-t border-slate-100 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-9">
+          <footer className={onboardingStageFooterClass}>
             <button
               type="button"
               onClick={() => showStage("workflow")}
@@ -582,7 +586,10 @@ function RegisterPageInner() {
               <ArrowLeft className="h-4 w-4" />
               Back
             </button>
-            <div className="flex flex-col items-stretch gap-2 sm:items-end">
+            <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-4">
+              <p className="text-center text-xs text-slate-500">
+                No card required.
+              </p>
               <Button
                 type="button"
                 onClick={continueToAccount}
@@ -591,9 +598,6 @@ function RegisterPageInner() {
                 Secure my workspace
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
-              <p className="text-center text-xs text-slate-500 sm:text-right">
-                No card required.
-              </p>
             </div>
           </footer>
         </div>
@@ -771,16 +775,6 @@ function RegisterPageInner() {
               <ArrowLeft className="h-3.5 w-3.5" />
               Back to my first day
             </button>
-
-            <p className="text-center text-xs text-slate-500">
-              <Link
-                href="/clinic-fit"
-                className="font-medium text-primary underline underline-offset-2"
-              >
-                Check clinic fit and rollout limits
-              </Link>{" "}
-              before moving live work.
-            </p>
 
             <p className="text-center text-xs text-slate-400">
               By creating a workspace you agree to the{" "}

--- a/apps/web/components/onboarding/clinic-intent-builder.tsx
+++ b/apps/web/components/onboarding/clinic-intent-builder.tsx
@@ -75,6 +75,7 @@ export function ClinicIntentBuilder({
   showClinicModel = true,
   showFirstGoal = true,
   goalLegend = "What would feel useful first?",
+  beforeChoices,
   afterChoices,
 }: {
   clinicModel: ClinicModel;
@@ -85,6 +86,7 @@ export function ClinicIntentBuilder({
   showClinicModel?: boolean;
   showFirstGoal?: boolean;
   goalLegend?: string;
+  beforeChoices?: ReactNode;
   afterChoices?: ReactNode;
 }) {
   const selectedModel = clinicModelOption(clinicModel);
@@ -97,12 +99,14 @@ export function ClinicIntentBuilder({
   return (
     <div
       className={cn(
-        "grid gap-8",
+        "grid gap-6",
         showFirstGoal &&
-          "lg:grid-cols-[minmax(0,1.28fr)_minmax(340px,0.72fr)] lg:gap-12",
+          "lg:grid-cols-[minmax(0,1.3fr)_minmax(320px,0.7fr)] lg:items-start lg:gap-8",
       )}
     >
       <div className="min-w-0">
+        {beforeChoices}
+
         {intro ? (
           <p className="max-w-2xl text-[15px] leading-7 text-slate-600 sm:text-base">
             {intro}
@@ -155,11 +159,15 @@ export function ClinicIntentBuilder({
         ) : null}
 
         {showFirstGoal ? (
-          <fieldset className={showClinicModel || intro ? "mt-7" : undefined}>
+          <fieldset
+            className={
+              showClinicModel || intro || beforeChoices ? "mt-6" : undefined
+            }
+          >
             <legend className="text-sm font-semibold text-slate-950 sm:text-base">
               {goalLegend}
             </legend>
-            <div className="mt-3 grid gap-2.5 sm:grid-cols-2">
+            <div className="mt-2.5 grid gap-2.5 sm:grid-cols-2">
               {goalOptions.map((option) => {
                 const Icon = goalIcons[option.value];
                 const active = firstGoal === option.value;
@@ -170,7 +178,7 @@ export function ClinicIntentBuilder({
                     aria-pressed={active}
                     onClick={() => onFirstGoalChange(option.value)}
                     className={cn(
-                      "flex min-h-14 items-center gap-3 rounded-xl border px-3.5 py-3 text-left transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                      "flex min-h-14 items-center gap-3 rounded-xl border px-3.5 py-2.5 text-left transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                       active
                         ? "border-primary bg-primary/5 shadow-[0_8px_24px_-20px_rgba(5,150,105,0.7)]"
                         : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/70",
@@ -212,7 +220,7 @@ export function ClinicIntentBuilder({
       {showFirstGoal ? (
         <aside
           aria-live="polite"
-          className="relative overflow-hidden rounded-[24px] border border-primary/15 bg-[linear-gradient(155deg,#ffffff_0%,#f5fbf8_72%,#f7f5ff_100%)] px-5 py-6 shadow-[0_24px_60px_-42px_rgba(5,150,105,0.55)] sm:px-7 sm:py-8 lg:min-h-[570px]"
+          className="relative overflow-hidden rounded-[24px] border border-primary/15 bg-[linear-gradient(155deg,#ffffff_0%,#f5fbf8_72%,#f7f5ff_100%)] px-5 py-5 shadow-[0_24px_60px_-42px_rgba(5,150,105,0.55)] sm:px-6 sm:py-6 lg:min-h-[480px]"
         >
           <div
             aria-hidden="true"
@@ -223,7 +231,7 @@ export function ClinicIntentBuilder({
             className="absolute -right-4 top-6 h-20 w-20 rounded-full border border-rose-100"
           />
           <div className="relative">
-            <div className="flex items-center gap-3 lg:justify-center">
+            <div className="flex items-center gap-3">
               <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary lg:hidden">
                 <Sparkles className="h-5 w-5" strokeWidth={1.8} />
               </span>
@@ -231,26 +239,26 @@ export function ClinicIntentBuilder({
                 <h3 className="font-heading text-lg font-semibold text-slate-950 sm:text-xl">
                   Your first OpenVPM day
                 </h3>
-                <p className="mt-0.5 text-xs text-slate-500 lg:text-center">
+                <p className="mt-0.5 text-xs text-slate-500">
                   Shaped for {selectedModel.shortLabel.toLowerCase()} care
                 </p>
               </div>
             </div>
 
-            <ol key={`${clinicModel}-${firstGoal}`} className="mt-6 space-y-3">
+            <ol key={`${clinicModel}-${firstGoal}`} className="mt-4 space-y-2">
               {tasks.map((task, index) => {
                 const Icon = taskIcons[index] ?? PawPrint;
                 return (
                   <li
                     key={task}
                     style={{ animationDelay: `${index * 90}ms` }}
-                    className="onboarding-task-in relative flex items-center gap-3 rounded-2xl border border-white bg-white/90 p-3 shadow-[0_12px_30px_-22px_rgba(15,23,42,0.4)] sm:p-4"
+                    className="onboarding-task-in relative flex items-center gap-3 rounded-2xl border border-white bg-white/90 p-2.5 shadow-[0_12px_30px_-22px_rgba(15,23,42,0.4)] sm:p-3"
                   >
                     <span className="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-[11px] font-bold text-primary-foreground shadow-sm">
                       {index + 1}
                     </span>
-                    <span className="ml-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                      <Icon className="h-5 w-5" strokeWidth={1.8} />
+                    <span className="ml-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                      <Icon className="h-[18px] w-[18px]" strokeWidth={1.8} />
                     </span>
                     <span className="text-sm font-medium leading-5 text-slate-800">
                       {task}
@@ -260,17 +268,7 @@ export function ClinicIntentBuilder({
               })}
             </ol>
 
-            {selectedModel.readiness === "design_partner" ? (
-              <div className="mt-5 flex gap-3 rounded-xl border border-violet-100 bg-white/75 p-3.5">
-                <HeartPulse className="mt-0.5 h-4 w-4 shrink-0 text-violet-600" />
-                <p className="text-xs leading-5 text-slate-600">
-                  We’ll validate one real workflow with you and be clear about
-                  anything that isn’t ready yet.
-                </p>
-              </div>
-            ) : null}
-
-            <div className="mt-6 flex items-center gap-2 text-xs text-primary">
+            <div className="mt-4 flex items-center gap-2 text-xs text-primary">
               <ShieldCheck className="h-4 w-4" strokeWidth={1.8} />
               <span>Nothing moves until you review it.</span>
             </div>

--- a/apps/web/components/onboarding/first-day-recommendations.tsx
+++ b/apps/web/components/onboarding/first-day-recommendations.tsx
@@ -84,7 +84,7 @@ function RecommendationCard({
   return (
     <li
       className={cn(
-        "group flex min-w-0 flex-col rounded-sm bg-white p-3 pb-4 shadow-[0_18px_40px_-24px_rgba(15,23,42,0.55)] ring-1 ring-black/5",
+        "group flex min-h-[292px] min-w-0 flex-col rounded-sm bg-white p-3 pb-5 shadow-[0_18px_40px_-24px_rgba(15,23,42,0.55)] ring-1 ring-black/5",
         "transition duration-300 ease-out hover:z-10 hover:-translate-y-1.5 hover:rotate-0 hover:shadow-xl",
         "motion-reduce:transform-none motion-reduce:transition-none",
         tilt,
@@ -92,7 +92,7 @@ function RecommendationCard({
     >
       <div
         className={cn(
-          "flex min-h-32 flex-col justify-between overflow-hidden rounded-[3px] bg-gradient-to-br p-4",
+          "flex min-h-36 flex-col justify-between overflow-hidden rounded-[3px] bg-gradient-to-br p-4",
           palette.picture,
         )}
       >
@@ -131,23 +131,8 @@ export function FirstDayRecommendations({
     : FIRST_GOAL_RECOMMENDATIONS[primaryGoal];
 
   return (
-    <section aria-labelledby="first-day-recommendations-heading">
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
-        <div>
-          <h3
-            id="first-day-recommendations-heading"
-            className="font-heading text-xl font-semibold text-slate-950"
-          >
-            Here’s what I think will help first.
-          </h3>
-          <p className="mt-1 text-sm text-slate-500">
-            Pick one useful win. The rest will still be here when you’re ready.
-          </p>
-        </div>
-        <p className="text-xs text-slate-500">Nothing here blocks launch.</p>
-      </div>
-
-      <ul className="mt-6 grid gap-6 sm:grid-cols-3 sm:gap-5">
+    <section aria-label="Your first-day recommendations">
+      <ul className="grid gap-6 sm:grid-cols-3 sm:gap-5">
         <RecommendationCard
           title={primaryRecommendation.title}
           body={primaryRecommendation.body}

--- a/apps/web/lib/__tests__/clinic-fit-ui.test.ts
+++ b/apps/web/lib/__tests__/clinic-fit-ui.test.ts
@@ -22,9 +22,9 @@ describe("public clinic fit guidance", () => {
     expect(page.match(/href={clinicFitDemoUrl}/g)).toHaveLength(2);
   });
 
-  it("keeps the fit check optional and reachable before signup", () => {
-    expect(register).toContain('href="/clinic-fit"');
-    expect(register).toContain("Check clinic fit and rollout limits");
+  it("keeps the fit check public without adding friction to signup", () => {
+    expect(register).not.toContain('href="/clinic-fit"');
+    expect(register).not.toContain("Check clinic fit and rollout limits");
     expect(middleware).toContain('"/clinic-fit"');
   });
 });

--- a/apps/web/lib/__tests__/demo-conversion-ui.test.ts
+++ b/apps/web/lib/__tests__/demo-conversion-ui.test.ts
@@ -53,8 +53,10 @@ describe("demo conversion bridge UI", () => {
     expect(register).toContain("Step 3 of 4");
     expect(register).toContain("Step 4 of 4");
     expect(register).toContain("What would you like to see?");
-    expect(register).toContain(
-      "Here are some useful workflows for your practice.",
+    expect(register).toContain("Pick one useful workflow and we’ll shape");
+    expect(register).toContain("around it.");
+    expect(register).not.toContain(
+      "Just your practice name and work email for now.",
     );
     expect(register).toContain('label="Practice name"');
     expect(register).toContain('label="Work email"');
@@ -87,7 +89,7 @@ describe("demo conversion bridge UI", () => {
     expect(register).toContain("FUNNEL_EVENTS.signupProfileCompleted");
     expect(register).toContain("FUNNEL_EVENTS.signupSubmitted");
     expect(register).toContain("FUNNEL_EVENTS.signupSucceeded");
-    expect(register).toContain(
+    expect(register).not.toContain(
       "No patient or client information belongs here.",
     );
   });

--- a/apps/web/lib/__tests__/onboarding-ui-states.test.ts
+++ b/apps/web/lib/__tests__/onboarding-ui-states.test.ts
@@ -98,12 +98,11 @@ describe("onboarding UI states", () => {
     expect(settingsRouter).toContain("firstGoalSelectedAt");
   });
 
-  it("personalizes new care models without overstating pilot readiness", () => {
-    expect(clinicIntentBuilder).toContain(
+  it("personalizes new care models with a compact review-first plan", () => {
+    expect(clinicIntentBuilder).not.toContain(
       'selectedModel.readiness === "design_partner"',
     );
-    expect(clinicIntentBuilder).toContain("one real workflow");
-    expect(clinicIntentBuilder).toContain("anything that isn’t ready yet");
+    expect(clinicIntentBuilder).not.toContain("HeartPulse className");
     expect(clinicIntentBuilder).toContain("Nothing moves until you review it.");
     expect(choosePath).toContain("FUNNEL_EVENTS.onboardingModelSelected");
     expect(choosePath).toContain("FUNNEL_EVENTS.onboardingGoalSelected");

--- a/apps/web/lib/__tests__/request-only-booking-ui.test.ts
+++ b/apps/web/lib/__tests__/request-only-booking-ui.test.ts
@@ -152,8 +152,14 @@ describe("request-only booking UI", () => {
       "Start with one real appointment, then decide what deserves a larger rollout.",
     );
     expect(allSetStep).toContain("FirstDayRecommendations");
-    expect(firstDayRecommendations).toContain(
+    expect(firstDayRecommendations).not.toContain(
       "Here’s what I think will help first.",
+    );
+    expect(firstDayRecommendations).not.toContain(
+      "Pick one useful win. The rest will still be here when you’re ready.",
+    );
+    expect(firstDayRecommendations).not.toContain(
+      "Nothing here blocks launch.",
     );
     expect(firstDayRecommendations).toContain("Make getting paid easy");
     expect(firstDayRecommendations).toContain("Get paid faster");


### PR DESCRIPTION
## What changed

- Tightens and aligns the four-step registration walkthrough so the primary actions stay in a predictable place.
- Refines the first-day workflow preview and recommendation cards for a simpler, more branded introduction.
- Removes cautionary and redundant copy that added friction without changing product safeguards.
- Updates the onboarding source-contract tests to preserve the approved copy and layout decisions.

## Why

The first trial experience should make OpenVPM feel calm, useful, and purpose-built for a clinic. This change reduces visual and copy friction while preserving the existing account, payment, and workflow safety boundaries.

## Validation

- Open-source release policy: passed (1,308 tracked files)
- Production dependency audit: no known high-severity vulnerabilities
- Type-check: passed across all packages
- Tests: 4,023 passed; 6 expected integration skips
- Next.js optimized production build: passed
- Manual desktop walkthrough: steps 1-3 share aligned frame/footer/action geometry; no horizontal overflow or console errors

## Scope

Seven onboarding UI/test files only. The signup, checkout, and outbound-email security hardening already merged to main in #213 remains unchanged.