### PR TITLE
Restore private hosted object storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,11 @@ OPENPIMS_APP_DB_PASSWORD=
 NEXTAUTH_SECRET="generate-a-secret-with-openssl-rand-base64-32"
 NEXTAUTH_URL="http://localhost:3000"
 
-# S3-compatible storage (MinIO for local dev)
+# Primary private object storage. Local development defaults to MinIO/S3.
+# Hosted deployments may instead set FILE_STORAGE_PROVIDER=vercel_blob and a
+# dedicated private BLOB_READ_WRITE_TOKEN; never reuse the replica store token.
+FILE_STORAGE_PROVIDER=s3
+BLOB_READ_WRITE_TOKEN=
 S3_ENDPOINT="http://localhost:9000"
 S3_ACCESS_KEY="openpims"
 S3_SECRET_KEY="openpims123"
@@ -24,6 +28,8 @@ FILE_REPLICA_REQUIRED=false
 FILE_REPLICA_ENABLED=false
 FILE_REPLICA_ALL_PRACTICES=false
 FILE_REPLICA_PRACTICE_IDS=
+FILE_REPLICA_PROVIDER=s3
+FILE_REPLICA_BLOB_READ_WRITE_TOKEN=
 FILE_REPLICA_S3_ENDPOINT=
 FILE_REPLICA_S3_ACCESS_KEY=
 FILE_REPLICA_S3_SECRET_KEY=

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -1013,6 +1013,29 @@ describe("health route", () => {
     expect(body).not.toContain("clinic-private-bucket");
   });
 
