### PR TITLE
OPENVPM-71: harden patient merge transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
   rls:
     name: RLS tenant isolation
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:16-alpine
@@ -153,6 +154,15 @@ jobs:
         env:
           TEMPLATE_CATALOG_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run server/__tests__/template-catalog-search.integration.test.ts
+
+      # Steven Dennis exposed a real route-level patient merge 500 caused by
+      # changing isolation inside a nested savepoint. Exercise the protected
+      # router as openpims_app and prove the event is written in the outer
+      # SERIALIZABLE tenant transaction with replay and RLS cleanup intact.
+      - name: Execute patient merge transaction contract
+        env:
+          PATIENT_MERGE_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/patient-merge-transaction.integration.test.ts
 
       # Compile, bind, and execute the exact read-only SQL used by the shared
       # platform-admin and daily SMS operations queues. Unit tests cannot catch

--- a/apps/web/lib/__tests__/tenant-db.test.ts
+++ b/apps/web/lib/__tests__/tenant-db.test.ts
@@ -1,5 +1,50 @@
 import { describe, expect, it, vi } from "vitest";
-import { withTenantReadOnlySnapshot } from "../tenant-db";
+import { withTenant, withTenantReadOnlySnapshot } from "../tenant-db";
+
+function sqlText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(sqlText).join(" ");
+  if (!value || typeof value !== "object") return "";
+  const candidate = value as { queryChunks?: unknown[]; value?: unknown };
+  return [
+    ...(candidate.queryChunks ?? []),
+    ...(candidate.value === undefined ? [] : [candidate.value]),
+  ]
+    .map(sqlText)
+    .join(" ");
+}
+
+describe("tenant database transactions", () => {
+  it("sets serializable isolation before tenant scope and application work", async () => {
+    const execute = vi.fn(async (_statement: unknown) => undefined);
+    const tx = { execute };
+    const work = vi.fn(async () => "merged");
+    const transaction = vi.fn(
+      async (fn: (transactionDb: typeof tx) => Promise<unknown>) => fn(tx),
+    );
+
+    await expect(
+      withTenant({ transaction } as never, "practice-1", work as never, {
+        isolationLevel: "serializable",
+      }),
+    ).resolves.toBe("merged");
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(sqlText(execute.mock.calls[0]?.[0])).toContain(
+      "set transaction isolation level serializable",
+    );
+    expect(sqlText(execute.mock.calls[1]?.[0])).toContain(
+      "app.current_practice_id",
+    );
+    expect(execute.mock.invocationCallOrder[0]).toBeLessThan(
+      execute.mock.invocationCallOrder[1]!,
+    );
+    expect(execute.mock.invocationCallOrder[1]).toBeLessThan(
+      work.mock.invocationCallOrder[0]!,
+    );
+  });
+});
 
 describe("tenant database snapshots", () => {
   it("sets repeatable-read/read-only characteristics before tenant scope and export reads", async () => {

--- a/apps/web/lib/tenant-db.ts
+++ b/apps/web/lib/tenant-db.ts
@@ -1,6 +1,10 @@
 import { sql } from "drizzle-orm";
 import type { Database } from "@openpims/db/client";
 
+export type TenantTransactionOptions = {
+  isolationLevel?: "serializable";
+};
+
 /**
  * Tenant database context for Postgres Row-Level Security (defense-in-depth
  * behind the app-layer practiceId filters).
@@ -18,8 +22,16 @@ export async function withTenant<T>(
   db: Database,
   practiceId: string,
   fn: (tx: Database) => Promise<T>,
+  options: TenantTransactionOptions = {},
 ): Promise<T> {
   return db.transaction(async (tx) => {
+    if (options.isolationLevel === "serializable") {
+      // PostgreSQL requires transaction characteristics to be set before the
+      // tenant GUC or any other statement. This must remain on the outermost
+      // transaction; setting it inside a Drizzle savepoint raises SQLSTATE
+      // 25001 and turns otherwise safe patient merges into HTTP 500s.
+      await tx.execute(sql`set transaction isolation level serializable`);
+    }
     await tx.execute(
       sql`select set_config('app.current_practice_id', ${practiceId}, true)`,
     );

--- a/apps/web/server/__tests__/patient-merge-transaction.integration.test.ts
+++ b/apps/web/server/__tests__/patient-merge-transaction.integration.test.ts
@@ -1,0 +1,567 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it, vi } from "vitest";
+import * as schema from "../../../../packages/db/schema/index";
+import { appRouter } from "../routers/_app";
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithPatientMergePostgres =
+  process.env.PATIENT_MERGE_DB_INTEGRATION === "1" ? describe : describe.skip;
+
+describeWithPatientMergePostgres(
+  "patient merge outer transaction PostgreSQL contract",
+  () => {
+    it("runs the full protected route as openpims_app in one serializable tenant transaction", async () => {
+      const adminUrl = process.env.DATABASE_URL;
+      if (!adminUrl) throw new Error("DATABASE_URL is required");
+
+      const databaseName = `openpims_patient_merge_${randomUUID().replaceAll("-", "")}`;
+      if (!/^openpims_patient_merge_[a-f0-9]+$/.test(databaseName)) {
+        throw new Error("unsafe disposable database name");
+      }
+
+      const databaseUrl = new URL(adminUrl);
+      databaseUrl.pathname = `/${databaseName}`;
+      databaseUrl.search = "";
+      databaseUrl.hash = "";
+
+      const appUrl = new URL(databaseUrl);
+      appUrl.username = "openpims_app";
+      appUrl.password =
+        process.env.OPENPIMS_APP_DB_PASSWORD?.trim() || "openpims_app";
+
+      const adminSql = postgres(adminUrl, { max: 1 });
+      let ownerSql: ReturnType<typeof postgres> | undefined;
+      let appSql: ReturnType<typeof postgres> | undefined;
+      let raceSqlA: ReturnType<typeof postgres> | undefined;
+      let raceSqlB: ReturnType<typeof postgres> | undefined;
+      await adminSql.unsafe(`create database "${databaseName}"`);
+
+      try {
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:migrate"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+          timeout: 45_000,
+        });
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:rls"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+          timeout: 45_000,
+        });
+
+        ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+        const ownerDb = drizzle(ownerSql, { schema });
+
+        const [practice] = await ownerDb
+          .insert(schema.practices)
+          .values({ name: "Synthetic Patient Merge Clinic" })
+          .returning({ id: schema.practices.id });
+        if (!practice) throw new Error("failed to seed practice");
+
+        const [location] = await ownerDb
+          .insert(schema.locations)
+          .values({
+            practiceId: practice.id,
+            name: "Synthetic Merge Clinic",
+            isPrimary: true,
+          })
+          .returning({ id: schema.locations.id });
+        if (!location) throw new Error("failed to seed location");
+
+        const [admin] = await ownerDb
+          .insert(schema.users)
+          .values({
+            practiceId: practice.id,
+            email: "synthetic-patient-merge@example.invalid",
+            passwordHash: "not-a-real-password-hash",
+            name: "Synthetic Merge Admin",
+            role: "admin",
+            emailVerifiedAt: new Date(),
+          })
+          .returning({ id: schema.users.id });
+        if (!admin) throw new Error("failed to seed admin");
+
+        const [client] = await ownerDb
+          .insert(schema.clients)
+          .values({
+            practiceId: practice.id,
+            firstName: "Synthetic",
+            lastName: "Owner",
+          })
+          .returning({ id: schema.clients.id });
+        if (!client) throw new Error("failed to seed client");
+
+        const [
+          keepPatient,
+          sourcePatient,
+          retryKeepPatient,
+          retrySourcePatient,
+          raceKeepPatient,
+          raceSourcePatient,
+          lineageKeepPatient,
+          lineageSourcePatient,
+        ] = await ownerDb
+          .insert(schema.patients)
+          .values([
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Canonical",
+              species: "canine",
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Duplicate",
+              species: "canine",
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Retry Canonical",
+              species: "feline",
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Retry Duplicate",
+              species: "feline",
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Race Canonical",
+              species: "canine",
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Race Duplicate",
+              species: "canine",
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Lineage Canonical",
+              species: "feline",
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Lineage Duplicate",
+              species: "feline",
+            },
+          ])
+          .returning({ id: schema.patients.id });
+        if (
+          !keepPatient ||
+          !sourcePatient ||
+          !retryKeepPatient ||
+          !retrySourcePatient ||
+          !raceKeepPatient ||
+          !raceSourcePatient ||
+          !lineageKeepPatient ||
+          !lineageSourcePatient
+        ) {
+          throw new Error("failed to seed patients");
+        }
+
+        const futureStart = new Date(Date.now() + 86_400_000);
+        const futureEnd = new Date(futureStart.getTime() + 1_800_000);
+        const [successAppointment, retryAppointment, raceAppointment] =
+          await ownerDb
+            .insert(schema.appointments)
+            .values([
+              {
+                practiceId: practice.id,
+                locationId: location.id,
+                clientId: client.id,
+                patientId: sourcePatient.id,
+                startTime: futureStart,
+                endTime: futureEnd,
+              },
+              {
+                practiceId: practice.id,
+                locationId: location.id,
+                clientId: client.id,
+                patientId: retrySourcePatient.id,
+                startTime: new Date(futureStart.getTime() + 3_600_000),
+                endTime: new Date(futureEnd.getTime() + 3_600_000),
+              },
+              {
+                practiceId: practice.id,
+                locationId: location.id,
+                clientId: client.id,
+                patientId: raceSourcePatient.id,
+                startTime: new Date(futureStart.getTime() + 7_200_000),
+                endTime: new Date(futureEnd.getTime() + 7_200_000),
+              },
+            ])
+            .returning({
+              id: schema.appointments.id,
+              updatedAt: schema.appointments.updatedAt,
+            });
+        const [successWaitlist, retryWaitlist, raceWaitlist] = await ownerDb
+          .insert(schema.appointmentWaitlist)
+          .values([
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              patientId: sourcePatient.id,
+              createdBy: admin.id,
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              patientId: retrySourcePatient.id,
+              createdBy: admin.id,
+            },
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              patientId: raceSourcePatient.id,
+              createdBy: admin.id,
+            },
+          ])
+          .returning({
+            id: schema.appointmentWaitlist.id,
+            updatedAt: schema.appointmentWaitlist.updatedAt,
+          });
+        if (
+          !successAppointment ||
+          !retryAppointment ||
+          !raceAppointment ||
+          !successWaitlist ||
+          !retryWaitlist ||
+          !raceWaitlist
+        ) {
+          throw new Error("failed to seed movable scheduling records");
+        }
+
+        await ownerSql.unsafe(`
+          create table patient_merge_transaction_observations (
+            practice_id uuid not null,
+            operation_id uuid not null,
+            isolation_level text not null,
+            tenant_context text
+          );
+
+          create table patient_merge_failure_injections (
+            patient_id uuid primary key
+          );
+
+          create function observe_patient_merge_transaction()
+          returns trigger
+          language plpgsql
+          security definer
+          set search_path = public, pg_temp
+          as $function$
+          begin
+            if new.reason = 'Synthetic lineage constraint injection.' then
+              raise exception using
+                errcode = '23514',
+                message = 'A canonical patient with incoming merge history cannot be retired.';
+            end if;
+
+            insert into patient_merge_transaction_observations (
+              practice_id,
+              operation_id,
+              isolation_level,
+              tenant_context
+            ) values (
+              new.practice_id,
+              new.operation_id,
+              current_setting('transaction_isolation'),
+              nullif(current_setting('app.current_practice_id', true), '')
+            );
+            if new.reason = 'Synthetic concurrent merge race.' then
+              perform pg_catalog.pg_sleep(1);
+            end if;
+            return new;
+          end
+          $function$;
+
+          create trigger observe_patient_merge_transaction_trigger
+          before insert on patient_merge_events
+          for each row execute function observe_patient_merge_transaction();
+
+          create function inject_patient_merge_retirement_failure()
+          returns trigger
+          language plpgsql
+          security definer
+          set search_path = public, pg_temp
+          as $function$
+          begin
+            if new.deleted_at is not null
+              and old.deleted_at is null
+              and exists (
+                select 1
+                from patient_merge_failure_injections injection
+                where injection.patient_id = old.id
+              )
+            then
+              raise exception 'synthetic serialization conflict after merge writes'
+                using errcode = '40001';
+            end if;
+            return new;
+          end
+          $function$;
+
+          create trigger inject_patient_merge_retirement_failure_trigger
+          before update on patients
+          for each row execute function inject_patient_merge_retirement_failure();
+        `);
+
+        await ownerSql`
+          insert into patient_merge_failure_injections (patient_id)
+          values (${retrySourcePatient.id})
+        `;
+
+        appSql = postgres(appUrl.toString(), { max: 1 });
+        const appDb = drizzle(appSql, { schema });
+        const operationId = randomUUID();
+        const caller = appRouter.createCaller({
+          db: appDb,
+          session: {
+            user: {
+              id: admin.id,
+              email: "synthetic-patient-merge@example.invalid",
+              name: "Synthetic Merge Admin",
+              role: "admin",
+              practiceId: practice.id,
+            },
+          },
+        } as never);
+
+        const merged = await caller.patients.merge({
+          keepId: keepPatient.id,
+          mergeId: sourcePatient.id,
+          reason: "Synthetic duplicate chart verified for transaction proof.",
+          operationId,
+        });
+        expect(merged).toMatchObject({
+          id: keepPatient.id,
+          mergeMetadata: {
+            sourcePatientId: sourcePatient.id,
+            canonicalId: keepPatient.id,
+            replayed: false,
+          },
+        });
+
+        const replayed = await caller.patients.merge({
+          keepId: keepPatient.id,
+          mergeId: sourcePatient.id,
+          reason: "Synthetic duplicate chart verified for transaction proof.",
+          operationId,
+        });
+        expect(replayed.mergeMetadata).toMatchObject({
+          sourcePatientId: sourcePatient.id,
+          canonicalId: keepPatient.id,
+          replayed: true,
+        });
+
+        await expect(
+          caller.patients.merge({
+            keepId: keepPatient.id,
+            mergeId: sourcePatient.id,
+            reason: "Conflicting reuse of a completed synthetic operation.",
+            operationId,
+          }),
+        ).rejects.toMatchObject({
+          code: "CONFLICT",
+          message:
+            "This patient merge operation ID was already used for different details.",
+        });
+
+        const retryOperationId = randomUUID();
+        await expect(
+          caller.patients.merge({
+            keepId: retryKeepPatient.id,
+            mergeId: retrySourcePatient.id,
+            reason: "Synthetic serialization conflict injection.",
+            operationId: retryOperationId,
+          }),
+        ).rejects.toMatchObject({
+          code: "CONFLICT",
+          message:
+            "Patient records changed during the merge. Refresh both charts and retry.",
+        });
+
+        const lineageOperationId = randomUUID();
+        await expect(
+          caller.patients.merge({
+            keepId: lineageKeepPatient.id,
+            mergeId: lineageSourcePatient.id,
+            reason: "Synthetic lineage constraint injection.",
+            operationId: lineageOperationId,
+          }),
+        ).rejects.toMatchObject({
+          code: "PRECONDITION_FAILED",
+          message:
+            "The patient merge no longer satisfies the identity safety checks. Refresh both charts before continuing.",
+        });
+
+        raceSqlA = postgres(appUrl.toString(), { max: 1 });
+        raceSqlB = postgres(appUrl.toString(), { max: 1 });
+        const raceContext = (database: unknown) =>
+          ({
+            db: database,
+            session: {
+              user: {
+                id: admin.id,
+                email: "synthetic-patient-merge@example.invalid",
+                name: "Synthetic Merge Admin",
+                role: "admin",
+                practiceId: practice.id,
+              },
+            },
+          }) as never;
+        const raceCallerA = appRouter.createCaller(
+          raceContext(drizzle(raceSqlA, { schema })),
+        );
+        const raceCallerB = appRouter.createCaller(
+          raceContext(drizzle(raceSqlB, { schema })),
+        );
+        const raceOperationId = randomUUID();
+        const raceInput = {
+          keepId: raceKeepPatient.id,
+          mergeId: raceSourcePatient.id,
+          reason: "Synthetic concurrent merge race.",
+          operationId: raceOperationId,
+        };
+        const firstRaceCall = raceCallerA.patients.merge(raceInput);
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+        const raceResults = await Promise.allSettled([
+          firstRaceCall,
+          raceCallerB.patients.merge(raceInput),
+        ]);
+        const fulfilledRaces = raceResults.filter(
+          (result) => result.status === "fulfilled",
+        );
+        const rejectedRaces = raceResults.filter(
+          (result) => result.status === "rejected",
+        );
+        expect(fulfilledRaces).toHaveLength(1);
+        expect(rejectedRaces).toHaveLength(1);
+        expect(rejectedRaces[0]).toMatchObject({
+          reason: {
+            code: "CONFLICT",
+            message:
+              "Patient records changed during the merge. Refresh both charts and retry.",
+          },
+        });
+
+        const raceReplay = await raceCallerA.patients.merge(raceInput);
+        expect(raceReplay.mergeMetadata).toMatchObject({
+          sourcePatientId: raceSourcePatient.id,
+          canonicalId: raceKeepPatient.id,
+          replayed: true,
+        });
+
+        const [state] = await ownerSql<
+          Array<{
+            sourceDeleted: boolean;
+            events: number;
+            mergeAudits: number;
+            observations: number;
+            isolationLevel: string;
+            tenantContext: string | null;
+            retryPatientsActive: number;
+            retryEvents: number;
+            retryAudits: number;
+            retryObservations: number;
+            successAppointmentMoved: boolean;
+            successWaitlistMoved: boolean;
+            retryAppointmentPreserved: boolean;
+            retryWaitlistPreserved: boolean;
+            retryAppointmentTimestampPreserved: boolean;
+            retryWaitlistTimestampPreserved: boolean;
+            raceSourceDeleted: boolean;
+            raceEvents: number;
+            raceAudits: number;
+            raceAppointmentMoved: boolean;
+            raceWaitlistMoved: boolean;
+            lineagePatientsActive: number;
+            lineageEvents: number;
+            lineageAudits: number;
+          }>
+        >`
+          select
+            (select deleted_at is not null from patients where id = ${sourcePatient.id}) as "sourceDeleted",
+            (select count(*)::int from patient_merge_events where operation_id = ${operationId}) as events,
+            (select count(*)::int from audit_log where action = 'merged' and entity_id = ${keepPatient.id}) as "mergeAudits",
+            (select count(*)::int from patient_merge_transaction_observations where operation_id = ${operationId}) as observations,
+            (select isolation_level from patient_merge_transaction_observations where operation_id = ${operationId}) as "isolationLevel",
+            (select tenant_context from patient_merge_transaction_observations where operation_id = ${operationId}) as "tenantContext",
+            (select count(*)::int from patients where id in (${retryKeepPatient.id}, ${retrySourcePatient.id}) and deleted_at is null) as "retryPatientsActive",
+            (select count(*)::int from patient_merge_events where operation_id = ${retryOperationId}) as "retryEvents",
+            (select count(*)::int from audit_log where action = 'merged' and entity_id = ${retryKeepPatient.id}) as "retryAudits",
+            (select count(*)::int from patient_merge_transaction_observations where operation_id = ${retryOperationId}) as "retryObservations",
+            (select patient_id = ${keepPatient.id} from appointments where id = ${successAppointment.id}) as "successAppointmentMoved",
+            (select patient_id = ${keepPatient.id} from appointment_waitlist where id = ${successWaitlist.id}) as "successWaitlistMoved",
+            (select patient_id = ${retrySourcePatient.id} from appointments where id = ${retryAppointment.id}) as "retryAppointmentPreserved",
+            (select patient_id = ${retrySourcePatient.id} from appointment_waitlist where id = ${retryWaitlist.id}) as "retryWaitlistPreserved",
+            (select date_trunc('milliseconds', updated_at) = ${retryAppointment.updatedAt.toISOString()}::timestamptz from appointments where id = ${retryAppointment.id}) as "retryAppointmentTimestampPreserved",
+            (select date_trunc('milliseconds', updated_at) = ${retryWaitlist.updatedAt.toISOString()}::timestamptz from appointment_waitlist where id = ${retryWaitlist.id}) as "retryWaitlistTimestampPreserved",
+            (select deleted_at is not null from patients where id = ${raceSourcePatient.id}) as "raceSourceDeleted",
+            (select count(*)::int from patient_merge_events where operation_id = ${raceOperationId}) as "raceEvents",
+            (select count(*)::int from audit_log where action = 'merged' and entity_id = ${raceKeepPatient.id}) as "raceAudits",
+            (select patient_id = ${raceKeepPatient.id} from appointments where id = ${raceAppointment.id}) as "raceAppointmentMoved",
+            (select patient_id = ${raceKeepPatient.id} from appointment_waitlist where id = ${raceWaitlist.id}) as "raceWaitlistMoved",
+            (select count(*)::int from patients where id in (${lineageKeepPatient.id}, ${lineageSourcePatient.id}) and deleted_at is null) as "lineagePatientsActive",
+            (select count(*)::int from patient_merge_events where operation_id = ${lineageOperationId}) as "lineageEvents",
+            (select count(*)::int from audit_log where action = 'merged' and entity_id = ${lineageKeepPatient.id}) as "lineageAudits"
+        `;
+        expect(state).toEqual({
+          sourceDeleted: true,
+          events: 1,
+          mergeAudits: 1,
+          observations: 1,
+          isolationLevel: "serializable",
+          tenantContext: practice.id,
+          retryPatientsActive: 2,
+          retryEvents: 0,
+          retryAudits: 0,
+          retryObservations: 0,
+          successAppointmentMoved: true,
+          successWaitlistMoved: true,
+          retryAppointmentPreserved: true,
+          retryWaitlistPreserved: true,
+          retryAppointmentTimestampPreserved: true,
+          retryWaitlistTimestampPreserved: true,
+          raceSourceDeleted: true,
+          raceEvents: 1,
+          raceAudits: 1,
+          raceAppointmentMoved: true,
+          raceWaitlistMoved: true,
+          lineagePatientsActive: 2,
+          lineageEvents: 0,
+          lineageAudits: 0,
+        });
+
+        const [noContext] = await appSql<Array<{ patients: number }>>`
+          select count(*)::int as patients from patients
+        `;
+        expect(noContext).toEqual({ patients: 0 });
+      } finally {
+        if (raceSqlB) await raceSqlB.end();
+        if (raceSqlA) await raceSqlA.end();
+        if (appSql) await appSql.end();
+        if (ownerSql) await ownerSql.end();
+        await adminSql.unsafe(
+          `drop database if exists "${databaseName}" with (force)`,
+        );
+        await adminSql.end();
+      }
+    }, 120_000);
+  },
+);

--- a/apps/web/server/__tests__/patients-query-scoping.test.ts
+++ b/apps/web/server/__tests__/patients-query-scoping.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it } from "vitest";
 
 const source = readFileSync(
   new URL("../routers/patients.ts", import.meta.url),
-  "utf8"
+  "utf8",
 );
+const trpcSource = readFileSync(new URL("../trpc.ts", import.meta.url), "utf8");
 
 describe("patients query scoping", () => {
   it("keeps patient owner display joins tenant scoped and active", () => {
@@ -20,9 +21,15 @@ describe("patients query scoping", () => {
     expect(source).toContain("patientOwnerSearchConditions");
     expect(source).toContain("patientSearchTokens(value).map");
     expect(source).toContain("literalPatientSearchMatch(patients.name, token)");
-    expect(source).toContain("literalPatientSearchMatch(patients.breed, token)");
-    expect(source).toContain("literalPatientSearchMatch(clients.firstName, token)");
-    expect(source).toContain("literalPatientSearchMatch(clients.lastName, token)");
+    expect(source).toContain(
+      "literalPatientSearchMatch(patients.breed, token)",
+    );
+    expect(source).toContain(
+      "literalPatientSearchMatch(clients.firstName, token)",
+    );
+    expect(source).toContain(
+      "literalPatientSearchMatch(clients.lastName, token)",
+    );
     expect(source).toContain("escape '\\\\'");
     expect(source).toContain("patientSearchOrder(input.query)");
     expect(source).toContain("when lower(${patients.name}) = ${phrase} then 0");
@@ -37,16 +44,16 @@ describe("patients query scoping", () => {
     expect(source).toContain("${practices.deletedAt} is null");
     expect(source).toContain("await assertActivePractice(ctx)");
     expect(
-      source.match(/activePracticePredicate\(ctx\.practiceId\)/g)?.length ?? 0
+      source.match(/activePracticePredicate\(ctx\.practiceId\)/g)?.length ?? 0,
     ).toBeGreaterThanOrEqual(10);
     expect(source).toMatch(
-      /eq\(patients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(patients\.deletedAt\)/
+      /eq\(patients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(patients\.deletedAt\)/,
     );
     expect(source).toMatch(
-      /eq\(appointments\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointments\.deletedAt\)/
+      /eq\(appointments\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointments\.deletedAt\)/,
     );
     expect(source).toMatch(
-      /eq\(appointmentWaitlist\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+eq\(appointmentWaitlist\.status, "waiting"\)/
+      /eq\(appointmentWaitlist\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+eq\(appointmentWaitlist\.status, "waiting"\)/,
     );
     expect(source).toContain(
       "from ${invoices} where ${invoices.practiceId} = ${practiceId} and ${invoices.patientId} = ${patientId}",
@@ -55,31 +62,33 @@ describe("patients query scoping", () => {
 
   it("scopes patient detail child reads through the tenant patient", () => {
     const weightsRead = source.match(
-      /\.from\(patientWeights\)[\s\S]+?\.orderBy\(desc\(patientWeights\.recordedAt\)\)/
+      /\.from\(patientWeights\)[\s\S]+?\.orderBy\(desc\(patientWeights\.recordedAt\)\)/,
     )?.[0];
     expect(weightsRead).toContain("eq(patientWeights.patientId, patient.id)");
     expect(weightsRead).toContain("from ${patients}");
-    expect(weightsRead).toContain("${patients.id} = ${patientWeights.patientId}");
+    expect(weightsRead).toContain(
+      "${patients.id} = ${patientWeights.patientId}",
+    );
     expect(weightsRead).toContain("${patients.practiceId} = ${ctx.practiceId}");
     expect(weightsRead).toContain("${patients.deletedAt} is null");
     expect(weightsRead).toContain("activePracticePredicate(ctx.practiceId)");
 
     const allergiesRead = source.match(
-      /\.from\(patientAllergies\)[\s\S]+?eq\(patientAllergies\.patientId, patient\.id\)[\s\S]+?\.orderBy\(desc\(patientAllergies\.notedAt\)/
+      /\.from\(patientAllergies\)[\s\S]+?eq\(patientAllergies\.patientId, patient\.id\)[\s\S]+?\.orderBy\(desc\(patientAllergies\.notedAt\)/,
     )?.[0];
     expect(allergiesRead).toContain(".leftJoin(");
     expect(allergiesRead).toContain(
-      "clinicalRecordCorrections.patientAllergyId"
+      "clinicalRecordCorrections.patientAllergyId",
     );
     expect(allergiesRead).toContain(
-      "eq(clinicalRecordCorrections.practiceId, ctx.practiceId)"
+      "eq(clinicalRecordCorrections.practiceId, ctx.practiceId)",
     );
     expect(allergiesRead).toContain("from ${patients}");
     expect(allergiesRead).toContain(
-      "${patients.id} = ${patientAllergies.patientId}"
+      "${patients.id} = ${patientAllergies.patientId}",
     );
     expect(allergiesRead).toContain(
-      "${patients.practiceId} = ${ctx.practiceId}"
+      "${patients.practiceId} = ${ctx.practiceId}",
     );
     expect(allergiesRead).toContain("${patients.deletedAt} is null");
     expect(allergiesRead).toContain("activePracticePredicate(ctx.practiceId)");
@@ -98,22 +107,27 @@ describe("patients query scoping", () => {
     expect(deleteBlock).toContain("eq(patients.practiceId, ctx.practiceId)");
     expect(deleteBlock).toContain("activePracticePredicate(ctx.practiceId)");
     expect(deleteBlock).toContain("eq(appointments.patientId, input.id)");
-    expect(deleteBlock).toContain("eq(appointments.practiceId, ctx.practiceId)");
     expect(deleteBlock).toContain(
-      "inArray(appointments.status, activeAppointmentStatuses)"
+      "eq(appointments.practiceId, ctx.practiceId)",
     );
     expect(deleteBlock).toContain(
-      "eq(appointmentWaitlist.patientId, input.id)"
+      "inArray(appointments.status, activeAppointmentStatuses)",
     );
     expect(deleteBlock).toContain(
-      "eq(appointmentWaitlist.practiceId, ctx.practiceId)"
+      "eq(appointmentWaitlist.patientId, input.id)",
+    );
+    expect(deleteBlock).toContain(
+      "eq(appointmentWaitlist.practiceId, ctx.practiceId)",
     );
     expect(deleteBlock).toContain('eq(appointmentWaitlist.status, "waiting")');
   });
 
   it("keeps merge preview and execution admin-only, transactional, and fail-closed", () => {
     const previewStart = source.indexOf("previewMerge: protectedProcedure");
-    const mergeStart = source.indexOf("merge: protectedProcedure", previewStart);
+    const mergeStart = source.indexOf(
+      "merge: protectedProcedure",
+      previewStart,
+    );
     const duplicatesStart = source.indexOf(
       "findDuplicates: protectedProcedure",
       mergeStart,
@@ -123,14 +137,22 @@ describe("patients query scoping", () => {
     expect(previewStart).toBeGreaterThanOrEqual(0);
     expect(mergeBlock).toContain('.use(requireRole("admin"))');
     expect(mergeBlock).toContain("ctx.db.transaction(async (tx) =>");
-    expect(mergeBlock).toContain(
+    expect(mergeBlock).not.toContain(
       "set transaction isolation level serializable",
     );
+    expect(trpcSource).toMatch(
+      /path === "patients\.merge"\s*\? \{ isolationLevel: "serializable" \}/,
+    );
+    expect(trpcSource).toContain('path === "patients.merge" && !result.ok');
+    expect(trpcSource).toContain("throw result.error");
     expect(source).toContain('.orderBy(asc(patients.id))\n    .for("update")');
     expect(source).toContain("sourceHasIncomingAliases");
     expect(source).toContain("sourceWasPreviouslyMerged");
     expect(source).toContain("targetWasPreviouslyMerged");
     expect(source).toContain("appointmentCollisions");
+    expect(source).toMatch(
+      /appointmentHistory:[\s\S]*?\$\{appointments\.clientId\} = \$\{mergePatient\.clientId\}[\s\S]*?\) is not true/,
+    );
     expect(source).toContain("waitlistCollisions");
     expect(source).toContain("consentRequests:");
     expect(source).toContain("captureSessions:");
@@ -200,5 +222,4 @@ describe("patients query scoping", () => {
     expect(source).toContain("requestedPatientId: input.id");
     expect(source).toContain("canonicalPatientId: patient.id");
   });
-
 });

--- a/apps/web/server/__tests__/patients-safety.test.ts
+++ b/apps/web/server/__tests__/patients-safety.test.ts
@@ -826,10 +826,17 @@ describe("patients mutation safety", () => {
         entityId: PATIENT_ID,
       }),
     );
-    expect(updateSet).toHaveBeenNthCalledWith(1, { patientId: PATIENT_ID });
-    expect(updateSet).toHaveBeenNthCalledWith(2, { patientId: PATIENT_ID });
+    expect(updateSet).toHaveBeenNthCalledWith(1, {
+      patientId: PATIENT_ID,
+      updatedAt: expect.any(Date),
+    });
+    expect(updateSet).toHaveBeenNthCalledWith(2, {
+      patientId: PATIENT_ID,
+      updatedAt: expect.any(Date),
+    });
     expect(updateSet).toHaveBeenNthCalledWith(3, {
       deletedAt: expect.any(Date),
+      updatedAt: expect.any(Date),
     });
   });
 

--- a/apps/web/server/__tests__/trpc-post-commit.test.ts
+++ b/apps/web/server/__tests__/trpc-post-commit.test.ts
@@ -5,9 +5,11 @@ const mocks = vi.hoisted(() => {
   let tenantDepth = 0;
   const events: string[] = [];
   const executeErrors: unknown[] = [];
+  const patientMergeResolverErrors: unknown[] = [];
   return {
     events,
     executeErrors,
+    patientMergeResolverErrors,
     get systemDepth() {
       return systemDepth;
     },
@@ -31,6 +33,7 @@ const mocks = vi.hoisted(() => {
         database: unknown,
         _practiceId: string,
         fn: (tx: unknown) => Promise<unknown>,
+        _options?: { isolationLevel?: "serializable" },
       ) => {
         tenantDepth += 1;
         events.push("tenant:begin");
@@ -98,11 +101,19 @@ const router = createRouter({
     });
     return { ok: true };
   }),
+  patients: createRouter({
+    merge: protectedProcedure.mutation(() => {
+      const error = mocks.patientMergeResolverErrors.shift();
+      if (error) throw error;
+      return { ok: true };
+    }),
+  }),
 });
 
 afterEach(() => {
   mocks.events.length = 0;
   mocks.executeErrors.length = 0;
+  mocks.patientMergeResolverErrors.length = 0;
   vi.clearAllMocks();
 });
 
@@ -146,6 +157,86 @@ describe("tRPC post-commit effects", () => {
       commitIndex,
     );
   });
+
+  it("selects serializable isolation only for the patient merge path", async () => {
+    const caller = router.createCaller({
+      db: { kind: "root-tenant" },
+      session: {
+        user: {
+          id: "user-1",
+          email: "owner@example.com",
+          name: "Owner",
+          role: "admin",
+          practiceId: "practice-1",
+        },
+      },
+    } as never);
+
+    await expect(caller.patients.merge()).resolves.toEqual({ ok: true });
+
+    expect(mocks.withTenant).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "practice-1",
+      expect.any(Function),
+      { isolationLevel: "serializable" },
+    );
+  });
+
+  it.each([
+    [
+      { code: "40001" },
+      "CONFLICT",
+      "Patient records changed during the merge. Refresh both charts and retry.",
+    ],
+    [
+      {
+        code: "23505",
+        constraint_name: "patient_merge_events_operation_uq",
+      },
+      "CONFLICT",
+      "This patient merge conflicts with another completed operation. Refresh both charts before continuing.",
+    ],
+    [
+      {
+        code: "23514",
+        message:
+          "A canonical patient with incoming merge history cannot be retired.",
+      },
+      "PRECONDITION_FAILED",
+      "The patient merge no longer satisfies the identity safety checks. Refresh both charts before continuing.",
+    ],
+    [
+      {
+        code: "23503",
+        message:
+          "Patient merge source and target must belong to the recorded client.",
+      },
+      "PRECONDITION_FAILED",
+      "The patient merge no longer satisfies the identity safety checks. Refresh both charts before continuing.",
+    ],
+  ])(
+    "maps patient merge database failures to stable typed responses",
+    async (error, code, message) => {
+      mocks.patientMergeResolverErrors.push(error);
+      const caller = router.createCaller({
+        db: { kind: "root-tenant" },
+        session: {
+          user: {
+            id: "user-1",
+            email: "owner@example.com",
+            name: "Owner",
+            role: "admin",
+            practiceId: "practice-1",
+          },
+        },
+      } as never);
+
+      await expect(caller.patients.merge()).rejects.toMatchObject({
+        code,
+        message,
+      });
+    },
+  );
 
   it("maps only the named deferred SOAP invariant and runs no audit or effect", async () => {
     mocks.executeErrors.push({

--- a/apps/web/server/routers/patients.ts
+++ b/apps/web/server/routers/patients.ts
@@ -498,8 +498,6 @@ async function analyzePatientMerge(
     });
   }
 
-  const targetAppointments = alias(appointments, "merge_target_appointments");
-  const targetWaitlist = alias(appointmentWaitlist, "merge_target_waitlist");
   const [row] = await db
     .select({
       sourceHasIncomingAliases: sql<number>`(
@@ -524,36 +522,36 @@ async function analyzePatientMerge(
           and ${appointments.clientId} = ${mergePatient.clientId}
           and ${appointments.deletedAt} is null
           and ${appointments.status} in ('scheduled', 'confirmed')
-          and ${appointments.startTime} > ${now}
+          and ${appointments.startTime} > ${now.toISOString()}
       )`,
       appointmentHistory: sql<number>`(
         select count(*)::int from ${appointments}
         where ${appointments.practiceId} = ${practiceId}
           and ${appointments.patientId} = ${mergeId}
-          and not (
+          and (
             ${appointments.clientId} = ${mergePatient.clientId}
             and ${appointments.deletedAt} is null
             and ${appointments.status} in ('scheduled', 'confirmed')
-            and ${appointments.startTime} > ${now}
-          )
+            and ${appointments.startTime} > ${now.toISOString()}
+          ) is not true
       )`,
       appointmentCollisions: sql<number>`(
-        select count(*)::int from ${appointments}
-        where ${appointments.practiceId} = ${practiceId}
-          and ${appointments.patientId} = ${mergeId}
-          and ${appointments.clientId} = ${mergePatient.clientId}
-          and ${appointments.deletedAt} is null
-          and ${appointments.status} in ('scheduled', 'confirmed')
-          and ${appointments.startTime} > ${now}
+        select count(*)::int from appointments as merge_source_appointments
+        where merge_source_appointments.practice_id = ${practiceId}
+          and merge_source_appointments.patient_id = ${mergeId}
+          and merge_source_appointments.client_id = ${mergePatient.clientId}
+          and merge_source_appointments.deleted_at is null
+          and merge_source_appointments.status in ('scheduled', 'confirmed')
+          and merge_source_appointments.start_time > ${now.toISOString()}
           and exists (
-            select 1 from ${targetAppointments}
-            where ${targetAppointments.practiceId} = ${practiceId}
-              and ${targetAppointments.patientId} = ${keepId}
-              and ${targetAppointments.clientId} = ${keepPatient.clientId}
-              and ${targetAppointments.deletedAt} is null
-              and ${targetAppointments.status} in ('scheduled', 'confirmed')
-              and ${targetAppointments.startTime} = ${appointments.startTime}
-              and ${targetAppointments.endTime} = ${appointments.endTime}
+            select 1 from appointments as merge_target_appointments
+            where merge_target_appointments.practice_id = ${practiceId}
+              and merge_target_appointments.patient_id = ${keepId}
+              and merge_target_appointments.client_id = ${keepPatient.clientId}
+              and merge_target_appointments.deleted_at is null
+              and merge_target_appointments.status in ('scheduled', 'confirmed')
+              and merge_target_appointments.start_time = merge_source_appointments.start_time
+              and merge_target_appointments.end_time = merge_source_appointments.end_time
           )
       )`,
       waitingListEntries: sql<number>`(
@@ -575,22 +573,22 @@ async function analyzePatientMerge(
           )
       )`,
       waitlistCollisions: sql<number>`(
-        select count(*)::int from ${appointmentWaitlist}
-        where ${appointmentWaitlist.practiceId} = ${practiceId}
-          and ${appointmentWaitlist.patientId} = ${mergeId}
-          and ${appointmentWaitlist.clientId} = ${mergePatient.clientId}
-          and ${appointmentWaitlist.deletedAt} is null
-          and ${appointmentWaitlist.status} = 'waiting'
+        select count(*)::int from appointment_waitlist as merge_source_waitlist
+        where merge_source_waitlist.practice_id = ${practiceId}
+          and merge_source_waitlist.patient_id = ${mergeId}
+          and merge_source_waitlist.client_id = ${mergePatient.clientId}
+          and merge_source_waitlist.deleted_at is null
+          and merge_source_waitlist.status = 'waiting'
           and exists (
-            select 1 from ${targetWaitlist}
-            where ${targetWaitlist.practiceId} = ${practiceId}
-              and ${targetWaitlist.patientId} = ${keepId}
-              and ${targetWaitlist.clientId} = ${keepPatient.clientId}
-              and ${targetWaitlist.deletedAt} is null
-              and ${targetWaitlist.status} = 'waiting'
-              and ${targetWaitlist.typeId} is not distinct from ${appointmentWaitlist.typeId}
-              and ${targetWaitlist.preferredFrom} is not distinct from ${appointmentWaitlist.preferredFrom}
-              and ${targetWaitlist.preferredTo} is not distinct from ${appointmentWaitlist.preferredTo}
+            select 1 from appointment_waitlist as merge_target_waitlist
+            where merge_target_waitlist.practice_id = ${practiceId}
+              and merge_target_waitlist.patient_id = ${keepId}
+              and merge_target_waitlist.client_id = ${keepPatient.clientId}
+              and merge_target_waitlist.deleted_at is null
+              and merge_target_waitlist.status = 'waiting'
+              and merge_target_waitlist.type_id is not distinct from merge_source_waitlist.type_id
+              and merge_target_waitlist.preferred_from is not distinct from merge_source_waitlist.preferred_from
+              and merge_target_waitlist.preferred_to is not distinct from merge_source_waitlist.preferred_to
           )
       )`,
       weights: sql<number>`(select count(*)::int from ${patientWeights} where ${patientWeights.patientId} = ${mergeId})`,
@@ -1389,9 +1387,13 @@ export const patientsRouter = createRouter({
     .use(requireRole("admin"))
     .input(patientMergeInput)
     .mutation(async ({ ctx, input }) => {
+      // protectedProcedure selects SERIALIZABLE on the outer tenant
+      // transaction before setting the RLS tenant context. The nested
+      // transaction here is intentionally only a savepoint: it ensures every
+      // merge write rolls back when tRPC converts a resolver exception into
+      // an error result, and it must not change transaction isolation.
       return ctx.db.transaction(async (tx) => {
         const mergeDb = tx as unknown as Database;
-        await tx.execute(sql`set transaction isolation level serializable`);
         await assertActivePractice({ db: mergeDb, practiceId: ctx.practiceId });
 
         const [existingEvent] = await mergeDb
@@ -1464,7 +1466,7 @@ export const patientsRouter = createRouter({
 
         const movedAppointments = await tx
           .update(appointments)
-          .set({ patientId: input.keepId })
+          .set({ patientId: input.keepId, updatedAt: mergeNow })
           .where(
             and(
               eq(appointments.patientId, input.mergeId),
@@ -1472,7 +1474,7 @@ export const patientsRouter = createRouter({
               eq(appointments.practiceId, ctx.practiceId),
               isNull(appointments.deletedAt),
               inArray(appointments.status, mergeMovableAppointmentStatuses),
-              sql`${appointments.startTime} > ${mergeNow}`,
+              sql`${appointments.startTime} > ${mergeNow.toISOString()}`,
             ),
           )
           .returning({ id: appointments.id });
@@ -1488,7 +1490,7 @@ export const patientsRouter = createRouter({
 
         const movedWaitlistEntries = await tx
           .update(appointmentWaitlist)
-          .set({ patientId: input.keepId })
+          .set({ patientId: input.keepId, updatedAt: mergeNow })
           .where(
             and(
               eq(appointmentWaitlist.patientId, input.mergeId),
@@ -1556,7 +1558,7 @@ export const patientsRouter = createRouter({
 
         const [retiredSource] = await tx
           .update(patients)
-          .set({ deletedAt: mergedAt })
+          .set({ deletedAt: mergedAt, updatedAt: mergedAt })
           .where(
             and(
               eq(patients.id, input.mergeId),

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -181,6 +181,95 @@ function practiceNotFound(): TRPCError {
   return new TRPCError({ code: "NOT_FOUND", message: "Practice not found" });
 }
 
+function postgresErrorDetails(error: unknown): {
+  code?: unknown;
+  constraintName?: unknown;
+  message?: unknown;
+} {
+  const visited = new Set<object>();
+  let current = error;
+
+  for (let depth = 0; depth < 6; depth += 1) {
+    if (typeof current !== "object" || current === null) return {};
+    if (visited.has(current)) return {};
+    visited.add(current);
+
+    const candidate = current as {
+      code?: unknown;
+      constraint_name?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    };
+    if (
+      typeof candidate.code === "string" &&
+      /^[0-9A-Z]{5}$/.test(candidate.code)
+    ) {
+      return {
+        code: candidate.code,
+        constraintName: candidate.constraint_name,
+        message: candidate.message,
+      };
+    }
+    current = candidate.cause;
+  }
+
+  return {};
+}
+
+function patientMergeDatabaseError(error: unknown): TRPCError | null {
+  const { code, constraintName, message } = postgresErrorDetails(error);
+
+  if (code === "40001") {
+    return new TRPCError({
+      code: "CONFLICT",
+      message:
+        "Patient records changed during the merge. Refresh both charts and retry.",
+    });
+  }
+
+  if (
+    code === "23505" &&
+    (constraintName === "patient_merge_events_operation_uq" ||
+      constraintName === "patient_merge_events_source_uq")
+  ) {
+    return new TRPCError({
+      code: "CONFLICT",
+      message:
+        "This patient merge conflicts with another completed operation. Refresh both charts before continuing.",
+    });
+  }
+
+  if (
+    code === "23514" &&
+    ((typeof constraintName === "string" &&
+      constraintName.startsWith("patient_merge_events_")) ||
+      message ===
+        "A canonical patient with incoming merge history cannot be retired." ||
+      message ===
+        "A patient already recorded as a merge alias cannot be a merge target.")
+  ) {
+    return new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "The patient merge no longer satisfies the identity safety checks. Refresh both charts before continuing.",
+    });
+  }
+
+  if (
+    code === "23503" &&
+    message ===
+      "Patient merge source and target must belong to the recorded client."
+  ) {
+    return new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "The patient merge no longer satisfies the identity safety checks. Refresh both charts before continuing.",
+    });
+  }
+
+  return null;
+}
+
 /**
  * Public / pre-auth endpoints (registration, the token-based client portal).
  * They have no tenant session and do their own scoping (tokens, email, rate
@@ -235,72 +324,93 @@ export const protectedProcedure = t.procedure.use(
     // Run the whole request in a tenant DB context so Postgres RLS scopes every
     // query to this practice (defense-in-depth behind the app-layer filters).
     const effects: PostCommitEffect[] = [];
-    const result = await withTenant(ctx.db, user.practiceId, async (tx) => {
-      // Hosted read-only guard: block mutations unless the practice has an
-      // active trial or subscription. This MUST run inside withTenant (via tx),
-      // not on the raw connection — under the least-privilege production role
-      // RLS only returns the practices row when app.current_practice_id is set,
-      // so a context-less lookup returns zero rows and would wrongly read-only
-      // every tenant (the owner role used in dev bypasses RLS and hid this).
-      if (
-        type === "mutation" &&
-        billingEnforced() &&
-        !HOSTED_READ_ONLY_MUTATION_ALLOWLIST.has(path)
-      ) {
-        const [practice] = await tx
-          .select({
-            tier: practices.subscriptionTier,
-            billingStatus: practices.billingStatus,
-            trialEndsAt: practices.trialEndsAt,
-          })
-          .from(practices)
-          .where(
-            and(eq(practices.id, user.practiceId), isNull(practices.deletedAt)),
-          )
-          .limit(1);
-        if (!practice) {
-          throw practiceNotFound();
-        }
+    const result = await withTenant(
+      ctx.db,
+      user.practiceId,
+      async (tx) => {
+        // Hosted read-only guard: block mutations unless the practice has an
+        // active trial or subscription. This MUST run inside withTenant (via tx),
+        // not on the raw connection — under the least-privilege production role
+        // RLS only returns the practices row when app.current_practice_id is set,
+        // so a context-less lookup returns zero rows and would wrongly read-only
+        // every tenant (the owner role used in dev bypasses RLS and hid this).
         if (
-          !hasHostedFullAccess(
-            practice.tier,
-            practice.billingStatus,
-            practice.trialEndsAt,
-          )
+          type === "mutation" &&
+          billingEnforced() &&
+          !HOSTED_READ_ONLY_MUTATION_ALLOWLIST.has(path)
         ) {
-          throw new TRPCError({
-            code: "FORBIDDEN",
-            message:
-              "OpenVPM Cloud is read-only until your trial or subscription is active. You can still manage billing and export your data.",
-          });
+          const [practice] = await tx
+            .select({
+              tier: practices.subscriptionTier,
+              billingStatus: practices.billingStatus,
+              trialEndsAt: practices.trialEndsAt,
+            })
+            .from(practices)
+            .where(
+              and(
+                eq(practices.id, user.practiceId),
+                isNull(practices.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!practice) {
+            throw practiceNotFound();
+          }
+          if (
+            !hasHostedFullAccess(
+              practice.tier,
+              practice.billingStatus,
+              practice.trialEndsAt,
+            )
+          ) {
+            throw new TRPCError({
+              code: "FORBIDDEN",
+              message:
+                "OpenVPM Cloud is read-only until your trial or subscription is active. You can still manage billing and export your data.",
+            });
+          }
         }
-      }
 
-      const result = await next({
-        ctx: {
-          session: ctx.session,
-          user,
-          practiceId: user.practiceId,
-          ip: ctx.ip,
-          db: tx,
-          postCommitEffect: (effect: PostCommitEffect) => {
-            if (type !== "mutation") {
-              throw new Error("Post-commit effects are mutation-only.");
-            }
-            effects.push(effect);
+        const result = await next({
+          ctx: {
+            session: ctx.session,
+            user,
+            practiceId: user.practiceId,
+            ip: ctx.ip,
+            db: tx,
+            postCommitEffect: (effect: PostCommitEffect) => {
+              if (type !== "mutation") {
+                throw new Error("Post-commit effects are mutation-only.");
+              }
+              effects.push(effect);
+            },
           },
-        },
-      });
+        });
 
-      if (type === "mutation" && result.ok) {
-        // Surface deferred clinical invariants while this transaction can
-        // still return a truthful procedure error. The audit is scheduled
-        // only after withTenant confirms the commit succeeded.
-        await tx.execute(sql`set constraints all immediate`);
+        if (path === "patients.merge" && !result.ok) {
+          // tRPC represents resolver exceptions as error results. Rethrowing
+          // here keeps the outer tenant transaction fail-closed and exposes
+          // the wrapped PostgreSQL cause to the narrow merge error mapper.
+          throw result.error;
+        }
+
+        if (type === "mutation" && result.ok) {
+          // Surface deferred clinical invariants while this transaction can
+          // still return a truthful procedure error. The audit is scheduled
+          // only after withTenant confirms the commit succeeded.
+          await tx.execute(sql`set constraints all immediate`);
+        }
+
+        return result;
+      },
+      path === "patients.merge"
+        ? { isolationLevel: "serializable" }
+        : undefined,
+    ).catch((error: unknown) => {
+      if (path === "patients.merge") {
+        const mapped = patientMergeDatabaseError(error);
+        if (mapped) throw mapped;
       }
-
-      return result;
-    }).catch((error: unknown) => {
       if (
         type === "mutation" &&
         typeof error === "object" &&


### PR DESCRIPTION
## Outcome

Fixes the patient merge HTTP 500 reported from Steven Dennis's clinic workflow without weakening tenant isolation or atomicity.

## Safety design

- Selects SERIALIZABLE on the outer tenant transaction before the RLS tenant context.
- Keeps the merge's nested transaction as a savepoint, with no illegal inner isolation change.
- Forces failed tRPC merge results to abort the outer transaction.
- Maps only known PostgreSQL serialization, merge-ledger uniqueness, lineage, and ownership failures to stable typed responses.
- Treats patient-bound appointments with a null client as immutable history and blocks the merge.
- Uses explicit SQL aliases and ISO timestamps for PostgreSQL-safe merge analysis and updates.

## Verification

- 4,092 web tests passed (11 opt-in integrations skipped in the general run).
- Real least-privilege PostgreSQL contract passed as openpims_app:
  - SERIALIZABLE + correct tenant GUC
  - appointment and waitlist movement
  - event/audit/source retirement
  - idempotent replay
  - injected 40001 after partial writes rolls back all rows and timestamps
  - unnamed lineage-trigger 23514 maps to PRECONDITION_FAILED
  - two-connection same-operation race yields one winner, one typed conflict, one durable event/audit, then exact replay
  - RLS context clears on pooled connection reuse
- 82 migration-integrity tests passed (1 opt-in skipped).
- Repository type checks passed.
- Production Next.js build passed.
- Two independent read-only reviews returned PASS.

## Rollout

Application and CI only; no schema migration or production data write. Merge only after hosted required checks pass.

Closes OPENVPM-71