### PR TITLE
Make patient search owner-aware and deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,14 @@ jobs:
       - name: Execute finance schema adoption contract
         run: pnpm --filter @openpims/db db:finance-adoption:test
 
+      # Exercise the clinic-facing patient + owner search through the real
+      # router and least-privilege RLS role. The fixture proves literal LIKE
+      # escaping, deterministic bounds, context cleanup, and cross-tenant deny.
+      - name: Execute patient and owner search database contract
+        env:
+          PATIENT_SEARCH_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/patient-search.integration.test.ts
+
       # Compile, bind, and execute the exact read-only SQL used by the shared
       # platform-admin and daily SMS operations queues. Unit tests cannot catch
       # postgres.js timestamp encoders or correlated identifier rendering.

--- a/apps/web/app/(dashboard)/care-reminders/page.tsx
+++ b/apps/web/app/(dashboard)/care-reminders/page.tsx
@@ -196,7 +196,7 @@ export default function CareRemindersPage() {
                       id="care-reminder-patient"
                       value={patientQuery}
                       onChange={(event) => setPatientQuery(event.target.value)}
-                      placeholder="Search active patients"
+                      placeholder="Search active patients or owners"
                       autoComplete="off"
                     />
                     {patientSearch.isFetching ? (

--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -300,7 +300,7 @@ function PatientAssignmentPanel({
             maxLength={APPOINTMENT_PATIENT_SEARCH_MAX_LENGTH}
             aria-label="Search patient to attach"
             aria-invalid={!searchIsValid}
-            placeholder="Search patient name or breed"
+            placeholder="Search patient, owner, or breed"
             onChange={(event) => setSearch(event.target.value)}
           />
           {!searchIsValid ? (

--- a/apps/web/app/(dashboard)/patients/page.tsx
+++ b/apps/web/app/(dashboard)/patients/page.tsx
@@ -117,7 +117,7 @@ export default function PatientsPage() {
         <div className="relative w-full min-w-0 sm:max-w-sm sm:flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
-            placeholder="Search patients..."
+            placeholder="Search patients or owners..."
             value={search}
             maxLength={PATIENT_SEARCH_MAX_LENGTH}
             onChange={(e) => setSearch(e.target.value)}

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -1281,7 +1281,7 @@ function RecordsPageContent() {
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search patients by name..."
+            placeholder="Search patients by patient or owner name..."
             value={searchQuery}
             maxLength={PATIENT_SEARCH_MAX_LENGTH}
             onChange={(e) => {

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -2143,7 +2143,7 @@ function BookingForm({
             ) : (
               <div className="relative mt-1">
                 <Input
-                  placeholder="Search patients..."
+                  placeholder="Search patients or owners..."
                   value={patientSearch}
                   maxLength={APPOINTMENT_PATIENT_SEARCH_MAX_LENGTH}
                   aria-invalid={!canSearchPatients}

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -176,7 +176,8 @@ const sections: Section[] = [
       {
         name: "patients.search",
         method: "GET",
-        description: "Quick search patients by name. Returns up to 10 results.",
+        description:
+          "Quick search by patient, owner, or breed. Returns up to 10 deterministically ordered results.",
         input: `{ query: string }`,
         response: `Patient[]`,
       },

--- a/apps/web/components/common/command-search.tsx
+++ b/apps/web/components/common/command-search.tsx
@@ -289,6 +289,14 @@ export function CommandSearch({
                         {patient.breed}
                       </span>
                     )}
+                    {(patient.clientFirstName || patient.clientLastName) && (
+                      <span className="text-muted-foreground">
+                        Owner:{" "}
+                        {[patient.clientFirstName, patient.clientLastName]
+                          .filter(Boolean)
+                          .join(" ")}
+                      </span>
+                    )}
                   </Command.Item>
                 ))}
               </Command.Group>

--- a/apps/web/lib/__tests__/command-search-ui.test.ts
+++ b/apps/web/lib/__tests__/command-search-ui.test.ts
@@ -62,6 +62,8 @@ describe("command search UI", () => {
     expect(source).toContain(
       "{hasQuery && !searchUnavailable && clientResults.length > 0 && ("
     );
+    expect(source).toContain("patient.clientFirstName || patient.clientLastName");
+    expect(source).toContain("Owner:");
     expect(source).not.toContain("const patientResults = patients.data ?? []");
     expect(source).not.toContain("const clientResults = clients.data ?? []");
   });

--- a/apps/web/lib/__tests__/patient-search.test.ts
+++ b/apps/web/lib/__tests__/patient-search.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  PATIENT_SEARCH_MAX_TOKENS,
+  escapePatientSearchToken,
+  hasBoundedPatientSearchTokens,
+  normalizePatientSearchPhrase,
+  patientSearchContainsPattern,
+  patientSearchTokens,
+} from "@/lib/patients/search";
+
+describe("patient and owner search normalization", () => {
+  it("normalizes whitespace and case while preserving token order", () => {
+    expect(normalizePatientSearchPhrase("  LuCy\t  GRAY  ")).toBe("lucy gray");
+    expect(patientSearchTokens("  LuCy\t  GRAY  ")).toEqual(["lucy", "gray"]);
+    expect(patientSearchTokens("gray lucy")).toEqual(["gray", "lucy"]);
+  });
+
+  it("deduplicates tokens without broadening an empty search", () => {
+    expect(patientSearchTokens("lucy LUCY gray lucy")).toEqual([
+      "lucy",
+      "gray",
+    ]);
+    expect(patientSearchTokens("   ")).toEqual([]);
+  });
+
+  it("escapes LIKE syntax so wildcard characters stay literal", () => {
+    expect(escapePatientSearchToken(String.raw`50%_off\today`)).toBe(
+      String.raw`50\%\_off\\today`,
+    );
+    expect(patientSearchContainsPattern("50%_off")).toBe(
+      String.raw`%50\%\_off%`,
+    );
+  });
+
+  it("bounds unique query complexity", () => {
+    const allowed = Array.from(
+      { length: PATIENT_SEARCH_MAX_TOKENS },
+      (_, index) => `token${index}`,
+    ).join(" ");
+    expect(hasBoundedPatientSearchTokens(allowed)).toBe(true);
+    expect(hasBoundedPatientSearchTokens(`${allowed} overflow`)).toBe(false);
+    expect(hasBoundedPatientSearchTokens("same ".repeat(50))).toBe(true);
+  });
+});

--- a/apps/web/lib/patients/search.ts
+++ b/apps/web/lib/patients/search.ts
@@ -1,0 +1,25 @@
+export const PATIENT_SEARCH_MAX_TOKENS = 8;
+
+export function normalizePatientSearchPhrase(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLocaleLowerCase("en-US");
+}
+
+export function patientSearchTokens(value: string): string[] {
+  const normalized = normalizePatientSearchPhrase(value);
+  if (!normalized) return [];
+
+  return [...new Set(normalized.split(" "))];
+}
+
+export function hasBoundedPatientSearchTokens(value: string): boolean {
+  return patientSearchTokens(value).length <= PATIENT_SEARCH_MAX_TOKENS;
+}
+
+/** Escape PostgreSQL LIKE metacharacters before the server adds wildcards. */
+export function escapePatientSearchToken(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
+export function patientSearchContainsPattern(token: string): string {
+  return `%${escapePatientSearchToken(token)}%`;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -78,6 +78,7 @@
     "@types/react-dom": "^19.2.4",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.5.26",
+    "postgres": "^3.4.0",
     "tailwindcss": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "tsx": "^4.23.12",

--- a/apps/web/server/__tests__/patient-search.integration.test.ts
+++ b/apps/web/server/__tests__/patient-search.integration.test.ts
@@ -1,0 +1,290 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { sql as drizzleSql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import * as schema from "../../../../packages/db/schema/index";
+import { patientsRouter } from "../routers/patients";
+import { withTenant } from "@/lib/tenant-db";
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithPatientSearchPostgres =
+  process.env.PATIENT_SEARCH_DB_INTEGRATION === "1" ? describe : describe.skip;
+
+describeWithPatientSearchPostgres(
+  "patient + owner search PostgreSQL contract",
+  () => {
+    it("is literal, deterministic, bounded, and tenant isolated", async () => {
+      const adminUrl = process.env.DATABASE_URL;
+      if (!adminUrl) throw new Error("DATABASE_URL is required");
+
+      const databaseName = `openpims_patient_search_${randomUUID().replaceAll("-", "")}`;
+      if (!/^openpims_patient_search_[a-f0-9]+$/.test(databaseName)) {
+        throw new Error("unsafe disposable database name");
+      }
+
+      const databaseUrl = new URL(adminUrl);
+      databaseUrl.pathname = `/${databaseName}`;
+      databaseUrl.search = "";
+      databaseUrl.hash = "";
+
+      const adminSql = postgres(adminUrl, { max: 1 });
+      let ownerSql: ReturnType<typeof postgres> | undefined;
+
+      await adminSql.unsafe(`create database "${databaseName}"`);
+
+      try {
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:migrate"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+        });
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:rls"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+        });
+
+        ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+        const ownerDb = drizzle(ownerSql, { schema });
+
+        const [practiceA, practiceB] = await ownerDb
+          .insert(schema.practices)
+          .values([
+            { name: "Synthetic Search Clinic A" },
+            { name: "Synthetic Search Clinic B" },
+          ])
+          .returning({ id: schema.practices.id });
+        if (!practiceA || !practiceB)
+          throw new Error("failed to seed practices");
+
+        const [grayOwner, percentOwner, otherOwner, crossTenantOwner] =
+          await ownerDb
+            .insert(schema.clients)
+            .values([
+              {
+                practiceId: practiceA.id,
+                firstName: "Morgan",
+                lastName: "Gray",
+              },
+              {
+                practiceId: practiceA.id,
+                firstName: "Literal",
+                lastName: "Owner",
+              },
+              {
+                practiceId: practiceA.id,
+                firstName: "Exact",
+                lastName: "Patient",
+              },
+              {
+                practiceId: practiceB.id,
+                firstName: "Morgan",
+                lastName: "Gray",
+              },
+            ])
+            .returning({ id: schema.clients.id });
+        if (!grayOwner || !percentOwner || !otherOwner || !crossTenantOwner) {
+          throw new Error("failed to seed clients");
+        }
+
+        const [exactGray, literalPatient, wildcardDecoy, crossTenantPatient] =
+          await ownerDb
+            .insert(schema.patients)
+            .values([
+              {
+                practiceId: practiceA.id,
+                clientId: otherOwner.id,
+                name: "Gray",
+                species: "canine",
+              },
+              {
+                practiceId: practiceA.id,
+                clientId: percentOwner.id,
+                name: "50%_off",
+                species: "feline",
+              },
+              {
+                practiceId: practiceA.id,
+                clientId: percentOwner.id,
+                name: "50xxoff",
+                species: "feline",
+              },
+              {
+                practiceId: practiceB.id,
+                clientId: crossTenantOwner.id,
+                name: "Lucy",
+                species: "canine",
+              },
+            ])
+            .returning({ id: schema.patients.id });
+        if (
+          !exactGray ||
+          !literalPatient ||
+          !wildcardDecoy ||
+          !crossTenantPatient
+        ) {
+          throw new Error("failed to seed base patients");
+        }
+
+        const ambiguousPatients = await ownerDb
+          .insert(schema.patients)
+          .values(
+            Array.from({ length: 24 }, () => ({
+              practiceId: practiceA.id,
+              clientId: grayOwner.id,
+              name: "Lucy",
+              species: "canine" as const,
+            })),
+          )
+          .returning({ id: schema.patients.id });
+
+        const session = (practiceId: string) => ({
+          user: {
+            id: randomUUID(),
+            email: "synthetic-search@example.invalid",
+            name: "Synthetic Search User",
+            role: "front_desk",
+            practiceId,
+          },
+        });
+        const caller = (db: typeof ownerDb, practiceId: string) =>
+          patientsRouter.createCaller({
+            db,
+            session: session(practiceId),
+          } as never);
+
+        await ownerSql`set role openpims_app`;
+        const [emptyContext] = await ownerSql<
+          Array<{
+            currentUser: string;
+            practiceId: string | null;
+            bypass: string | null;
+          }>
+        >`
+          select
+            current_user as "currentUser",
+            nullif(current_setting('app.current_practice_id', true), '') as "practiceId",
+            nullif(current_setting('app.rls_bypass', true), '') as bypass
+        `;
+        expect(emptyContext).toEqual({
+          currentUser: "openpims_app",
+          practiceId: null,
+          bypass: null,
+        });
+        const [noContext] = await ownerSql<
+          Array<{ count: number }>
+        >`select count(*)::int as count from patients`;
+        expect(noContext?.count).toBe(0);
+
+        const runAsTenant = <T>(
+          practiceId: string,
+          fn: (tenantCaller: ReturnType<typeof caller>) => Promise<T>,
+        ) => fn(caller(ownerDb, practiceId));
+
+        const combined = await runAsTenant(practiceA.id, (tenantCaller) =>
+          tenantCaller.search({ query: "  LuCy   gRaY  " }),
+        );
+        const reversed = await runAsTenant(practiceA.id, (tenantCaller) =>
+          tenantCaller.search({ query: "gray lucy" }),
+        );
+        const duplicate = await runAsTenant(practiceA.id, (tenantCaller) =>
+          tenantCaller.search({ query: "lucy LUCY gray" }),
+        );
+
+        const expectedAmbiguousIds = ambiguousPatients
+          .map((patient) => patient.id)
+          .sort()
+          .slice(0, 10);
+        expect(combined.map((patient) => patient.id)).toEqual(
+          expectedAmbiguousIds,
+        );
+        expect(reversed.map((patient) => patient.id)).toEqual(
+          expectedAmbiguousIds,
+        );
+        expect(duplicate.map((patient) => patient.id)).toEqual(
+          expectedAmbiguousIds,
+        );
+        expect(combined).toHaveLength(10);
+
+        const exact = await runAsTenant(practiceA.id, (tenantCaller) =>
+          tenantCaller.search({ query: "gray" }),
+        );
+        expect(exact[0]?.id).toBe(exactGray.id);
+
+        const literal = await runAsTenant(practiceA.id, (tenantCaller) =>
+          tenantCaller.search({ query: "50%_off" }),
+        );
+        expect(literal.map((patient) => patient.id)).toEqual([
+          literalPatient.id,
+        ]);
+        expect(literal.map((patient) => patient.id)).not.toContain(
+          wildcardDecoy.id,
+        );
+
+        const listed = await runAsTenant(practiceA.id, (tenantCaller) =>
+          tenantCaller.list({
+            search: "lucy gray",
+            limit: 7,
+            offset: 0,
+          }),
+        );
+        expect(listed.items).toHaveLength(7);
+        expect(listed.total).toBe(24);
+
+        const [crossTenant] = await withTenant(
+          ownerDb,
+          practiceA.id,
+          async (tx) =>
+            tx.execute<{ count: number }>(drizzleSql`
+              select count(*)::int as count
+              from ${schema.patients}
+              where ${schema.patients.practiceId} = ${practiceB.id}
+            `),
+        );
+        expect(crossTenant?.count).toBe(0);
+
+        const [contextAfterSearch] = await ownerSql<
+          Array<{ practiceId: string | null }>
+        >`
+          select nullif(current_setting('app.current_practice_id', true), '') as "practiceId"
+        `;
+        expect(contextAfterSearch?.practiceId).toBeNull();
+
+        await ownerSql`reset role`;
+
+        await ownerSql`set enable_seqscan = off`;
+        try {
+          const plan = await ownerSql`
+            explain (format json)
+            select p.id
+            from patients p
+            left join clients c
+              on c.id = p.client_id
+             and c.practice_id = ${practiceA.id}
+             and c.deleted_at is null
+            where p.practice_id = ${practiceA.id}
+              and p.deleted_at is null
+              and (
+                p.name ilike ${"%lucy%"} escape '\\'
+                or c.first_name ilike ${"%lucy%"} escape '\\'
+                or c.last_name ilike ${"%lucy%"} escape '\\'
+              )
+            limit 10
+          `;
+          expect(JSON.stringify(plan)).toContain("patients_practice_id_uq");
+        } finally {
+          await ownerSql`reset enable_seqscan`;
+        }
+      } finally {
+        if (ownerSql) await ownerSql.end();
+        await adminSql.unsafe(
+          `drop database if exists "${databaseName}" with (force)`,
+        );
+        await adminSql.end();
+      }
+    }, 60_000);
+  },
+);

--- a/apps/web/server/__tests__/patients-query-scoping.test.ts
+++ b/apps/web/server/__tests__/patients-query-scoping.test.ts
@@ -16,6 +16,20 @@ describe("patients query scoping", () => {
     expect(clientLeftJoins.length).toBeGreaterThanOrEqual(3);
   });
 
+  it("uses bounded literal patient + owner tokens with stable quick-search order", () => {
+    expect(source).toContain("patientOwnerSearchConditions");
+    expect(source).toContain("patientSearchTokens(value).map");
+    expect(source).toContain("literalPatientSearchMatch(patients.name, token)");
+    expect(source).toContain("literalPatientSearchMatch(patients.breed, token)");
+    expect(source).toContain("literalPatientSearchMatch(clients.firstName, token)");
+    expect(source).toContain("literalPatientSearchMatch(clients.lastName, token)");
+    expect(source).toContain("escape '\\\\'");
+    expect(source).toContain("patientSearchOrder(input.query)");
+    expect(source).toContain("when lower(${patients.name}) = ${phrase} then 0");
+    expect(source).toContain("asc(patients.id)");
+    expect(source).toContain(".limit(10)");
+  });
+
   it("requires an active practice for patient reads, writes, and merge dependencies", () => {
     expect(source).toContain("function activePracticePredicate");
     expect(source).toContain("function assertActivePractice");

--- a/apps/web/server/__tests__/patients-safety.test.ts
+++ b/apps/web/server/__tests__/patients-safety.test.ts
@@ -253,6 +253,12 @@ describe("patients mutation safety", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
+      callerWithDb(db).search({
+        query: "one two three four five six seven eight nine",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    await expect(
       callerWithDb(db).addWeight({
         patientId: PATIENT_ID,
         weightKg: "12.3456",

--- a/apps/web/server/routers/patients.ts
+++ b/apps/web/server/routers/patients.ts
@@ -4,7 +4,6 @@ import {
   and,
   isNull,
   isNotNull,
-  ilike,
   or,
   sql,
   desc,
@@ -12,7 +11,7 @@ import {
   inArray,
   asc,
 } from "drizzle-orm";
-import type { SQLWrapper } from "drizzle-orm";
+import type { SQL, SQLWrapper } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 import {
@@ -69,6 +68,12 @@ import {
   PATIENT_SEARCH_MAX_LENGTH,
 } from "@/lib/patients/policy";
 import { listOffsetInput } from "./pagination";
+import {
+  hasBoundedPatientSearchTokens,
+  normalizePatientSearchPhrase,
+  patientSearchContainsPattern,
+  patientSearchTokens,
+} from "@/lib/patients/search";
 
 const patientSpeciesInput = z.enum([
   "canine",
@@ -106,11 +111,19 @@ const patientSearchInput = z
   .string()
   .trim()
   .max(PATIENT_SEARCH_MAX_LENGTH)
-  .optional();
+  .optional()
+  .refine(
+    (value) => value === undefined || hasBoundedPatientSearchTokens(value),
+    {
+      message: "Search query has too many distinct words.",
+    },
+  );
 const patientSearchQueryInput = clinicalTextInput(
   "Search query",
   PATIENT_SEARCH_MAX_LENGTH,
-);
+).refine(hasBoundedPatientSearchTokens, {
+  message: "Search query has too many distinct words.",
+});
 const patientNameInput = clinicalTextInput(
   "Patient name",
   PATIENT_NAME_MAX_LENGTH,
@@ -173,6 +186,38 @@ type PatientsContext = {
   db: Pick<Database, "select">;
   practiceId: string;
 };
+
+function literalPatientSearchMatch(column: SQLWrapper, token: string): SQL {
+  const pattern = patientSearchContainsPattern(token);
+  return sql`${column} ilike ${pattern} escape '\\'`;
+}
+
+function patientOwnerSearchConditions(value: string): SQL[] {
+  return patientSearchTokens(value).map(
+    (token) =>
+      or(
+        literalPatientSearchMatch(patients.name, token),
+        literalPatientSearchMatch(patients.breed, token),
+        literalPatientSearchMatch(clients.firstName, token),
+        literalPatientSearchMatch(clients.lastName, token),
+      )!,
+  );
+}
+
+function patientSearchOrder(value: string): SQL[] {
+  const phrase = normalizePatientSearchPhrase(value);
+  return [
+    sql`case
+      when lower(${patients.name}) = ${phrase} then 0
+      when lower(btrim(${clients.firstName} || ' ' || ${clients.lastName})) = ${phrase} then 1
+      else 2
+    end`,
+    sql`lower(${patients.name}) asc`,
+    sql`lower(${clients.lastName}) asc nulls last`,
+    sql`lower(${clients.firstName}) asc nulls last`,
+    asc(patients.id),
+  ];
+}
 
 const patientIdentitySelection = {
   id: patients.id,
@@ -802,19 +847,14 @@ export const patientsRouter = createRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      const conditions: ReturnType<typeof eq>[] = [
+      const conditions: SQL[] = [
         eq(patients.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
         isNull(patients.deletedAt),
       ];
 
       if (input.search) {
-        conditions.push(
-          or(
-            ilike(patients.name, `%${input.search}%`),
-            ilike(patients.breed, `%${input.search}%`),
-          )!,
-        );
+        conditions.push(...patientOwnerSearchConditions(input.search));
       }
       if (input.species) {
         conditions.push(eq(patients.species, input.species));
@@ -822,6 +862,24 @@ export const patientsRouter = createRouter({
       if (input.status) {
         conditions.push(eq(patients.status, input.status));
       }
+
+      const countQuery = input.search
+        ? ctx.db
+            .select({ count: sql<number>`count(*)` })
+            .from(patients)
+            .leftJoin(
+              clients,
+              and(
+                eq(patients.clientId, clients.id),
+                eq(clients.practiceId, ctx.practiceId),
+                isNull(clients.deletedAt),
+              ),
+            )
+            .where(and(...conditions))
+        : ctx.db
+            .select({ count: sql<number>`count(*)` })
+            .from(patients)
+            .where(and(...conditions));
 
       const [items, countResult] = await Promise.all([
         ctx.db
@@ -849,13 +907,14 @@ export const patientsRouter = createRouter({
             ),
           )
           .where(and(...conditions))
-          .orderBy(desc(patients.createdAt))
+          .orderBy(
+            ...(input.search
+              ? patientSearchOrder(input.search)
+              : [desc(patients.createdAt), asc(patients.id)]),
+          )
           .limit(input.limit)
           .offset(input.offset),
-        ctx.db
-          .select({ count: sql<number>`count(*)` })
-          .from(patients)
-          .where(and(...conditions)),
+        countQuery,
       ]);
 
       return {
@@ -872,14 +931,11 @@ export const patientsRouter = createRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
-      const conditions = [
+      const conditions: SQL[] = [
         eq(patients.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
         isNull(patients.deletedAt),
-        or(
-          ilike(patients.name, `%${input.query}%`),
-          ilike(patients.breed, `%${input.query}%`),
-        )!,
+        ...patientOwnerSearchConditions(input.query),
       ];
       if (input.status) {
         conditions.push(eq(patients.status, input.status));
@@ -903,6 +959,7 @@ export const patientsRouter = createRouter({
           ),
         )
         .where(and(...conditions))
+        .orderBy(...patientSearchOrder(input.query))
         .limit(10);
     }),
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       postcss:
         specifier: 8.5.26
         version: 8.5.26
+      postgres:
+        specifier: ^3.4.0
+        version: 3.4.8
       tailwindcss:
         specifier: ^3.4.0
         version: 3.4.19(tsx@4.23.12)


### PR DESCRIPTION
## Summary

Clinic staff can now find a patient with patient and owner terms in either order, while keeping existing patient and breed lookup behavior.

- tokenizes and deduplicates bounded search input
- treats `%`, `_`, and backslashes as literal characters
- ranks exact patient names first and applies stable tie-breaking
- shows owner context in quick-search results and updates clinic-facing search prompts
- runs the full router contract against PostgreSQL and the least-privilege RLS role in protected CI

## Safety

Search remains tenant-scoped, owner joins require the same active practice, quick search remains capped at 10, list limits remain unchanged, and ambiguous results are never auto-selected. The PostgreSQL contract proves no-context and cross-tenant denial plus transaction-local context cleanup.

## Verification

- `pnpm --filter @openpims/web test` — 4,071 passed, 9 skipped
- `pnpm --filter @openpims/web exec tsc --noEmit`
- `pnpm --filter @openpims/db exec tsc --noEmit`
- `pnpm --filter @openpims/web build`
- `pnpm --filter @openpims/db db:migrations:check` — 82 passed, 1 skipped
- opt-in real PostgreSQL patient-search contract — passed; disposable database removed

Jira: OPENVPM-66
