### PR TITLE
OPENVPM-85: stabilize baseline PostgreSQL CI timeout

### DIFF
--- a/apps/web/lib/__tests__/baseline-postconditions.integration.test.ts
+++ b/apps/web/lib/__tests__/baseline-postconditions.integration.test.ts
@@ -164,6 +164,6 @@ describeWithBaselinePostgres(
           ),
         );
       }
-    });
+    }, 60_000);
   },
 );


### PR DESCRIPTION
## Summary

Give the dedicated real-PostgreSQL snapshotless-baseline contract an explicit 60-second integration-test timeout. The production assertions, cleanup, and runtime code are unchanged.

## Evidence

- main failure: https://github.com/evangauer/openvpm/actions/runs/32666085028
- three consecutive local real-PostgreSQL passes: 3.39s, 2.17s, 2.12s
- zero disposable `openpims_baseline_*` databases remain
- web typecheck passed
- migration-history suite passed (82 passed, 1 opt-in skipped)

Jira: OPENVPM-85