### PR TITLE
Add privacy-safe acquisition outcome reporting

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -134,6 +134,7 @@ export default function AdminPage() {
       utils.admin.overview.invalidate();
       utils.admin.activationFunnel.invalidate();
       utils.admin.activationRecovery.invalidate();
+      utils.admin.journeyFunnel.invalidate();
     },
     onError: (err) => setAnalyticsError(err.message),
   });
@@ -1246,6 +1247,122 @@ export default function AdminPage() {
                   ) : null}
                 </tbody>
               </table>
+            </div>
+
+            <div className="mt-6">
+              <h3 className="font-heading text-base font-semibold">
+                Acquisition outcomes · registrations in the past {journey.days}
+                days
+              </h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Restricted aggregate cohorts use fixed product-owned channel
+                buckets and canonical milestones. Rates use registered practices
+                as the denominator; missing values stay Unknown and unrecognized
+                values become Other without being displayed.
+              </p>
+              <div className="mt-3 overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Source</th>
+                      <th className="px-3 py-2 font-medium">Medium</th>
+                      <th className="px-3 py-2 font-medium">Campaign</th>
+                      <th className="px-3 py-2 font-medium">Registered</th>
+                      <th className="px-3 py-2 font-medium">Activated</th>
+                      <th className="px-3 py-2 font-medium">Payment method</th>
+                      <th className="px-3 py-2 font-medium">
+                        Positive payment
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {journey.acquisitionOutcomes.map((outcome) => (
+                      <tr
+                        key={`${outcome.source}:${outcome.medium}:${outcome.campaign}`}
+                      >
+                        <td className="px-3 py-2 font-medium">
+                          {outcome.source}
+                        </td>
+                        <td className="px-3 py-2">{outcome.medium}</td>
+                        <td className="px-3 py-2">{outcome.campaign}</td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.registrations}
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.activated}{" "}
+                          <span className="text-xs text-muted-foreground">
+                            {formatPct(outcome.activationRate)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.paymentMethodCollected}{" "}
+                          <span className="text-xs text-muted-foreground">
+                            {formatPct(outcome.paymentMethodRate)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.firstPositivePayment}{" "}
+                          <span className="text-xs text-muted-foreground">
+                            {formatPct(outcome.positivePaymentRate)}
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                    {journey.acquisitionOutcomes.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={7}
+                          className="px-3 py-6 text-center text-muted-foreground"
+                        >
+                          No registered acquisition cohorts in this window.
+                        </td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+              {journey.acquisitionOutcomesTruncated ? (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Showing the top {journey.acquisitionOutcomeRowLimit} bucket
+                  combinations in deterministic order. Additional combinations
+                  are omitted from this bounded operator view.
+                </p>
+              ) : null}
+            </div>
+
+            <div className="mt-6">
+              <h3 className="font-heading text-base font-semibold">
+                Period activity · milestone events in the past {journey.days}
+                days
+              </h3>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                {[
+                  ["Registered", journey.periodActivity.registrations],
+                  ["Activated", journey.periodActivity.activated],
+                  [
+                    "Payment method",
+                    journey.periodActivity.paymentMethodCollected,
+                  ],
+                  [
+                    "Positive payment",
+                    journey.periodActivity.firstPositivePayment,
+                  ],
+                ].map(([label, value]) => (
+                  <div
+                    key={String(label)}
+                    className="rounded-md bg-muted/30 p-3"
+                  >
+                    <p className="text-xs text-muted-foreground">{label}</p>
+                    <p className="mt-1 font-heading text-xl font-bold tabular-nums">
+                      {value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                These counts use the exact milestone occurrence time and are not
+                a signup cohort conversion rate.
+              </p>
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
               Anonymous first touch is carried across openvpm.com, demo, and

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -39,6 +39,18 @@ vi.mock("@/lib/admin/activation-funnel", () => ({
 
 vi.mock("@/lib/admin/journey-funnel", () => ({
   computeJourneyFunnel: mocks.computeJourneyFunnel,
+  safeAcquisitionBucket: (
+    dimension: "source" | "medium" | "campaign",
+    value: unknown,
+  ) => {
+    const known = {
+      source: new Set(["demo", "Other", "Unknown"]),
+      medium: new Set(["product", "Other", "Unknown"]),
+      campaign: new Set(["demo_dashboard", "Other", "Unknown"]),
+    }[dimension];
+    if (typeof value !== "string" || value.length === 0) return "Unknown";
+    return known.has(value) ? value : "Other";
+  },
 }));
 
 vi.mock("@/lib/admin/clinic-pilots", () => ({
@@ -128,6 +140,28 @@ function journey(days: number): JourneyFunnel {
   return {
     days,
     weeks: [],
+    acquisitionOutcomes: [
+      {
+        source: "demo<script>",
+        medium: "product",
+        campaign: "demo_dashboard",
+        registrations: 5,
+        activated: 2,
+        paymentMethodCollected: 1,
+        firstPositivePayment: 1,
+        activationRate: 0.4,
+        paymentMethodRate: 0.2,
+        positivePaymentRate: 0.2,
+      },
+    ],
+    acquisitionOutcomeRowLimit: 20,
+    acquisitionOutcomesTruncated: true,
+    periodActivity: {
+      registrations: 6,
+      activated: 3,
+      paymentMethodCollected: 2,
+      firstPositivePayment: 1,
+    },
     totals: {
       visitors: 20,
       demos: 8,
@@ -285,6 +319,20 @@ describe("activation digest cron", () => {
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
+        html: expect.stringContaining(
+          "Acquisition outcomes · registered in this window",
+        ),
+      }),
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining(
+          "Period activity · milestone events in this window:",
+        ),
+      }),
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
         html: expect.stringContaining("Supported clinic cohort"),
       }),
     );
@@ -294,6 +342,10 @@ describe("activation digest cron", () => {
       )[0]?.[0].html ?? "";
     expect(html).not.toContain("North &lt;Clinic&gt;");
     expect(html).not.toContain("North <Clinic>");
+    expect(html).toContain(">Other</td>");
+    expect(html).not.toContain("demo&lt;script&gt;");
+    expect(html).not.toContain("demo<script>");
+    expect(html).toContain("Showing the top 20 bucket combinations");
     expect(html).toContain("aggregate-only");
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({ to: "ops@openvpm.com" }),

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/admin/activation-funnel";
 import {
   computeJourneyFunnel,
+  safeAcquisitionBucket,
   type JourneyFunnel,
 } from "@/lib/admin/journey-funnel";
 import { loadClinicPilotQueue } from "@/lib/admin/clinic-pilots";
@@ -93,6 +94,17 @@ function pct(rate: number): string {
   return `${Math.round(rate * 100)}%`;
 }
 
+function escapeHtml(value: string): string {
+  const replacements: Record<string, string> = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  };
+  return value.replace(/[&<>"']/g, (character) => replacements[character]!);
+}
+
 function funnelSection(title: string, funnel: ActivationFunnel): string {
   const {
     signups,
@@ -157,6 +169,22 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
     paymentMethodRate,
     positivePaymentRate,
   } = funnel.totals;
+  const acquisitionRows = funnel.acquisitionOutcomes
+    .map(
+      (outcome) => `<tr style="font-size:13px;color:#111827;">
+    <td style="padding:5px 12px 5px 0;">${escapeHtml(safeAcquisitionBucket("source", outcome.source))}</td>
+    <td style="padding:5px 12px 5px 0;">${escapeHtml(safeAcquisitionBucket("medium", outcome.medium))}</td>
+    <td style="padding:5px 12px 5px 0;">${escapeHtml(safeAcquisitionBucket("campaign", outcome.campaign))}</td>
+    <td style="padding:5px 12px 5px 0;">${outcome.registrations}</td>
+    <td style="padding:5px 12px 5px 0;">${outcome.activated} <span style="color:#6b7280;">${pct(outcome.activationRate)}</span></td>
+    <td style="padding:5px 12px 5px 0;">${outcome.paymentMethodCollected} <span style="color:#6b7280;">${pct(outcome.paymentMethodRate)}</span></td>
+    <td style="padding:5px 0;">${outcome.firstPositivePayment} <span style="color:#6b7280;">${pct(outcome.positivePaymentRate)}</span></td>
+  </tr>`,
+    )
+    .join("");
+  const acquisitionBody =
+    acquisitionRows ||
+    `<tr><td colspan="7" style="padding:8px 0;color:#6b7280;font-size:13px;">No registered acquisition cohorts in this window.</td></tr>`;
   return `<h2 style="margin:24px 0 8px;font-size:16px;color:#111827;">${title}</h2>
 <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
   <tr style="text-align:left;color:#6b7280;font-size:13px;">
@@ -178,7 +206,24 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
 </table>
 <p style="margin:8px 0 0;color:#374151;font-size:13px;line-height:1.5;"><strong>Signup path:</strong> ${signupProfileViewed} plan start(s) → ${signupProfileCompleted} plan(s) built → ${signupAccountViewed} account form(s) → ${signupSubmitted} submission(s) → ${registrations} registered.</p>
 <p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Left before trying: ${funnel.totals.leftBeforeTrying} · Demo without signup: ${funnel.totals.demoAbandoned} · Signup without activation: ${funnel.totals.registrationAbandoned} · Activated without payment method: ${funnel.totals.activationAbandoned} · Payment method without positive payment after trial: ${funnel.totals.paymentAbandoned} · Client errors: ${funnel.totals.clientErrors}</p>
-<p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>`;
+<p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>
+<h3 style="margin:16px 0 4px;font-size:14px;color:#111827;">Acquisition outcomes · registered in this window</h3>
+<p style="margin:0 0 6px;color:#6b7280;font-size:12px;line-height:1.5;">Restricted aggregate cohorts use fixed product-owned channel buckets and canonical milestones. Rates use registrations as the denominator; missing values stay Unknown and unrecognized values become Other without being displayed.</p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+  <tr style="text-align:left;color:#6b7280;font-size:12px;">
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Source</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Medium</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Campaign</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Registered</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Activated</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Payment method</th>
+    <th style="padding:4px 0;font-weight:500;">Positive payment</th>
+  </tr>
+  ${acquisitionBody}
+</table>
+${funnel.acquisitionOutcomesTruncated ? `<p style="margin:4px 0 0;color:#6b7280;font-size:12px;line-height:1.5;">Showing the top ${funnel.acquisitionOutcomeRowLimit} bucket combinations in deterministic order; additional combinations are omitted.</p>` : ""}
+<p style="margin:10px 0 0;color:#374151;font-size:13px;line-height:1.5;"><strong>Period activity · milestone events in this window:</strong> ${funnel.periodActivity.registrations} registered · ${funnel.periodActivity.activated} activated · ${funnel.periodActivity.paymentMethodCollected} payment method · ${funnel.periodActivity.firstPositivePayment} first positive payment.</p>
+<p style="margin:4px 0 0;color:#6b7280;font-size:12px;line-height:1.5;">Period activity uses exact milestone occurrence time and is not a signup cohort conversion rate.</p>`;
 }
 
 type ClinicPilotQueue = Awaited<ReturnType<typeof loadClinicPilotQueue>>;

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -104,6 +104,32 @@ describe("admin UI", () => {
     expect(compactSource).toContain("active trial with a collected");
   });
 
+  it("separates acquisition cohort outcomes from period activity", () => {
+    expect(source).toContain(
+      "Acquisition outcomes · registrations in the past",
+    );
+    expect(source).toContain("journey.acquisitionOutcomes.map");
+    expect(source).toContain("outcome.source");
+    expect(source).toContain("outcome.medium");
+    expect(source).toContain("outcome.campaign");
+    expect(source).toContain("outcome.registrations");
+    expect(source).toContain("formatPct(outcome.activationRate)");
+    expect(source).toContain("formatPct(outcome.paymentMethodRate)");
+    expect(source).toContain("formatPct(outcome.positivePaymentRate)");
+    expect(source).toContain("fixed product-owned channel");
+    expect(source).toContain("missing values stay Unknown");
+    expect(source).toContain("unrecognized values become Other");
+    expect(source).toContain("journey.acquisitionOutcomesTruncated");
+    expect(source).toContain("journey.acquisitionOutcomeRowLimit");
+    expect(source).toContain("Period activity · milestone events in the past");
+    expect(source).toContain("journey.periodActivity.registrations");
+    expect(source).toContain("journey.periodActivity.activated");
+    expect(source).toContain("journey.periodActivity.paymentMethodCollected");
+    expect(source).toContain("journey.periodActivity.firstPositivePayment");
+    expect(source).toContain("utils.admin.journeyFunnel.invalidate()");
+    expect(compactSource).toContain("not a signup cohort conversion rate");
+  });
+
   it("shows trial source and setup stage for diagnosing individual drop-off", () => {
     expect(source).toContain("{p.acquisitionSource}");
     expect(source).toContain("{p.onboardingIntent}");

--- a/apps/web/lib/__tests__/journey-funnel.test.ts
+++ b/apps/web/lib/__tests__/journey-funnel.test.ts
@@ -22,7 +22,11 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
 
-const { computeJourneyFunnel } = await import("@/lib/admin/journey-funnel");
+const {
+  ACQUISITION_OUTCOME_ROW_LIMIT,
+  computeJourneyFunnel,
+  safeAcquisitionBucket,
+} = await import("@/lib/admin/journey-funnel");
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -54,6 +58,34 @@ describe("computeJourneyFunnel", () => {
       ],
       [{ historicalUnknown: "2", repairableGap: "1" }],
       [{ count: "4" }],
+      [
+        {
+          source: "demo",
+          medium: "product",
+          campaign: "demo_dashboard",
+          registrations: "4",
+          activated: "2",
+          paymentMethodCollected: "1",
+          firstPositivePayment: "1",
+        },
+        {
+          source: "clinic_alice",
+          medium: "",
+          campaign: "private_launch_name",
+          registrations: "1",
+          activated: "0",
+          paymentMethodCollected: "0",
+          firstPositivePayment: "0",
+        },
+      ],
+      [
+        {
+          registrations: "7",
+          activated: "3",
+          paymentMethodCollected: "2",
+          firstPositivePayment: "1",
+        },
+      ],
     );
 
     const result = await computeJourneyFunnel(mocks.db as never, 30);
@@ -73,6 +105,42 @@ describe("computeJourneyFunnel", () => {
         firstPositivePayment: 1,
       },
     ]);
+    expect(result.acquisitionOutcomes).toEqual([
+      {
+        source: "demo",
+        medium: "product",
+        campaign: "demo_dashboard",
+        registrations: 4,
+        activated: 2,
+        paymentMethodCollected: 1,
+        firstPositivePayment: 1,
+        activationRate: 0.5,
+        paymentMethodRate: 0.25,
+        positivePaymentRate: 0.25,
+      },
+      {
+        source: "Other",
+        medium: "Unknown",
+        campaign: "Other",
+        registrations: 1,
+        activated: 0,
+        paymentMethodCollected: 0,
+        firstPositivePayment: 0,
+        activationRate: 0,
+        paymentMethodRate: 0,
+        positivePaymentRate: 0,
+      },
+    ]);
+    expect(result.acquisitionOutcomeRowLimit).toBe(
+      ACQUISITION_OUTCOME_ROW_LIMIT,
+    );
+    expect(result.acquisitionOutcomesTruncated).toBe(false);
+    expect(result.periodActivity).toEqual({
+      registrations: 7,
+      activated: 3,
+      paymentMethodCollected: 2,
+      firstPositivePayment: 1,
+    });
     expect(result.totals).toMatchObject({
       visitors: 20,
       demos: 8,
@@ -104,7 +172,7 @@ describe("computeJourneyFunnel", () => {
       paymentMethodRate: 0.2,
       positivePaymentRate: 1,
     });
-    expect(mocks.execute).toHaveBeenCalledTimes(3);
+    expect(mocks.execute).toHaveBeenCalledTimes(5);
     const errorSql = new PgDialect().sqlToQuery(
       mocks.execute.mock.calls[2]![0] as SQL,
     ).sql;
@@ -115,8 +183,19 @@ describe("computeJourneyFunnel", () => {
   });
 
   it("returns safe zero rates when no journey has started", async () => {
-    mocks.executeResults.push([], [], []);
+    mocks.executeResults.push([], [], [], [], []);
     const result = await computeJourneyFunnel(mocks.db as never, 7);
+    expect(result.acquisitionOutcomes).toEqual([]);
+    expect(result.acquisitionOutcomeRowLimit).toBe(
+      ACQUISITION_OUTCOME_ROW_LIMIT,
+    );
+    expect(result.acquisitionOutcomesTruncated).toBe(false);
+    expect(result.periodActivity).toEqual({
+      registrations: 0,
+      activated: 0,
+      paymentMethodCollected: 0,
+      firstPositivePayment: 0,
+    });
     expect(result.totals).toMatchObject({
       visitors: 0,
       demos: 0,
@@ -188,5 +267,83 @@ describe("computeJourneyFunnel", () => {
     expect(errorQuery).toMatch(
       /select count\(\*\)::int as count\s+from funnel_events\s+where event_name = 'client_error'/,
     );
+  });
+
+  it("keeps acquisition cohorts aggregate, allowlisted, and canonical", async () => {
+    mocks.executeResults.push([], [], [], [], []);
+
+    await computeJourneyFunnel(mocks.db as never, 30);
+
+    const acquisitionSql = new PgDialect().sqlToQuery(
+      mocks.execute.mock.calls[3]![0] as SQL,
+    ).sql;
+    const periodSql = new PgDialect().sqlToQuery(
+      mocks.execute.mock.calls[4]![0] as SQL,
+    ).sql;
+
+    expect(acquisitionSql).toContain(
+      "from practice_conversion_milestones registered",
+    );
+    expect(acquisitionSql).toContain("registered.milestone = 'registered'");
+    expect(acquisitionSql).toContain(
+      "p.settings ->> 'analyticsExcluded' is distinct from 'true'",
+    );
+    expect(acquisitionSql).toContain("then 'Unknown'");
+    expect(acquisitionSql).toContain("else 'Other'");
+    expect(acquisitionSql).toContain("^[a-z0-9._:/-]{1,80}$");
+    expect(acquisitionSql).toContain("then 'homepage'");
+    expect(acquisitionSql).toContain("then 'solution'");
+    expect(acquisitionSql).toContain("then 'demo'");
+    expect(acquisitionSql).toContain("activated.milestone = 'activated'");
+    expect(acquisitionSql).toContain(
+      "payment_method.milestone = 'payment_method_collected'",
+    );
+    expect(acquisitionSql).toContain(
+      "positive_payment.milestone = 'first_positive_payment'",
+    );
+    expect(acquisitionSql).toContain(
+      "order by registrations desc, source, medium, campaign",
+    );
+    expect(acquisitionSql).toContain("limit $2");
+    expect(periodSql).toContain("where pcm.occurred_at >= $1::timestamptz");
+    expect(periodSql).not.toMatch(
+      /amount_cents|currency|email|patient|client/i,
+    );
+  });
+
+  it("never returns arbitrary acquisition tokens and caps row cardinality", async () => {
+    expect(safeAcquisitionBucket("source", "demo")).toBe("demo");
+    expect(safeAcquisitionBucket("source", "clinic_alice")).toBe("Other");
+    expect(safeAcquisitionBucket("source", "")).toBe("Unknown");
+
+    const rows = Array.from(
+      { length: ACQUISITION_OUTCOME_ROW_LIMIT + 1 },
+      (_, index) => ({
+        source: index === 0 ? "demo" : `private_clinic_${index}`,
+        medium: "product",
+        campaign: "demo_dashboard",
+        registrations: "1",
+        activated: "0",
+        paymentMethodCollected: "0",
+        firstPositivePayment: "0",
+      }),
+    );
+    mocks.executeResults.push([], [], [], rows, []);
+
+    const result = await computeJourneyFunnel(mocks.db as never, 30);
+
+    expect(result.acquisitionOutcomes).toHaveLength(
+      ACQUISITION_OUTCOME_ROW_LIMIT,
+    );
+    expect(result.acquisitionOutcomesTruncated).toBe(true);
+    expect(result.acquisitionOutcomes[0]?.source).toBe("demo");
+    expect(
+      result.acquisitionOutcomes
+        .slice(1)
+        .every((row) => row.source === "Other"),
+    ).toBe(true);
+    expect(
+      result.acquisitionOutcomes.some((row) => row.source.includes("clinic")),
+    ).toBe(false);
   });
 });

--- a/apps/web/lib/admin/journey-funnel.ts
+++ b/apps/web/lib/admin/journey-funnel.ts
@@ -5,6 +5,70 @@ import { funnelRate } from "@/lib/admin/activation-funnel";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 export const ABANDONMENT_GRACE_DAYS = 7;
+export const ACQUISITION_OUTCOME_ROW_LIMIT = 20;
+
+const ACQUISITION_BUCKETS = {
+  source: new Set<string>([
+    "homepage",
+    "navigation",
+    "cloud",
+    "feature",
+    "solution",
+    "role",
+    "comparison",
+    "content",
+    "install",
+    "second_pims",
+    "why",
+    "demo",
+    "clinic_fit",
+    "marketing",
+    "direct",
+    "Other",
+    "Unknown",
+  ]),
+  medium: new Set<string>([
+    "product",
+    "organic",
+    "cpc",
+    "paid_social",
+    "email",
+    "referral",
+    "direct",
+    "Other",
+    "Unknown",
+  ]),
+  campaign: new Set<string>([
+    "demo_login",
+    "demo_dashboard",
+    "demo_ask_ai",
+    "demo_day_board",
+    "demo_whiteboard",
+    "demo_client_portal",
+    "demo_patients",
+    "demo_clients",
+    "demo_records",
+    "demo_billing",
+    "demo_inbox",
+    "demo_inventory",
+    "demo_reports",
+    "demo_settings",
+    "demo_other",
+    "demo_cta",
+    "launch",
+    "direct",
+    "Other",
+    "Unknown",
+  ]),
+} as const;
+
+export function safeAcquisitionBucket(
+  dimension: keyof typeof ACQUISITION_BUCKETS,
+  value: unknown,
+): string {
+  if (typeof value !== "string" || value.length === 0) return "Unknown";
+  return ACQUISITION_BUCKETS[dimension].has(value) ? value : "Other";
+}
 
 export interface JourneyFunnelWeek {
   weekStart: string;
@@ -52,9 +116,33 @@ export interface JourneyFunnelTotals {
   positivePaymentRate: number;
 }
 
+export interface AcquisitionOutcome {
+  source: string;
+  medium: string;
+  campaign: string;
+  registrations: number;
+  activated: number;
+  paymentMethodCollected: number;
+  firstPositivePayment: number;
+  activationRate: number;
+  paymentMethodRate: number;
+  positivePaymentRate: number;
+}
+
+export interface JourneyFunnelPeriodActivity {
+  registrations: number;
+  activated: number;
+  paymentMethodCollected: number;
+  firstPositivePayment: number;
+}
+
 export interface JourneyFunnel {
   days: number;
   weeks: JourneyFunnelWeek[];
+  acquisitionOutcomes: AcquisitionOutcome[];
+  acquisitionOutcomeRowLimit: number;
+  acquisitionOutcomesTruncated: boolean;
+  periodActivity: JourneyFunnelPeriodActivity;
   totals: JourneyFunnelTotals;
 }
 
@@ -77,6 +165,23 @@ interface JourneyRow {
   paymentAbandoned: number | string;
 }
 
+interface AcquisitionOutcomeRow {
+  source: string;
+  medium: string;
+  campaign: string;
+  registrations: number | string;
+  activated: number | string;
+  paymentMethodCollected: number | string;
+  firstPositivePayment: number | string;
+}
+
+interface PeriodActivityRow {
+  registrations: number | string;
+  activated: number | string;
+  paymentMethodCollected: number | string;
+  firstPositivePayment: number | string;
+}
+
 function rowsFromExecute<T>(result: unknown): T[] {
   if (Array.isArray(result)) return result as T[];
   const rows = (result as { rows?: unknown[] } | null)?.rows;
@@ -93,10 +198,14 @@ export async function computeJourneyFunnel(
     now.getTime() - ABANDONMENT_GRACE_DAYS * DAY_MS,
   ).toISOString();
 
-  const { weeklyResult, unattributedResult, errorsResult } = await withSystem(
-    db,
-    async (tx) => {
-      const weeklyResult = await tx.execute(sql`
+  const {
+    weeklyResult,
+    unattributedResult,
+    errorsResult,
+    acquisitionResult,
+    periodActivityResult,
+  } = await withSystem(db, async (tx) => {
+    const weeklyResult = await tx.execute(sql`
       with first_touch_all_time as (
         select
           fe.anonymous_id,
@@ -262,7 +371,7 @@ export async function computeJourneyFunnel(
       order by s.week_start
     `);
 
-      const unattributedResult = await tx.execute(sql`
+    const unattributedResult = await tx.execute(sql`
       select
         count(*) filter (
           where not (
@@ -291,16 +400,186 @@ export async function computeJourneyFunnel(
         and p.deleted_at is null
         and p.settings ->> 'analyticsExcluded' is distinct from 'true'
     `);
-      const errorsResult = await tx.execute(sql`
+    const errorsResult = await tx.execute(sql`
       select count(*)::int as count
       from funnel_events
       where event_name = 'client_error'
         and deleted_at is null
         and created_at >= ${windowStart}::timestamptz
     `);
-      return { weeklyResult, unattributedResult, errorsResult };
-    },
-  );
+
+    // Signup-cohort outcomes use only canonical business milestones. The
+    // allowlist keeps legacy or malformed acquisition values out of operator
+    // surfaces and gives every missing dimension an explicit Unknown bucket.
+    const acquisitionResult = await tx.execute(sql`
+      with raw_signup_cohort as (
+        select
+          p.id as practice_id,
+          lower(btrim(coalesce(
+            p.settings -> 'acquisition' ->> 'source', ''
+          ))) as raw_source,
+          lower(btrim(coalesce(
+            p.settings -> 'acquisition' ->> 'medium', ''
+          ))) as raw_medium,
+          lower(btrim(coalesce(
+            p.settings -> 'acquisition' ->> 'campaign', ''
+          ))) as raw_campaign
+        from practice_conversion_milestones registered
+        join practices p on p.id = registered.practice_id
+        where registered.milestone = 'registered'
+          and registered.occurred_at >= ${windowStart}::timestamptz
+          and p.deleted_at is null
+          and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+      ), signup_cohort as (
+        select
+          practice_id,
+          case
+            when raw_source = ''
+              or raw_source !~ '^[a-z0-9._:/-]{1,80}$'
+              then 'Unknown'
+            when raw_source in (
+              'homepage_hero', 'homepage_start_small',
+              'homepage_pricing', 'homepage_closing', 'homepage_demo'
+            ) then 'homepage'
+            when raw_source in (
+              'nav', 'mobile_nav', 'resources_nav', 'footer'
+            ) then 'navigation'
+            when raw_source ~ '^cloud_(hero|founding_offer|closing)(_fit)?$'
+              then 'cloud'
+            when raw_source ~ '^feature_(schedule|records|billing|patients|communications|inventory|whiteboard|compliance|reports)_(hero|fit|hosting|hosting_fit|closing)$'
+              then 'feature'
+            when raw_source ~ '^solution_(general-practice|specialty-referral|emergency-critical-care|equine|mobile-house-call|multi-location|shelter-nonprofit|exotics-avian)_(hero|hosting|hosting_fit|closing)$'
+              or raw_source in (
+                'solutions_index_hosting', 'solutions_index_hosting_fit',
+                'solutions_index_closing'
+              )
+              then 'solution'
+            when raw_source ~ '^role_(practice-owners|practice-managers|veterinarians|veterinary-technicians|front-desk)_(hero|fit|hosting|hosting_fit|closing)$'
+              then 'role'
+            when raw_source ~ '^(compare|comparison)_openvpm-vs-(cornerstone|avimark|ezyvet|shepherd|provet-cloud|digitail|vetspire|idexx-neo|daysmart-vet|hippo-manager|navetor|impromed|openvpms)_(hero|fit|hosting|hosting_fit|closing)$'
+              or raw_source in (
+                'compare_index_hosting', 'compare_index_hosting_fit'
+              )
+              then 'comparison'
+            when raw_source = 'blog'
+              or raw_source ~ '^glossary_(pims|soap-notes|emr-vs-pims|controlled-substance-log|audit-trail|open-api|rest-api|webhook|vendor-lock-in|data-portability|open-source-veterinary-software|agplv3|self-hosting|managed-hosting|cloud-vs-on-premise|two-way-texting|appointment-reminder)_closing$'
+              then 'content'
+            when raw_source in ('install_demo', 'install_cloud')
+              then 'install'
+            when raw_source in (
+              'second_pims_hosting', 'second_pims_hosting_fit',
+              'second_pims_closing'
+            ) then 'second_pims'
+            when raw_source = 'why_closing' then 'why'
+            when raw_source = 'demo' then 'demo'
+            when raw_source = 'clinic_fit' then 'clinic_fit'
+            when raw_source = 'marketing' then 'marketing'
+            when raw_source = 'direct' then 'direct'
+            else 'Other'
+          end as source,
+          case
+            when raw_medium = ''
+              or raw_medium !~ '^[a-z0-9._:/-]{1,80}$'
+              then 'Unknown'
+            when raw_medium = 'product' then 'product'
+            when raw_medium = 'organic' then 'organic'
+            when raw_medium = 'cpc' then 'cpc'
+            when raw_medium in ('paid/social', 'paid_social')
+              then 'paid_social'
+            when raw_medium = 'email' then 'email'
+            when raw_medium = 'referral' then 'referral'
+            when raw_medium = 'direct' then 'direct'
+            else 'Other'
+          end as medium,
+          case
+            when raw_campaign = ''
+              or raw_campaign !~ '^[a-z0-9._:/-]{1,80}$'
+              then 'Unknown'
+            when raw_campaign in (
+              'demo_login', 'demo_dashboard', 'demo_ask_ai',
+              'demo_day_board', 'demo_whiteboard', 'demo_client_portal',
+              'demo_patients', 'demo_clients', 'demo_records',
+              'demo_billing', 'demo_inbox', 'demo_inventory',
+              'demo_reports', 'demo_settings', 'demo_other', 'demo_cta'
+            ) then raw_campaign
+            when raw_campaign in ('launch', 'clinic_launch-2026')
+              then 'launch'
+            when raw_campaign = 'direct' then 'direct'
+            else 'Other'
+          end as campaign
+        from raw_signup_cohort
+      ), outcomes as (
+        select
+          cohort.*,
+          exists (
+            select 1
+            from practice_conversion_milestones activated
+            where activated.practice_id = cohort.practice_id
+              and activated.milestone = 'activated'
+          ) as activated,
+          exists (
+            select 1
+            from practice_conversion_milestones payment_method
+            where payment_method.practice_id = cohort.practice_id
+              and payment_method.milestone = 'payment_method_collected'
+          ) as payment_method_collected,
+          exists (
+            select 1
+            from practice_conversion_milestones positive_payment
+            where positive_payment.practice_id = cohort.practice_id
+              and positive_payment.milestone = 'first_positive_payment'
+          ) as first_positive_payment
+        from signup_cohort cohort
+      )
+      select
+        source,
+        medium,
+        campaign,
+        count(*)::int as registrations,
+        count(*) filter (where activated)::int as activated,
+        count(*) filter (
+          where payment_method_collected
+        )::int as "paymentMethodCollected",
+        count(*) filter (
+          where first_positive_payment
+        )::int as "firstPositivePayment"
+      from outcomes
+      group by source, medium, campaign
+      order by registrations desc, source, medium, campaign
+      limit ${ACQUISITION_OUTCOME_ROW_LIMIT + 1}
+    `);
+
+    // Period activity is intentionally separate from signup-cohort outcomes:
+    // it counts exact business-event timestamps in the requested window.
+    const periodActivityResult = await tx.execute(sql`
+      select
+        count(distinct pcm.practice_id) filter (
+          where pcm.milestone = 'registered'
+        )::int as registrations,
+        count(distinct pcm.practice_id) filter (
+          where pcm.milestone = 'activated'
+        )::int as activated,
+        count(distinct pcm.practice_id) filter (
+          where pcm.milestone = 'payment_method_collected'
+        )::int as "paymentMethodCollected",
+        count(distinct pcm.practice_id) filter (
+          where pcm.milestone = 'first_positive_payment'
+        )::int as "firstPositivePayment"
+      from practice_conversion_milestones pcm
+      join practices p on p.id = pcm.practice_id
+      where pcm.occurred_at >= ${windowStart}::timestamptz
+        and p.deleted_at is null
+        and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+    `);
+
+    return {
+      weeklyResult,
+      unattributedResult,
+      errorsResult,
+      acquisitionResult,
+      periodActivityResult,
+    };
+  });
 
   const rawWeeks = rowsFromExecute<JourneyRow>(weeklyResult);
   const weeks = rawWeeks.map((row) => ({
@@ -338,10 +617,44 @@ export async function computeJourneyFunnel(
   const repairableAttributionGaps =
     Number(unattributedRows[0]?.repairableGap) || 0;
   const errorRows = rowsFromExecute<{ count: number | string }>(errorsResult);
+  const rawAcquisitionOutcomes =
+    rowsFromExecute<AcquisitionOutcomeRow>(acquisitionResult);
+  const acquisitionOutcomesTruncated =
+    rawAcquisitionOutcomes.length > ACQUISITION_OUTCOME_ROW_LIMIT;
+  const acquisitionOutcomes = rawAcquisitionOutcomes
+    .slice(0, ACQUISITION_OUTCOME_ROW_LIMIT)
+    .map((row) => {
+      const registrations = Number(row.registrations) || 0;
+      const activated = Number(row.activated) || 0;
+      const paymentMethodCollected = Number(row.paymentMethodCollected) || 0;
+      const firstPositivePayment = Number(row.firstPositivePayment) || 0;
+      return {
+        source: safeAcquisitionBucket("source", row.source),
+        medium: safeAcquisitionBucket("medium", row.medium),
+        campaign: safeAcquisitionBucket("campaign", row.campaign),
+        registrations,
+        activated,
+        paymentMethodCollected,
+        firstPositivePayment,
+        activationRate: funnelRate(activated, registrations),
+        paymentMethodRate: funnelRate(paymentMethodCollected, registrations),
+        positivePaymentRate: funnelRate(firstPositivePayment, registrations),
+      };
+    });
+  const periodRow = rowsFromExecute<PeriodActivityRow>(periodActivityResult)[0];
 
   return {
     days,
     weeks,
+    acquisitionOutcomes,
+    acquisitionOutcomeRowLimit: ACQUISITION_OUTCOME_ROW_LIMIT,
+    acquisitionOutcomesTruncated,
+    periodActivity: {
+      registrations: Number(periodRow?.registrations) || 0,
+      activated: Number(periodRow?.activated) || 0,
+      paymentMethodCollected: Number(periodRow?.paymentMethodCollected) || 0,
+      firstPositivePayment: Number(periodRow?.firstPositivePayment) || 0,
+    },
     totals: {
       visitors,
       demos,

--- a/docs/conversion-observability.md
+++ b/docs/conversion-observability.md
@@ -57,6 +57,23 @@ The platform admin funnel and weekly activation digest expose:
 - mapped Stripe evidence not yet projected; and
 - signed Stripe evidence that could not be mapped to an active practice.
 
+The restricted acquisition-outcomes table groups practices registered in the
+reporting window into fixed, product-owned `source`, `medium`, and `campaign`
+buckets. Empty or malformed dimensions are labeled `Unknown`. Syntactically
+valid values outside the fixed vocabulary are labeled `Other` and are never
+echoed into the admin UI or email. The query fetches at most 21 deterministic
+rows and the application exposes at most the top 20, with an explicit
+truncation marker. The table never includes clinic identity, contact data,
+payment amounts, or clinical data. Activation, payment-method, and
+positive-payment rates all use that registration cohort as their denominator.
+A separately labeled period-activity summary counts exact milestone occurrence
+timestamps in the window, so cohort outcomes and recent event volume cannot be
+mistaken for each other.
+
+GA4/GTM remains a marketing acquisition and site-behavior layer. It is not the
+source of truth for registration, activation, card collection, payment, or
+revenue, and canonical milestone evidence is never exported to it.
+
 Journey cohorts are anchored to each anonymous visitor's all-time first-party
 touch, then filtered to the reporting window. Returning visitors are not
 re-cohorted. Abandonment ages from the exact stage event: first touch before a


### PR DESCRIPTION
## Summary
- add platform-admin acquisition outcome cohorts grouped by fixed product-owned source, medium, and campaign buckets
- keep canonical registration, activation, payment-method, and positive-payment milestones as lifecycle/financial truth
- separate signup-cohort conversion from period milestone activity
- include the bounded aggregate view in the weekly activation digest
- document GA4/GTM as acquisition/site behavior only, with no lifecycle or payment evidence export

## Privacy and safety
- no clinic/user identity, patient/client/clinical data, Stripe identifiers, payment amounts, or secrets
- public attribution values are never echoed raw: missing/malformed values become `Unknown`; unrecognized values become `Other`
- digest/operator output is capped at 20 deterministic bucket combinations
- deleted and analytics-excluded practices are excluded
- no schema change and no production mutation

## Validation
- focused Vitest: 3 files / 23 tests passed
- apps/web TypeScript passed
- git diff --check passed
- exact aggregate SQL exercised read-only against production