### PR TITLE
OPENVPM-61: enforce append-only migration integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Verify append-only migration history
         env:
-          MIGRATION_INTEGRITY_BASE_REF: ${{ github.event.pull_request.base.sha || github.sha }}
+          MIGRATION_INTEGRITY_EVENT_NAME: ${{ github.event_name }}
+          MIGRATION_INTEGRITY_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MIGRATION_INTEGRITY_PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: pnpm --filter @openpims/db db:migrations:check
 
   rls:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
 
@@ -41,6 +43,7 @@ jobs:
   migration-integrity:
     name: Migration history integrity
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -48,6 +51,7 @@ jobs:
           # The append-only check resolves the actual merge base and compares
           # every pre-existing SQL/snapshot byte plus every journal entry.
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
 
@@ -87,6 +91,8 @@ jobs:
       OPENPIMS_APP_DB_PASSWORD: openpims_app
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
 
@@ -100,6 +106,14 @@ jobs:
       # Apply committed migrations, apply RLS (+ least-priv role), then prove
       # tenant isolation against a real Postgres on every PR.
       - run: pnpm --filter @openpims/db db:migrate
+
+      # A data-only migration has no schema snapshot to prove it ran. Exercise
+      # the baseline command against a disposable database and prove that exact
+      # and later cutoffs both fail without a ledger until live data is safe.
+      - name: Execute snapshotless baseline safety contract
+        env:
+          BASELINE_POSTCONDITION_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run lib/__tests__/baseline-postconditions.integration.test.ts
 
       # Schema drift guard: if drizzle-kit generate produces anything, a schema
       # change was committed without its migration (or a migration was written

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,31 @@ jobs:
       - run: pnpm build
         # Note: next build includes linting — no separate lint step needed
 
+  migration-integrity:
+    name: Migration history integrity
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The append-only check resolves the actual merge base and compares
+          # every pre-existing SQL/snapshot byte plus every journal entry.
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify append-only migration history
+        env:
+          MIGRATION_INTEGRITY_BASE_REF: ${{ github.event.pull_request.base.sha || github.sha }}
+        run: pnpm --filter @openpims/db db:migrations:check
+
   rls:
     name: RLS tenant isolation
     runs-on: ubuntu-latest

--- a/apps/web/lib/__tests__/baseline-postconditions.integration.test.ts
+++ b/apps/web/lib/__tests__/baseline-postconditions.integration.test.ts
@@ -1,0 +1,169 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { eq, sql as drizzleSql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { runBaseline } from "../../../../packages/db/baseline";
+import { db } from "../../../../packages/db/client";
+import { bookingPages } from "../../../../packages/db/schema/booking";
+import { practices } from "../../../../packages/db/schema/practices";
+import { appointmentTypes } from "../../../../packages/db/schema/scheduling";
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithBaselinePostgres =
+  process.env.BASELINE_POSTCONDITION_DB_INTEGRATION === "1"
+    ? describe
+    : describe.skip;
+
+describeWithBaselinePostgres(
+  "baseline data-only migration PostgreSQL contract",
+  () => {
+    it("refuses exact and later cutoffs without a false ledger, then baselines compliant data once", async () => {
+      const adminUrl = process.env.DATABASE_URL;
+      if (!adminUrl) throw new Error("DATABASE_URL is required");
+
+      const databaseName = `openpims_baseline_${randomUUID().replaceAll("-", "")}`;
+      if (!/^openpims_baseline_[a-f0-9]+$/.test(databaseName)) {
+        throw new Error("unsafe disposable database name");
+      }
+      const databaseUrl = new URL(adminUrl);
+      databaseUrl.pathname = `/${databaseName}`;
+      databaseUrl.search = "";
+      databaseUrl.hash = "";
+
+      await db.execute(drizzleSql.raw(`create database "${databaseName}"`));
+
+      try {
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:migrate"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+        });
+
+        process.env.DATABASE_URL = databaseUrl.toString();
+        await db.execute(drizzleSql.raw("drop schema drizzle cascade"));
+
+        const [practice] = await db
+          .insert(practices)
+          .values({ name: "Synthetic baseline safety clinic" })
+          .returning({ id: practices.id });
+        if (!practice) throw new Error("failed to create synthetic practice");
+        const [page] = await db
+          .insert(bookingPages)
+          .values({
+            practiceId: practice.id,
+            slug: `baseline-${randomUUID()}`,
+            published: true,
+            config: {},
+          })
+          .returning({ id: bookingPages.id });
+        if (!page) throw new Error("failed to create synthetic booking page");
+
+        const expectNoLedger = async () => {
+          const rows = (await db.execute(
+            drizzleSql.raw(
+              "select to_regclass('drizzle.__drizzle_migrations')::text as ledger",
+            ),
+          )) as unknown as Array<{ ledger: string | null }>;
+          expect(rows[0]?.ledger).toBeNull();
+        };
+
+        await expect(
+          runBaseline({
+            url: databaseUrl.toString(),
+            through: "0052",
+            apply: true,
+            log: () => undefined,
+          }),
+        ).rejects.toThrow(
+          "data-only migration 0052_booking_page_request_types has 1 active booking page row",
+        );
+        await expectNoLedger();
+
+        await expect(
+          runBaseline({
+            url: databaseUrl.toString(),
+            through: "0053",
+            apply: true,
+            log: () => undefined,
+          }),
+        ).rejects.toThrow(
+          "Cannot baseline through 0053_invoice_line_taxability",
+        );
+        await expectNoLedger();
+
+        for (const invalidConfig of [
+          { bookableTypeIds: "not-an-array" },
+          { bookableTypeIds: ["not-a-uuid"] },
+          { bookableTypeIds: [randomUUID()] },
+        ]) {
+          await db
+            .update(bookingPages)
+            .set({ config: invalidConfig, published: true })
+            .where(eq(bookingPages.id, page.id));
+          await expect(
+            runBaseline({
+              url: databaseUrl.toString(),
+              through: "0052",
+              apply: true,
+              log: () => undefined,
+            }),
+          ).rejects.toThrow(
+            "data-only migration 0052_booking_page_request_types has 1 active booking page row",
+          );
+          await expectNoLedger();
+        }
+
+        const [appointmentType] = await db
+          .insert(appointmentTypes)
+          .values({
+            practiceId: practice.id,
+            name: "Synthetic viable request type",
+          })
+          .returning({ id: appointmentTypes.id });
+        if (!appointmentType) {
+          throw new Error("failed to create synthetic appointment type");
+        }
+        await db
+          .update(bookingPages)
+          .set({
+            config: { bookableTypeIds: [appointmentType.id] },
+            published: true,
+          })
+          .where(eq(bookingPages.id, page.id));
+
+        await expect(
+          runBaseline({
+            url: databaseUrl.toString(),
+            through: "0052",
+            apply: true,
+            log: () => undefined,
+          }),
+        ).resolves.toBeUndefined();
+
+        const ledgerRows = (await db.execute(
+          drizzleSql.raw(
+            'select count(*)::int as count from drizzle."__drizzle_migrations"',
+          ),
+        )) as unknown as Array<{ count: number }>;
+        expect(ledgerRows[0]?.count).toBe(53);
+
+        await expect(
+          runBaseline({
+            url: databaseUrl.toString(),
+            through: "0052",
+            apply: true,
+            log: () => undefined,
+          }),
+        ).rejects.toThrow("A migration ledger already exists with 53 row(s)");
+      } finally {
+        process.env.DATABASE_URL = adminUrl;
+        await db.execute(
+          drizzleSql.raw(
+            `drop database if exists "${databaseName}" with (force)`,
+          ),
+        );
+      }
+    });
+  },
+);

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertSnapshotlessMigrationPostconditions,
   selectBaselineSnapshot,
+  snapshotlessMigrationPostconditions,
   type JournalEntry,
 } from "../../../../packages/db/baseline";
 
