### PR TITLE
OPENVPM-80 Fail before migration on RLS ownership drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       # tenant isolation against a real Postgres on every PR.
       - run: pnpm --filter @openpims/db db:migrate
 
+      - name: Execute RLS ownership preflight contract
+        run: pnpm --filter @openpims/db db:rls:preflight:test
+
       # A data-only migration has no schema snapshot to prove it ran. Exercise
       # the baseline command against a disposable database and prove that exact
       # and later cutoffs both fail without a ledger until live data is safe.

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -48,6 +48,12 @@ jobs:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
         run: pnpm db:drift
 
+      - name: Verify RLS deployment ownership
+        if: steps.configured.outputs.ready == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: pnpm db:rls:preflight
+
       - name: Apply migrations
         if: steps.configured.outputs.ready == 'true'
         env:
@@ -97,6 +103,12 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DEMO_DATABASE_URL }}
         run: pnpm db:drift
+
+      - name: Verify RLS deployment ownership
+        if: steps.configured.outputs.ready == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.DEMO_DATABASE_URL }}
+        run: pnpm db:rls:preflight
 
       - name: Apply migrations
         if: steps.configured.outputs.ready == 'true'

--- a/apps/web/lib/__tests__/db-rls-preflight.test.ts
+++ b/apps/web/lib/__tests__/db-rls-preflight.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  describeRlsDeploymentCapabilityFailure,
+  rlsDeploymentCapabilityIsReady,
+} from "@openpims/db/rls-preflight";
+
+describe("RLS deployment ownership preflight", () => {
+  it("passes only when every managed public object is manageable", () => {
+    expect(
+      rlsDeploymentCapabilityIsReady({
+        currentRole: "migration_owner",
+        unmanageableObjects: [],
+      }),
+    ).toBe(true);
+    expect(
+      rlsDeploymentCapabilityIsReady({
+        currentRole: "migration_owner",
+        unmanageableObjects: ["table out_of_band_table"],
+      }),
+    ).toBe(false);
+  });
+
+  it("emits a bounded, PHI-free operator error with a no-mutation guarantee", () => {
+    const message = describeRlsDeploymentCapabilityFailure({
+      currentRole: "staging_migrator",
+      unmanageableObjects: Array.from(
+        { length: 12 },
+        (_, index) => `table drift_${index}`,
+      ),
+    });
+
+    expect(message).toContain("RLS ownership preflight failed");
+    expect(message).toContain("12 public object(s)");
+    expect(message).toContain("and 2 more");
+    expect(message).toContain("No migrations, role/password changes, grants");
+    expect(message).not.toContain("drift_11");
+  });
+
+  it("runs before any RLS role or policy mutation", () => {
+    const source = readFileSync(
+      new URL("../../../../packages/db/apply-rls.ts", import.meta.url),
+      "utf8",
+    );
+    const preflight = source.indexOf("assertRlsDeploymentCapability(sql)");
+    const roleLookup = source.indexOf("select 1 from pg_roles");
+    const policyApply = source.indexOf("sql.unsafe(sqlText)");
+
+    expect(preflight).toBeGreaterThanOrEqual(0);
+    expect(preflight).toBeLessThan(roleLookup);
+    expect(preflight).toBeLessThan(policyApply);
+    expect(source).toContain("err instanceof Error ? err.message : err");
+  });
+
+  it("gates both hosted environments before migrations", () => {
+    const workflow = readFileSync(
+      new URL("../../../../.github/workflows/migrate.yml", import.meta.url),
+      "utf8",
+    );
+    const jobs = workflow.split("  demo:");
+    expect(jobs).toHaveLength(2);
+    for (const job of jobs) {
+      const preflight = job.indexOf("run: pnpm db:rls:preflight");
+      const migrate = job.indexOf("run: pnpm db:migrate");
+      expect(preflight).toBeGreaterThanOrEqual(0);
+      expect(preflight).toBeLessThan(migrate);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:seed": "pnpm --filter @openpims/db db:seed",
     "db:reset": "pnpm --filter @openpims/db db:reset",
     "db:rls": "pnpm --filter @openpims/db db:rls",
+    "db:rls:preflight": "pnpm --filter @openpims/db db:rls:preflight",
     "db:rls:test": "pnpm --filter @openpims/db db:rls:test",
     "db:drift": "pnpm --filter @openpims/db db:drift",
     "db:baseline": "pnpm --filter @openpims/db db:baseline",

--- a/packages/db/apply-rls.ts
+++ b/packages/db/apply-rls.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import postgres from "postgres";
+import { assertRlsDeploymentCapability } from "./rls-preflight";
 
 function nonBlankEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
@@ -22,15 +23,20 @@ const sqlText = readFileSync(join(here, "rls", "enable-rls.sql"), "utf8");
 
 const sql = postgres(url, { max: 1 });
 try {
+  // Fail before role/password, grant, function, policy, or table mutations when
+  // the deployment credential cannot manage every object touched below.
+  await assertRlsDeploymentCapability(sql);
+
   // Ensure the least-privilege app role exists BEFORE the grants run. No
   // credential is committed: the password comes from OPENPIMS_APP_DB_PASSWORD.
-  const [exists] = await sql`select 1 from pg_roles where rolname = 'openpims_app'`;
+  const [exists] =
+    await sql`select 1 from pg_roles where rolname = 'openpims_app'`;
   const appPw = nonBlankEnv("OPENPIMS_APP_DB_PASSWORD");
   if (!exists) {
     if (!appPw) {
       console.error(
         "openpims_app role does not exist. Create it with a strong password, " +
-          "or set OPENPIMS_APP_DB_PASSWORD and re-run `pnpm db:rls`."
+          "or set OPENPIMS_APP_DB_PASSWORD and re-run `pnpm db:rls`.",
       );
       process.exit(1);
     }
@@ -47,7 +53,10 @@ try {
   await sql.unsafe(sqlText).simple();
   console.log("✓ RLS policies applied (run as the DB owner).");
 } catch (err) {
-  console.error("✗ Failed to apply RLS policies:", err);
+  console.error(
+    "✗ Failed to apply RLS policies:",
+    err instanceof Error ? err.message : err,
+  );
   process.exitCode = 1;
 } finally {
   await sql.end();

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,7 +7,8 @@
     ".": "./schema/index.ts",
     "./client": "./client.ts",
     "./connection-policy": "./connection-policy.ts",
-    "./schema-drift": "./schema-drift.ts"
+    "./schema-drift": "./schema-drift.ts",
+    "./rls-preflight": "./rls-preflight.ts"
   },
   "scripts": {
     "type-check": "tsc --noEmit",
@@ -17,6 +18,8 @@
     "db:seed": "tsx seed.ts",
     "db:reset": "tsx reset.ts",
     "db:rls": "tsx apply-rls.ts",
+    "db:rls:preflight": "tsx rls-preflight.ts",
+    "db:rls:preflight:test": "tsx test-rls-preflight.ts",
     "db:rls:test": "tsx test-rls.ts",
     "db:sms-provider-resolutions:test": "tsx test-sms-provider-event-resolutions.ts",
     "db:migration-runs:test": "tsx test-migration-runs.ts",

--- a/packages/db/rls-preflight.ts
+++ b/packages/db/rls-preflight.ts
@@ -1,0 +1,155 @@
+import { config } from "dotenv";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+export type RlsDeploymentCapability = {
+  currentRole: string;
+  unmanageableObjects: string[];
+};
+
+type RlsCapabilityRow = {
+  currentRole: string;
+  unmanageableObjects: string[] | null;
+};
+
+type SqlClient = ReturnType<typeof postgres>;
+
+/**
+ * Inspect every public object the idempotent RLS script grants on, alters, or
+ * replaces. This is deliberately read-only so deployment can fail before a
+ * migration, password rotation, grant, policy, or other database mutation.
+ */
+export async function inspectRlsDeploymentCapability(
+  sql: SqlClient,
+): Promise<RlsDeploymentCapability> {
+  const [row] = await sql<RlsCapabilityRow[]>`
+    with managed_objects as (
+      select
+        case c.relkind
+          when 'S' then 'sequence '
+          when 'v' then 'view '
+          when 'm' then 'materialized view '
+          when 'f' then 'foreign table '
+          else 'table '
+        end || quote_ident(c.relname) as label,
+        c.relowner as owner_oid
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public'
+        and c.relkind in ('r', 'p', 'v', 'm', 'f', 'S')
+
+      union all
+
+      select
+        'function ' || p.oid::regprocedure::text as label,
+        p.proowner as owner_oid
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'public'
+        and p.proname = any(array[
+          'app_current_practice_id',
+          'app_rls_bypass',
+          'enforce_clinic_pilot_projection_audit',
+          'reject_clinic_pilot_event_mutation',
+          'restore_soap_note_addendum',
+          'restore_soap_note_replacement',
+          'validate_sms_provider_event_resolution_insert'
+        ]::text[])
+
+    ), actor as (
+      select rolsuper
+      from pg_roles
+      where rolname = current_user
+    )
+    select
+      current_user as "currentRole",
+      coalesce(
+        array_agg(managed_objects.label order by managed_objects.label)
+          filter (
+            where not actor.rolsuper
+              and not pg_has_role(
+                current_user,
+                pg_get_userbyid(managed_objects.owner_oid),
+                'USAGE'
+              )
+          ),
+        array[]::text[]
+      ) as "unmanageableObjects"
+    from managed_objects
+    cross join actor
+    group by actor.rolsuper
+  `;
+
+  if (!row) {
+    throw new Error(
+      "RLS ownership preflight could not identify the database role.",
+    );
+  }
+
+  return {
+    currentRole: row.currentRole,
+    unmanageableObjects: row.unmanageableObjects ?? [],
+  };
+}
+
+export function rlsDeploymentCapabilityIsReady(
+  capability: RlsDeploymentCapability,
+): boolean {
+  return capability.unmanageableObjects.length === 0;
+}
+
+export function describeRlsDeploymentCapabilityFailure(
+  capability: RlsDeploymentCapability,
+): string {
+  const shown = capability.unmanageableObjects.slice(0, 10).join(", ");
+  const remaining = capability.unmanageableObjects.length - 10;
+  return (
+    `RLS ownership preflight failed for role ${capability.currentRole}: ` +
+    `${capability.unmanageableObjects.length} public object(s) cannot be managed` +
+    `${shown ? ` (${shown}${remaining > 0 ? `, and ${remaining} more` : ""})` : ""}. ` +
+    "No migrations, role/password changes, grants, or RLS changes were attempted. " +
+    "Use the approved database-owner migration credential or reconcile object ownership first."
+  );
+}
+
+export async function assertRlsDeploymentCapability(
+  sql: SqlClient,
+): Promise<RlsDeploymentCapability> {
+  const capability = await inspectRlsDeploymentCapability(sql);
+  if (!rlsDeploymentCapabilityIsReady(capability)) {
+    throw new Error(describeRlsDeploymentCapabilityFailure(capability));
+  }
+  return capability;
+}
+
+function nonBlankEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+async function main(): Promise<number> {
+  config({ path: "../../.env" });
+  const url = nonBlankEnv("DATABASE_URL");
+  if (!url) {
+    console.error("DATABASE_URL not set");
+    return 1;
+  }
+
+  const sql = postgres(url, { max: 1 });
+  try {
+    const capability = await assertRlsDeploymentCapability(sql);
+    console.log(
+      `✓ RLS ownership preflight passed for role ${capability.currentRole}.`,
+    );
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    return 1;
+  } finally {
+    await sql.end();
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exitCode = await main();
+}

--- a/packages/db/test-rls-preflight.ts
+++ b/packages/db/test-rls-preflight.ts
@@ -1,0 +1,116 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import postgres from "postgres";
+import {
+  assertRlsDeploymentCapability,
+  inspectRlsDeploymentCapability,
+  rlsDeploymentCapabilityIsReady,
+} from "./rls-preflight";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+const adminUrl = requiredEnv("DATABASE_URL");
+const suffix = randomUUID().replaceAll("-", "");
+const databaseName = `openpims_rls_preflight_${suffix}`;
+const runnerRole = `openpims_preflight_runner_${suffix}`;
+const foreignRole = `openpims_preflight_foreign_${suffix}`;
+const runnerPassword = randomUUID();
+const safeIdentifier = /^[a-z][a-z0-9_]+$/;
+
+for (const identifier of [databaseName, runnerRole, foreignRole]) {
+  if (!safeIdentifier.test(identifier) || identifier.length > 63) {
+    throw new Error("unsafe disposable PostgreSQL identifier");
+  }
+}
+
+const targetAdminUrl = new URL(adminUrl);
+targetAdminUrl.pathname = `/${databaseName}`;
+targetAdminUrl.search = "";
+targetAdminUrl.hash = "";
+
+const runnerUrl = new URL(targetAdminUrl);
+runnerUrl.username = runnerRole;
+runnerUrl.password = runnerPassword;
+
+const repoRoot = resolve(process.cwd(), "../..");
+const admin = postgres(adminUrl, { max: 1 });
+let targetAdmin: ReturnType<typeof postgres> | undefined;
+let runner: ReturnType<typeof postgres> | undefined;
+
+try {
+  await admin.unsafe(
+    `create role "${runnerRole}" login password '${runnerPassword}'`,
+  );
+  await admin.unsafe(`create role "${foreignRole}" nologin`);
+  await admin.unsafe(`create database "${databaseName}" owner "${runnerRole}"`);
+
+  execFileSync("pnpm", ["--filter", "@openpims/db", "db:migrate"], {
+    cwd: repoRoot,
+    env: { ...process.env, DATABASE_URL: runnerUrl.toString() },
+    encoding: "utf8",
+  });
+
+  targetAdmin = postgres(targetAdminUrl.toString(), { max: 1 });
+  await targetAdmin.unsafe(
+    "create table public.preflight_foreign_probe(id integer)",
+  );
+  await targetAdmin.unsafe(
+    `alter table public.preflight_foreign_probe owner to "${foreignRole}"`,
+  );
+  await targetAdmin.unsafe(
+    `create table public.preflight_acl_probe(id integer); alter table public.preflight_acl_probe owner to "${runnerRole}"`,
+  );
+
+  runner = postgres(runnerUrl.toString(), { max: 1 });
+  const [aclBefore] = await runner<
+    Array<{ acl: string | null }>
+  >`select relacl::text as acl from pg_class where oid = 'public.preflight_acl_probe'::regclass`;
+
+  const blocked = await inspectRlsDeploymentCapability(runner);
+  if (
+    blocked.currentRole !== runnerRole ||
+    blocked.unmanageableObjects.join(",") !== "table preflight_foreign_probe" ||
+    rlsDeploymentCapabilityIsReady(blocked)
+  ) {
+    throw new Error(
+      `unexpected blocked preflight result: ${JSON.stringify(blocked)}`,
+    );
+  }
+
+  let rejected = false;
+  try {
+    await assertRlsDeploymentCapability(runner);
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) throw new Error("ownership mismatch did not fail closed");
+
+  const [aclAfter] = await runner<
+    Array<{ acl: string | null }>
+  >`select relacl::text as acl from pg_class where oid = 'public.preflight_acl_probe'::regclass`;
+  if (aclAfter?.acl !== aclBefore?.acl) {
+    throw new Error("RLS ownership preflight mutated table privileges");
+  }
+
+  await targetAdmin.unsafe("drop table public.preflight_foreign_probe");
+  const ready = await inspectRlsDeploymentCapability(runner);
+  if (!rlsDeploymentCapabilityIsReady(ready)) {
+    throw new Error(`compliant owner did not pass: ${JSON.stringify(ready)}`);
+  }
+
+  console.log(
+    "RLS ownership preflight PostgreSQL contract passed: mismatch refused without ACL mutation; compliant owner accepted.",
+  );
+} finally {
+  if (runner) await runner.end();
+  if (targetAdmin) await targetAdmin.end();
+  await admin.unsafe(`drop database if exists "${databaseName}" with (force)`);
+  await admin.unsafe(`drop role if exists "${foreignRole}"`);
+  await admin.unsafe(`drop role if exists "${runnerRole}"`);
+  await admin.end();
+}


### PR DESCRIPTION
## Summary
- add a read-only database ownership preflight before hosted migrations
- run the same guard before any role, grant, function, policy, or RLS mutation
- add bounded operator errors and a disposable PostgreSQL no-mutation contract

## Verification
- focused unit contract
- web and database TypeScript checks
- disposable PostgreSQL mismatch/compliant-owner drill
- read-only hosted role capability checks

## Safety boundary
This PR does not alter hosted data, table ownership, credentials, RLS policies, migrations, or application behavior. It intentionally leaves ownership reconciliation as a separate deployment operation.