+  it("accepts a private Blob primary without requiring S3 credentials", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    vi.stubEnv("FILE_STORAGE_PROVIDER", "vercel_blob");
+    vi.stubEnv("BLOB_READ_WRITE_TOKEN", "vercel_blob_rw_test");
+    vi.stubEnv("S3_ENDPOINT", "");
+    vi.stubEnv("S3_ACCESS_KEY", "");
+    vi.stubEnv("S3_SECRET_KEY", "");
+    vi.stubEnv("S3_BUCKET", "");
+    vi.stubEnv("S3_REGION", "");
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.checkObjectStorageHealth).toHaveBeenCalledTimes(1);
+    expect(json.checks.hostedStorage).toEqual({
+      ok: true,
+      detail: "Object storage bucket reachable",
+    });
+    expect(JSON.stringify(json)).not.toContain("vercel_blob_rw_test");
+  });
+
   it("keeps an intentionally absent file replica advisory", async () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -82,6 +82,17 @@ const HOSTED_STORAGE_ENV_NAMES = [
   "S3_REGION",
 ];
 
+function hostedStorageEnvCheck(): { ok: boolean; detail: string } {
+  if (envValue("FILE_STORAGE_PROVIDER") === "vercel_blob") {
+    return hostedEnvCheck(
+      ["BLOB_READ_WRITE_TOKEN"],
+      "Hosted private Blob storage env present",
+    );
+  }
+
+  return hostedEnvCheck(HOSTED_STORAGE_ENV_NAMES, "Hosted storage envs present");
+}
+
 const HOSTED_EMAIL_ENV_NAMES = [
   "RESEND_API_KEY",
   "RESEND_WEBHOOK_SECRET",
@@ -528,10 +539,7 @@ export async function GET() {
       "Hosted billing envs present",
     );
     checks.hostedSubscriptionTax = hostedSubscriptionTaxCheck();
-    const hostedStorageEnv = hostedEnvCheck(
-      HOSTED_STORAGE_ENV_NAMES,
-      "Hosted storage envs present",
-    );
+    const hostedStorageEnv = hostedStorageEnvCheck();
     checks.hostedStorage = hostedStorageEnv.ok
       ? await checkObjectStorageHealth()
       : hostedStorageEnv;

--- a/apps/web/lib/__tests__/s3.test.ts
+++ b/apps/web/lib/__tests__/s3.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const send = vi.fn();
+  const blobPut = vi.fn();
+  const blobGet = vi.fn();
+  const blobDel = vi.fn();
+  const blobList = vi.fn();
 
   return {
     send,
@@ -11,6 +15,11 @@ const mocks = vi.hoisted(() => {
     DeleteObjectCommand: vi.fn((input: unknown) => ({ input })),
     HeadBucketCommand: vi.fn((input: unknown) => ({ input })),
     getSignedUrl: vi.fn(),
+    blobPut,
+    blobGet,
+    blobDel,
+    blobList,
+    BlobNotFoundError: class BlobNotFoundError extends Error {},
   };
 });
 
@@ -24,6 +33,14 @@ vi.mock("@aws-sdk/client-s3", () => ({
 
 vi.mock("@aws-sdk/s3-request-presigner", () => ({
   getSignedUrl: mocks.getSignedUrl,
+}));
+
+vi.mock("@vercel/blob", () => ({
+  BlobNotFoundError: mocks.BlobNotFoundError,
+  put: mocks.blobPut,
+  get: mocks.blobGet,
+  del: mocks.blobDel,
+  list: mocks.blobList,
 }));
 
 const {
@@ -41,6 +58,8 @@ const {
   replicaStorageRolloutEnabled,
   uploadFile,
   uploadManagedFile,
+  uploadReplicaFile,
+  readReplicaObject,
 } = await import("../s3");
 
 afterEach(() => {
@@ -279,6 +298,182 @@ describe("S3 object reads", () => {
   });
 });
 
+describe("private Blob storage", () => {
+  it("writes, reads, deletes, and health-checks the primary private store", async () => {
+    vi.stubEnv("FILE_STORAGE_PROVIDER", "vercel_blob");
+    vi.stubEnv("BLOB_READ_WRITE_TOKEN", "primary-blob-token");
+    const body = new Uint8Array([1, 2, 3]);
+    mocks.blobPut.mockResolvedValueOnce({
+      url: "https://primary.private.blob.vercel-storage.com/attachments/file",
+      etag: "primary-etag-1",
+    });
+    mocks.blobGet.mockResolvedValueOnce({
+      statusCode: 200,
+      stream: new Response(body).body,
+      blob: {
+        size: body.byteLength,
+        contentType: "application/pdf",
+        etag: "primary-etag-1",
+      },
+    });
+    mocks.blobDel.mockResolvedValueOnce(undefined);
+    mocks.blobList.mockResolvedValueOnce({ blobs: [], hasMore: false });
+
+    await expect(
+      uploadManagedFile(
+        "attachments/file",
+        Buffer.from(body),
+        "application/pdf",
+        "a".repeat(64),
+      ),
+    ).resolves.toEqual({
+      url: "https://primary.private.blob.vercel-storage.com/attachments/file",
+      etag: "primary-etag-1",
+      versionId: "primary-etag-1",
+    });
+    expect(mocks.blobPut).toHaveBeenCalledWith(
+      "attachments/file",
+      Buffer.from(body),
+      expect.objectContaining({
+        access: "private",
+        token: "primary-blob-token",
+        addRandomSuffix: false,
+        allowOverwrite: false,
+        maximumSizeInBytes: body.byteLength,
+      }),
+    );
+
+    await expect(
+      readPrimaryObject("attachments/file", {
+        maxBytes: 10,
+        versionId: "primary-etag-1",
+      }),
+    ).resolves.toMatchObject({
+      status: "available",
+      body,
+      contentType: "application/pdf",
+      etag: "primary-etag-1",
+      versionId: "primary-etag-1",
+    });
+    expect(mocks.blobGet).toHaveBeenCalledWith(
+      "attachments/file",
+      expect.objectContaining({
+        access: "private",
+        token: "primary-blob-token",
+        useCache: false,
+      }),
+    );
+
+    await expect(deleteFile("attachments/file")).resolves.toBeUndefined();
+    expect(mocks.blobDel).toHaveBeenCalledWith(
+      "attachments/file",
+      expect.objectContaining({
+        token: "primary-blob-token",
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+
+    await expect(checkObjectStorageHealth()).resolves.toEqual({
+      ok: true,
+      detail: "Object storage bucket reachable",
+    });
+    expect(mocks.blobList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "primary-blob-token",
+        limit: 1,
+      }),
+    );
+  });
+
+  it("stores an immutable replica and uses the ETag as exact version evidence", async () => {
+    vi.stubEnv("FILE_REPLICA_PROVIDER", "vercel_blob");
+    vi.stubEnv("FILE_REPLICA_BLOB_READ_WRITE_TOKEN", "replica-blob-token");
+    mocks.blobPut.mockResolvedValueOnce({
+      url: "https://store.private.blob.vercel-storage.com/attachments/file",
+      etag: "blob-etag-1",
+    });
+
+    await expect(
+      uploadReplicaFile(
+        "attachments/file",
+        Buffer.from("clinic-file"),
+        "application/pdf",
+        "a".repeat(64),
+      ),
+    ).resolves.toEqual({
+      url: "https://store.private.blob.vercel-storage.com/attachments/file",
+      etag: "blob-etag-1",
+      versionId: "blob-etag-1",
+    });
+    expect(mocks.blobPut).toHaveBeenCalledWith(
+      "attachments/file",
+      Buffer.from("clinic-file"),
+      expect.objectContaining({
+        access: "private",
+        token: "replica-blob-token",
+        addRandomSuffix: false,
+        allowOverwrite: false,
+        maximumSizeInBytes: 11,
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("reads private Blob objects from origin and verifies the requested ETag", async () => {
+    vi.stubEnv("FILE_REPLICA_PROVIDER", "vercel_blob");
+    vi.stubEnv("FILE_REPLICA_BLOB_READ_WRITE_TOKEN", "replica-blob-token");
+    const body = new Uint8Array([1, 2, 3]);
+    mocks.blobGet.mockResolvedValueOnce({
+      statusCode: 200,
+      stream: new Response(body).body,
+      blob: {
+        size: body.byteLength,
+        contentType: "application/pdf",
+        etag: "blob-etag-1",
+      },
+    });
+
+    await expect(
+      readReplicaObject("attachments/file", {
+        maxBytes: 10,
+        versionId: "blob-etag-1",
+      }),
+    ).resolves.toMatchObject({
+      status: "available",
+      body,
+      contentType: "application/pdf",
+      etag: "blob-etag-1",
+      versionId: "blob-etag-1",
+    });
+    expect(mocks.blobGet).toHaveBeenCalledWith(
+      "attachments/file",
+      expect.objectContaining({
+        access: "private",
+        token: "replica-blob-token",
+        useCache: false,
+      }),
+    );
+  });
+
+  it("requires a distinct configured private Blob store for replica rollout", () => {
+    vi.stubEnv("FILE_STORAGE_PROVIDER", "vercel_blob");
+    vi.stubEnv("BLOB_READ_WRITE_TOKEN", "same-store-token");
+    vi.stubEnv("FILE_REPLICA_PROVIDER", "vercel_blob");
+    vi.stubEnv("FILE_REPLICA_BLOB_READ_WRITE_TOKEN", "same-store-token");
+    expect(replicaStorageReadiness()).toEqual({
+      intended: true,
+      ready: false,
+      detail: "Replica storage must use a different storage target",
+    });
+
+    vi.stubEnv("FILE_REPLICA_BLOB_READ_WRITE_TOKEN", "independent-token");
+    expect(replicaStorageReadiness()).toMatchObject({
+      intended: true,
+      ready: true,
+    });
+  });
+});
+
 describe("S3 health checks", () => {
   it("requires an explicit all-practice flag or valid UUID cohort before rollout", () => {
     vi.stubEnv("S3_ENDPOINT", "https://primary.example");
@@ -345,7 +540,7 @@ describe("S3 health checks", () => {
     expect(replicaStorageReadiness()).toEqual({
       intended: true,
       ready: false,
-      detail: "Replica storage must use a different endpoint or bucket",
+      detail: "Replica storage must use a different storage target",
     });
   });
 

--- a/apps/web/lib/s3.ts
+++ b/apps/web/lib/s3.ts
@@ -6,6 +6,14 @@ import {
   HeadBucketCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl as awsGetSignedUrl } from "@aws-sdk/s3-request-presigner";
+import {
+  BlobNotFoundError,
+  del as deleteBlob,
+  get as getBlob,
+  list as listBlobs,
+  put as putBlob,
+} from "@vercel/blob";
+import { createHash } from "node:crypto";
 
 export const FILE_REPLICA_TARGET = "independent-v1";
 
@@ -13,20 +21,30 @@ const REPLICA_ENV_NAMES = [
   "FILE_REPLICA_ENABLED",
   "FILE_REPLICA_ALL_PRACTICES",
   "FILE_REPLICA_PRACTICE_IDS",
+  "FILE_REPLICA_PROVIDER",
   "FILE_REPLICA_S3_ENDPOINT",
   "FILE_REPLICA_S3_REGION",
   "FILE_REPLICA_S3_ACCESS_KEY",
   "FILE_REPLICA_S3_SECRET_KEY",
   "FILE_REPLICA_S3_BUCKET",
+  "FILE_REPLICA_BLOB_READ_WRITE_TOKEN",
 ] as const;
 
-interface StorageConfig {
+interface S3StorageConfig {
+  provider: "s3";
   endpoint?: string;
   region: string;
   accessKeyId: string;
   secretAccessKey: string;
   bucket: string;
 }
+
+interface BlobStorageConfig {
+  provider: "vercel_blob";
+  token: string;
+}
+
+type StorageConfig = S3StorageConfig | BlobStorageConfig;
 
 export interface StoredObjectWrite {
   url: string;
@@ -65,7 +83,15 @@ function storageEnv(name: string): string | undefined {
 }
 
 function primaryStorageConfig(): StorageConfig {
+  if (storageEnv("FILE_STORAGE_PROVIDER") === "vercel_blob") {
+    return {
+      provider: "vercel_blob",
+      token: storageEnv("BLOB_READ_WRITE_TOKEN") ?? "",
+    };
+  }
+
   return {
+    provider: "s3",
     endpoint: storageEnv("S3_ENDPOINT"),
     region: storageEnv("S3_REGION") ?? "us-east-1",
     accessKeyId: storageEnv("S3_ACCESS_KEY") ?? "",
@@ -78,7 +104,15 @@ function replicaStorageConfig(): StorageConfig | null {
   const readiness = replicaStorageReadiness();
   if (!readiness.ready) return null;
 
+  if (storageEnv("FILE_REPLICA_PROVIDER") === "vercel_blob") {
+    return {
+      provider: "vercel_blob",
+      token: replicaBlobToken()!,
+    };
+  }
+
   return {
+    provider: "s3",
     endpoint: storageEnv("FILE_REPLICA_S3_ENDPOINT"),
     region: storageEnv("FILE_REPLICA_S3_REGION") ?? "us-east-1",
     accessKeyId: storageEnv("FILE_REPLICA_S3_ACCESS_KEY")!,
@@ -88,10 +122,16 @@ function replicaStorageConfig(): StorageConfig | null {
 }
 
 function publicStorageEndpoint(config: StorageConfig): string {
+  if (config.provider !== "s3") {
+    throw new Error("Public S3 endpoint requested for non-S3 storage");
+  }
   return config.endpoint ?? "https://s3.amazonaws.com";
 }
 
 function s3Client(config: StorageConfig): S3Client {
+  if (config.provider !== "s3") {
+    throw new Error("S3 client requested for non-S3 storage");
+  }
   return new S3Client({
     endpoint: config.endpoint,
     region: config.region,
@@ -104,6 +144,9 @@ function s3Client(config: StorageConfig): S3Client {
 }
 
 function canonicalStorageIdentity(config: StorageConfig): string {
+  if (config.provider === "vercel_blob") {
+    return `vercel_blob/${createHash("sha256").update(config.token).digest("hex")}`;
+  }
   const endpoint = (config.endpoint ?? "https://s3.amazonaws.com")
     .replace(/\/+$/, "")
     .toLowerCase();
@@ -112,6 +155,16 @@ function canonicalStorageIdentity(config: StorageConfig): string {
 
 function envFlag(name: string): boolean {
   return /^(1|true|yes|on)$/i.test(process.env[name]?.trim() ?? "");
+}
+
+function replicaBlobToken(): string | undefined {
+  const dedicated = storageEnv("FILE_REPLICA_BLOB_READ_WRITE_TOKEN");
+  if (dedicated) return dedicated;
+  // The Vercel CLI injects this standard name when a Blob store is connected.
+  // It is safe for replica use only while the primary remains on S3.
+  return storageEnv("FILE_STORAGE_PROVIDER") === "vercel_blob"
+    ? undefined
+    : storageEnv("BLOB_READ_WRITE_TOKEN");
 }
 
 export function replicaStorageRolloutIntended(): boolean {
@@ -162,12 +215,23 @@ export function replicaStorageReadiness(): {
   detail: string;
 } {
   const intended = replicaStorageRolloutIntended();
+  const provider = storageEnv("FILE_REPLICA_PROVIDER") ?? "s3";
+  if (provider !== "s3" && provider !== "vercel_blob") {
+    return {
+      intended,
+      ready: false,
+      detail: "Replica storage provider is unsupported",
+    };
+  }
+
   const accessKeyId = storageEnv("FILE_REPLICA_S3_ACCESS_KEY");
   const secretAccessKey = storageEnv("FILE_REPLICA_S3_SECRET_KEY");
   const bucket = storageEnv("FILE_REPLICA_S3_BUCKET");
-  const missing = [accessKeyId, secretAccessKey, bucket].filter(
-    (value) => !value,
-  ).length;
+  const blobToken = replicaBlobToken();
+  const missing =
+    provider === "vercel_blob"
+      ? Number(!blobToken)
+      : [accessKeyId, secretAccessKey, bucket].filter((value) => !value).length;
 
   if (missing > 0) {
     return {
@@ -179,13 +243,17 @@ export function replicaStorageReadiness(): {
     };
   }
 
-  const replica: StorageConfig = {
-    endpoint: storageEnv("FILE_REPLICA_S3_ENDPOINT"),
-    region: storageEnv("FILE_REPLICA_S3_REGION") ?? "us-east-1",
-    accessKeyId: accessKeyId!,
-    secretAccessKey: secretAccessKey!,
-    bucket: bucket!,
-  };
+  const replica: StorageConfig =
+    provider === "vercel_blob"
+      ? { provider, token: blobToken! }
+      : {
+          provider,
+          endpoint: storageEnv("FILE_REPLICA_S3_ENDPOINT"),
+          region: storageEnv("FILE_REPLICA_S3_REGION") ?? "us-east-1",
+          accessKeyId: accessKeyId!,
+          secretAccessKey: secretAccessKey!,
+          bucket: bucket!,
+        };
   if (
     canonicalStorageIdentity(replica) ===
     canonicalStorageIdentity(primaryStorageConfig())
@@ -193,7 +261,7 @@ export function replicaStorageReadiness(): {
     return {
       intended,
       ready: false,
-      detail: "Replica storage must use a different endpoint or bucket",
+      detail: "Replica storage must use a different storage target",
     };
   }
 
@@ -228,6 +296,9 @@ export function replicaStorageReadiness(): {
 }
 
 function objectUrl(config: StorageConfig, key: string): string {
+  if (config.provider !== "s3") {
+    throw new Error("S3 object URL requested for non-S3 storage");
+  }
   return `${publicStorageEndpoint(config)}/${config.bucket}/${key}`;
 }
 
@@ -247,6 +318,25 @@ async function putObject(
   );
 
   try {
+    if (config.provider === "vercel_blob") {
+      const result = await putBlob(key, body, {
+        access: "private",
+        token: config.token,
+        contentType,
+        addRandomSuffix: false,
+        allowOverwrite: false,
+        maximumSizeInBytes: body.byteLength,
+        abortSignal: controller.signal,
+      });
+      return {
+        url: result.url,
+        etag: result.etag,
+        // Private Blob pathnames are immutable because overwrite is disabled.
+        // The provider ETag is therefore the exact immutable version evidence.
+        versionId: result.etag,
+      };
+    }
+
     const result = await s3Client(config).send(
       new PutObjectCommand({
         Bucket: config.bucket,
@@ -346,6 +436,41 @@ async function readObject(
   );
 
   try {
+    if (config.provider === "vercel_blob") {
+      const res = await getBlob(key, {
+        access: "private",
+        token: config.token,
+        useCache: false,
+        abortSignal: controller.signal,
+      });
+      if (!res) return { status: "missing" };
+      if (res.statusCode !== 200 || !res.stream) return { status: "failed" };
+      if (requestedVersionId && res.blob.etag !== requestedVersionId) {
+        return { status: "failed" };
+      }
+      if (
+        typeof options.maxBytes === "number" &&
+        res.blob.size > options.maxBytes
+      ) {
+        await res.stream.cancel().catch(() => undefined);
+        return { status: "failed" };
+      }
+      const body = new Uint8Array(await new Response(res.stream).arrayBuffer());
+      if (
+        typeof options.maxBytes === "number" &&
+        body.byteLength > options.maxBytes
+      ) {
+        return { status: "failed" };
+      }
+      return {
+        status: "available",
+        body,
+        contentType: res.blob.contentType,
+        etag: res.blob.etag,
+        versionId: res.blob.etag,
+      };
+    }
+
     const res = await s3Client(config).send(
       new GetObjectCommand({
         Bucket: config.bucket,
@@ -382,7 +507,12 @@ async function readObject(
       ...(responseVersionId ? { versionId: responseVersionId } : {}),
     };
   } catch (error) {
-    return { status: isMissingObjectError(error) ? "missing" : "failed" };
+    return {
+      status:
+        error instanceof BlobNotFoundError || isMissingObjectError(error)
+          ? "missing"
+          : "failed",
+    };
   } finally {
     clearTimeout(timeout);
   }
@@ -434,12 +564,18 @@ export async function getSignedUrl(
   key: string,
   expiresIn = 3600,
 ): Promise<string> {
+  const config = primaryStorageConfig();
+  if (config.provider !== "s3") {
+    throw new Error(
+      "Direct signed URLs are unavailable for private Blob storage; use the authenticated file proxy.",
+    );
+  }
   const command = new GetObjectCommand({
-    Bucket: primaryStorageConfig().bucket,
+    Bucket: config.bucket,
     Key: key,
   });
 
-  return awsGetSignedUrl(s3Client(primaryStorageConfig()), command, {
+  return awsGetSignedUrl(s3Client(config), command, {
     expiresIn,
   });
 }
@@ -458,6 +594,13 @@ export async function deleteFile(key: string): Promise<void> {
   );
 
   try {
+    if (config.provider === "vercel_blob") {
+      await deleteBlob(key, {
+        token: config.token,
+        abortSignal: controller.signal,
+      });
+      return;
+    }
     await s3Client(config).send(
       new DeleteObjectCommand({
         Bucket: config.bucket,
@@ -481,6 +624,14 @@ export async function checkObjectStorageHealth(
 
   try {
     const config = primaryStorageConfig();
+    if (config.provider === "vercel_blob") {
+      await listBlobs({
+        token: config.token,
+        limit: 1,
+        abortSignal: controller.signal,
+      });
+      return { ok: true, detail: "Object storage bucket reachable" };
+    }
     await s3Client(config).send(
       new HeadBucketCommand({
         Bucket: config.bucket,
@@ -510,6 +661,14 @@ export async function checkReplicaStorageHealth(
   );
 
   try {
+    if (config.provider === "vercel_blob") {
+      await listBlobs({
+        token: config.token,
+        limit: 1,
+        abortSignal: controller.signal,
+      });
+      return { ok: true, detail: "Replica object storage reachable" };
+    }
     await s3Client(config).send(
       new HeadBucketCommand({ Bucket: config.bucket }),
       { abortSignal: controller.signal },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "@trpc/react-query": "^11.0.0",
     "@trpc/server": "^11.0.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/blob": "2.8.0",
     "@vercel/oidc": "^3.8.4",
     "ai": "^6.0.209",
     "bcryptjs": "^2.4.3",

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -88,6 +88,10 @@ STRIPE_PRICE_CLOUD_LOCATION=...
 STRIPE_PRICE_CLOUD_LOCATION_ANNUAL=...
 STRIPE_TAX_ENABLED=true
 
+# Use either a complete S3-compatible group or a dedicated private Vercel Blob
+# store. The primary and replica must never point to the same store.
+FILE_STORAGE_PROVIDER=s3 # or vercel_blob
+BLOB_READ_WRITE_TOKEN= # required only for vercel_blob
 S3_ENDPOINT=...
 S3_ACCESS_KEY=...
 S3_SECRET_KEY=...
@@ -100,6 +104,8 @@ FILE_REPLICA_REQUIRED=false
 FILE_REPLICA_ENABLED=false
 FILE_REPLICA_ALL_PRACTICES=false
 FILE_REPLICA_PRACTICE_IDS=
+FILE_REPLICA_PROVIDER=s3 # or vercel_blob
+FILE_REPLICA_BLOB_READ_WRITE_TOKEN= # dedicated replica token for vercel_blob
 FILE_REPLICA_S3_ENDPOINT=
 FILE_REPLICA_S3_ACCESS_KEY=
 FILE_REPLICA_S3_SECRET_KEY=

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@15.5.23(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@20.19.37)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@vercel/blob':
+        specifier: 2.8.0
+        version: 2.8.0
       '@vercel/oidc':
         specifier: ^3.8.4
         version: 3.8.4
@@ -2120,6 +2123,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/blob@2.8.0':
+    resolution: {integrity: sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==}
+    engines: {node: '>=20.0.0'}
+
   '@vercel/cli-config@0.2.3':
     resolution: {integrity: sha512-Ggh0Wmi92TUkUexmSUPkkDtvJmbjUr7IvF5T3FkSsWrXXs3GFzOujfxFpECdJZpux1JG4SWDv9BT4w++TDgD6A==}
 
@@ -2209,6 +2216,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2829,6 +2839,10 @@ packages:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -2844,6 +2858,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -3447,6 +3464,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3636,6 +3657,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -5424,6 +5449,15 @@ snapshots:
       next: 15.5.23(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@20.19.37)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
+  '@vercel/blob@2.8.0':
+    dependencies:
+      '@vercel/oidc': 3.8.4
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.28.0
+
   '@vercel/cli-config@0.2.3':
     dependencies:
       xdg-app-paths: 5.5.1
@@ -5525,6 +5559,10 @@ snapshots:
       tslib: 2.8.1
 
   assertion-error@2.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   asynckit@0.4.0: {}
 
@@ -6112,6 +6150,8 @@ snapshots:
     dependencies:
       binary-extensions: 2.3.0
 
+  is-buffer@2.0.5: {}
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
@@ -6123,6 +6163,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
@@ -6711,6 +6753,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rgbcolor@1.0.1:
@@ -6959,6 +7003,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  throttleit@2.1.0: {}
 
   tiny-invariant@1.3.3: {}
 


### PR DESCRIPTION
## What changed

- add private Vercel Blob support for primary and independent replica object storage
- keep S3/MinIO as the default self-hosted path
- make hosted health checks provider-aware
- document the private-store configuration and independent-store requirement

## Why

Production had placeholder S3 credentials, leaving file uploads and file reads without a usable primary object store. This restores a private hosted storage path without changing tenant manifests or exposing objects publicly. It also allows the already-provisioned independent replica store to pass provider-aware readiness checks.

## Safety

- private store only
- deterministic immutable object keys with overwrite disabled
- authenticated same-origin file proxy remains the read boundary
- exact ETag verification and byte caps on reads
- primary and replica targets must be distinct
- no database/schema/client-record changes
- no credentials in the repository

## Validation

- web TypeScript check passed
- production build passed
- 154 focused storage/upload/health tests passed
- full web suite: 4,042 passed; 6 expected integration skips
- pnpm production audit: no known vulnerabilities
- Gitleaks pre-commit scan: no leaks
- git diff --check passed