@@ -22,6 +24,12 @@ describe("committed Drizzle migrations", () => {
 
     expect(ci).toContain("pnpm --filter @openpims/db db:migrate");
     expect(ci).not.toContain("drizzle-kit push --force");
+    expect(ci).toContain(
+      "lib/__tests__/baseline-postconditions.integration.test.ts",
+    );
+    expect(ci).toContain('BASELINE_POSTCONDITION_DB_INTEGRATION: "1"');
+    expect(migrationIntegrityJob).toContain("timeout-minutes: 15");
+    expect(migrationIntegrityJob).toContain("persist-credentials: false");
     expect(migrationIntegrityJob).toContain(
       "MIGRATION_INTEGRITY_EVENT_NAME: ${{ github.event_name }}",
     );
@@ -1343,6 +1351,87 @@ describe("committed Drizzle migrations", () => {
       "validating schema against preceding snapshot 0051_wide_maximus",
     );
   });
+
+  it("checks snapshotless postconditions at the exact and every later cutoff", async () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries: JournalEntry[] };
+    const cutoff0051 = journal.entries.findIndex(
+      (entry) => entry.tag === "0051_wide_maximus",
+    );
+    const cutoff0052 = journal.entries.findIndex(
+      (entry) => entry.tag === "0052_booking_page_request_types",
+    );
+    const cutoff0053 = journal.entries.findIndex(
+      (entry) => entry.tag === "0053_invoice_line_taxability",
+    );
+    const checked: string[] = [];
+    const reader = async (entry: JournalEntry) => {
+      checked.push(entry.tag);
+      return 0;
+    };
+
+    await assertSnapshotlessMigrationPostconditions(
+      journal.entries,
+      cutoff0051,
+      reader,
+    );
+    expect(checked).toEqual([]);
+
+    await assertSnapshotlessMigrationPostconditions(
+      journal.entries,
+      cutoff0052,
+      reader,
+    );
+    await assertSnapshotlessMigrationPostconditions(
+      journal.entries,
+      cutoff0053,
+      reader,
+    );
+    expect(checked).toEqual([
+      "0052_booking_page_request_types",
+      "0052_booking_page_request_types",
+    ]);
+  });
+
+  it("fails closed when a snapshotless data postcondition is violated", async () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries: JournalEntry[] };
+    const cutoff = journal.entries.findIndex(
+      (entry) => entry.tag === "0053_invoice_line_taxability",
+    );
+
+    await expect(
+      assertSnapshotlessMigrationPostconditions(
+        journal.entries,
+        cutoff,
+        async (entry, contract) => {
+          expect(entry.tag).toBe("0052_booking_page_request_types");
+          expect(contract).toBe(snapshotlessMigrationPostconditions[entry.tag]);
+          return 1;
+        },
+      ),
+    ).rejects.toThrow(
+      "Cannot baseline through 0053_invoice_line_taxability: data-only migration 0052_booking_page_request_types has 1 active booking page row",
+    );
+  });
+
+  it.each([Number.NaN, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid snapshotless violation count %s",
+    async (violations) => {
+      const entries: JournalEntry[] = [
+        { idx: 0, tag: "0052_booking_page_request_types", when: 1 },
+      ];
+      await expect(
+        assertSnapshotlessMigrationPostconditions(
+          entries,
+          0,
+          async () => violations,
+        ),
+      ).rejects.toThrow("returned invalid violation count");
+    },
+  );
 
   it("refuses an unapproved missing baseline snapshot with a deliberate error", () => {
     const journal = JSON.parse(

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -1,6 +1,10 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  selectBaselineSnapshot,
+  type JournalEntry,
+} from "../../../../packages/db/baseline";
 
 const repoRoot = resolve(process.cwd(), "../..");
 
@@ -1295,6 +1299,51 @@ describe("committed Drizzle migrations", () => {
     expect(sql).toContain("'{bookableTypeIds}'");
     expect(sql).toContain("jsonb_array_length(legacy.active_type_ids) = 0");
     expect(sql).toContain("THEN false");
+  });
+
+  it("selects the preceding snapshot for intentional data-only baseline 0052", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries: JournalEntry[] };
+    const cutoff = journal.entries.findIndex(
+      (entry) => entry.tag === "0052_booking_page_request_types",
+    );
+    const selection = selectBaselineSnapshot(
+      journal.entries,
+      cutoff,
+      (entry) => {
+        const prefix = entry.tag.split("_", 1)[0];
+        return existsSync(
+          resolve(repoRoot, `packages/db/drizzle/meta/${prefix}_snapshot.json`),
+        );
+      },
+    );
+
+    expect(selection.target.tag).toBe("0052_booking_page_request_types");
+    expect(selection.snapshot.tag).toBe("0051_wide_maximus");
+    expect(selection.explanation).toContain("intentional data-only migration");
+    expect(selection.explanation).toContain(
+      "validating schema against preceding snapshot 0051_wide_maximus",
+    );
+  });
+
+  it("refuses an unapproved missing baseline snapshot with a deliberate error", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries: JournalEntry[] };
+    const cutoff = journal.entries.findIndex(
+      (entry) => entry.tag === "0053_invoice_line_taxability",
+    );
+
+    expect(() =>
+      selectBaselineSnapshot(
+        journal.entries,
+        cutoff,
+        (entry) => entry.tag !== "0053_invoice_line_taxability",
+      ),
+    ).toThrow(
+      "expected snapshot 0053_snapshot.json for 0053_invoice_line_taxability, but it is missing and is not an approved snapshotless migration",
+    );
   });
 
   it("backfills immutable invoice-line and product taxability", () => {

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -15,9 +15,26 @@ function readRepoFile(path: string): string {
 describe("committed Drizzle migrations", () => {
   it("exercises committed migrations in the CI RLS isolation job", () => {
     const ci = readRepoFile(".github/workflows/ci.yml");
+    const migrationIntegrityJob = ci.slice(
+      ci.indexOf("  migration-integrity:"),
+      ci.indexOf("\n  rls:"),
+    );
 
     expect(ci).toContain("pnpm --filter @openpims/db db:migrate");
     expect(ci).not.toContain("drizzle-kit push --force");
+    expect(migrationIntegrityJob).toContain(
+      "MIGRATION_INTEGRITY_EVENT_NAME: ${{ github.event_name }}",
+    );
+    expect(migrationIntegrityJob).toContain(
+      "MIGRATION_INTEGRITY_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+    );
+    expect(migrationIntegrityJob).toContain(
+      "MIGRATION_INTEGRITY_PUSH_BEFORE_SHA: ${{ github.event.before }}",
+    );
+    expect(migrationIntegrityJob).not.toContain("github.sha");
+    expect(migrationIntegrityJob).not.toContain(
+      "MIGRATION_INTEGRITY_BASE_REF:",
+    );
   });
 
   it("includes a baseline migration registered in the Drizzle journal", () => {

--- a/apps/web/lib/__tests__/migration-journal-integrity.test.ts
+++ b/apps/web/lib/__tests__/migration-journal-integrity.test.ts
@@ -1,0 +1,419 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { snapshotlessMigrationReasons } from "../../../../packages/db/baseline";
+
+type JournalEntry = {
+  idx: number;
+  tag: string;
+  when: number;
+};
+
+type Journal = {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+};
+
+type Snapshot = {
+  id: string;
+  prevId: string;
+};
+
+type MigrationFixture = {
+  journal: Journal;
+  sqlFiles: string[];
+  snapshots: Record<string, Snapshot>;
+};
+
+const repoRoot = resolve(process.cwd(), "../..");
+const migrationDirectory = resolve(repoRoot, "packages/db/drizzle");
+const metadataDirectory = resolve(migrationDirectory, "meta");
+const journalPath = resolve(metadataDirectory, "_journal.json");
+const zeroSnapshotId = "00000000-0000-0000-0000-000000000000";
+
+// There are currently no SQL/journal bijection exceptions. This named,
+// reviewed allowlist prevents a future exception from being smuggled in as an
+// unexplained filtering rule.
+const sqlBijectionExceptions = new Set<string>();
+
+function migrationPrefix(tag: string): string {
+  const match = /^(\d{4})_[a-z0-9_]+$/.exec(tag);
+  if (!match) throw new Error(`invalid migration tag ${tag}`);
+  return match[1]!;
+}
+
+function loadFixture(): MigrationFixture {
+  const journal = JSON.parse(readFileSync(journalPath, "utf8")) as Journal;
+  const sqlFiles = readdirSync(migrationDirectory)
+    .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+    .sort();
+  const snapshots = Object.fromEntries(
+    readdirSync(metadataDirectory)
+      .filter((name) => /^\d{4}_snapshot\.json$/.test(name))
+      .sort()
+      .map((name) => [
+        name,
+        JSON.parse(
+          readFileSync(resolve(metadataDirectory, name), "utf8"),
+        ) as Snapshot,
+      ]),
+  );
+  return { journal, sqlFiles, snapshots };
+}
+
+function cloneFixture(fixture: MigrationFixture): MigrationFixture {
+  return structuredClone(fixture);
+}
+
+function validateJournal(journal: Journal): void {
+  if (journal.entries.length === 0) throw new Error("journal is empty");
+
+  const indexes = new Set<number>();
+  const tags = new Set<string>();
+  for (const [position, entry] of journal.entries.entries()) {
+    if (indexes.has(entry.idx)) {
+      throw new Error(`duplicate journal index ${entry.idx}`);
+    }
+    indexes.add(entry.idx);
+    if (entry.idx !== position) {
+      throw new Error(
+        `journal indexes must be contiguous from 0: position ${position} has ${entry.idx}`,
+      );
+    }
+
+    if (tags.has(entry.tag))
+      throw new Error(`duplicate journal tag ${entry.tag}`);
+    tags.add(entry.tag);
+
+    const prefix = migrationPrefix(entry.tag);
+    if (prefix !== String(entry.idx).padStart(4, "0")) {
+      throw new Error(
+        `journal tag ${entry.tag} does not match index ${entry.idx}`,
+      );
+    }
+
+    const previous = journal.entries[position - 1];
+    if (previous && entry.when <= previous.when) {
+      throw new Error(
+        `journal timestamps must strictly increase: ${entry.tag} (${entry.when}) follows ${previous.tag} (${previous.when})`,
+      );
+    }
+  }
+}
+
+function validateSqlBijection(fixture: MigrationFixture): void {
+  const journalTags = fixture.journal.entries
+    .map((entry) => entry.tag)
+    .filter((tag) => !sqlBijectionExceptions.has(tag));
+  const sqlTags = fixture.sqlFiles
+    .map((name) => name.replace(/\.sql$/, ""))
+    .filter((tag) => !sqlBijectionExceptions.has(tag));
+
+  for (const tag of journalTags) {
+    const matches = sqlTags.filter((candidate) => candidate === tag).length;
+    if (matches !== 1) {
+      throw new Error(
+        `journal migration ${tag} must map to exactly one SQL file; found ${matches}`,
+      );
+    }
+  }
+
+  const journalTagSet = new Set(journalTags);
+  for (const tag of sqlTags) {
+    if (!journalTagSet.has(tag)) {
+      throw new Error(`orphan SQL migration ${tag}.sql is not in the journal`);
+    }
+  }
+}
+
+function validateSnapshotLineage(fixture: MigrationFixture): void {
+  const entriesByPrefix = new Map(
+    fixture.journal.entries.map((entry) => [migrationPrefix(entry.tag), entry]),
+  );
+  const expectedSnapshotNames = fixture.journal.entries
+    .filter((entry) => snapshotlessMigrationReasons[entry.tag] === undefined)
+    .map((entry) => `${migrationPrefix(entry.tag)}_snapshot.json`);
+  const actualSnapshotNames = Object.keys(fixture.snapshots).sort();
+
+  for (const entry of fixture.journal.entries) {
+    const snapshotName = `${migrationPrefix(entry.tag)}_snapshot.json`;
+    const snapshotExists = fixture.snapshots[snapshotName] !== undefined;
+    const approvedReason = snapshotlessMigrationReasons[entry.tag];
+    if (approvedReason && snapshotExists) {
+      throw new Error(
+        `approved snapshotless migration ${entry.tag} unexpectedly has ${snapshotName}`,
+      );
+    }
+    if (!approvedReason && !snapshotExists) {
+      throw new Error(`missing snapshot ${snapshotName} for ${entry.tag}`);
+    }
+  }
+
+  for (const snapshotName of actualSnapshotNames) {
+    const prefix = snapshotName.slice(0, 4);
+    if (!entriesByPrefix.has(prefix)) {
+      throw new Error(
+        `orphan snapshot ${snapshotName} does not map to a journal prefix`,
+      );
+    }
+  }
+
+  if (actualSnapshotNames.join("\n") !== expectedSnapshotNames.join("\n")) {
+    throw new Error(
+      "snapshot files do not map to the expected migration prefixes",
+    );
+  }
+
+  let expectedPrevId = zeroSnapshotId;
+  const ids = new Set<string>();
+  for (const name of expectedSnapshotNames) {
+    const snapshot = fixture.snapshots[name]!;
+    if (ids.has(snapshot.id)) {
+      throw new Error(`duplicate snapshot id ${snapshot.id} in ${name}`);
+    }
+    ids.add(snapshot.id);
+    if (snapshot.prevId !== expectedPrevId) {
+      throw new Error(
+        `broken snapshot lineage at ${name}: expected prevId ${expectedPrevId}, received ${snapshot.prevId}`,
+      );
+    }
+    expectedPrevId = snapshot.id;
+  }
+}
+
+function validateIntegrity(fixture: MigrationFixture): void {
+  validateJournal(fixture.journal);
+  validateSqlBijection(fixture);
+  validateSnapshotLineage(fixture);
+}
+
+function stripSqlCommentsAndStrings(sql: string): string {
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/--.*$/gm, " ")
+    .replace(/'(?:''|[^'])*'/g, "''")
+    .replace(/\$([a-zA-Z0-9_]*)\$[\s\S]*?\$\1\$/g, "$$");
+}
+
+function assertDataOnlySql(tag: string, sql: string): void {
+  const ddlKeyword = stripSqlCommentsAndStrings(sql).match(
+    /\b(?:create|alter|drop|truncate|rename|grant|revoke|comment|reindex|cluster)\b/i,
+  );
+  if (ddlKeyword) {
+    throw new Error(
+      `${tag} is allowlisted as data-only but contains DDL keyword ${ddlKeyword[0]}`,
+    );
+  }
+}
+
+type RawJournalSegments = {
+  prefix: string;
+  entries: string[];
+  suffix: string;
+};
+
+/** Split journal entries without normalizing a byte of the existing objects. */
+function rawJournalSegments(raw: string): RawJournalSegments {
+  const entriesKey = raw.indexOf('"entries"');
+  const arrayStart = raw.indexOf("[", entriesKey);
+  if (entriesKey === -1 || arrayStart === -1) {
+    throw new Error("journal does not contain an entries array");
+  }
+
+  const entries: string[] = [];
+  let arrayDepth = 1;
+  let objectDepth = 0;
+  let inString = false;
+  let escaped = false;
+  let segmentStart = arrayStart + 1;
+  let arrayEnd = -1;
+
+  for (let index = arrayStart + 1; index < raw.length; index++) {
+    const character = raw[index]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === "[") arrayDepth++;
+    else if (character === "]") {
+      arrayDepth--;
+      if (arrayDepth === 0) {
+        arrayEnd = index;
+        break;
+      }
+    } else if (character === "{") objectDepth++;
+    else if (character === "}") {
+      objectDepth--;
+      if (objectDepth === 0) {
+        entries.push(raw.slice(segmentStart, index + 1));
+        segmentStart = index + 1;
+      }
+    }
+  }
+
+  if (arrayEnd === -1) throw new Error("journal entries array is not closed");
+  return {
+    prefix: raw.slice(0, arrayStart + 1),
+    entries,
+    suffix: raw.slice(arrayEnd),
+  };
+}
+
+function gitText(...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).trim();
+}
+
+describe("Drizzle migration journal integrity", () => {
+  it("keeps journal, SQL, and snapshot history deterministic and bijective", () => {
+    validateIntegrity(loadFixture());
+    expect([...sqlBijectionExceptions]).toEqual([]);
+    expect(snapshotlessMigrationReasons).toEqual({
+      "0052_booking_page_request_types":
+        "intentional data-only migration; it changes rows without changing schema",
+    });
+  });
+
+  it("keeps intentional migration 0052 data-only and DDL-free", () => {
+    const tag = "0052_booking_page_request_types";
+    const sql = readFileSync(resolve(migrationDirectory, `${tag}.sql`), "utf8");
+    expect(() => assertDataOnlySql(tag, sql)).not.toThrow();
+    expect(sql).toMatch(/\bUPDATE\s+booking_pages\b/i);
+  });
+
+  it("rejects a duplicate journal index", () => {
+    const fixture = cloneFixture(loadFixture());
+    fixture.journal.entries[1]!.idx = fixture.journal.entries[0]!.idx;
+    expect(() => validateIntegrity(fixture)).toThrow("duplicate journal index");
+  });
+
+  it("rejects a duplicate journal tag", () => {
+    const fixture = cloneFixture(loadFixture());
+    fixture.journal.entries[1]!.tag = fixture.journal.entries[0]!.tag;
+    expect(() => validateIntegrity(fixture)).toThrow("duplicate journal tag");
+  });
+
+  it("rejects a journal timestamp regression", () => {
+    const fixture = cloneFixture(loadFixture());
+    fixture.journal.entries[1]!.when = fixture.journal.entries[0]!.when;
+    expect(() => validateIntegrity(fixture)).toThrow(
+      "journal timestamps must strictly increase",
+    );
+  });
+
+  it("rejects a missing SQL migration", () => {
+    const fixture = cloneFixture(loadFixture());
+    fixture.sqlFiles = fixture.sqlFiles.filter(
+      (name) => name !== "0052_booking_page_request_types.sql",
+    );
+    expect(() => validateIntegrity(fixture)).toThrow(
+      "0052_booking_page_request_types must map to exactly one SQL file; found 0",
+    );
+  });
+
+  it("rejects an orphan SQL migration", () => {
+    const fixture = cloneFixture(loadFixture());
+    fixture.sqlFiles.push("0091_orphan_fixture.sql");
+    expect(() => validateIntegrity(fixture)).toThrow(
+      "orphan SQL migration 0091_orphan_fixture.sql",
+    );
+  });
+
+  it("rejects broken snapshot lineage", () => {
+    const fixture = cloneFixture(loadFixture());
+    fixture.snapshots["0053_snapshot.json"]!.prevId = zeroSnapshotId;
+    expect(() => validateIntegrity(fixture)).toThrow(
+      "broken snapshot lineage at 0053_snapshot.json",
+    );
+  });
+
+  it.skipIf(!process.env.MIGRATION_INTEGRITY_BASE_REF)(
+    "preserves merge-base migration artifacts byte-for-byte and adds only at the tail",
+    () => {
+      const baseRef = process.env.MIGRATION_INTEGRITY_BASE_REF!;
+      const mergeBase = gitText("merge-base", "HEAD", baseRef);
+      const artifactChanges = gitText(
+        "diff",
+        "--name-status",
+        "--no-renames",
+        mergeBase,
+        "--",
+        "packages/db/drizzle",
+      )
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => {
+          const [status, path] = line.split("\t");
+          return { status: status!, path: path! };
+        });
+      const changedExistingArtifacts = artifactChanges.filter(
+        ({ status, path }) =>
+          status !== "A" &&
+          (/^packages\/db\/drizzle\/\d{4}_.+\.sql$/.test(path) ||
+            /^packages\/db\/drizzle\/meta\/\d{4}_snapshot\.json$/.test(path)),
+      );
+      expect(
+        changedExistingArtifacts,
+        "merge-base SQL and snapshots must remain byte-for-byte identical",
+      ).toEqual([]);
+
+      const baseJournalRaw = execFileSync(
+        "git",
+        ["show", `${mergeBase}:packages/db/drizzle/meta/_journal.json`],
+        { cwd: repoRoot, encoding: "utf8" },
+      );
+      const addedArtifacts = artifactChanges.filter(
+        ({ status, path }) =>
+          status === "A" &&
+          (/^packages\/db\/drizzle\/\d{4}_.+\.sql$/.test(path) ||
+            /^packages\/db\/drizzle\/meta\/\d{4}_snapshot\.json$/.test(path)),
+      );
+      for (const { path } of addedArtifacts) {
+        expect(readFileSync(resolve(repoRoot, path)).length).toBeGreaterThan(0);
+      }
+
+      const currentJournalRaw = readFileSync(journalPath, "utf8");
+      const baseSegments = rawJournalSegments(baseJournalRaw);
+      const currentSegments = rawJournalSegments(currentJournalRaw);
+      const baseJournal = JSON.parse(baseJournalRaw) as Journal;
+      const currentJournal = JSON.parse(currentJournalRaw) as Journal;
+
+      expect(currentSegments.prefix).toBe(baseSegments.prefix);
+      expect(currentSegments.suffix).toBe(baseSegments.suffix);
+      expect(currentSegments.entries.length).toBeGreaterThanOrEqual(
+        baseSegments.entries.length,
+      );
+      expect(
+        currentSegments.entries.slice(0, baseSegments.entries.length),
+      ).toEqual(baseSegments.entries);
+      expect(
+        currentJournal.entries.slice(0, baseJournal.entries.length),
+      ).toEqual(baseJournal.entries);
+
+      const baseTail = baseJournal.entries.at(-1)!;
+      const additions = currentJournal.entries.slice(
+        baseJournal.entries.length,
+      );
+      expect(additions.every((entry) => entry.idx > baseTail.idx)).toBe(true);
+
+      for (const { path } of addedArtifacts) {
+        const name = path.split("/").at(-1)!;
+        const prefix = Number(name.slice(0, 4));
+        expect(
+          prefix,
+          `${path} was not added after merge-base tail`,
+        ).toBeGreaterThan(baseTail.idx);
+      }
+    },
+  );
+});

--- a/apps/web/lib/__tests__/migration-journal-integrity.test.ts
+++ b/apps/web/lib/__tests__/migration-journal-integrity.test.ts
@@ -274,6 +274,68 @@ function gitText(...args: string[]): string {
   }).trim();
 }
 
+type MigrationIntegrityCiContext = {
+  eventName?: string;
+  pullRequestBaseSha?: string;
+  pushBeforeSha?: string;
+};
+
+function validCommitSha(value: string | undefined, source: string): string {
+  const sha = value?.trim();
+  if (!sha) {
+    throw new Error(
+      `Migration integrity base is missing; expected ${source}. Refusing to compare HEAD to itself.`,
+    );
+  }
+  if (/^0{40}$/.test(sha)) {
+    throw new Error(
+      `Migration integrity base from ${source} is all zeroes. Refusing to compare HEAD to itself; rerun from an event with a real pre-change commit.`,
+    );
+  }
+  if (!/^[0-9a-f]{40}$/i.test(sha)) {
+    throw new Error(
+      `Migration integrity base from ${source} is not a full commit SHA: ${sha}.`,
+    );
+  }
+  return sha;
+}
+
+function selectCiMigrationBaseRef({
+  eventName,
+  pullRequestBaseSha,
+  pushBeforeSha,
+}: MigrationIntegrityCiContext): string {
+  if (eventName === "pull_request") {
+    return validCommitSha(
+      pullRequestBaseSha,
+      "github.event.pull_request.base.sha",
+    );
+  }
+  if (eventName === "push") {
+    return validCommitSha(pushBeforeSha, "github.event.before");
+  }
+  throw new Error(
+    `Migration integrity does not support GitHub event ${eventName ?? "(missing)"}; expected pull_request or push.`,
+  );
+}
+
+function configuredMigrationBaseRef(): string | undefined {
+  const eventName = process.env.MIGRATION_INTEGRITY_EVENT_NAME?.trim();
+  if (eventName) {
+    return selectCiMigrationBaseRef({
+      eventName,
+      pullRequestBaseSha: process.env.MIGRATION_INTEGRITY_PR_BASE_SHA,
+      pushBeforeSha: process.env.MIGRATION_INTEGRITY_PUSH_BEFORE_SHA,
+    });
+  }
+  return process.env.MIGRATION_INTEGRITY_BASE_REF?.trim() || undefined;
+}
+
+const hasConfiguredMigrationBase = Boolean(
+  process.env.MIGRATION_INTEGRITY_EVENT_NAME?.trim() ||
+  process.env.MIGRATION_INTEGRITY_BASE_REF?.trim(),
+);
+
 describe("Drizzle migration journal integrity", () => {
   it("keeps journal, SQL, and snapshot history deterministic and bijective", () => {
     validateIntegrity(loadFixture());
@@ -282,6 +344,32 @@ describe("Drizzle migration journal integrity", () => {
       "0052_booking_page_request_types":
         "intentional data-only migration; it changes rows without changing schema",
     });
+
+    const pullRequestBase = "1".repeat(40);
+    const pushBefore = "2".repeat(40);
+    expect(
+      selectCiMigrationBaseRef({
+        eventName: "pull_request",
+        pullRequestBaseSha: pullRequestBase,
+        pushBeforeSha: pushBefore,
+      }),
+    ).toBe(pullRequestBase);
+    expect(
+      selectCiMigrationBaseRef({
+        eventName: "push",
+        pullRequestBaseSha: pullRequestBase,
+        pushBeforeSha: pushBefore,
+      }),
+    ).toBe(pushBefore);
+    expect(() => selectCiMigrationBaseRef({ eventName: "push" })).toThrow(
+      "expected github.event.before",
+    );
+    expect(() =>
+      selectCiMigrationBaseRef({
+        eventName: "push",
+        pushBeforeSha: "0".repeat(40),
+      }),
+    ).toThrow("github.event.before is all zeroes");
   });
 
   it("keeps intentional migration 0052 data-only and DDL-free", () => {
@@ -337,10 +425,17 @@ describe("Drizzle migration journal integrity", () => {
     );
   });
 
-  it.skipIf(!process.env.MIGRATION_INTEGRITY_BASE_REF)(
+  it.skipIf(!hasConfiguredMigrationBase)(
     "preserves merge-base migration artifacts byte-for-byte and adds only at the tail",
     () => {
-      const baseRef = process.env.MIGRATION_INTEGRITY_BASE_REF!;
+      const baseRef = configuredMigrationBaseRef()!;
+      try {
+        gitText("cat-file", "-e", `${baseRef}^{commit}`);
+      } catch {
+        throw new Error(
+          `Migration integrity base ${baseRef} is unavailable in the checkout. Keep actions/checkout fetch-depth at 0 and verify the event SHA exists.`,
+        );
+      }
       const mergeBase = gitText("merge-base", "HEAD", baseRef);
       const artifactChanges = gitText(
         "diff",

--- a/apps/web/lib/__tests__/migration-journal-integrity.test.ts
+++ b/apps/web/lib/__tests__/migration-journal-integrity.test.ts
@@ -2,12 +2,17 @@ import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { snapshotlessMigrationReasons } from "../../../../packages/db/baseline";
+import {
+  snapshotlessMigrationPostconditions,
+  snapshotlessMigrationReasons,
+} from "../../../../packages/db/baseline";
 
 type JournalEntry = {
   idx: number;
+  version: string;
   tag: string;
   when: number;
+  breakpoints: boolean;
 };
 
 type Journal = {
@@ -64,15 +69,62 @@ function loadFixture(): MigrationFixture {
 }
 
 function cloneFixture(fixture: MigrationFixture): MigrationFixture {
-  return structuredClone(fixture);
+  return {
+    journal: structuredClone(fixture.journal),
+    sqlFiles: [...fixture.sqlFiles],
+    // Mutation tests only alter top-level lineage IDs. Keep the large table
+    // payloads shared and immutable so each negative case stays deterministic
+    // under hosted-runner load.
+    snapshots: Object.fromEntries(
+      Object.entries(fixture.snapshots).map(([name, snapshot]) => [
+        name,
+        { ...snapshot },
+      ]),
+    ),
+  };
 }
 
+const canonicalFixture = loadFixture();
+
 function validateJournal(journal: Journal): void {
+  if (journal.version !== "7") {
+    throw new Error(`unsupported journal version ${String(journal.version)}`);
+  }
+  if (journal.dialect !== "postgresql") {
+    throw new Error(`unsupported journal dialect ${String(journal.dialect)}`);
+  }
   if (journal.entries.length === 0) throw new Error("journal is empty");
 
   const indexes = new Set<number>();
   const tags = new Set<string>();
   for (const [position, entry] of journal.entries.entries()) {
+    if (!Number.isSafeInteger(entry.idx) || entry.idx < 0) {
+      throw new Error(`invalid journal index ${String(entry.idx)}`);
+    }
+    if (entry.version !== journal.version) {
+      throw new Error(
+        `journal entry ${position} has version ${String(entry.version)}; expected ${journal.version}`,
+      );
+    }
+    if (typeof entry.breakpoints !== "boolean") {
+      throw new Error(
+        `journal entry ${position} has invalid breakpoints ${String(entry.breakpoints)}`,
+      );
+    }
+    if (
+      typeof entry.when !== "number" ||
+      !Number.isSafeInteger(entry.when) ||
+      entry.when <= 0
+    ) {
+      throw new Error(
+        `journal entry ${position} has invalid timestamp ${String(entry.when)}`,
+      );
+    }
+    if (typeof entry.tag !== "string") {
+      throw new Error(
+        `journal entry ${position} has invalid tag ${String(entry.tag)}`,
+      );
+    }
     if (indexes.has(entry.idx)) {
       throw new Error(`duplicate journal index ${entry.idx}`);
     }
@@ -193,11 +245,27 @@ function stripSqlCommentsAndStrings(sql: string): string {
   return sql
     .replace(/\/\*[\s\S]*?\*\//g, " ")
     .replace(/--.*$/gm, " ")
-    .replace(/'(?:''|[^'])*'/g, "''")
-    .replace(/\$([a-zA-Z0-9_]*)\$[\s\S]*?\$\1\$/g, "$$");
+    .replace(/'(?:''|[^'])*'/g, "''");
 }
 
 function assertDataOnlySql(tag: string, sql: string): void {
+  const withoutComments = sql
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/--.*$/gm, " ");
+  const dollarQuote = withoutComments.match(/\$[a-zA-Z0-9_]*\$/);
+  if (dollarQuote) {
+    throw new Error(
+      `${tag} is allowlisted as data-only but contains an unverifiable dollar-quoted body`,
+    );
+  }
+  const proceduralKeyword =
+    stripSqlCommentsAndStrings(sql).match(/\b(?:do|execute)\b/i);
+  if (proceduralKeyword) {
+    throw new Error(
+      `${tag} is allowlisted as data-only but contains procedural keyword ${proceduralKeyword[0]}`,
+    );
+  }
+
   const ddlKeyword = stripSqlCommentsAndStrings(sql).match(
     /\b(?:create|alter|drop|truncate|rename|grant|revoke|comment|reindex|cluster)\b/i,
   );
@@ -338,12 +406,15 @@ const hasConfiguredMigrationBase = Boolean(
 
 describe("Drizzle migration journal integrity", () => {
   it("keeps journal, SQL, and snapshot history deterministic and bijective", () => {
-    validateIntegrity(loadFixture());
+    validateIntegrity(canonicalFixture);
     expect([...sqlBijectionExceptions]).toEqual([]);
     expect(snapshotlessMigrationReasons).toEqual({
       "0052_booking_page_request_types":
         "intentional data-only migration; it changes rows without changing schema",
     });
+    expect(Object.keys(snapshotlessMigrationPostconditions).sort()).toEqual(
+      Object.keys(snapshotlessMigrationReasons).sort(),
+    );
 
     const pullRequestBase = "1".repeat(40);
     const pushBefore = "2".repeat(40);
@@ -372,35 +443,86 @@ describe("Drizzle migration journal integrity", () => {
     ).toThrow("github.event.before is all zeroes");
   });
 
-  it("keeps intentional migration 0052 data-only and DDL-free", () => {
-    const tag = "0052_booking_page_request_types";
-    const sql = readFileSync(resolve(migrationDirectory, `${tag}.sql`), "utf8");
-    expect(() => assertDataOnlySql(tag, sql)).not.toThrow();
-    expect(sql).toMatch(/\bUPDATE\s+booking_pages\b/i);
+  it("keeps every approved snapshotless migration data-only and DDL-free", () => {
+    for (const tag of Object.keys(snapshotlessMigrationReasons)) {
+      const sql = readFileSync(
+        resolve(migrationDirectory, `${tag}.sql`),
+        "utf8",
+      );
+      expect(() => assertDataOnlySql(tag, sql)).not.toThrow();
+    }
+
+    const bookingPageMigration = readFileSync(
+      resolve(migrationDirectory, "0052_booking_page_request_types.sql"),
+      "utf8",
+    );
+    expect(bookingPageMigration).toMatch(/\bUPDATE\s+booking_pages\b/i);
+  });
+
+  it("rejects procedural or dollar-quoted DDL in a data-only migration", () => {
+    expect(() =>
+      assertDataOnlySql(
+        "0091_fixture",
+        "DO $$ BEGIN EXECUTE 'CREATE TABLE unsafe(id int)'; END $$;",
+      ),
+    ).toThrow("unverifiable dollar-quoted body");
   });
 
   it("rejects a duplicate journal index", () => {
-    const fixture = cloneFixture(loadFixture());
+    const fixture = cloneFixture(canonicalFixture);
     fixture.journal.entries[1]!.idx = fixture.journal.entries[0]!.idx;
     expect(() => validateIntegrity(fixture)).toThrow("duplicate journal index");
   });
 
   it("rejects a duplicate journal tag", () => {
-    const fixture = cloneFixture(loadFixture());
+    const fixture = cloneFixture(canonicalFixture);
     fixture.journal.entries[1]!.tag = fixture.journal.entries[0]!.tag;
     expect(() => validateIntegrity(fixture)).toThrow("duplicate journal tag");
   });
 
   it("rejects a journal timestamp regression", () => {
-    const fixture = cloneFixture(loadFixture());
+    const fixture = cloneFixture(canonicalFixture);
     fixture.journal.entries[1]!.when = fixture.journal.entries[0]!.when;
     expect(() => validateIntegrity(fixture)).toThrow(
       "journal timestamps must strictly increase",
     );
   });
 
+  it.each([
+    ["missing", undefined],
+    ["null", null],
+    ["string", "1782547263384"],
+    ["object", { value: 1782547263384 }],
+    ["unsafe integer", Number.MAX_SAFE_INTEGER + 1],
+  ])("rejects a %s journal timestamp", (_label, value) => {
+    const fixture = cloneFixture(canonicalFixture);
+    (fixture.journal.entries[1] as unknown as Record<string, unknown>).when =
+      value;
+    expect(() => validateIntegrity(fixture)).toThrow(
+      "journal entry 1 has invalid timestamp",
+    );
+  });
+
+  it("rejects an invalid journal entry version", () => {
+    const fixture = cloneFixture(canonicalFixture);
+    fixture.journal.entries[1]!.version = "6";
+    expect(() => validateIntegrity(fixture)).toThrow(
+      "journal entry 1 has version 6; expected 7",
+    );
+  });
+
+  it("rejects an invalid journal breakpoint shape", () => {
+    const fixture = cloneFixture(canonicalFixture);
+    (
+      fixture.journal.entries[1] as unknown as Record<string, unknown>
+    ).breakpoints = "true";
+    expect(() => validateIntegrity(fixture)).toThrow(
+      "journal entry 1 has invalid breakpoints true",
+    );
+  });
+
   it("rejects a missing SQL migration", () => {
-    const fixture = cloneFixture(loadFixture());
+    const fixture = cloneFixture(canonicalFixture);
     fixture.sqlFiles = fixture.sqlFiles.filter(
       (name) => name !== "0052_booking_page_request_types.sql",
     );
@@ -410,7 +532,7 @@ describe("Drizzle migration journal integrity", () => {
   });
 
   it("rejects an orphan SQL migration", () => {
-    const fixture = cloneFixture(loadFixture());
+    const fixture = cloneFixture(canonicalFixture);
     fixture.sqlFiles.push("0091_orphan_fixture.sql");
     expect(() => validateIntegrity(fixture)).toThrow(
       "orphan SQL migration 0091_orphan_fixture.sql",
@@ -418,7 +540,7 @@ describe("Drizzle migration journal integrity", () => {
   });
 
   it("rejects broken snapshot lineage", () => {
-    const fixture = cloneFixture(loadFixture());
+    const fixture = cloneFixture(canonicalFixture);
     fixture.snapshots["0053_snapshot.json"]!.prevId = zeroSnapshotId;
     expect(() => validateIntegrity(fixture)).toThrow(
       "broken snapshot lineage at 0053_snapshot.json",

--- a/packages/db/baseline.ts
+++ b/packages/db/baseline.ts
@@ -21,13 +21,11 @@
  * Anything after --through is left for `pnpm db:migrate` to apply normally.
  */
 import { config } from "dotenv";
-config({ path: "../../.env" });
-
 import { createHash } from "crypto";
 import { existsSync, readFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
-import postgres from "postgres";
+import postgres, { type Sql } from "postgres";
 import { isPooledDatabaseConnection } from "./connection-policy";
 import { describeDrift, driftIsClean, type SchemaDrift } from "./schema-drift";
 
@@ -51,6 +49,105 @@ export const snapshotlessMigrationReasons: Readonly<Record<string, string>> = {
   "0052_booking_page_request_types":
     "intentional data-only migration; it changes rows without changing schema",
 };
+
+export type SnapshotlessMigrationPostcondition = {
+  /** Held until commit so the verified rows cannot change before ledger writes. */
+  lockSql: string;
+  /** Must return exactly one row with a non-negative integer `violations`. */
+  violationCountSql: string;
+  violationLabel: string;
+};
+
+/**
+ * A schema snapshot cannot prove a data-only migration ran. Each approved
+ * snapshotless migration therefore needs a live, PHI-free postcondition and a
+ * table lock that makes the apply-time proof atomic with the ledger write.
+ */
+export const snapshotlessMigrationPostconditions: Readonly<
+  Record<string, SnapshotlessMigrationPostcondition>
+> = {
+  "0052_booking_page_request_types": {
+    lockSql: "lock table booking_pages, appointment_types in share mode",
+    violationCountSql: `
+      select count(*)::int as violations
+      from booking_pages bp
+      where bp.deleted_at is null
+        and (
+          jsonb_typeof(bp.config -> 'bookableTypeIds') is distinct from 'array'
+          or exists (
+            select 1
+            from jsonb_array_elements(
+              case
+                when jsonb_typeof(bp.config -> 'bookableTypeIds') = 'array'
+                  then bp.config -> 'bookableTypeIds'
+                else '[]'::jsonb
+              end
+            ) selected(value)
+            where jsonb_typeof(selected.value) is distinct from 'string'
+              or (selected.value #>> '{}') !~*
+                '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          )
+          or (
+            bp.published
+            and not exists (
+              select 1
+              from jsonb_array_elements(
+                case
+                  when jsonb_typeof(bp.config -> 'bookableTypeIds') = 'array'
+                    then bp.config -> 'bookableTypeIds'
+                  else '[]'::jsonb
+                end
+              ) selected(value)
+              join appointment_types at
+                on at.id::text = selected.value #>> '{}'
+                and at.practice_id = bp.practice_id
+                and at.deleted_at is null
+            )
+          )
+        )
+    `,
+    violationLabel:
+      "active booking page rows with an invalid requestable-type list or a published list that has no active same-practice appointment type",
+  },
+};
+
+type SnapshotlessPostconditionReader = (
+  entry: JournalEntry,
+  contract: SnapshotlessMigrationPostcondition,
+) => Promise<number>;
+
+/** Verify every data-only migration at or before the selected cutoff. */
+export async function assertSnapshotlessMigrationPostconditions(
+  entries: readonly JournalEntry[],
+  cutoff: number,
+  readViolations: SnapshotlessPostconditionReader,
+): Promise<void> {
+  const target = entries[cutoff];
+  if (!target) throw new Error(`Invalid migration journal cutoff ${cutoff}.`);
+
+  for (const entry of entries.slice(0, cutoff + 1)) {
+    if (!snapshotlessMigrationReasons[entry.tag]) continue;
+
+    const contract = snapshotlessMigrationPostconditions[entry.tag];
+    if (!contract) {
+      throw new Error(
+        `Cannot baseline through ${target.tag}: approved snapshotless migration ${entry.tag} has no live data postcondition.`,
+      );
+    }
+
+    const violations = await readViolations(entry, contract);
+    if (!Number.isSafeInteger(violations) || violations < 0) {
+      throw new Error(
+        `Cannot baseline through ${target.tag}: data postcondition for ${entry.tag} returned invalid violation count ${String(violations)}.`,
+      );
+    }
+    if (violations > 0) {
+      throw new Error(
+        `Cannot baseline through ${target.tag}: data-only migration ${entry.tag} has ${violations} ${contract.violationLabel}. Apply or verify that migration's data repair before writing a baseline ledger.`,
+      );
+    }
+  }
+}
 
 export type BaselineSnapshotSelection = {
   target: JournalEntry;
@@ -101,8 +198,10 @@ function snapshotPath(entry: JournalEntry): string {
 }
 
 /** Verify the live database contains every table/column at the chosen cutoff. */
+type BaselineSql = Pick<Sql, "unsafe">;
+
 async function findBaselineDrift(
-  client: ReturnType<typeof postgres>,
+  client: BaselineSql,
   entry: JournalEntry,
 ): Promise<SchemaDrift> {
   const snapshot = JSON.parse(
@@ -118,11 +217,11 @@ async function findBaselineDrift(
     );
   }
 
-  const rows = await client<
+  const rows = await client.unsafe<
     { table_name: string; column_name: string }[]
-  >`select table_name, column_name
+  >(`select table_name, column_name
     from information_schema.columns
-    where table_schema = 'public'`;
+    where table_schema = 'public'`);
   const live = new Map<string, Set<string>>();
   for (const row of rows) {
     const columns = live.get(row.table_name);
@@ -171,7 +270,154 @@ function safeTarget(raw: string): string {
   }
 }
 
+async function assertNoMigrationLedger(client: BaselineSql): Promise<void> {
+  const existing = await client.unsafe<{ n: number }[]>(`
+    select count(*)::int as n
+    from information_schema.tables
+    where table_schema = 'drizzle' and table_name = '__drizzle_migrations'
+  `);
+  if (existing[0]?.n <= 0) return;
+
+  const applied = await client.unsafe<{ n: number }[]>(`
+    select count(*)::int as n from drizzle."__drizzle_migrations"
+  `);
+  throw new Error(
+    `A migration ledger already exists with ${applied[0]?.n ?? 0} row(s). Baselining is a one-time operation; use \`pnpm db:migrate\` instead.`,
+  );
+}
+
+async function assertBaselineState(
+  client: BaselineSql,
+  entries: readonly JournalEntry[],
+  cutoff: number,
+  selection: BaselineSnapshotSelection,
+  lockPostconditionTables: boolean,
+): Promise<void> {
+  const drift = await findBaselineDrift(client, selection.snapshot);
+  if (!driftIsClean(drift)) {
+    throw new Error(
+      `Cannot baseline through ${selection.target.tag}: the live database does not match snapshot ${selection.snapshot.tag}.\n${describeDrift(drift)}\nApply the missing schema changes, then run the baseline again.`,
+    );
+  }
+
+  await assertSnapshotlessMigrationPostconditions(
+    entries,
+    cutoff,
+    async (_entry, contract) => {
+      if (lockPostconditionTables) await client.unsafe(contract.lockSql);
+      const rows = await client.unsafe<{ violations: number }[]>(
+        contract.violationCountSql,
+      );
+      return Number(rows[0]?.violations);
+    },
+  );
+}
+
+export type BaselineRunOptions = {
+  url: string;
+  through: string;
+  apply: boolean;
+  log?: (message: string) => void;
+};
+
+/** Run a dry-run or atomic one-time baseline against an explicit database. */
+export async function runBaseline({
+  url,
+  through,
+  apply,
+  log = console.log,
+}: BaselineRunOptions): Promise<void> {
+  const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+    entries: JournalEntry[];
+  };
+  const cutoff = journal.entries.findIndex((entry) =>
+    entry.tag.startsWith(through),
+  );
+  if (cutoff === -1) {
+    throw new Error(
+      `No migration in the journal starts with "${through}".\n` +
+        `Known tags: ${journal.entries.map((entry) => entry.tag).join(", ")}`,
+    );
+  }
+
+  const toMark = journal.entries.slice(0, cutoff + 1);
+  const remaining = journal.entries.slice(cutoff + 1);
+  const selection = selectBaselineSnapshot(journal.entries, cutoff, (entry) =>
+    existsSync(snapshotPath(entry)),
+  );
+
+  const pooled = isPooledDatabaseConnection(url);
+  const client = postgres(url, { max: 1, prepare: !pooled });
+  log(`Target: ${safeTarget(url)}`);
+
+  const printPlan = () => {
+    if (selection.explanation) log(selection.explanation);
+    log(`\nWill mark ${toMark.length} migration(s) as already applied:`);
+    for (const entry of toMark) log(`  ✓ ${entry.tag}`);
+
+    if (remaining.length > 0) {
+      log(
+        `\nWill leave ${remaining.length} migration(s) for \`pnpm db:migrate\`:`,
+      );
+      for (const entry of remaining) log(`  → ${entry.tag}`);
+    } else {
+      log("\nNo migrations left over — the selected snapshot is current.");
+    }
+  };
+
+  try {
+    if (!apply) {
+      await assertNoMigrationLedger(client);
+      await assertBaselineState(
+        client,
+        journal.entries,
+        cutoff,
+        selection,
+        false,
+      );
+      printPlan();
+      log("\nDry run. Re-run with --apply to write the ledger.");
+      return;
+    }
+
+    await client.begin(async (tx) => {
+      // Serialize baseline operators, then re-check every condition inside the
+      // same transaction that writes the ledger. Data-table locks are held
+      // through commit so a verified postcondition cannot change underneath us.
+      await tx.unsafe(`select pg_advisory_xact_lock(
+        hashtext('openpims'), hashtext('db:baseline')
+      )`);
+      await assertNoMigrationLedger(tx);
+      await assertBaselineState(tx, journal.entries, cutoff, selection, true);
+      printPlan();
+
+      await tx.unsafe("create schema if not exists drizzle");
+      await tx.unsafe(`
+        create table if not exists drizzle."__drizzle_migrations" (
+          id serial primary key,
+          hash text not null,
+          created_at bigint
+        )
+      `);
+      for (const entry of toMark) {
+        await tx.unsafe(
+          `insert into drizzle."__drizzle_migrations" (hash, created_at)
+           values ($1, $2)`,
+          [migrationHash(entry.tag), entry.when],
+        );
+      }
+    });
+
+    log(`\nBaseline written. ${toMark.length} migration(s) recorded.`);
+    log("Run `pnpm db:migrate` to apply anything outstanding.");
+  } finally {
+    await client.end();
+  }
+}
+
 async function main() {
+  config({ path: "../../.env" });
+
   const args = process.argv.slice(2);
   const apply = args.includes("--apply");
   const throughArg = args[args.indexOf("--through") + 1];
@@ -194,108 +440,12 @@ async function main() {
     return 1;
   }
 
-  const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
-    entries: JournalEntry[];
-  };
-  const cutoff = journal.entries.findIndex((entry) =>
-    entry.tag.startsWith(throughArg),
-  );
-  if (cutoff === -1) {
-    console.error(
-      `No migration in the journal starts with "${throughArg}".\n` +
-        `Known tags: ${journal.entries.map((entry) => entry.tag).join(", ")}`,
-    );
-    return 1;
-  }
-
-  const toMark = journal.entries.slice(0, cutoff + 1);
-  const remaining = journal.entries.slice(cutoff + 1);
-  const selection = selectBaselineSnapshot(journal.entries, cutoff, (entry) =>
-    existsSync(snapshotPath(entry)),
-  );
-
-  const pooled = isPooledDatabaseConnection(url);
-  const client = postgres(url, { max: 1, prepare: !pooled });
-  console.log(`Target: ${safeTarget(url)}`);
-
   try {
-    const existing = await client`
-      select count(*)::int as n
-      from information_schema.tables
-      where table_schema = 'drizzle' and table_name = '__drizzle_migrations'
-    `;
-    const ledgerExists = existing[0]?.n > 0;
-
-    if (ledgerExists) {
-      const applied = await client`
-        select count(*)::int as n from drizzle."__drizzle_migrations"
-      `;
-      console.log(
-        `A migration ledger already exists with ${applied[0]?.n ?? 0} row(s).`,
-      );
-      console.log(
-        "Baselining is a one-time operation — use `pnpm db:migrate` instead.",
-      );
-      return 1;
-    }
-
-    if (selection.explanation) console.log(selection.explanation);
-    const drift = await findBaselineDrift(client, selection.snapshot);
-    if (!driftIsClean(drift)) {
-      console.error(
-        `Cannot baseline through ${selection.target.tag}: the live database does not match snapshot ${selection.snapshot.tag}.`,
-      );
-      console.error(describeDrift(drift));
-      console.error(
-        "Apply the missing schema changes, then run the baseline again.",
-      );
-      return 1;
-    }
-
-    console.log(
-      `\nWill mark ${toMark.length} migration(s) as already applied:`,
-    );
-    for (const entry of toMark) console.log(`  ✓ ${entry.tag}`);
-
-    if (remaining.length > 0) {
-      console.log(
-        `\nWill leave ${remaining.length} migration(s) for \`pnpm db:migrate\`:`,
-      );
-      for (const entry of remaining) console.log(`  → ${entry.tag}`);
-    } else {
-      console.log(
-        "\nNo migrations left over — the selected snapshot is current.",
-      );
-    }
-
-    if (!apply) {
-      console.log("\nDry run. Re-run with --apply to write the ledger.");
-      return 0;
-    }
-
-    await client.begin(async (tx) => {
-      await tx.unsafe("create schema if not exists drizzle");
-      await tx.unsafe(`
-        create table if not exists drizzle."__drizzle_migrations" (
-          id serial primary key,
-          hash text not null,
-          created_at bigint
-        )
-      `);
-      for (const entry of toMark) {
-        await tx.unsafe(
-          `insert into drizzle."__drizzle_migrations" (hash, created_at)
-           values ($1, $2)`,
-          [migrationHash(entry.tag), entry.when],
-        );
-      }
-    });
-
-    console.log(`\nBaseline written. ${toMark.length} migration(s) recorded.`);
-    console.log("Run `pnpm db:migrate` to apply anything outstanding.");
+    await runBaseline({ url, through: throughArg, apply });
     return 0;
-  } finally {
-    await client.end();
+  } catch (err) {
+    console.error("Baseline failed:", err instanceof Error ? err.message : err);
+    return 1;
   }
 }
 
@@ -304,13 +454,5 @@ const isMainModule =
   resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (isMainModule) {
-  main()
-    .then((code) => process.exit(code))
-    .catch((err) => {
-      console.error(
-        "Baseline failed:",
-        err instanceof Error ? err.message : err,
-      );
-      process.exit(1);
-    });
+  main().then((code) => process.exit(code));
 }

--- a/packages/db/baseline.ts
+++ b/packages/db/baseline.ts
@@ -24,14 +24,14 @@ import { config } from "dotenv";
 config({ path: "../../.env" });
 
 import { createHash } from "crypto";
-import { readFileSync } from "fs";
-import { dirname, join } from "path";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import postgres from "postgres";
 import { isPooledDatabaseConnection } from "./connection-policy";
 import { describeDrift, driftIsClean, type SchemaDrift } from "./schema-drift";
 
-type JournalEntry = { idx: number; tag: string; when: number };
+export type JournalEntry = { idx: number; tag: string; when: number };
 type SnapshotTable = {
   name: string;
   schema: string;
@@ -39,41 +39,61 @@ type SnapshotTable = {
 };
 type MigrationSnapshot = { tables: Record<string, SnapshotTable> };
 
-const args = process.argv.slice(2);
-const apply = args.includes("--apply");
-const throughArg = args[args.indexOf("--through") + 1];
-
-if (!args.includes("--through") || !throughArg || throughArg.startsWith("--")) {
-  console.error(
-    "Usage: pnpm db:baseline --through <migration-prefix> [--apply]\n" +
-      "Example: pnpm db:baseline --through 0030 --apply",
-  );
-  process.exit(1);
-}
-
-const url = process.env.DATABASE_URL?.trim();
-if (!url) {
-  console.error("DATABASE_URL not set");
-  process.exit(1);
-}
-
 const here = dirname(fileURLToPath(import.meta.url));
 const journalPath = join(here, "drizzle", "meta", "_journal.json");
-const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
-  entries: JournalEntry[];
+
+/**
+ * Drizzle snapshots describe schema state, so a deliberately data-only SQL
+ * migration does not need to generate one. Keep every such exception explicit:
+ * an unrecognized gap is an integrity error, not a file-system accident.
+ */
+export const snapshotlessMigrationReasons: Readonly<Record<string, string>> = {
+  "0052_booking_page_request_types":
+    "intentional data-only migration; it changes rows without changing schema",
 };
 
-const cutoff = journal.entries.findIndex((e) => e.tag.startsWith(throughArg));
-if (cutoff === -1) {
-  console.error(
-    `No migration in the journal starts with "${throughArg}".\n` +
-      `Known tags: ${journal.entries.map((e) => e.tag).join(", ")}`,
-  );
-  process.exit(1);
-}
+export type BaselineSnapshotSelection = {
+  target: JournalEntry;
+  snapshot: JournalEntry;
+  explanation?: string;
+};
 
-const toMark = journal.entries.slice(0, cutoff + 1);
-const remaining = journal.entries.slice(cutoff + 1);
+export function selectBaselineSnapshot(
+  entries: readonly JournalEntry[],
+  cutoff: number,
+  hasSnapshot: (entry: JournalEntry) => boolean,
+): BaselineSnapshotSelection {
+  const target = entries[cutoff];
+  if (!target) throw new Error(`Invalid migration journal cutoff ${cutoff}.`);
+
+  const skipped: Array<{ entry: JournalEntry; reason: string }> = [];
+  for (let index = cutoff; index >= 0; index--) {
+    const candidate = entries[index]!;
+    if (hasSnapshot(candidate)) {
+      return {
+        target,
+        snapshot: candidate,
+        explanation:
+          skipped.length === 0
+            ? undefined
+            : `Migration ${target.tag} has no snapshot because it is an ${skipped[0]!.reason}; validating schema against preceding snapshot ${candidate.tag} while marking through ${target.tag}.`,
+      };
+    }
+
+    const reason = snapshotlessMigrationReasons[candidate.tag];
+    if (!reason) {
+      const prefix = candidate.tag.split("_", 1)[0];
+      throw new Error(
+        `Cannot baseline through ${target.tag}: expected snapshot ${prefix}_snapshot.json for ${candidate.tag}, but it is missing and is not an approved snapshotless migration.`,
+      );
+    }
+    skipped.push({ entry: candidate, reason });
+  }
+
+  throw new Error(
+    `Cannot baseline through ${target.tag}: no schema snapshot exists at or before the selected migration.`,
+  );
+}
 
 function snapshotPath(entry: JournalEntry): string {
   const prefix = entry.tag.split("_", 1)[0];
@@ -81,7 +101,10 @@ function snapshotPath(entry: JournalEntry): string {
 }
 
 /** Verify the live database contains every table/column at the chosen cutoff. */
-async function findBaselineDrift(entry: JournalEntry): Promise<SchemaDrift> {
+async function findBaselineDrift(
+  client: ReturnType<typeof postgres>,
+  entry: JournalEntry,
+): Promise<SchemaDrift> {
   const snapshot = JSON.parse(
     readFileSync(snapshotPath(entry), "utf8"),
   ) as MigrationSnapshot;
@@ -139,9 +162,6 @@ function migrationHash(tag: string): string {
   return createHash("sha256").update(sql).digest("hex");
 }
 
-const pooled = isPooledDatabaseConnection(url);
-const client = postgres(url, { max: 1, prepare: !pooled });
-
 function safeTarget(raw: string): string {
   try {
     const parsed = new URL(raw);
@@ -152,90 +172,145 @@ function safeTarget(raw: string): string {
 }
 
 async function main() {
-  console.log(`Target: ${safeTarget(url!)}`);
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const throughArg = args[args.indexOf("--through") + 1];
 
-  const existing = await client`
-    select count(*)::int as n
-    from information_schema.tables
-    where table_schema = 'drizzle' and table_name = '__drizzle_migrations'
-  `;
-  const ledgerExists = existing[0]?.n > 0;
+  if (
+    !args.includes("--through") ||
+    !throughArg ||
+    throughArg.startsWith("--")
+  ) {
+    console.error(
+      "Usage: pnpm db:baseline --through <migration-prefix> [--apply]\n" +
+        "Example: pnpm db:baseline --through 0030 --apply",
+    );
+    return 1;
+  }
 
-  if (ledgerExists) {
-    const applied = await client`
-      select count(*)::int as n from drizzle."__drizzle_migrations"
+  const url = process.env.DATABASE_URL?.trim();
+  if (!url) {
+    console.error("DATABASE_URL not set");
+    return 1;
+  }
+
+  const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+    entries: JournalEntry[];
+  };
+  const cutoff = journal.entries.findIndex((entry) =>
+    entry.tag.startsWith(throughArg),
+  );
+  if (cutoff === -1) {
+    console.error(
+      `No migration in the journal starts with "${throughArg}".\n` +
+        `Known tags: ${journal.entries.map((entry) => entry.tag).join(", ")}`,
+    );
+    return 1;
+  }
+
+  const toMark = journal.entries.slice(0, cutoff + 1);
+  const remaining = journal.entries.slice(cutoff + 1);
+  const selection = selectBaselineSnapshot(journal.entries, cutoff, (entry) =>
+    existsSync(snapshotPath(entry)),
+  );
+
+  const pooled = isPooledDatabaseConnection(url);
+  const client = postgres(url, { max: 1, prepare: !pooled });
+  console.log(`Target: ${safeTarget(url)}`);
+
+  try {
+    const existing = await client`
+      select count(*)::int as n
+      from information_schema.tables
+      where table_schema = 'drizzle' and table_name = '__drizzle_migrations'
     `;
+    const ledgerExists = existing[0]?.n > 0;
+
+    if (ledgerExists) {
+      const applied = await client`
+        select count(*)::int as n from drizzle."__drizzle_migrations"
+      `;
+      console.log(
+        `A migration ledger already exists with ${applied[0]?.n ?? 0} row(s).`,
+      );
+      console.log(
+        "Baselining is a one-time operation — use `pnpm db:migrate` instead.",
+      );
+      return 1;
+    }
+
+    if (selection.explanation) console.log(selection.explanation);
+    const drift = await findBaselineDrift(client, selection.snapshot);
+    if (!driftIsClean(drift)) {
+      console.error(
+        `Cannot baseline through ${selection.target.tag}: the live database does not match snapshot ${selection.snapshot.tag}.`,
+      );
+      console.error(describeDrift(drift));
+      console.error(
+        "Apply the missing schema changes, then run the baseline again.",
+      );
+      return 1;
+    }
+
     console.log(
-      `A migration ledger already exists with ${applied[0]?.n ?? 0} row(s).`,
+      `\nWill mark ${toMark.length} migration(s) as already applied:`,
     );
-    console.log(
-      "Baselining is a one-time operation — use `pnpm db:migrate` instead.",
-    );
-    return 1;
-  }
+    for (const entry of toMark) console.log(`  ✓ ${entry.tag}`);
 
-  const target = toMark[toMark.length - 1]!;
-  const drift = await findBaselineDrift(target);
-  if (!driftIsClean(drift)) {
-    console.error(
-      `Cannot baseline through ${target.tag}: the live database does not match that migration snapshot.`,
-    );
-    console.error(describeDrift(drift));
-    console.error(
-      "Apply or push the missing schema changes, then run the baseline again.",
-    );
-    return 1;
-  }
-
-  console.log(`\nWill mark ${toMark.length} migration(s) as already applied:`);
-  for (const entry of toMark) console.log(`  ✓ ${entry.tag}`);
-
-  if (remaining.length > 0) {
-    console.log(
-      `\nWill leave ${remaining.length} migration(s) for \`pnpm db:migrate\`:`,
-    );
-    for (const entry of remaining) console.log(`  → ${entry.tag}`);
-  } else {
-    console.log(
-      "\nNo migrations left over — the selected snapshot is current.",
-    );
-  }
-
-  if (!apply) {
-    console.log("\nDry run. Re-run with --apply to write the ledger.");
-    return 0;
-  }
-
-  await client.begin(async (tx) => {
-    await tx.unsafe("create schema if not exists drizzle");
-    await tx.unsafe(`
-      create table if not exists drizzle."__drizzle_migrations" (
-        id serial primary key,
-        hash text not null,
-        created_at bigint
-      )
-    `);
-    for (const entry of toMark) {
-      await tx.unsafe(
-        `insert into drizzle."__drizzle_migrations" (hash, created_at)
-         values ($1, $2)`,
-        [migrationHash(entry.tag), entry.when],
+    if (remaining.length > 0) {
+      console.log(
+        `\nWill leave ${remaining.length} migration(s) for \`pnpm db:migrate\`:`,
+      );
+      for (const entry of remaining) console.log(`  → ${entry.tag}`);
+    } else {
+      console.log(
+        "\nNo migrations left over — the selected snapshot is current.",
       );
     }
-  });
 
-  console.log(`\nBaseline written. ${toMark.length} migration(s) recorded.`);
-  console.log("Run `pnpm db:migrate` to apply anything outstanding.");
-  return 0;
+    if (!apply) {
+      console.log("\nDry run. Re-run with --apply to write the ledger.");
+      return 0;
+    }
+
+    await client.begin(async (tx) => {
+      await tx.unsafe("create schema if not exists drizzle");
+      await tx.unsafe(`
+        create table if not exists drizzle."__drizzle_migrations" (
+          id serial primary key,
+          hash text not null,
+          created_at bigint
+        )
+      `);
+      for (const entry of toMark) {
+        await tx.unsafe(
+          `insert into drizzle."__drizzle_migrations" (hash, created_at)
+           values ($1, $2)`,
+          [migrationHash(entry.tag), entry.when],
+        );
+      }
+    });
+
+    console.log(`\nBaseline written. ${toMark.length} migration(s) recorded.`);
+    console.log("Run `pnpm db:migrate` to apply anything outstanding.");
+    return 0;
+  } finally {
+    await client.end();
+  }
 }
 
-main()
-  .then(async (code) => {
-    await client.end();
-    process.exit(code);
-  })
-  .catch(async (err) => {
-    console.error("Baseline failed:", err instanceof Error ? err.message : err);
-    await client.end();
-    process.exit(1);
-  });
+const isMainModule =
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(
+        "Baseline failed:",
+        err instanceof Error ? err.message : err,
+      );
+      process.exit(1);
+    });
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,6 +20,7 @@
     "db:rls:test": "tsx test-rls.ts",
     "db:sms-provider-resolutions:test": "tsx test-sms-provider-event-resolutions.ts",
     "db:migration-runs:test": "tsx test-migration-runs.ts",
+    "db:migrations:check": "pnpm --filter @openpims/web exec vitest run lib/__tests__/migration-journal-integrity.test.ts lib/__tests__/db-migrations.test.ts",
     "db:drift": "tsx check-drift.ts",
     "db:baseline": "tsx baseline.ts",
     "db:studio": "drizzle-kit studio"


### PR DESCRIPTION
## Summary

- enforce byte-for-byte append-only Drizzle migration history against the event-specific merge base
- make one-time baselining fail closed for snapshotless data migrations unless live postconditions pass atomically with the ledger write
- validate future journal entry shape and harden the CI trust boundary

## Safety boundaries

- no migration SQL, schema, runtime application behavior, dependency, or lockfile changes
- no production database access or deployment
- one transaction, advisory lock, table locks, postcondition verification, and ledger write for apply mode
- exact and later cutoffs refuse without ledger writes when booking-page data is invalid

## Verification

- `MIGRATION_INTEGRITY_EVENT_NAME=pull_request MIGRATION_INTEGRITY_PR_BASE_SHA=676f0b09d30a0a6f8804736fc7475cbd1f408d1a pnpm --filter @openpims/db db:migrations:check` — 83/83 pass
- `pnpm --filter @openpims/db exec tsc --noEmit` — pass
- `pnpm --filter @openpims/web exec tsc --noEmit` — pass
- dedicated disposable PostgreSQL contract previously passed for refusal, rollback, malformed/stale IDs, compliant apply, and idempotent rerun
- full repository suite previously passed 4,066 tests with 8 skips

## Promotion gate

This remains a draft and is not production-approved. Do not merge until hosted CI is green and the exact `Migration history integrity` context is required by `main` branch protection. Human release approval remains required.

Jira: https://get-talky.atlassian.net/browse/OPENVPM-61