### PR TITLE
OPENVPM-86: treat client search wildcards literally

### DIFF
--- a/apps/web/lib/__tests__/client-search.test.ts
+++ b/apps/web/lib/__tests__/client-search.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  clientSearchContainsPattern,
+  escapeClientSearchValue,
+} from "@/lib/clients/search";
+
+describe("client search normalization", () => {
+  it("escapes LIKE syntax so wildcard characters stay literal", () => {
+    expect(escapeClientSearchValue(String.raw`50%_off\today`)).toBe(
+      String.raw`50\%\_off\\today`,
+    );
+    expect(clientSearchContainsPattern("50%_off")).toBe(
+      String.raw`%50\%\_off%`,
+    );
+  });
+
+  it("preserves normal clinic search input", () => {
+    expect(clientSearchContainsPattern("Linda Hoffman")).toBe(
+      "%Linda Hoffman%",
+    );
+    expect(clientSearchContainsPattern("555-0100")).toBe("%555-0100%");
+  });
+});

--- a/apps/web/lib/clients/search.ts
+++ b/apps/web/lib/clients/search.ts
@@ -1,0 +1,10 @@
+export function escapeClientSearchValue(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+}
+
+export function clientSearchContainsPattern(value: string): string {
+  return `%${escapeClientSearchValue(value)}%`;
+}

--- a/apps/web/server/__tests__/patient-search.integration.test.ts
+++ b/apps/web/server/__tests__/patient-search.integration.test.ts
@@ -6,6 +6,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { describe, expect, it } from "vitest";
 import * as schema from "../../../../packages/db/schema/index";
+import { clientsRouter } from "../routers/clients";
 import { patientsRouter } from "../routers/patients";
 import { withTenant } from "@/lib/tenant-db";
 
