### PR TITLE
Make template catalog selection searchable and bounded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,14 @@ jobs:
           PATIENT_SEARCH_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run server/__tests__/patient-search.integration.test.ts
 
+      # Template catalog selection is a clinic-facing data boundary. Exercise
+      # the real router as the least-privilege app role and prove literal,
+      # bounded, deterministic, active-only, tenant-isolated search behavior.
+      - name: Execute template catalog search contract
+        env:
+          TEMPLATE_CATALOG_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/template-catalog-search.integration.test.ts
+
       # Compile, bind, and execute the exact read-only SQL used by the shared
       # platform-admin and daily SMS operations queues. Unit tests cannot catch
       # postgres.js timestamp encoders or correlated identifier rendering.

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -4966,6 +4966,7 @@ const CATEGORY_BADGE: Record<string, string> = {
 };
 
 interface TemplateItem {
+  draftId: number;
   itemType: "service" | "product";
   itemId?: string | null;
   description: string;
@@ -4978,6 +4979,7 @@ function TemplatesTab() {
   const formatCurrency = useCurrencyFormatter();
   const utils = trpc.useUtils();
   const [showAdd, setShowAdd] = useState(false);
+  const nextTemplateItemDraftId = useRef(1);
   const {
     data: templateList,
     isLoading,
@@ -5012,6 +5014,7 @@ function TemplatesTab() {
   });
   const [addItems, setAddItems] = useState<TemplateItem[]>([
     {
+      draftId: 0,
       itemType: "service",
       itemId: null,
       description: "",
@@ -5028,6 +5031,7 @@ function TemplatesTab() {
     setAddForm({ name: "", description: "", category: "other" });
     setAddItems([
       {
+        draftId: nextTemplateItemDraftId.current++,
         itemType: "service",
         itemId: null,
         description: "",
@@ -5042,6 +5046,7 @@ function TemplatesTab() {
     setAddItems((currentItems) => [
       ...currentItems,
       {
+        draftId: nextTemplateItemDraftId.current++,
         itemType: "service",
         itemId: null,
         description: "",
@@ -5060,7 +5065,7 @@ function TemplatesTab() {
 
   const updateItem = (
     index: number,
-    field: keyof TemplateItem,
+    field: Exclude<keyof TemplateItem, "draftId">,
     value: string | number | null,
   ) => {
     setAddItems((currentItems) =>
@@ -5118,7 +5123,7 @@ function TemplatesTab() {
     }))
     .filter((item) => item.description.length > 0);
   const hasCatalogLink = (itemId?: string | null) => Boolean(itemId);
-  const isTemplateItemFormValid = (item: TemplateItem) =>
+  const isTemplateItemFormValid = (item: Omit<TemplateItem, "draftId">) =>
     hasCatalogLink(item.itemId) &&
     item.description.trim().length > 0 &&
     item.description.trim().length <=
@@ -5368,7 +5373,7 @@ function TemplatesTab() {
             <h4 className="text-sm font-medium">Items</h4>
             {addItems.map((item, index) => (
               <div
-                key={index}
+                key={item.draftId}
                 className="grid grid-cols-2 items-center gap-2 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto_auto]"
               >
                 <div className="col-span-2 min-w-0 lg:col-span-1">

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -47,6 +47,10 @@ import { BookingTab } from "@/components/settings/booking-tab";
 import { ProviderHours } from "@/components/settings/provider-hours";
 import { MigrationHelpRequest } from "@/components/onboarding/migration-help-request";
 import { ServicesTab } from "@/components/settings/services-tab";
+import {
+  TemplateCatalogPicker,
+  type TemplateCatalogItem,
+} from "@/components/templates/catalog-picker";
 import { useWelcome } from "@/components/welcome/welcome-provider";
 import { cn, isValidEmail } from "@/lib/utils";
 import { toast } from "sonner";
@@ -4980,12 +4984,6 @@ function TemplatesTab() {
     error: templatesError,
     refetch: refetchTemplates,
   } = trpc.templates.list.useQuery();
-  const {
-    data: templateProducts,
-    isLoading: templateProductsLoading,
-    error: templateProductsError,
-    refetch: refetchTemplateProducts,
-  } = trpc.templates.listProducts.useQuery(undefined, { enabled: showAdd });
   const createMutation = trpc.templates.create.useMutation({
     onSuccess: () => {
       utils.templates.list.invalidate();
@@ -5091,18 +5089,18 @@ function TemplatesTab() {
     );
   };
 
-  const selectTemplateProduct = (index: number, productId: string) => {
-    const product = templateProducts?.find(
-      (candidate) => candidate.id === productId,
-    );
+  const selectTemplateCatalogItem = (
+    index: number,
+    catalogItem: TemplateCatalogItem | null,
+  ) => {
     setAddItems((currentItems) =>
       currentItems.map((item, itemIndex) =>
         itemIndex === index
           ? {
               ...item,
-              itemId: product?.id ?? null,
-              description: product?.name ?? "",
-              defaultUnitPrice: product?.unitPrice ?? "0",
+              itemId: catalogItem?.id ?? null,
+              description: catalogItem?.name ?? "",
+              defaultUnitPrice: catalogItem?.unitPrice ?? "0",
             }
           : item,
       ),
@@ -5119,14 +5117,9 @@ function TemplatesTab() {
       sortOrder: index,
     }))
     .filter((item) => item.description.length > 0);
-  const activeTemplateProductIds = new Set(
-    templateProducts?.map((product) => product.id) ?? [],
-  );
-  const hasActiveTemplateProductLink = (itemId?: string | null) =>
-    Boolean(itemId && activeTemplateProductIds.has(itemId));
+  const hasCatalogLink = (itemId?: string | null) => Boolean(itemId);
   const isTemplateItemFormValid = (item: TemplateItem) =>
-    (item.itemType !== "product" ||
-      hasActiveTemplateProductLink(item.itemId)) &&
+    hasCatalogLink(item.itemId) &&
     item.description.trim().length > 0 &&
     item.description.trim().length <=
       TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH &&
@@ -5136,23 +5129,8 @@ function TemplatesTab() {
       item.defaultUnitPrice,
       item.defaultQuantity,
     );
-  const templateProductsMissing =
-    !templateProductsLoading && !templateProductsError && !templateProducts;
-  const templateProductCatalogUnavailable =
-    templateProductsLoading ||
-    Boolean(templateProductsError) ||
-    templateProductsMissing;
-  const hasProductRows = addItems.some((item) => item.itemType === "product");
-  const hasUnlinkedProductRows = addItems.some(
-    (item) =>
-      item.itemType === "product" && !hasActiveTemplateProductLink(item.itemId),
-  );
-  const hasStaleProductRows = addItems.some(
-    (item) =>
-      item.itemType === "product" &&
-      Boolean(item.itemId) &&
-      !templateProductCatalogUnavailable &&
-      !hasActiveTemplateProductLink(item.itemId),
+  const hasUnlinkedCatalogRows = addItems.some(
+    (item) => !hasCatalogLink(item.itemId),
   );
   const canCreateTemplate =
     addForm.name.trim().length > 0 &&
@@ -5162,8 +5140,7 @@ function TemplatesTab() {
     templateItemsToCreate.length > 0 &&
     templateItemsToCreate.length <= TREATMENT_TEMPLATE_MAX_ITEMS &&
     templateItemsToCreate.every(isTemplateItemFormValid) &&
-    !hasUnlinkedProductRows &&
-    (!hasProductRows || !templateProductCatalogUnavailable) &&
+    !hasUnlinkedCatalogRows &&
     !createMutation.isPending;
 
   const selectedTemplate = templateList?.find(
@@ -5392,53 +5369,27 @@ function TemplatesTab() {
             {addItems.map((item, index) => (
               <div
                 key={index}
-                className="grid grid-cols-[1fr_auto_auto_auto_auto] items-center gap-2"
+                className="grid grid-cols-2 items-center gap-2 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto_auto]"
               >
-                {item.itemType === "product" ? (
-                  <select
-                    aria-label={`Inventory product ${index + 1}`}
-                    className="h-10 min-w-0 rounded-md border border-input bg-background px-2 text-sm"
-                    value={item.itemId ?? ""}
-                    aria-invalid={
-                      Boolean(item.itemId) &&
-                      !templateProductCatalogUnavailable &&
-                      !hasActiveTemplateProductLink(item.itemId)
-                    }
-                    disabled={
-                      templateProductCatalogUnavailable ||
-                      templateProducts?.length === 0
-                    }
-                    onChange={(e) =>
-                      selectTemplateProduct(index, e.target.value)
-                    }
-                  >
-                    <option value="">
-                      {templateProductsLoading
-                        ? "Loading inventory products..."
-                        : templateProductsError || templateProductsMissing
-                          ? "Inventory products unavailable"
-                          : templateProducts?.length === 0
-                            ? "No inventory products found"
-                            : "Choose an inventory product"}
-                    </option>
-                    {templateProducts?.map((product) => (
-                      <option key={product.id} value={product.id}>
-                        {product.name}
-                        {product.sku ? ` (${product.sku})` : ""} —{" "}
-                        {formatCurrency(product.unitPrice)}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <Input
-                    placeholder="Item description"
-                    maxLength={TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH}
-                    value={item.description}
-                    onChange={(e) =>
-                      updateItem(index, "description", e.target.value)
+                <div className="col-span-2 min-w-0 lg:col-span-1">
+                  <TemplateCatalogPicker
+                    itemType={item.itemType}
+                    value={item.itemId ?? null}
+                    selectedLabel={item.description}
+                    excludedIds={addItems
+                      .filter(
+                        (candidate, candidateIndex) =>
+                          candidateIndex !== index &&
+                          candidate.itemType === item.itemType &&
+                          Boolean(candidate.itemId),
+                      )
+                      .map((candidate) => candidate.itemId!)}
+                    formatPrice={formatCurrency}
+                    onSelect={(catalogItem) =>
+                      selectTemplateCatalogItem(index, catalogItem)
                     }
                   />
-                )}
+                </div>
                 <select
                   aria-label={`Item type ${index + 1}`}
                   className="h-10 rounded-md border border-input bg-background px-2 text-sm"
@@ -5459,7 +5410,7 @@ function TemplatesTab() {
                   min={TREATMENT_TEMPLATE_ITEM_QUANTITY_MIN}
                   max={TREATMENT_TEMPLATE_ITEM_QUANTITY_MAX}
                   step={1}
-                  className="w-20"
+                  className="w-full lg:w-20"
                   value={item.defaultQuantity}
                   onChange={(e) =>
                     updateItem(
@@ -5475,7 +5426,7 @@ function TemplatesTab() {
                   min={0}
                   max={TREATMENT_TEMPLATE_UNIT_PRICE_MAX}
                   step="0.01"
-                  className="w-28"
+                  className="w-full lg:w-28"
                   value={item.defaultUnitPrice}
                   onChange={(e) =>
                     updateItem(index, "defaultUnitPrice", e.target.value)
@@ -5484,6 +5435,7 @@ function TemplatesTab() {
                 <Button
                   size="sm"
                   variant="ghost"
+                  aria-label={`Remove item ${index + 1}`}
                   disabled={addItems.length <= 1}
                   onClick={() => removeItemRow(index)}
                 >
@@ -5491,35 +5443,10 @@ function TemplatesTab() {
                 </Button>
               </div>
             ))}
-            {hasProductRows &&
-            (templateProductsError || templateProductsMissing) ? (
-              <div className="flex flex-wrap items-center gap-2 text-sm text-destructive">
-                <span>
-                  Inventory products could not load. Product template items are
-                  disabled until the catalog is available.
-                </span>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void refetchTemplateProducts()}
-                >
-                  Retry
-                </Button>
-              </div>
-            ) : null}
-            {hasProductRows &&
-            !templateProductCatalogUnavailable &&
-            templateProducts?.length === 0 ? (
+            {hasUnlinkedCatalogRows ? (
               <p className="text-sm text-muted-foreground">
-                Add an inventory product before creating a product template
-                item.
-              </p>
-            ) : null}
-            {hasStaleProductRows ? (
-              <p role="alert" className="text-sm text-destructive">
-                A selected inventory product is no longer active. Choose an
-                active product before creating this template.
+                Search for and select an active service or inventory product for
+                every template row.
               </p>
             ) : null}
             <Button

--- a/apps/web/components/templates/catalog-picker.tsx
+++ b/apps/web/components/templates/catalog-picker.tsx
@@ -41,6 +41,7 @@ export function TemplateCatalogPicker({
   const [query, setQuery] = useState("");
   const [highlight, setHighlight] = useState(0);
   const deferredQuery = useDeferredValue(query);
+  const queryIsStale = query !== deferredQuery;
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -57,6 +58,13 @@ export function TemplateCatalogPicker({
       ),
     [catalogQuery.data, excluded, value],
   );
+  const activeOption =
+    !queryIsStale && !catalogQuery.isFetching && !catalogQuery.error
+      ? results[highlight]
+      : undefined;
+  const activeOptionId = activeOption
+    ? `${listboxId}-option-${activeOption.id}`
+    : undefined;
 
   useEffect(() => {
     if (!open) return;
@@ -101,8 +109,7 @@ export function TemplateCatalogPicker({
       setHighlight((current) => Math.max(current - 1, 0));
       event.preventDefault();
     } else if (event.key === "Enter") {
-      const item = results[highlight];
-      if (item) choose(item);
+      if (activeOption) choose(activeOption);
       event.preventDefault();
     } else if (event.key === "Escape") {
       close();
@@ -124,7 +131,11 @@ export function TemplateCatalogPicker({
           !value && "text-muted-foreground",
         )}
         onClick={() => {
-          setOpen((current) => !current);
+          if (open) {
+            close();
+            return;
+          }
+          setOpen(true);
           setTimeout(() => inputRef.current?.focus(), 0);
         }}
         onKeyDown={(event) => {
@@ -147,7 +158,12 @@ export function TemplateCatalogPicker({
             <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
             <input
               ref={inputRef}
+              role="combobox"
               aria-label={`Search ${label}s`}
+              aria-autocomplete="list"
+              aria-expanded="true"
+              aria-controls={listboxId}
+              aria-activedescendant={activeOptionId}
               maxLength={TEMPLATE_CATALOG_SEARCH_MAX_LENGTH}
               value={query}
               placeholder={`Search ${label} name, code, or category`}
@@ -189,9 +205,10 @@ export function TemplateCatalogPicker({
             id={listboxId}
             role="listbox"
             aria-label={`Available ${label}s`}
+            aria-busy={queryIsStale || catalogQuery.isFetching}
             className="max-h-72 overflow-y-auto p-1"
           >
-            {catalogQuery.isFetching ? (
+            {queryIsStale || catalogQuery.isFetching ? (
               <div className="flex items-center justify-center gap-2 px-3 py-6 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> Searching...
               </div>
@@ -207,6 +224,7 @@ export function TemplateCatalogPicker({
               results.map((item, index) => (
                 <button
                   key={item.id}
+                  id={`${listboxId}-option-${item.id}`}
                   type="button"
                   role="option"
                   aria-selected={item.id === value}

--- a/apps/web/components/templates/catalog-picker.tsx
+++ b/apps/web/components/templates/catalog-picker.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import {
+  useDeferredValue,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Check, ChevronsUpDown, Loader2, Search, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { trpc } from "@/lib/trpc";
+import { TEMPLATE_CATALOG_SEARCH_MAX_LENGTH } from "@/lib/templates/catalog-search";
+
+export type TemplateCatalogItem = {
+  id: string;
+  itemType: "service" | "product";
+  name: string;
+  code: string | null;
+  category: string | null;
+  unitPrice: string;
+};
+
+export function TemplateCatalogPicker({
+  itemType,
+  value,
+  selectedLabel,
+  excludedIds,
+  onSelect,
+  formatPrice,
+}: {
+  itemType: "service" | "product";
+  value: string | null;
+  selectedLabel: string;
+  excludedIds: string[];
+  onSelect: (item: TemplateCatalogItem | null) => void;
+  formatPrice: (price: string) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const deferredQuery = useDeferredValue(query);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
+  const catalogQuery = trpc.templates.searchCatalog.useQuery(
+    { itemType, search: deferredQuery },
+    { enabled: open },
+  );
+  const excluded = useMemo(() => new Set(excludedIds), [excludedIds]);
+  const results = useMemo(
+    () =>
+      (catalogQuery.data ?? []).filter(
+        (item) => item.id === value || !excluded.has(item.id),
+      ),
+    [catalogQuery.data, excluded, value],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePointer);
+    return () =>
+      document.removeEventListener("pointerdown", closeOnOutsidePointer);
+  }, [open]);
+
+  useEffect(() => {
+    setHighlight(0);
+  }, [deferredQuery, itemType, open]);
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector<HTMLElement>(`[data-index="${highlight}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+  };
+
+  const choose = (item: TemplateCatalogItem) => {
+    onSelect(item);
+    close();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "ArrowDown") {
+      setHighlight((current) =>
+        Math.min(current + 1, Math.max(results.length - 1, 0)),
+      );
+      event.preventDefault();
+    } else if (event.key === "ArrowUp") {
+      setHighlight((current) => Math.max(current - 1, 0));
+      event.preventDefault();
+    } else if (event.key === "Enter") {
+      const item = results[highlight];
+      if (item) choose(item);
+      event.preventDefault();
+    } else if (event.key === "Escape") {
+      close();
+      event.preventDefault();
+    }
+  };
+
+  const label = itemType === "service" ? "service" : "inventory product";
+
+  return (
+    <div ref={rootRef} className="relative min-w-0">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        className={cn(
+          "flex min-h-11 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-left text-sm",
+          !value && "text-muted-foreground",
+        )}
+        onClick={() => {
+          setOpen((current) => !current);
+          setTimeout(() => inputRef.current?.focus(), 0);
+        }}
+        onKeyDown={(event) => {
+          if (!open && (event.key === "ArrowDown" || event.key === "Enter")) {
+            setOpen(true);
+            setTimeout(() => inputRef.current?.focus(), 0);
+            event.preventDefault();
+          }
+        }}
+      >
+        <span className="truncate">
+          {value ? selectedLabel : `Search ${label}s...`}
+        </span>
+        <ChevronsUpDown className="h-4 w-4 shrink-0" />
+      </button>
+
+      {open ? (
+        <div className="absolute z-40 mt-1 w-[min(28rem,calc(100vw-2rem))] rounded-md border border-border bg-popover shadow-lg">
+          <div className="flex min-h-11 items-center gap-2 border-b border-border px-3">
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              aria-label={`Search ${label}s`}
+              maxLength={TEMPLATE_CATALOG_SEARCH_MAX_LENGTH}
+              value={query}
+              placeholder={`Search ${label} name, code, or category`}
+              className="min-w-0 flex-1 bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            {query ? (
+              <button
+                type="button"
+                aria-label="Clear search"
+                className="rounded p-2 text-muted-foreground hover:bg-accent"
+                onClick={() => {
+                  setQuery("");
+                  inputRef.current?.focus();
+                }}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            ) : null}
+          </div>
+
+          {value ? (
+            <button
+              type="button"
+              className="flex min-h-11 w-full items-center gap-2 border-b border-border px-3 text-left text-sm text-muted-foreground hover:bg-accent"
+              onClick={() => {
+                onSelect(null);
+                setQuery("");
+                inputRef.current?.focus();
+              }}
+            >
+              <X className="h-4 w-4" /> Clear selected {label}
+            </button>
+          ) : null}
+
+          <div
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            aria-label={`Available ${label}s`}
+            className="max-h-72 overflow-y-auto p-1"
+          >
+            {catalogQuery.isFetching ? (
+              <div className="flex items-center justify-center gap-2 px-3 py-6 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Searching...
+              </div>
+            ) : catalogQuery.error ? (
+              <div role="alert" className="px-3 py-6 text-sm text-destructive">
+                Catalog search failed. Edit the query to retry.
+              </div>
+            ) : results.length === 0 ? (
+              <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                No active {label}s match &quot;{query.trim()}&quot;.
+              </p>
+            ) : (
+              results.map((item, index) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  role="option"
+                  aria-selected={item.id === value}
+                  data-index={index}
+                  className={cn(
+                    "flex min-h-11 w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm",
+                    index === highlight && "bg-accent",
+                  )}
+                  onMouseEnter={() => setHighlight(index)}
+                  onClick={() => choose(item)}
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center",
+                      item.id === value ? "text-primary" : "text-transparent",
+                    )}
+                  >
+                    <Check className="h-4 w-4" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium">
+                      {item.name}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {[item.code, item.category].filter(Boolean).join(" · ") ||
+                        "No code or category"}
+                    </span>
+                  </span>
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    {formatPrice(item.unitPrice)}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/__tests__/template-catalog-picker-ui.test.ts
+++ b/apps/web/lib/__tests__/template-catalog-picker-ui.test.ts
@@ -23,8 +23,19 @@ describe("template catalog picker UI", () => {
     expect(source).toContain('event.key === "Escape"');
     expect(source).toContain('role="listbox"');
     expect(source).toContain('role="option"');
+    expect(source).toContain('role="combobox"');
+    expect(source).toContain("aria-activedescendant={activeOptionId}");
     expect(source).toContain("min-h-11");
     expect(source).toContain("calc(100vw-2rem)");
+  });
+
+  it("does not select results while a deferred query is stale or fetching", () => {
+    expect(source).toContain("const queryIsStale = query !== deferredQuery");
+    expect(source).toContain(
+      "!queryIsStale && !catalogQuery.isFetching && !catalogQuery.error",
+    );
+    expect(source).toContain("if (activeOption) choose(activeOption)");
+    expect(source).toContain("queryIsStale || catalogQuery.isFetching");
   });
 
   it("filters catalog ids already selected in another row", () => {

--- a/apps/web/lib/__tests__/template-catalog-picker-ui.test.ts
+++ b/apps/web/lib/__tests__/template-catalog-picker-ui.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("template catalog picker UI", () => {
+  const source = readFileSync(
+    "components/templates/catalog-picker.tsx",
+    "utf8",
+  );
+
+  it("supports query editing, clearing, and bounded server re-search", () => {
+    expect(source).toContain("trpc.templates.searchCatalog.useQuery");
+    expect(source).toContain("useDeferredValue(query)");
+    expect(source).toContain("maxLength={TEMPLATE_CATALOG_SEARCH_MAX_LENGTH}");
+    expect(source).toContain('aria-label="Clear search"');
+    expect(source).toContain("Clear selected {label}");
+    expect(source).toContain("onSelect(null)");
+  });
+
+  it("supports keyboard and touch-sized listbox selection", () => {
+    expect(source).toContain('event.key === "ArrowDown"');
+    expect(source).toContain('event.key === "ArrowUp"');
+    expect(source).toContain('event.key === "Enter"');
+    expect(source).toContain('event.key === "Escape"');
+    expect(source).toContain('role="listbox"');
+    expect(source).toContain('role="option"');
+    expect(source).toContain("min-h-11");
+    expect(source).toContain("calc(100vw-2rem)");
+  });
+
+  it("filters catalog ids already selected in another row", () => {
+    expect(source).toContain("new Set(excludedIds)");
+    expect(source).toContain("item.id === value || !excluded.has(item.id)");
+  });
+});

--- a/apps/web/lib/__tests__/template-catalog-search.test.ts
+++ b/apps/web/lib/__tests__/template-catalog-search.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  escapeTemplateCatalogLike,
+  hasDuplicateTemplateCatalogItems,
+  TEMPLATE_CATALOG_RESULT_LIMIT,
+  TEMPLATE_CATALOG_SEARCH_MAX_LENGTH,
+} from "../templates/catalog-search";
+
+describe("template catalog search policy", () => {
+  it("escapes SQL wildcard characters as literal input", () => {
+    expect(escapeTemplateCatalogLike("100%_care\\kit")).toBe(
+      "100\\%\\_care\\\\kit",
+    );
+  });
+
+  it("keeps the catalog query and response bounded", () => {
+    expect(TEMPLATE_CATALOG_SEARCH_MAX_LENGTH).toBe(120);
+    expect(TEMPLATE_CATALOG_RESULT_LIMIT).toBe(20);
+  });
+
+  it("detects duplicate linked rows by item type and id", () => {
+    expect(
+      hasDuplicateTemplateCatalogItems([
+        { itemType: "service", itemId: "same" },
+        { itemType: "service", itemId: "same" },
+      ]),
+    ).toBe(true);
+    expect(
+      hasDuplicateTemplateCatalogItems([
+        { itemType: "service", itemId: "same" },
+        { itemType: "product", itemId: "same" },
+        { itemType: "service" },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/__tests__/templates-settings-ui.test.ts
+++ b/apps/web/lib/__tests__/templates-settings-ui.test.ts
@@ -21,7 +21,7 @@ describe("treatment template settings UI", () => {
     expect(source).toContain("Templates");
     expect(source).toContain("trpc.templates.create.useMutation");
     expect(source).toContain("trpc.templates.getById.useQuery");
-    expect(source).toContain("trpc.templates.listProducts.useQuery");
+    expect(source).toContain("<TemplateCatalogPicker");
   });
 
   it("keeps template create controls aligned to shared policy", () => {
@@ -41,49 +41,48 @@ describe("treatment template settings UI", () => {
     expect(isTreatmentTemplateItemTotalValid("99999999.99", 2)).toBe(false);
     expect(source).toContain("maxLength={TREATMENT_TEMPLATE_NAME_MAX_LENGTH}");
     expect(source).toContain(
-      "maxLength={TREATMENT_TEMPLATE_DESCRIPTION_MAX_LENGTH}"
+      "maxLength={TREATMENT_TEMPLATE_DESCRIPTION_MAX_LENGTH}",
     );
     expect(source).toContain(
-      "maxLength={TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH}"
+      "item.description.trim().length <=\n      TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH",
     );
     expect(source).toContain("min={TREATMENT_TEMPLATE_ITEM_QUANTITY_MIN}");
     expect(source).toContain("max={TREATMENT_TEMPLATE_ITEM_QUANTITY_MAX}");
     expect(source).toContain("max={TREATMENT_TEMPLATE_UNIT_PRICE_MAX}");
     expect(source).toContain(
-      "disabled={addItems.length >= TREATMENT_TEMPLATE_MAX_ITEMS}"
+      "disabled={addItems.length >= TREATMENT_TEMPLATE_MAX_ITEMS}",
     );
     expect(source).toContain("const templateItemsToCreate = addItems");
     expect(source).toContain("const canCreateTemplate =");
     expect(source).toContain(
-      "templateItemsToCreate.every(isTemplateItemFormValid)"
+      "templateItemsToCreate.every(isTemplateItemFormValid)",
     );
     expect(source).toContain("disabled={!canCreateTemplate}");
     expect(source).toContain("items: templateItemsToCreate");
   });
 
-  it("links product template rows to inventory and fails closed without the catalog", () => {
+  it("links service and product rows through the searchable catalog picker", () => {
     expect(source).toContain("itemId?: string | null");
-    expect(source).toContain("const selectTemplateProduct =");
-    expect(source).toContain("itemId: product?.id ?? null");
-    expect(source).toContain("description: product?.name ?? \"\"");
-    expect(source).toContain("defaultUnitPrice: product?.unitPrice ?? \"0\"");
+    expect(source).toContain("const selectTemplateCatalogItem =");
+    expect(source).toContain("itemId: catalogItem?.id ?? null");
+    expect(source).toContain('description: catalogItem?.name ?? ""');
+    expect(source).toContain('defaultUnitPrice: catalogItem?.unitPrice ?? "0"');
     expect(source).toContain("itemId: item.itemId || undefined");
-    expect(source).toContain(
-      'item.itemType !== "product" ||\n      hasActiveTemplateProductLink(item.itemId)',
-    );
-    expect(source).toContain("const hasUnlinkedProductRows = addItems.some(");
-    expect(source).toContain("const activeTemplateProductIds = new Set(");
-    expect(source).toContain("const hasActiveTemplateProductLink =");
-    expect(source).toContain("const hasStaleProductRows = addItems.some(");
-    expect(source).toContain("!hasActiveTemplateProductLink(item.itemId)");
-    expect(source).toContain("!hasUnlinkedProductRows");
-    expect(source).toContain("!templateProductCatalogUnavailable");
-    expect(source).toContain("Inventory products could not load");
-    expect(source).toContain("onClick={() => void refetchTemplateProducts()}");
-    expect(source).toContain('aria-invalid={');
-    expect(source).toContain('role="alert"');
-    expect(source).toContain("selected inventory product is no longer active");
+    expect(source).toContain("const hasUnlinkedCatalogRows = addItems.some(");
+    expect(source).toContain("!hasUnlinkedCatalogRows");
+    expect(source).toContain("excludedIds={addItems");
+    expect(source).toContain("candidate.itemType === item.itemType");
+    expect(source).toContain("Search for and select an active service");
     expect(source).toContain("item.hasActiveProductLink !== true");
     expect(source).toContain("Missing or archived inventory product");
+  });
+
+  it("uses a responsive item grid and labels row removal", () => {
+    expect(source).toContain(
+      'className="grid grid-cols-2 items-center gap-2 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto_auto]"',
+    );
+    expect(source).toContain("aria-label={`Remove item ${index + 1}`}");
+    expect(source).toContain('className="w-full lg:w-20"');
+    expect(source).toContain('className="w-full lg:w-28"');
   });
 });

--- a/apps/web/lib/__tests__/templates-settings-ui.test.ts
+++ b/apps/web/lib/__tests__/templates-settings-ui.test.ts
@@ -78,6 +78,9 @@ describe("treatment template settings UI", () => {
   });
 
   it("uses a responsive item grid and labels row removal", () => {
+    expect(source).toContain("draftId: number");
+    expect(source).toContain("key={item.draftId}");
+    expect(source).toContain("nextTemplateItemDraftId.current++");
     expect(source).toContain(
       'className="grid grid-cols-2 items-center gap-2 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto_auto]"',
     );

--- a/apps/web/lib/templates/catalog-search.ts
+++ b/apps/web/lib/templates/catalog-search.ts
@@ -1,0 +1,22 @@
+export const TEMPLATE_CATALOG_SEARCH_MAX_LENGTH = 120;
+export const TEMPLATE_CATALOG_RESULT_LIMIT = 20;
+
+export function escapeTemplateCatalogLike(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+}
+
+export function hasDuplicateTemplateCatalogItems(
+  items: Array<{ itemType: "service" | "product"; itemId?: string | null }>,
+): boolean {
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (!item.itemId) continue;
+    const key = `${item.itemType}:${item.itemId}`;
+    if (seen.has(key)) return true;
+    seen.add(key);
+  }
+  return false;
+}

--- a/apps/web/server/__tests__/template-catalog-search.integration.test.ts
+++ b/apps/web/server/__tests__/template-catalog-search.integration.test.ts
@@ -182,6 +182,25 @@ describeWithTemplateCatalogPostgres(
         `;
         expect(noContext).toEqual({ services: 0, products: 0 });
 
+        const initialServices = await caller(practiceA.id).searchCatalog({
+          itemType: "service",
+          search: "",
+        });
+        expect(initialServices).toHaveLength(TEMPLATE_CATALOG_RESULT_LIMIT);
+        expect(initialServices.map((item) => item.name)).toEqual(
+          [...initialServices.map((item) => item.name)].sort((left, right) =>
+            left.localeCompare(right, undefined, { sensitivity: "base" }),
+          ),
+        );
+
+        const initialProducts = await caller(practiceA.id).searchCatalog({
+          itemType: "product",
+          search: "",
+        });
+        expect(initialProducts.map((item) => item.id)).toEqual([
+          exactProduct.id,
+        ]);
+
         const exact = await caller(practiceA.id).searchCatalog({
           itemType: "service",
           search: "exam",

--- a/apps/web/server/__tests__/template-catalog-search.integration.test.ts
+++ b/apps/web/server/__tests__/template-catalog-search.integration.test.ts
@@ -1,0 +1,265 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { sql as drizzleSql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import * as schema from "../../../../packages/db/schema/index";
+import { withTenant } from "@/lib/tenant-db";
+import { TEMPLATE_CATALOG_RESULT_LIMIT } from "@/lib/templates/catalog-search";
+import { templatesRouter } from "../routers/templates";
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithTemplateCatalogPostgres =
+  process.env.TEMPLATE_CATALOG_DB_INTEGRATION === "1"
+    ? describe
+    : describe.skip;
+
+describeWithTemplateCatalogPostgres(
+  "template catalog PostgreSQL contract",
+  () => {
+    it("is literal, deterministic, bounded, active-only, and tenant isolated", async () => {
+      const adminUrl = process.env.DATABASE_URL;
+      if (!adminUrl) throw new Error("DATABASE_URL is required");
+
+      const databaseName = `openpims_template_catalog_${randomUUID().replaceAll("-", "")}`;
+      if (!/^openpims_template_catalog_[a-f0-9]+$/.test(databaseName)) {
+        throw new Error("unsafe disposable database name");
+      }
+
+      const databaseUrl = new URL(adminUrl);
+      databaseUrl.pathname = `/${databaseName}`;
+      databaseUrl.search = "";
+      databaseUrl.hash = "";
+
+      const adminSql = postgres(adminUrl, { max: 1 });
+      let ownerSql: ReturnType<typeof postgres> | undefined;
+      await adminSql.unsafe(`create database "${databaseName}"`);
+
+      try {
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:migrate"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+        });
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:rls"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+        });
+
+        ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+        const ownerDb = drizzle(ownerSql, { schema });
+        const [practiceA, practiceB] = await ownerDb
+          .insert(schema.practices)
+          .values([
+            { name: "Synthetic Template Clinic A" },
+            { name: "Synthetic Template Clinic B" },
+          ])
+          .returning({ id: schema.practices.id });
+        if (!practiceA || !practiceB)
+          throw new Error("failed to seed practices");
+
+        const serviceRows = await ownerDb
+          .insert(schema.services)
+          .values([
+            {
+              practiceId: practiceA.id,
+              name: "Exam",
+              code: "EXACT",
+              category: "Wellness",
+              defaultPrice: "75.00",
+            },
+            {
+              practiceId: practiceA.id,
+              name: "Examination follow-up",
+              code: "FOLLOW",
+              category: "Wellness",
+              defaultPrice: "45.00",
+            },
+            {
+              practiceId: practiceA.id,
+              name: "100%_care\\kit",
+              code: "LITERAL",
+              category: "Special",
+              defaultPrice: "12.00",
+            },
+            {
+              practiceId: practiceA.id,
+              name: "100xxcare-kit",
+              code: "DECOY",
+              category: "Special",
+              defaultPrice: "12.00",
+            },
+            ...Array.from({ length: 24 }, (_, index) => ({
+              practiceId: practiceA.id,
+              name: "General service",
+              code: `GENERAL-${String(index).padStart(2, "0")}`,
+              category: "General",
+              defaultPrice: "10.00",
+            })),
+            {
+              practiceId: practiceB.id,
+              name: "Exam",
+              code: "CROSS-TENANT",
+              category: "Wellness",
+              defaultPrice: "1.00",
+            },
+          ])
+          .returning({
+            id: schema.services.id,
+            name: schema.services.name,
+            code: schema.services.code,
+          });
+        const exactService = serviceRows.find(
+          (service) => service.code === "EXACT",
+        );
+        const literalService = serviceRows.find(
+          (service) => service.code === "LITERAL",
+        );
+        const decoyService = serviceRows.find(
+          (service) => service.code === "DECOY",
+        );
+        if (!exactService || !literalService || !decoyService) {
+          throw new Error("failed to seed services");
+        }
+
+        const [exactProduct, archivedProduct, crossTenantProduct] =
+          await ownerDb
+            .insert(schema.products)
+            .values([
+              {
+                practiceId: practiceA.id,
+                name: "Dental chews",
+                sku: "DENTAL-1",
+                category: "Dental",
+                unitPrice: "12.00",
+              },
+              {
+                practiceId: practiceA.id,
+                name: "Archived dental chews",
+                sku: "DENTAL-OLD",
+                category: "Dental",
+                unitPrice: "9.00",
+                deletedAt: new Date(),
+              },
+              {
+                practiceId: practiceB.id,
+                name: "Dental chews",
+                sku: "DENTAL-OTHER",
+                category: "Dental",
+                unitPrice: "1.00",
+              },
+            ])
+            .returning({ id: schema.products.id });
+        if (!exactProduct || !archivedProduct || !crossTenantProduct) {
+          throw new Error("failed to seed products");
+        }
+
+        const session = (practiceId: string) => ({
+          user: {
+            id: randomUUID(),
+            email: "synthetic-template@example.invalid",
+            name: "Synthetic Template Admin",
+            role: "admin",
+            practiceId,
+          },
+        });
+        const caller = (practiceId: string) =>
+          templatesRouter.createCaller({
+            db: ownerDb,
+            session: session(practiceId),
+          } as never);
+
+        await ownerSql`set role openpims_app`;
+        const [noContext] = await ownerSql<
+          Array<{ services: number; products: number }>
+        >`
+          select
+            (select count(*)::int from services) as services,
+            (select count(*)::int from products) as products
+        `;
+        expect(noContext).toEqual({ services: 0, products: 0 });
+
+        const exact = await caller(practiceA.id).searchCatalog({
+          itemType: "service",
+          search: "exam",
+        });
+        expect(exact[0]?.id).toBe(exactService.id);
+        expect(exact.map((item) => item.code)).not.toContain("CROSS-TENANT");
+
+        const literal = await caller(practiceA.id).searchCatalog({
+          itemType: "service",
+          search: "100%_care\\kit",
+        });
+        expect(literal.map((item) => item.id)).toEqual([literalService.id]);
+        expect(literal.map((item) => item.id)).not.toContain(decoyService.id);
+
+        const bounded = await caller(practiceA.id).searchCatalog({
+          itemType: "service",
+          search: "general",
+        });
+        expect(bounded).toHaveLength(TEMPLATE_CATALOG_RESULT_LIMIT);
+        expect(bounded.map((item) => item.code)).toEqual(
+          [...bounded.map((item) => item.code)].sort(),
+        );
+
+        const products = await caller(practiceA.id).searchCatalog({
+          itemType: "product",
+          search: "dental",
+        });
+        expect(products.map((item) => item.id)).toEqual([exactProduct.id]);
+        expect(products.map((item) => item.id)).not.toContain(
+          archivedProduct.id,
+        );
+        expect(products.map((item) => item.id)).not.toContain(
+          crossTenantProduct.id,
+        );
+
+        const [crossTenantCount] = await withTenant(
+          ownerDb,
+          practiceA.id,
+          async (tx) =>
+            tx.execute<{ count: number }>(drizzleSql`
+              select count(*)::int as count
+              from ${schema.services}
+              where ${schema.services.practiceId} = ${practiceB.id}
+            `),
+        );
+        expect(crossTenantCount?.count).toBe(0);
+
+        const [contextAfterSearch] = await ownerSql<
+          Array<{ practiceId: string | null }>
+        >`
+          select nullif(current_setting('app.current_practice_id', true), '') as "practiceId"
+        `;
+        expect(contextAfterSearch?.practiceId).toBeNull();
+
+        await ownerSql`reset role`;
+        await ownerSql`set enable_seqscan = off`;
+        try {
+          const plan = await ownerSql`
+            explain (format json)
+            select id
+            from services
+            where practice_id = ${practiceA.id}
+              and deleted_at is null
+              and name ilike ${"%general%"} escape '\\'
+            order by lower(name), id
+            limit ${TEMPLATE_CATALOG_RESULT_LIMIT}
+          `;
+          expect(JSON.stringify(plan)).toContain("services_practice_name_idx");
+        } finally {
+          await ownerSql`reset enable_seqscan`;
+        }
+      } finally {
+        if (ownerSql) await ownerSql.end();
+        await adminSql.unsafe(
+          `drop database if exists "${databaseName}" with (force)`,
+        );
+        await adminSql.end();
+      }
+    }, 60_000);
+  },
+);

--- a/apps/web/server/__tests__/templates-safety.test.ts
+++ b/apps/web/server/__tests__/templates-safety.test.ts
@@ -277,46 +277,111 @@ describe("treatment template safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("lists active tenant inventory products for template setup", async () => {
+  it("searches active tenant service and product catalogs for template setup", async () => {
+    const serviceOptions = [
+      {
+        id: SERVICE_ID,
+        name: "Wellness exam",
+        code: "EXAM",
+        category: "Wellness",
+        unitPrice: "75.00",
+      },
+    ];
     const productOptions = [
       {
         id: PRODUCT_ID,
         name: "Dental chews",
-        sku: "DENTAL-1",
+        code: "DENTAL-1",
+        category: "Dental",
         unitPrice: "12.00",
       },
     ];
     const { db, select } = createDb({
-      selectResults: [[{ id: PRACTICE_ID }], productOptions],
+      selectResults: [
+        [{ id: PRACTICE_ID }],
+        serviceOptions,
+        [{ id: PRACTICE_ID }],
+        productOptions,
+      ],
     });
 
-    await expect(callerWithDb(db).listProducts()).resolves.toEqual(
-      productOptions,
+    await expect(
+      callerWithDb(db).searchCatalog({ itemType: "service", search: "exam" }),
+    ).resolves.toEqual(
+      serviceOptions.map((item) => ({ ...item, itemType: "service" })),
     );
-    expect(select).toHaveBeenCalledTimes(2);
+    await expect(
+      callerWithDb(db).searchCatalog({ itemType: "product", search: "dental" }),
+    ).resolves.toEqual(
+      productOptions.map((item) => ({ ...item, itemType: "product" })),
+    );
+    expect(select).toHaveBeenCalledTimes(4);
   });
 
-  it("keeps the template product catalog admin-only and tenant-scoped", async () => {
+  it("keeps template catalog search admin-only, bounded, and tenant-scoped", async () => {
     const { db, select } = createDb();
 
     await expect(
-      callerWithDb(db, "veterinarian").listProducts(),
+      callerWithDb(db, "veterinarian").searchCatalog({
+        itemType: "service",
+        search: "exam",
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(select).not.toHaveBeenCalled();
 
     const source = readFileSync("server/routers/templates.ts", "utf8");
-    const listProductsBlock = source.slice(
-      source.indexOf("listProducts:"),
+    const searchCatalogBlock = source.slice(
+      source.indexOf("searchCatalog:"),
       source.indexOf("getById:"),
     );
-    expect(listProductsBlock).toContain('requireRole("admin")');
-    expect(listProductsBlock).toContain(
+    expect(searchCatalogBlock).toContain('requireRole("admin")');
+    expect(searchCatalogBlock).toContain("TEMPLATE_CATALOG_RESULT_LIMIT");
+    expect(searchCatalogBlock).toContain("escapeTemplateCatalogLike");
+    expect(searchCatalogBlock).toContain("escape '\\\\'");
+    expect(searchCatalogBlock).toContain(
       "eq(products.practiceId, ctx.practiceId)",
     );
-    expect(listProductsBlock).toContain(
+    expect(searchCatalogBlock).toContain(
+      "eq(services.practiceId, ctx.practiceId)",
+    );
+    expect(searchCatalogBlock).toContain(
       "activePracticePredicate(ctx.practiceId)",
     );
-    expect(listProductsBlock).toContain("isNull(products.deletedAt)");
+    expect(searchCatalogBlock).toContain("isNull(products.deletedAt)");
+    expect(searchCatalogBlock).toContain("isNull(services.deletedAt)");
+    expect(searchCatalogBlock).toContain("asc(products.id)");
+    expect(searchCatalogBlock).toContain("asc(services.id)");
+  });
+
+  it("rejects duplicate linked catalog items before DB work", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).create({
+        name: "Duplicate exam",
+        items: [
+          {
+            itemType: "service",
+            itemId: SERVICE_ID,
+            description: "Wellness exam",
+            defaultQuantity: 1,
+            defaultUnitPrice: "75.00",
+            sortOrder: 0,
+          },
+          {
+            itemType: "service",
+            itemId: SERVICE_ID,
+            description: "Wellness exam",
+            defaultQuantity: 1,
+            defaultUnitPrice: "75.00",
+            sortOrder: 1,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("reports missing and archived product links without exposing catalog data", async () => {
@@ -1073,7 +1138,9 @@ describe("treatment template safety", () => {
       message: "Practice not found",
     });
 
-    await expect(caller.listProducts()).rejects.toMatchObject({
+    await expect(
+      caller.searchCatalog({ itemType: "product", search: "" }),
+    ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
     });

--- a/apps/web/server/routers/templates.ts
+++ b/apps/web/server/routers/templates.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, isNull, asc, inArray, sql } from "drizzle-orm";
+import { eq, and, isNull, asc, inArray, sql, or } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 import {
@@ -35,6 +35,12 @@ import {
   TREATMENT_TEMPLATE_NAME_MAX_LENGTH,
   TREATMENT_TEMPLATE_UNIT_PRICE_PATTERN,
 } from "@/lib/templates/policy";
+import {
+  escapeTemplateCatalogLike,
+  hasDuplicateTemplateCatalogItems,
+  TEMPLATE_CATALOG_RESULT_LIMIT,
+  TEMPLATE_CATALOG_SEARCH_MAX_LENGTH,
+} from "@/lib/templates/catalog-search";
 
 type TemplatesDb = Pick<Database, "select" | "update">;
 
@@ -120,15 +126,25 @@ const templateMutableInput = {
   ),
 };
 
-const createTemplateInput = z.object({
-  ...templateMutableInput,
-  items: z
-    .array(templateItemInput)
-    .max(
-      TREATMENT_TEMPLATE_MAX_ITEMS,
-      `Templates can include at most ${TREATMENT_TEMPLATE_MAX_ITEMS} items.`
-    ),
-});
+const createTemplateInput = z
+  .object({
+    ...templateMutableInput,
+    items: z
+      .array(templateItemInput)
+      .max(
+        TREATMENT_TEMPLATE_MAX_ITEMS,
+        `Templates can include at most ${TREATMENT_TEMPLATE_MAX_ITEMS} items.`,
+      ),
+  })
+  .superRefine((input, ctx) => {
+    if (hasDuplicateTemplateCatalogItems(input.items)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["items"],
+        message: "A service or product can only appear once in a template.",
+      });
+    }
+  });
 
 function activePracticeWhere(practiceId: string) {
   return and(eq(practices.id, practiceId), isNull(practices.deletedAt));
@@ -353,15 +369,75 @@ export const templatesRouter = createRouter({
       .orderBy(asc(treatmentTemplates.name));
   }),
 
-  listProducts: protectedProcedure
+  searchCatalog: protectedProcedure
     .use(requireRole("admin"))
-    .query(async ({ ctx }) => {
+    .input(
+      z.object({
+        itemType: z.enum(["service", "product"]),
+        search: z
+          .string()
+          .trim()
+          .max(TEMPLATE_CATALOG_SEARCH_MAX_LENGTH)
+          .default(""),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
-      return ctx.db
+      const escapedSearch = escapeTemplateCatalogLike(input.search);
+      const containsPattern = `%${escapedSearch}%`;
+      const prefixPattern = `${escapedSearch}%`;
+
+      if (input.itemType === "service") {
+        const rows = await ctx.db
+          .select({
+            id: services.id,
+            name: services.name,
+            code: services.code,
+            category: services.category,
+            unitPrice: services.defaultPrice,
+          })
+          .from(services)
+          .where(
+            and(
+              eq(services.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(services.deletedAt),
+              input.search
+                ? or(
+                    sql`${services.name} ilike ${containsPattern} escape '\\'`,
+                    sql`${services.code} ilike ${containsPattern} escape '\\'`,
+                    sql`${services.category} ilike ${containsPattern} escape '\\'`,
+                  )
+                : undefined,
+            ),
+          )
+          .orderBy(
+            input.search
+              ? sql`case
+                  when lower(${services.name}) = lower(${input.search}) then 0
+                  when lower(${services.code}) = lower(${input.search}) then 1
+                  when ${services.name} ilike ${prefixPattern} escape '\\' then 2
+                  when ${services.code} ilike ${prefixPattern} escape '\\' then 3
+                  else 4
+                end`
+              : sql`0`,
+            sql`lower(${services.name})`,
+            sql`lower(coalesce(${services.code}, ''))`,
+            asc(services.id),
+          )
+          .limit(TEMPLATE_CATALOG_RESULT_LIMIT);
+        return rows.map((row) => ({
+          ...row,
+          itemType: "service" as const,
+        }));
+      }
+
+      const rows = await ctx.db
         .select({
           id: products.id,
           name: products.name,
-          sku: products.sku,
+          code: products.sku,
+          category: products.category,
           unitPrice: products.unitPrice,
         })
         .from(products)
@@ -369,10 +445,32 @@ export const templatesRouter = createRouter({
           and(
             eq(products.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(products.deletedAt)
-          )
+            isNull(products.deletedAt),
+            input.search
+              ? or(
+                  sql`${products.name} ilike ${containsPattern} escape '\\'`,
+                  sql`${products.sku} ilike ${containsPattern} escape '\\'`,
+                  sql`${products.category} ilike ${containsPattern} escape '\\'`,
+                )
+              : undefined,
+          ),
         )
-        .orderBy(asc(products.name), asc(products.id));
+        .orderBy(
+          input.search
+            ? sql`case
+                when lower(${products.name}) = lower(${input.search}) then 0
+                when lower(${products.sku}) = lower(${input.search}) then 1
+                when ${products.name} ilike ${prefixPattern} escape '\\' then 2
+                when ${products.sku} ilike ${prefixPattern} escape '\\' then 3
+                else 4
+              end`
+            : sql`0`,
+          sql`lower(${products.name})`,
+          sql`lower(coalesce(${products.sku}, ''))`,
+          asc(products.id),
+        )
+        .limit(TEMPLATE_CATALOG_RESULT_LIMIT);
+      return rows.map((row) => ({ ...row, itemType: "product" as const }));
     }),
 
   getById: protectedProcedure

--- a/apps/web/server/routers/templates.ts
+++ b/apps/web/server/routers/templates.ts
@@ -55,9 +55,12 @@ type TemplateInvoiceItem = {
   quantity: number;
 };
 
-const moneyInput = z.string().trim().refine((value) => {
-  return TREATMENT_TEMPLATE_UNIT_PRICE_PATTERN.test(value);
-}, "Amount must be a valid currency amount.");
+const moneyInput = z
+  .string()
+  .trim()
+  .refine((value) => {
+    return TREATMENT_TEMPLATE_UNIT_PRICE_PATTERN.test(value);
+  }, "Amount must be a valid currency amount.");
 
 const PRODUCT_LINK_REQUIRED_MESSAGE =
   "Every product template item must be linked to an active inventory product.";
@@ -67,7 +70,7 @@ const templateItemBaseInput = z.object({
   itemId: z.string().uuid().optional(),
   description: clinicalTextInput(
     "Template item description",
-    TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH
+    TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH,
   ),
   defaultQuantity: z
     .number()
@@ -86,7 +89,7 @@ const templateItemBaseInput = z.object({
 
 function refineTemplateItemTotal(
   item: z.infer<typeof templateItemBaseInput>,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
 ) {
   if (item.itemType === "product" && !item.itemId) {
     ctx.addIssue({
@@ -107,7 +110,7 @@ function refineTemplateItemTotal(
 }
 
 const templateItemInput = templateItemBaseInput.superRefine(
-  refineTemplateItemTotal
+  refineTemplateItemTotal,
 );
 
 const addTemplateItemInput = templateItemBaseInput
@@ -118,11 +121,11 @@ const templateMutableInput = {
   name: clinicalTextInput("Template name", TREATMENT_TEMPLATE_NAME_MAX_LENGTH),
   description: optionalClinicalTextInput(
     "Template description",
-    TREATMENT_TEMPLATE_DESCRIPTION_MAX_LENGTH
+    TREATMENT_TEMPLATE_DESCRIPTION_MAX_LENGTH,
   ),
   category: optionalClinicalTextInput(
     "Template category",
-    TREATMENT_TEMPLATE_CATEGORY_MAX_LENGTH
+    TREATMENT_TEMPLATE_CATEGORY_MAX_LENGTH,
   ),
 };
 
@@ -178,7 +181,7 @@ async function assertActivePractice(ctx: TemplatesContext) {
 async function lockActiveTemplateCatalogItems(
   ctx: TemplatesContext,
   items: Array<{ itemType: "service" | "product"; itemId?: string }>,
-  options: { lockProductsForStock?: boolean } = {}
+  options: { lockProductsForStock?: boolean } = {},
 ) {
   if (items.some((item) => item.itemType === "product" && !item.itemId)) {
     throw new TRPCError({
@@ -191,14 +194,14 @@ async function lockActiveTemplateCatalogItems(
     ...new Set(
       items
         .filter((item) => item.itemType === "service" && item.itemId)
-        .map((item) => item.itemId!)
+        .map((item) => item.itemId!),
     ),
   ];
   const productIds = [
     ...new Set(
       items
         .filter((item) => item.itemType === "product" && item.itemId)
-        .map((item) => item.itemId!)
+        .map((item) => item.itemId!),
     ),
   ];
 
@@ -217,8 +220,8 @@ async function lockActiveTemplateCatalogItems(
               inArray(services.id, serviceIds),
               eq(services.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(services.deletedAt)
-            )
+              isNull(services.deletedAt),
+            ),
           )
           .orderBy(asc(services.id))
           .for("share");
@@ -238,8 +241,8 @@ async function lockActiveTemplateCatalogItems(
               inArray(products.id, productIds),
               eq(products.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(products.deletedAt)
-            )
+              isNull(products.deletedAt),
+            ),
           )
           .orderBy(asc(products.id))
           .for(options.lockProductsForStock ? "update" : "share");
@@ -305,7 +308,7 @@ function templateInvoiceTaxTotals(
 
 async function deductTemplateProductStock(
   ctx: TemplatesContext,
-  items: readonly TemplateInvoiceItem[]
+  items: readonly TemplateInvoiceItem[],
 ) {
   const deductions = computeStockDeductions([...items]);
   const trackedRows =
@@ -318,12 +321,12 @@ async function deductTemplateProductStock(
             and(
               inArray(
                 products.id,
-                deductions.map((deduction) => deduction.productId)
+                deductions.map((deduction) => deduction.productId),
               ),
               eq(products.practiceId, ctx.practiceId),
               eq(products.inventoryTracked, true),
-              isNull(products.deletedAt)
-            )
+              isNull(products.deletedAt),
+            ),
           );
   const trackedIds = new Set(trackedRows.map((row) => row.id));
   for (const deduction of deductions) {
@@ -340,8 +343,8 @@ async function deductTemplateProductStock(
           eq(products.inventoryTracked, true),
           activePracticePredicate(ctx.practiceId),
           isNull(products.deletedAt),
-          sql`${products.stockQuantity} >= ${deduction.quantity}`
-        )
+          sql`${products.stockQuantity} >= ${deduction.quantity}`,
+        ),
       )
       .returning({ id: products.id, stockQuantity: products.stockQuantity });
 
@@ -363,8 +366,8 @@ export const templatesRouter = createRouter({
       .where(
         and(
           eq(treatmentTemplates.practiceId, ctx.practiceId),
-          isNull(treatmentTemplates.deletedAt)
-        )
+          isNull(treatmentTemplates.deletedAt),
+        ),
       )
       .orderBy(asc(treatmentTemplates.name));
   }),
@@ -412,15 +415,17 @@ export const templatesRouter = createRouter({
             ),
           )
           .orderBy(
-            input.search
-              ? sql`case
+            ...(input.search
+              ? [
+                  sql`case
                   when lower(${services.name}) = lower(${input.search}) then 0
                   when lower(${services.code}) = lower(${input.search}) then 1
                   when ${services.name} ilike ${prefixPattern} escape '\\' then 2
                   when ${services.code} ilike ${prefixPattern} escape '\\' then 3
                   else 4
-                end`
-              : sql`0`,
+                end`,
+                ]
+              : []),
             sql`lower(${services.name})`,
             sql`lower(coalesce(${services.code}, ''))`,
             asc(services.id),
@@ -456,15 +461,17 @@ export const templatesRouter = createRouter({
           ),
         )
         .orderBy(
-          input.search
-            ? sql`case
+          ...(input.search
+            ? [
+                sql`case
                 when lower(${products.name}) = lower(${input.search}) then 0
                 when lower(${products.sku}) = lower(${input.search}) then 1
                 when ${products.name} ilike ${prefixPattern} escape '\\' then 2
                 when ${products.sku} ilike ${prefixPattern} escape '\\' then 3
                 else 4
-              end`
-            : sql`0`,
+              end`,
+              ]
+            : []),
           sql`lower(${products.name})`,
           sql`lower(coalesce(${products.sku}, ''))`,
           asc(products.id),
@@ -485,8 +492,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.id, input.id),
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplates.deletedAt)
-          )
+            isNull(treatmentTemplates.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -503,8 +510,8 @@ export const templatesRouter = createRouter({
         .where(
           and(
             eq(treatmentTemplateItems.templateId, input.id),
-            isNull(treatmentTemplateItems.deletedAt)
-          )
+            isNull(treatmentTemplateItems.deletedAt),
+          ),
         )
         .orderBy(asc(treatmentTemplateItems.sortOrder));
 
@@ -512,7 +519,7 @@ export const templatesRouter = createRouter({
         ...new Set(
           items
             .filter((item) => item.itemType === "product" && item.itemId)
-            .map((item) => item.itemId!)
+            .map((item) => item.itemId!),
         ),
       ];
       const activeLinkedProducts =
@@ -526,11 +533,11 @@ export const templatesRouter = createRouter({
                   inArray(products.id, linkedProductIds),
                   eq(products.practiceId, ctx.practiceId),
                   activePracticePredicate(ctx.practiceId),
-                  isNull(products.deletedAt)
-                )
+                  isNull(products.deletedAt),
+                ),
               );
       const activeLinkedProductIds = new Set(
-        activeLinkedProducts.map((product) => product.id)
+        activeLinkedProducts.map((product) => product.id),
       );
 
       return {
@@ -539,9 +546,7 @@ export const templatesRouter = createRouter({
           ...item,
           hasActiveProductLink:
             item.itemType === "product"
-              ? Boolean(
-                  item.itemId && activeLinkedProductIds.has(item.itemId)
-                )
+              ? Boolean(item.itemId && activeLinkedProductIds.has(item.itemId))
               : null,
         })),
       };
@@ -559,7 +564,7 @@ export const templatesRouter = createRouter({
         // before the template persists its reference.
         await lockActiveTemplateCatalogItems(
           { db: tx, practiceId: ctx.practiceId },
-          input.items
+          input.items,
         );
 
         const [template] = await tx
@@ -582,7 +587,7 @@ export const templatesRouter = createRouter({
               defaultQuantity: item.defaultQuantity,
               defaultUnitPrice: item.defaultUnitPrice,
               sortOrder: item.sortOrder,
-            }))
+            })),
           );
         }
 
@@ -599,7 +604,7 @@ export const templatesRouter = createRouter({
         description: templateMutableInput.description,
         category: templateMutableInput.category,
         isActive: z.boolean().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -612,8 +617,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.id, id),
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplates.deletedAt)
-          )
+            isNull(treatmentTemplates.deletedAt),
+          ),
         )
         .returning();
 
@@ -640,8 +645,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.id, input.id),
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplates.deletedAt)
-          )
+            isNull(treatmentTemplates.deletedAt),
+          ),
         )
         .returning();
 
@@ -672,8 +677,8 @@ export const templatesRouter = createRouter({
               eq(treatmentTemplates.id, input.templateId),
               eq(treatmentTemplates.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(treatmentTemplates.deletedAt)
-            )
+              isNull(treatmentTemplates.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -686,7 +691,7 @@ export const templatesRouter = createRouter({
 
         await lockActiveTemplateCatalogItems(
           { db: tx, practiceId: ctx.practiceId },
-          [input]
+          [input],
         );
 
         const [item] = await tx
@@ -720,7 +725,7 @@ export const templatesRouter = createRouter({
         .from(treatmentTemplateItems)
         .innerJoin(
           treatmentTemplates,
-          eq(treatmentTemplateItems.templateId, treatmentTemplates.id)
+          eq(treatmentTemplateItems.templateId, treatmentTemplates.id),
         )
         .where(
           and(
@@ -728,8 +733,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             isNull(treatmentTemplates.deletedAt),
-            isNull(treatmentTemplateItems.deletedAt)
-          )
+            isNull(treatmentTemplateItems.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -747,8 +752,8 @@ export const templatesRouter = createRouter({
           and(
             eq(treatmentTemplateItems.id, input.id),
             activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplateItems.deletedAt)
-          )
+            isNull(treatmentTemplateItems.deletedAt),
+          ),
         )
         .returning();
 
@@ -768,7 +773,7 @@ export const templatesRouter = createRouter({
       z.object({
         templateId: z.string().uuid(),
         invoiceId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -782,8 +787,8 @@ export const templatesRouter = createRouter({
             eq(treatmentTemplates.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             isNull(treatmentTemplates.deletedAt),
-            eq(treatmentTemplates.isActive, true)
-          )
+            eq(treatmentTemplates.isActive, true),
+          ),
         )
         .limit(1);
 
@@ -808,8 +813,8 @@ export const templatesRouter = createRouter({
             eq(invoices.id, input.invoiceId),
             eq(invoices.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(invoices.deletedAt)
-          )
+            isNull(invoices.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -828,7 +833,8 @@ export const templatesRouter = createRouter({
       if (moneyToCents(invoice.paidAmount) > 0) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Cannot apply treatment templates to invoices with payments.",
+          message:
+            "Cannot apply treatment templates to invoices with payments.",
         });
       }
 
@@ -836,7 +842,7 @@ export const templatesRouter = createRouter({
         // Share the invoice serialization key used by direct charge edits so
         // concurrent template applications cannot calculate competing totals.
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${input.invoiceId}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${input.invoiceId}, 0))`,
         );
 
         // Fetch template items
@@ -846,8 +852,8 @@ export const templatesRouter = createRouter({
           .where(
             and(
               eq(treatmentTemplateItems.templateId, input.templateId),
-              isNull(treatmentTemplateItems.deletedAt)
-            )
+              isNull(treatmentTemplateItems.deletedAt),
+            ),
           )
           .orderBy(asc(treatmentTemplateItems.sortOrder));
 
@@ -868,7 +874,7 @@ export const templatesRouter = createRouter({
             itemType: item.itemType,
             itemId: item.itemId ?? undefined,
           })),
-          { lockProductsForStock: !invoice.isEstimate }
+          { lockProductsForStock: !invoice.isEstimate },
         );
 
         const invoiceItemRows = items.map((item) => {
@@ -895,7 +901,7 @@ export const templatesRouter = createRouter({
         if (!invoice.isEstimate) {
           await deductTemplateProductStock(
             { db: tx, practiceId: ctx.practiceId },
-            invoiceItemRows
+            invoiceItemRows,
           );
         }
 
@@ -913,8 +919,8 @@ export const templatesRouter = createRouter({
           .where(
             and(
               eq(invoiceItems.invoiceId, input.invoiceId),
-              isNull(invoiceItems.deletedAt)
-            )
+              isNull(invoiceItems.deletedAt),
+            ),
           );
 
         // Tax rate is configured per practice (region-aware), not hardcoded.
@@ -957,8 +963,8 @@ export const templatesRouter = createRouter({
               eq(invoices.status, invoice.status),
               eq(invoices.paidAmount, invoice.paidAmount ?? "0"),
               eq(invoices.isEstimate, invoice.isEstimate),
-              isNull(invoices.deletedAt)
-            )
+              isNull(invoices.deletedAt),
+            ),
           )
           .returning();
 


### PR DESCRIPTION
## What changed

- adds one admin-only, tenant-scoped search endpoint for active services and inventory products
- replaces free-text and unbounded product selection with a shared keyboard- and touch-friendly picker
- supports clear, replacement, and re-search without resetting the rest of a template draft
- prevents duplicate linked catalog rows and keeps stale/deleted references fail-closed at save time
- adds a real PostgreSQL/RLS contract to the protected CI lane

## Safety

- no schema migration or stored-template rewrite
- literal wildcard handling, exact-first stable ordering, and a hard 20-result cap
- no-context and cross-tenant reads fail closed under the least-privilege application role
- rollback is a single PR revert

## Verification

- 4,074 web tests passed; 9 opt-in tests skipped in the default suite
- dedicated real PostgreSQL/RLS catalog contract passed
- web and database typechecks passed
- production Next.js build passed
- migration-history checks passed (82 passed, 1 skipped)

Jira: OPENVPM-75