### PR TITLE
Harden staff invitation lifecycle

### DIFF
--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -106,6 +106,8 @@ function createDb(opts?: {
   const insertReturning = vi.fn(async () => opts?.insertedRows ?? []);
   const insertValues = vi.fn(() => ({ returning: insertReturning }));
   const insert = vi.fn(() => ({ values: insertValues }));
+  const deleteWhere = vi.fn(async () => undefined);
+  const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
 
   const transaction = vi.fn(async (fn: (tx: unknown) => unknown) => fn(db));
   const execute = vi.fn(async () => undefined);
@@ -115,9 +117,18 @@ function createDb(opts?: {
     select,
     update,
     insert,
+    delete: deleteFrom,
   };
 
-  return { db, transaction, execute, updateSet, insertValues };
+  return {
+    db,
+    transaction,
+    execute,
+    updateSet,
+    insertValues,
+    deleteFrom,
+    deleteWhere,
+  };
 }
 
 beforeEach(() => {
@@ -453,7 +464,42 @@ describe("settings admin stale target safety", () => {
         password: "password123",
         role: "front_desk",
       }),
-    ).rejects.toMatchObject({ code: "CONFLICT" });
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "A user with that email already exists.",
+    });
+
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(mocks.createAuthToken).not.toHaveBeenCalled();
+    expect(mocks.sendStaffInviteEmail).not.toHaveBeenCalled();
+  });
+
+  it("reports a cross-practice verified identity as a stable invite conflict", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [{ name: "Neighborhood Veterinary" }],
+        [
+          {
+            id: STAFF_ID,
+            email: "existing@example.com",
+            practiceId: "00000000-0000-0000-0000-0000000000bb",
+            emailVerifiedAt: new Date("2026-08-16T00:00:00Z"),
+            deletedAt: null,
+          },
+        ],
+        [],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).inviteStaff({
+        email: "existing@example.com",
+        role: "viewer",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "A user with that email already exists.",
+    });
 
     expect(insertValues).not.toHaveBeenCalled();
     expect(syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
@@ -809,6 +855,21 @@ describe("settings admin stale target safety", () => {
     expect(syncPracticeSubscriptionQuantities).not.toHaveBeenCalled();
   });
 
+  it("revokes outstanding auth tokens atomically when staff are deactivated", async () => {
+    const { db, deleteFrom, deleteWhere } = createDb({
+      selectResults: [[{ id: STAFF_ID, role: "viewer" }], [], []],
+      updatedRows: [{ id: STAFF_ID }],
+    });
+
+    await expect(
+      callerWithDb(db).deactivateUser({ id: STAFF_ID }),
+    ).resolves.toEqual({ success: true });
+
+    expect(deleteFrom).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(syncPracticeSubscriptionQuantities).toHaveBeenCalledTimes(1);
+  });
+
   it("does not sync billing after stale staff restore", async () => {
     const { db, updateSet } = createDb({ updatedRows: [] });
 
@@ -1141,6 +1202,8 @@ describe("settings scheduling metadata delete safety", () => {
       "eq(staffSchedules.practiceId, ctx.practiceId)",
     );
     expect(deactivateBlock).toContain("isNull(staffSchedules.deletedAt)");
+    expect(deactivateBlock).toContain("tx.delete(authTokens)");
+    expect(deactivateBlock).toContain("eq(authTokens.userId, input.id)");
   });
 
   it("guards staff role demotions with an admin roster lock", () => {

--- a/apps/web/server/__tests__/settings-staff-sync.test.ts
+++ b/apps/web/server/__tests__/settings-staff-sync.test.ts
@@ -11,9 +11,8 @@ vi.mock("@/lib/billing/subscription-sync", () => ({
 }));
 
 const { settingsRouter } = await import("../routers/settings");
-const { syncPracticeSubscriptionQuantities } = await import(
-  "@/lib/billing/subscription-sync"
-);
+const { syncPracticeSubscriptionQuantities } =
+  await import("@/lib/billing/subscription-sync");
 
 function callerWithDb(db: Record<string, unknown>) {
   const session = {
@@ -103,6 +102,9 @@ describe("settings staff billing sync", () => {
             ]),
           })),
         })),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn(async () => undefined),
       })),
     });
 

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -2345,7 +2345,7 @@ export const settingsRouter = createRouter({
       // serializes first invites and retries across practices, matching the
       // global unique-email boundary and ensuring only the newest token stays
       // active. A token failure rolls back a newly inserted staff seat.
-      const { user, token } = await ctx.db
+      const preparedIdentity = await ctx.db
         .transaction(async (tx) => {
           await tx.execute(
             sql`select pg_advisory_xact_lock(hashtext(${staffInviteLockKey(
@@ -2386,10 +2386,11 @@ export const settingsRouter = createRouter({
               Boolean(priorInvite);
 
             if (!isPendingInviteRetry) {
-              throw new TRPCError({
-                code: "CONFLICT",
-                message: "A user with that email already exists.",
-              });
+              // Returning a typed conflict keeps this expected outcome intact
+              // across database transaction adapters that may wrap thrown
+              // application errors. The caller translates it to a stable
+              // public CONFLICT after the transaction releases its email lock.
+              return { ok: false as const };
             }
             user = { id: existing.id, email: existing.email };
           } else {
@@ -2441,7 +2442,7 @@ export const settingsRouter = createRouter({
             type: "invite",
             db: tx as unknown as Database,
           });
-          return { user, token };
+          return { ok: true as const, user, token };
         })
         .catch((error) => {
           if (error instanceof TRPCError) throw error;
@@ -2452,6 +2453,13 @@ export const settingsRouter = createRouter({
               "The staff invitation could not be prepared. Please retry in a moment.",
           });
         });
+      if (!preparedIdentity.ok) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "A user with that email already exists.",
+        });
+      }
+      const { user, token } = preparedIdentity;
       const inviteUrl = `${appBaseUrl()}/accept-invite?token=${token}`;
 
       // Keep the pending seat synchronized even when delivery is refused. A
@@ -2753,6 +2761,11 @@ export const settingsRouter = createRouter({
             message: "Staff member changed. Refresh and try again.",
           });
         }
+
+        // Deactivation must revoke every outstanding credential in the same
+        // transaction as the user row. Otherwise a pending invite, reset, or
+        // verification link could become usable after a later restoration.
+        await tx.delete(authTokens).where(eq(authTokens.userId, input.id));
       });
       await syncBillingAfterStaffChange(ctx.db, ctx.practiceId);
       return { success: true };


### PR DESCRIPTION
## What changed

- preserves the expected `CONFLICT` response when an invited email already belongs to another account or practice
- revokes outstanding invite, reset, and verification tokens atomically when staff are deactivated
- adds regressions for cross-practice verified identities and deactivation token cleanup

## Why

A real production walkthrough showed that the database transaction adapter could wrap the intentional staff-invite conflict, turning it into a generic preparation error. The same walkthrough also found that deactivating an unaccepted invite left its token behind, creating avoidable credential residue if the account were later restored.

## Impact

Admins now receive the correct actionable duplicate-email message, and deactivated staff cannot retain usable auth links.

## Validation

- `settings-admin-safety.test.ts`: 50/50 passed
- adjacent auth/settings suites: 65/65 passed
- web TypeScript check passed
- Prettier check passed
- `git diff --check` passed