@@ -60,33 +61,49 @@ describeWithPatientSearchPostgres(
         if (!practiceA || !practiceB)
           throw new Error("failed to seed practices");
 
-        const [grayOwner, percentOwner, otherOwner, crossTenantOwner] =
-          await ownerDb
-            .insert(schema.clients)
-            .values([
-              {
-                practiceId: practiceA.id,
-                firstName: "Morgan",
-                lastName: "Gray",
-              },
-              {
-                practiceId: practiceA.id,
-                firstName: "Literal",
-                lastName: "Owner",
-              },
-              {
-                practiceId: practiceA.id,
-                firstName: "Exact",
-                lastName: "Patient",
-              },
-              {
-                practiceId: practiceB.id,
-                firstName: "Morgan",
-                lastName: "Gray",
-              },
-            ])
-            .returning({ id: schema.clients.id });
-        if (!grayOwner || !percentOwner || !otherOwner || !crossTenantOwner) {
+        const [
+          grayOwner,
+          percentOwner,
+          wildcardClient,
+          otherOwner,
+          crossTenantOwner,
+        ] = await ownerDb
+          .insert(schema.clients)
+          .values([
+            {
+              practiceId: practiceA.id,
+              firstName: "Morgan",
+              lastName: "Gray",
+            },
+            {
+              practiceId: practiceA.id,
+              firstName: "50%_off",
+              lastName: "Literal",
+            },
+            {
+              practiceId: practiceA.id,
+              firstName: "50xxoff",
+              lastName: "Wildcard Decoy",
+            },
+            {
+              practiceId: practiceA.id,
+              firstName: "Exact",
+              lastName: "Patient",
+            },
+            {
+              practiceId: practiceB.id,
+              firstName: "Morgan",
+              lastName: "Gray",
+            },
+          ])
+          .returning({ id: schema.clients.id });
+        if (
+          !grayOwner ||
+          !percentOwner ||
+          !wildcardClient ||
+          !otherOwner ||
+          !crossTenantOwner
+        ) {
           throw new Error("failed to seed clients");
         }
 
@@ -102,13 +119,13 @@ describeWithPatientSearchPostgres(
               },
               {
                 practiceId: practiceA.id,
-                clientId: percentOwner.id,
+                clientId: grayOwner.id,
                 name: "50%_off",
                 species: "feline",
               },
               {
                 practiceId: practiceA.id,
-                clientId: percentOwner.id,
+                clientId: otherOwner.id,
                 name: "50xxoff",
                 species: "feline",
               },
@@ -152,6 +169,11 @@ describeWithPatientSearchPostgres(
         });
         const caller = (db: typeof ownerDb, practiceId: string) =>
           patientsRouter.createCaller({
+            db,
+            session: session(practiceId),
+          } as never);
+        const clientCaller = (db: typeof ownerDb, practiceId: string) =>
+          clientsRouter.createCaller({
             db,
             session: session(practiceId),
           } as never);
@@ -223,6 +245,31 @@ describeWithPatientSearchPostgres(
         expect(literal.map((patient) => patient.id)).not.toContain(
           wildcardDecoy.id,
         );
+
+        const literalClient = await clientCaller(ownerDb, practiceA.id).search({
+          query: "50%_off",
+        });
+        expect(literalClient.map((client) => client.id)).toEqual([
+          percentOwner.id,
+        ]);
+        expect(literalClient.map((client) => client.id)).not.toContain(
+          wildcardClient.id,
+        );
+
+        const normalClient = await clientCaller(ownerDb, practiceA.id).search({
+          query: "Morgan Gray",
+        });
+        expect(normalClient.map((client) => client.id)).toEqual([grayOwner.id]);
+
+        const listedClients = await clientCaller(ownerDb, practiceA.id).list({
+          search: "50%_off",
+          limit: 25,
+          offset: 0,
+        });
+        expect(listedClients.items.map((client) => client.id)).toEqual([
+          percentOwner.id,
+        ]);
+        expect(listedClients.total).toBe(1);
 
         const listed = await runAsTenant(practiceA.id, (tenantCaller) =>
           tenantCaller.list({

--- a/apps/web/server/routers/clients.ts
+++ b/apps/web/server/routers/clients.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { eq, and, isNull, ilike, or, sql, desc, inArray } from "drizzle-orm";
+import {
+  eq,
+  and,
+  isNull,
+  or,
+  sql,
+  desc,
+  inArray,
+  type SQL,
+  type SQLWrapper,
+} from "drizzle-orm";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 import {
   appointmentWaitlist,
@@ -41,6 +51,7 @@ import {
   staffSmsConsentEventKey,
 } from "@/lib/messaging/consent-events";
 import { recordActivationAfterClientCreated } from "@/lib/funnel-events-server";
+import { clientSearchContainsPattern } from "@/lib/clients/search";
 
 const clientNameInput = z.string().trim().min(1).max(CLIENT_NAME_MAX_LENGTH);
 const clientEmailInput = z
@@ -98,6 +109,11 @@ type ClientsContext = {
   db: Pick<Database, "select">;
   practiceId: string;
 };
+
+function literalClientSearchMatch(column: SQLWrapper, value: string): SQL {
+  const pattern = clientSearchContainsPattern(value);
+  return sql`${column} ilike ${pattern} escape '\\'`;
+}
 
 function activePracticePredicate(practiceId: string) {
   return sql`exists (
@@ -201,14 +217,14 @@ export const clientsRouter = createRouter({
       if (input.search) {
         conditions.push(
           or(
-            ilike(clients.firstName, `%${input.search}%`),
-            ilike(clients.lastName, `%${input.search}%`),
-            ilike(
+            literalClientSearchMatch(clients.firstName, input.search),
+            literalClientSearchMatch(clients.lastName, input.search),
+            literalClientSearchMatch(
               sql`concat_ws(' ', ${clients.firstName}, ${clients.lastName})`,
-              `%${input.search}%`,
+              input.search,
             ),
-            ilike(clients.email, `%${input.search}%`),
-            ilike(clients.phone, `%${input.search}%`),
+            literalClientSearchMatch(clients.email, input.search),
+            literalClientSearchMatch(clients.phone, input.search),
           )!,
         );
       }
@@ -266,14 +282,14 @@ export const clientsRouter = createRouter({
             activePracticePredicate(ctx.practiceId),
             isNull(clients.deletedAt),
             or(
-              ilike(clients.firstName, `%${input.query}%`),
-              ilike(clients.lastName, `%${input.query}%`),
-              ilike(
+              literalClientSearchMatch(clients.firstName, input.query),
+              literalClientSearchMatch(clients.lastName, input.query),
+              literalClientSearchMatch(
                 sql`concat_ws(' ', ${clients.firstName}, ${clients.lastName})`,
-                `%${input.query}%`,
+                input.query,
               ),
-              ilike(clients.email, `%${input.query}%`),
-              ilike(clients.phone, `%${input.query}%`),
+              literalClientSearchMatch(clients.email, input.query),
+              literalClientSearchMatch(clients.phone, input.query),
             ),
           ),
         )


### PR DESCRIPTION
## Summary
- escape SQL LIKE metacharacters in both client list and quick-search paths
- preserve normal name, email, and phone partial matching
- extend the real PostgreSQL clinic search contract to prove literal matching, normal full-name search, and tenant isolation

## Verification
- focused unit/router tests: 37/37
- real PostgreSQL least-privilege search contract: passed; disposable DB removed
- full web suite: 4,077 passed, 9 opt-in skipped
- web typecheck: passed
- production build: passed
- diff check/format: passed

## Safety
No schema, migration, dependency, authorization, or write-path changes. This contains a live post-deployment finding from OPENVPM-66 before closing that clinic search surface.