### PR TITLE
OPENVPM-83: deterministic patient history search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,15 @@ jobs:
           PATIENT_SEARCH_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run server/__tests__/patient-search.integration.test.ts
 
+      # Steven Dennis's long-chart workflow crosses multiple clinical tables.
+      # Exercise the exact read-only POST projection as openpims_app, including
+      # literal matching, lifecycle lineage, keyset paging, role gates, RLS,
+      # clinic-local dates, and high-cardinality query-plan evidence.
+      - name: Execute patient history search contract
+        env:
+          PATIENT_HISTORY_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/patient-history.integration.test.ts
+
       # Template catalog selection is a clinic-facing data boundary. Exercise
       # the real router as the least-privilege app role and prove literal,
       # bounded, deterministic, active-only, tenant-isolated search behavior.

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -30,6 +30,7 @@ import { trpc } from "@/lib/trpc";
 import { useCurrencyFormatter } from "@/lib/locale/useCurrency";
 import { EmptyState } from "@/components/common/empty-state";
 import { Button } from "@/components/ui/button";
+import { PatientHistorySearch } from "@/components/patients/patient-history-search";
 import { CapturePhotos } from "@/components/records/capture-photos";
 import { ConsentSign } from "@/components/records/consent-sign";
 import { ClinicalCorrectionControl } from "@/components/records/clinical-correction-control";
@@ -205,6 +206,15 @@ function canCorrectClinicalRecordRole(role?: string | null): boolean {
   return role === "admin" || role === "veterinarian";
 }
 
+function canSearchPatientHistoryRole(role?: string | null): boolean {
+  return (
+    role === "admin" ||
+    role === "veterinarian" ||
+    role === "technician" ||
+    role === "viewer"
+  );
+}
+
 type VitalsFormState = {
   temperatureC: string;
   heartRateBpm: string;
@@ -264,6 +274,9 @@ export default function PatientDetailPage() {
   );
   const canRecordVitals = canRecordVitalsRole(session?.user?.role);
   const canCorrectClinicalRecords = canCorrectClinicalRecordRole(
+    session?.user?.role,
+  );
+  const canSearchPatientHistory = canSearchPatientHistoryRole(
     session?.user?.role,
   );
 
@@ -1008,14 +1021,23 @@ export default function PatientDetailPage() {
       ) : null}
 
       {/* Tab Navigation */}
-      <div className="mt-6 border-b border-border">
-        <div className="flex gap-0">
+      <div className="mt-6 overflow-x-auto border-b border-border">
+        <div
+          role="tablist"
+          aria-label="Patient chart sections"
+          className="flex min-w-max gap-0"
+        >
           {tabs.map((tab) => (
             <button
               key={tab.id}
+              id={`patient-tab-${tab.id}`}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              aria-controls={`patient-panel-${tab.id}`}
               onClick={() => setActiveTab(tab.id)}
               className={cn(
-                "relative px-4 py-2.5 text-sm font-medium transition-colors",
+                "relative min-h-11 px-4 py-2.5 text-sm font-medium transition-colors",
                 activeTab === tab.id
                   ? "text-primary"
                   : "text-muted-foreground hover:text-foreground",
@@ -1031,7 +1053,12 @@ export default function PatientDetailPage() {
       </div>
 
       {/* Tab Content */}
-      <div className="mt-6">
+      <div
+        id={`patient-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`patient-tab-${activeTab}`}
+        className="mt-6"
+      >
         {activeTab === "overview" && (
           <div className="rounded-lg border border-border bg-card p-6">
             <h3 className="font-heading text-base font-semibold mb-4">
@@ -1217,6 +1244,7 @@ export default function PatientDetailPage() {
             patientId={patient.id}
             timeZone={recordsTimeZone}
             canCorrectClinicalRecords={canCorrectClinicalRecords}
+            canSearchPatientHistory={canSearchPatientHistory}
           />
         )}
 
@@ -1704,11 +1732,14 @@ function MedicalRecordsTab({
   patientId,
   timeZone,
   canCorrectClinicalRecords,
+  canSearchPatientHistory,
 }: {
   patientId: string;
   timeZone?: string | null;
   canCorrectClinicalRecords: boolean;
+  canSearchPatientHistory: boolean;
 }) {
+  const [historySearchActive, setHistorySearchActive] = useState(false);
   const utils = trpc.useUtils();
   const {
     data: notes,
@@ -1724,34 +1755,32 @@ function MedicalRecordsTab({
   });
   const notesMissing = !isLoading && !error && !notes;
 
-  if (error) {
-    return (
-      <PatientDetailErrorPanel
-        message={`Unable to load medical records. ${error.message}`}
-      />
-    );
-  }
-  if (notesMissing) {
-    return (
-      <PatientDetailErrorPanel message="Unable to load medical records. Please retry." />
-    );
-  }
-  if (isLoading) {
-    return <PatientDetailLoadingPanel label="Loading medical records..." />;
-  }
-  if (!notes || notes.length === 0) {
-    return (
-      <EmptyState
-        icon={FileText}
-        title="No medical records yet"
-        description="SOAP notes written in Records will show up here."
-      />
-    );
-  }
-
   return (
     <div className="space-y-4">
-      {notes.map((note) => {
+      {canSearchPatientHistory ? (
+        <PatientHistorySearch
+          patientId={patientId}
+          timeZone={timeZone}
+          onSearchModeChange={setHistorySearchActive}
+        />
+      ) : null}
+      {!historySearchActive ? (
+        error ? (
+          <PatientDetailErrorPanel
+            message={`Unable to load medical records. ${error.message}`}
+          />
+        ) : notesMissing ? (
+          <PatientDetailErrorPanel message="Unable to load medical records. Please retry." />
+        ) : isLoading ? (
+          <PatientDetailLoadingPanel label="Loading medical records..." />
+        ) : !notes || notes.length === 0 ? (
+          <EmptyState
+            icon={FileText}
+            title="No medical records yet"
+            description="SOAP notes written in Records will show up here."
+          />
+        ) : (
+          notes.map((note) => {
         const hasOtherCurrentAppointmentSoap = Boolean(
           note.appointmentId &&
           notes.some(
@@ -1958,7 +1987,9 @@ function MedicalRecordsTab({
             ) : null}
           </div>
         );
-      })}
+          })
+        )
+      ) : null}
     </div>
   );
 }

--- a/apps/web/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/app/api/trpc/[trpc]/route.ts
@@ -9,6 +9,9 @@ function handler(req: Request) {
     req,
     router: appRouter,
     createContext: createTRPCContext,
+    // Only queries may be method-overridden; mutations remain POST-only.
+    // The history-search client uses this to keep clinical terms out of URLs.
+    allowMethodOverride: true,
     onError({ error, path, type }) {
       captureTrpcError({ error, path, type });
     },

--- a/apps/web/components/patients/patient-history-search.tsx
+++ b/apps/web/components/patients/patient-history-search.tsx
@@ -1,0 +1,490 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, Search, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { formatClinicalDate } from "@/lib/records/clinical-dates";
+import {
+  PATIENT_HISTORY_DEFAULT_PAGE_SIZE,
+  PATIENT_HISTORY_RECORD_TYPES,
+  type PatientHistoryRecordType,
+  type PatientHistoryStateFilter,
+} from "@/lib/records/patient-history";
+import { trpc } from "@/lib/trpc";
+
+type HistoryCursor = {
+  occurredAt: string;
+  recordType: PatientHistoryRecordType;
+  id: string;
+};
+
+type AppliedFilters = {
+  query?: string;
+  recordTypes: PatientHistoryRecordType[];
+  state: PatientHistoryStateFilter;
+  fromDate?: string;
+  toDate?: string;
+};
+
+const recordTypeLabels: Record<PatientHistoryRecordType, string> = {
+  soap_note: "SOAP",
+  prescription: "Medications",
+  vaccination: "Vaccines",
+  lab_result: "Labs",
+  procedure: "Procedures",
+  problem: "Problems",
+  vital_sign: "Vitals",
+  allergy: "Allergies",
+};
+
+const stateLabels: Record<PatientHistoryStateFilter, string> = {
+  all: "All records",
+  current: "Current",
+  corrected: "Corrected / retained",
+};
+
+function statusLabel(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+export function PatientHistorySearch({
+  patientId,
+  timeZone,
+  onSearchModeChange,
+}: {
+  patientId: string;
+  timeZone?: string | null;
+  onSearchModeChange: (active: boolean) => void;
+}) {
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [recordTypes, setRecordTypes] = useState<PatientHistoryRecordType[]>([
+    ...PATIENT_HISTORY_RECORD_TYPES,
+  ]);
+  const [state, setState] = useState<PatientHistoryStateFilter>("all");
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+  const [dateError, setDateError] = useState<string | null>(null);
+  const [applied, setApplied] = useState<AppliedFilters | null>(null);
+  const [cursorStack, setCursorStack] = useState<Array<HistoryCursor | null>>([
+    null,
+  ]);
+
+  function inputFor(filters: AppliedFilters, cursor: HistoryCursor | null) {
+    return {
+      patientId,
+      ...filters,
+      cursor: cursor ?? undefined,
+      limit: PATIENT_HISTORY_DEFAULT_PAGE_SIZE,
+    };
+  }
+
+  const currentCursor = cursorStack.at(-1) ?? null;
+  const search = trpc.records.searchPatientHistory.useQuery(
+    inputFor(
+      applied ?? {
+        recordTypes: [...PATIENT_HISTORY_RECORD_TYPES],
+        state: "all",
+      },
+      currentCursor,
+    ),
+    { enabled: applied !== null, retry: false },
+  );
+
+  function applyFilters(event: React.FormEvent) {
+    event.preventDefault();
+    if (fromDate && toDate && fromDate > toDate) {
+      setDateError("To date must be on or after From date.");
+      return;
+    }
+    setDateError(null);
+    const filters: AppliedFilters = {
+      query: query.trim() || undefined,
+      recordTypes,
+      state,
+      fromDate: fromDate || undefined,
+      toDate: toDate || undefined,
+    };
+    setApplied(filters);
+    onSearchModeChange(true);
+    setCursorStack([null]);
+  }
+
+  function clearFilters() {
+    setQuery("");
+    setRecordTypes([...PATIENT_HISTORY_RECORD_TYPES]);
+    setState("all");
+    setFromDate("");
+    setToDate("");
+    setDateError(null);
+    setApplied(null);
+    onSearchModeChange(false);
+    setCursorStack([null]);
+  }
+
+  function toggleRecordType(recordType: PatientHistoryRecordType) {
+    setRecordTypes((current) => {
+      if (current.includes(recordType)) {
+        return current.length === 1
+          ? current
+          : current.filter((candidate) => candidate !== recordType);
+      }
+      return PATIENT_HISTORY_RECORD_TYPES.filter(
+        (candidate) => current.includes(candidate) || candidate === recordType,
+      );
+    });
+  }
+
+  function goToNextPage() {
+    if (!applied || !search.data?.nextCursor) return;
+    const nextCursor = search.data.nextCursor;
+    setCursorStack((current) => [...current, nextCursor]);
+  }
+
+  function goToPreviousPage() {
+    if (!applied || cursorStack.length <= 1) return;
+    const nextStack = cursorStack.slice(0, -1);
+    setCursorStack(nextStack);
+  }
+
+  function retry() {
+    if (!applied) return;
+    void search.refetch();
+  }
+
+  if (!panelOpen) {
+    return (
+      <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-medium">Find in patient history</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Reduce a long chart to matching SOAP, medications, labs, and other
+              clinical records.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            className="min-h-11 w-full sm:w-auto"
+            onClick={() => setPanelOpen(true)}
+          >
+            <Search className="mr-2 h-4 w-4" />
+            Find in history
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const pageNumber = cursorStack.length;
+  const pageStart = search.data?.items.length
+    ? (pageNumber - 1) * PATIENT_HISTORY_DEFAULT_PAGE_SIZE + 1
+    : 0;
+  const pageEnd = search.data?.items.length
+    ? pageStart + search.data.items.length - 1
+    : 0;
+
+  return (
+    <section
+      aria-label="Find in patient history"
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-semibold">Find in patient history</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Exact text only. Private staff notes and worklists are never
+            searched here.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="min-h-11 min-w-11"
+          aria-label="Close history filters"
+          onClick={() => {
+            clearFilters();
+            setPanelOpen(false);
+          }}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <form onSubmit={applyFilters} className="space-y-4">
+        <div>
+          <label
+            htmlFor="patient-history-query"
+            className="text-sm font-medium"
+          >
+            Search medical history
+          </label>
+          <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+            <Input
+              id="patient-history-query"
+              type="search"
+              value={query}
+              maxLength={120}
+              autoComplete="off"
+              placeholder="Try carprofen, condition, or procedure"
+              className="min-h-11 flex-1"
+              onChange={(event) => setQuery(event.target.value)}
+            />
+            <Button
+              type="submit"
+              className="min-h-11 w-full sm:w-auto"
+              disabled={search.isFetching}
+            >
+              <Search className="mr-2 h-4 w-4" />
+              {search.isFetching ? "Searching..." : "Apply filters"}
+            </Button>
+          </div>
+        </div>
+
+        <fieldset>
+          <legend className="text-sm font-medium">Record types</legend>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {PATIENT_HISTORY_RECORD_TYPES.map((recordType) => {
+              const selected = recordTypes.includes(recordType);
+              return (
+                <button
+                  key={recordType}
+                  type="button"
+                  aria-pressed={selected}
+                  className={cn(
+                    "min-h-11 rounded-full border px-3 text-sm font-medium transition-colors",
+                    selected
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-background hover:bg-muted",
+                  )}
+                  onClick={() => toggleRecordType(recordType)}
+                >
+                  {recordTypeLabels[recordType]}
+                </button>
+              );
+            })}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            At least one record type stays selected.
+          </p>
+        </fieldset>
+
+        <fieldset>
+          <legend className="text-sm font-medium">Record state</legend>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {(["all", "current", "corrected"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={state === value}
+                className={cn(
+                  "min-h-11 rounded-full border px-3 text-sm font-medium transition-colors",
+                  state === value
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background hover:bg-muted",
+                )}
+                onClick={() => setState(value)}
+              >
+                {stateLabels[value]}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend className="text-sm font-medium">Clinical date</legend>
+          <div className="mt-2 grid gap-3 sm:grid-cols-2">
+            <label className="text-sm">
+              <span className="text-muted-foreground">From</span>
+              <Input
+                type="date"
+                value={fromDate}
+                className="mt-1 min-h-11"
+                onChange={(event) => {
+                  setFromDate(event.target.value);
+                  setDateError(null);
+                }}
+              />
+            </label>
+            <label className="text-sm">
+              <span className="text-muted-foreground">To</span>
+              <Input
+                type="date"
+                value={toDate}
+                className="mt-1 min-h-11"
+                onChange={(event) => {
+                  setToDate(event.target.value);
+                  setDateError(null);
+                }}
+              />
+            </label>
+          </div>
+          {dateError ? (
+            <p role="alert" className="mt-2 text-sm text-destructive">
+              {dateError}
+            </p>
+          ) : null}
+        </fieldset>
+
+        <div className="flex justify-end">
+          <Button type="button" variant="ghost" onClick={clearFilters}>
+            Clear filters
+          </Button>
+        </div>
+      </form>
+
+      {applied ? (
+        <div
+          className="mt-5 border-t border-border pt-4"
+          aria-busy={search.isFetching}
+        >
+          {search.error ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4">
+              <div className="flex items-start gap-2 text-destructive">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <div>
+                  <p className="font-medium">
+                    Unable to search patient history
+                  </p>
+                  <p className="mt-1 text-sm">{search.error.message}</p>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-3"
+                onClick={retry}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : search.isFetching && !search.data ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Searching authorized history...
+            </p>
+          ) : search.data ? (
+            <>
+              <p className="text-sm text-muted-foreground" aria-live="polite">
+                {search.data.total === 0
+                  ? "No matching records"
+                  : `Showing ${pageStart}-${pageEnd} of ${search.data.total} matching records`}
+              </p>
+
+              {search.data.items.length === 0 ? (
+                <div className="mt-3 rounded-md border border-dashed border-border p-6 text-center">
+                  <p className="font-medium">
+                    No history matches these filters
+                  </p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Try a different exact term, record type, state, or date
+                    range.
+                  </p>
+                </div>
+              ) : (
+                <div className="mt-3 space-y-3">
+                  {search.data.items.map((item) => (
+                    <article
+                      key={`${item.recordType}:${item.id}`}
+                      className="rounded-md border border-border p-4"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="font-medium">{item.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {recordTypeLabels[item.recordType]} ·{" "}
+                            {formatClinicalDate(item.occurredAt, timeZone)}
+                            {item.authorLabel && item.authorName
+                              ? ` · ${item.authorLabel} ${item.authorName}`
+                              : ""}
+                            {item.finalizerName
+                              ? ` · Finalized by ${item.finalizerName}`
+                              : ""}
+                          </p>
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                          <span className="rounded-full bg-muted px-2 py-0.5 text-xs capitalize">
+                            {statusLabel(item.status)}
+                          </span>
+                          {item.imported ? (
+                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                              Imported
+                            </span>
+                          ) : null}
+                          {item.corrected ? (
+                            <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs text-destructive">
+                              Corrected · retained
+                            </span>
+                          ) : (
+                            <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">
+                              Current
+                            </span>
+                          )}
+                          {item.replacesRecordId ? (
+                            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                              Current replacement
+                            </span>
+                          ) : null}
+                          {item.replacementRecordId ? (
+                            <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                              Original replaced
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                      {item.summary ? (
+                        <p className="mt-3 whitespace-pre-wrap break-words text-sm">
+                          {item.summary}
+                        </p>
+                      ) : (
+                        <p className="mt-3 text-sm text-muted-foreground">
+                          No additional text is stored for this record.
+                        </p>
+                      )}
+                    </article>
+                  ))}
+                </div>
+              )}
+
+              {search.data.total > 0 ? (
+                <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-xs text-muted-foreground">
+                    Page {pageNumber}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 sm:flex">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="min-h-11"
+                      disabled={cursorStack.length <= 1 || search.isFetching}
+                      onClick={goToPreviousPage}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="min-h-11"
+                      disabled={!search.data.nextCursor || search.isFetching}
+                      onClick={goToNextPage}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      ) : (
+        <p className="mt-4 border-t border-border pt-4 text-sm text-muted-foreground">
+          Apply filters to enter the read-only search view. The complete SOAP
+          timeline remains below.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/__tests__/patient-history-ui.test.ts
+++ b/apps/web/lib/__tests__/patient-history-ui.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const component = readFileSync(
+  "components/patients/patient-history-search.tsx",
+  "utf8",
+);
+const patientPage = readFileSync(
+  "app/(dashboard)/patients/[id]/page.tsx",
+  "utf8",
+);
+const recordsRouter = readFileSync("server/routers/records.ts", "utf8");
+const providers = readFileSync("lib/providers.tsx", "utf8");
+const trpcRoute = readFileSync("app/api/trpc/[trpc]/route.ts", "utf8");
+
+describe("patient history search UI", () => {
+  it("keeps the existing SOAP timeline until read-only filters are applied", () => {
+    const medicalRecordsTab = patientPage.slice(
+      patientPage.indexOf("function MedicalRecordsTab"),
+      patientPage.indexOf("function SoapAddendumControl"),
+    );
+    expect(patientPage).toContain("const [historySearchActive");
+    expect(medicalRecordsTab).toContain("!historySearchActive ? (");
+    expect(medicalRecordsTab).toContain("notes.map((note)");
+    expect(medicalRecordsTab.indexOf("<PatientHistorySearch")).toBeLessThan(
+      medicalRecordsTab.indexOf("error ? ("),
+    );
+    expect(component).toContain("onSearchModeChange(true)");
+    expect(component).toContain("onSearchModeChange(false)");
+    expect(component).toContain(
+      "The complete SOAP\n          timeline remains below.",
+    );
+  });
+
+  it("uses an explicit POST operation so clinical terms never enter URLs", () => {
+    expect(component).toContain("trpc.records.searchPatientHistory.useQuery(");
+    expect(recordsRouter).toContain("searchPatientHistory: protectedProcedure");
+    expect(recordsRouter).toContain(
+      "The client sends this query over POST so clinical terms stay out of URLs",
+    );
+    expect(providers).toContain(
+      'operation.path === "records.searchPatientHistory"',
+    );
+    expect(providers).toContain('methodOverride: "POST"');
+    expect(trpcRoute).toContain("allowMethodOverride: true");
+    expect(component).not.toContain("useSearchParams");
+    expect(component).not.toContain("localStorage");
+    expect(component).not.toContain("sessionStorage");
+    expect(component).not.toContain("window.history");
+  });
+
+  it("is clinical-role gated and leaves front desk on the existing SOAP view", () => {
+    expect(patientPage).toContain(
+      "function canSearchPatientHistoryRole(role?: string | null): boolean",
+    );
+    expect(patientPage).toContain('role === "viewer"');
+    const roleBlock = patientPage.slice(
+      patientPage.indexOf("function canSearchPatientHistoryRole"),
+      patientPage.indexOf("type VitalsFormState"),
+    );
+    expect(roleBlock).not.toContain('role === "front_desk"');
+    expect(recordsRouter).toContain(
+      '.use(requireRole("admin", "veterinarian", "technician", "viewer"))',
+    );
+  });
+
+  it("provides responsive accessible filters, result states, counts, and paging", () => {
+    for (const marker of [
+      'aria-label="Find in patient history"',
+      "aria-pressed={selected}",
+      "aria-pressed={state === value}",
+      'aria-live="polite"',
+      "aria-busy={search.isFetching}",
+      'role="alert"',
+      "No history matches these filters",
+      "Unable to search patient history",
+      "Clear filters",
+      "Previous",
+      "Next",
+      "min-h-11",
+      "sm:grid-cols-2",
+    ]) {
+      expect(component).toContain(marker);
+    }
+    expect(patientPage).toContain('role="tablist"');
+    expect(patientPage).toContain('role="tab"');
+    expect(patientPage).toContain('role="tabpanel"');
+    expect(patientPage).toContain("overflow-x-auto border-b");
+  });
+
+  it("labels provenance and immutable correction/replacement semantics", () => {
+    for (const label of [
+      "Imported",
+      "Corrected · retained",
+      "Current replacement",
+      "Original replaced",
+      "Private staff notes and worklists are never",
+    ]) {
+      expect(component).toContain(label);
+    }
+    expect(component).toContain("item.authorLabel");
+    expect(component).toContain("Finalized by ${item.finalizerName}");
+  });
+});

--- a/apps/web/lib/providers.tsx
+++ b/apps/web/lib/providers.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { httpBatchLink } from "@trpc/client";
+import { httpBatchLink, splitLink } from "@trpc/client";
 import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
@@ -19,12 +19,21 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const [trpcClient] = useState(() =>
     trpc.createClient({
       links: [
-        httpBatchLink({
-          url: "/api/trpc",
-          transformer: superjson,
+        splitLink({
+          condition: (operation) =>
+            operation.path === "records.searchPatientHistory",
+          true: httpBatchLink({
+            url: "/api/trpc",
+            transformer: superjson,
+            methodOverride: "POST",
+          }),
+          false: httpBatchLink({
+            url: "/api/trpc",
+            transformer: superjson,
+          }),
         }),
       ],
-    })
+    }),
   );
 
   return (

--- a/apps/web/lib/records/__tests__/patient-history.test.ts
+++ b/apps/web/lib/records/__tests__/patient-history.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  PATIENT_HISTORY_DEFAULT_PAGE_SIZE,
+  PATIENT_HISTORY_MAX_PAGE_SIZE,
+  PATIENT_HISTORY_QUERY_MAX_LENGTH,
+  PATIENT_HISTORY_RECORD_TYPES,
+  escapePatientHistoryQuery,
+  patientHistoryContainsPattern,
+} from "../patient-history";
+
+describe("patient history search policy", () => {
+  it("keeps LIKE wildcard and escape characters literal", () => {
+    expect(escapePatientHistoryQuery(String.raw`50%_off\plan`)).toBe(
+      String.raw`50\%\_off\\plan`,
+    );
+    expect(patientHistoryContainsPattern(String.raw`  50%_off\plan  `)).toBe(
+      String.raw`%50\%\_off\\plan%`,
+    );
+  });
+
+  it("pins the bounded allowlist and response sizes", () => {
+    expect(PATIENT_HISTORY_RECORD_TYPES).toEqual([
+      "soap_note",
+      "prescription",
+      "vaccination",
+      "lab_result",
+      "procedure",
+      "problem",
+      "vital_sign",
+      "allergy",
+    ]);
+    expect(PATIENT_HISTORY_QUERY_MAX_LENGTH).toBe(120);
+    expect(PATIENT_HISTORY_DEFAULT_PAGE_SIZE).toBe(25);
+    expect(PATIENT_HISTORY_MAX_PAGE_SIZE).toBe(50);
+  });
+});

--- a/apps/web/lib/records/patient-history.ts
+++ b/apps/web/lib/records/patient-history.ts
@@ -1,0 +1,35 @@
+export const PATIENT_HISTORY_RECORD_TYPES = [
+  "soap_note",
+  "prescription",
+  "vaccination",
+  "lab_result",
+  "procedure",
+  "problem",
+  "vital_sign",
+  "allergy",
+] as const;
+
+export type PatientHistoryRecordType =
+  (typeof PATIENT_HISTORY_RECORD_TYPES)[number];
+
+export const PATIENT_HISTORY_STATE_FILTERS = [
+  "all",
+  "current",
+  "corrected",
+] as const;
+
+export type PatientHistoryStateFilter =
+  (typeof PATIENT_HISTORY_STATE_FILTERS)[number];
+
+export const PATIENT_HISTORY_DEFAULT_PAGE_SIZE = 25;
+export const PATIENT_HISTORY_MAX_PAGE_SIZE = 50;
+export const PATIENT_HISTORY_QUERY_MAX_LENGTH = 120;
+
+/** Escape PostgreSQL LIKE metacharacters before the query adds wildcards. */
+export function escapePatientHistoryQuery(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
+export function patientHistoryContainsPattern(value: string): string {
+  return `%${escapePatientHistoryQuery(value.trim())}%`;
+}

--- a/apps/web/server/__tests__/patient-history-query.test.ts
+++ b/apps/web/server/__tests__/patient-history-query.test.ts
@@ -1,0 +1,96 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import { buildPatientHistoryQuery } from "../patient-history";
+
+const practiceId = "11111111-1111-4111-8111-111111111111";
+const patientId = "22222222-2222-4222-8222-222222222222";
+
+describe("patient history SQL projection", () => {
+  it("is explicit, tenant scoped, finalized-SOAP only, and private-surface free", () => {
+    const compiled = new PgDialect().sqlToQuery(
+      buildPatientHistoryQuery({
+        practiceId,
+        input: {
+          patientId,
+          query: String.raw`Carprofen%_\dose`,
+          recordTypes: ["soap_note", "prescription"],
+          state: "all",
+          limit: 25,
+        },
+      }),
+    );
+
+    expect(compiled.sql).toContain('from "soap_notes" soap');
+    expect(compiled.sql).toContain("soap.status = 'finalized'");
+    expect(compiled.sql).toContain('from "prescriptions" prescription');
+    expect(compiled.sql).toContain('from "soap_note_addenda" addendum');
+    expect(compiled.sql).toContain(
+      'left join "clinical_record_corrections" correction',
+    );
+    expect(compiled.sql).toContain(
+      'left join "soap_note_replacements" source_link',
+    );
+    expect(compiled.sql).toContain("history.record_type in (");
+    expect(compiled.sql).toContain("ilike");
+    expect(compiled.sql).toContain("escape '\\'");
+    expect(compiled.sql).toContain("string_to_array(page.search_text");
+    expect(compiled.sql).toContain("regexp_replace");
+    expect(compiled.sql).toContain("strpos(lower(match.line)");
+    expect(compiled.sql).toContain("limit 3");
+    expect(compiled.sql).toContain(
+      "order by matched.occurred_at desc, matched.record_type desc, matched.id desc",
+    );
+    expect(compiled.sql).not.toContain("clinical_notes");
+    expect(compiled.sql).not.toContain("communications");
+    expect(compiled.sql).not.toContain("appointment_notes");
+    expect(compiled.sql).not.toContain("follow_up_note");
+    expect(compiled.sql).not.toContain("follow_up_outcome");
+    expect(compiled.sql).not.toContain("prescriber.deleted_at");
+    expect(compiled.sql).not.toContain("administrator.deleted_at");
+    expect(compiled.sql).not.toContain("ordered_by.deleted_at");
+    expect(compiled.sql).not.toContain("performer.deleted_at");
+    expect(compiled.sql).not.toContain("recorder.deleted_at");
+    expect(compiled.params).toContain(practiceId);
+    expect(compiled.params).toContain(patientId);
+    expect(compiled.params).toContain(String.raw`%Carprofen\%\_\\dose%`);
+    expect(compiled.params).toContain(26);
+  });
+
+  it("composes date, correction, and keyset cursor predicates", () => {
+    const compiled = new PgDialect().sqlToQuery(
+      buildPatientHistoryQuery({
+        practiceId,
+        input: {
+          patientId,
+          recordTypes: ["lab_result"],
+          state: "corrected",
+          fromDate: "2026-03-08",
+          toDate: "2026-11-01",
+          cursor: {
+            occurredAt: "2026-08-20T16:00:00.000Z",
+            recordType: "lab_result",
+            id: "33333333-3333-4333-8333-333333333333",
+          },
+          limit: 10,
+        },
+      }),
+    );
+
+    expect(compiled.sql).toContain("history.corrected = true");
+    expect(compiled.sql).toContain("history.occurred_date >=");
+    expect(compiled.sql).toContain("history.occurred_date <=");
+    expect(compiled.sql).toContain(
+      "(matched.occurred_at, matched.record_type, matched.id) <",
+    );
+    expect(compiled.params).toEqual(
+      expect.arrayContaining([
+        "2026-03-08",
+        "2026-11-01",
+        "2026-08-20T16:00:00.000Z",
+        "lab_result",
+        "33333333-3333-4333-8333-333333333333",
+        11,
+      ]),
+    );
+  });
+});

--- a/apps/web/server/__tests__/patient-history.integration.test.ts
+++ b/apps/web/server/__tests__/patient-history.integration.test.ts
@@ -1,0 +1,679 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { eq, sql as drizzleSql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import * as schema from "../../../../packages/db/schema/index";
+import type { Database } from "@openpims/db/client";
+import { withTenant } from "@/lib/tenant-db";
+import {
+  addFinalizedSoapAddendum,
+  replaceFinalizedSoapNote,
+} from "@/lib/records/soap-lifecycle";
+import { buildPatientHistoryQuery } from "../patient-history";
+import { recordsRouter } from "../routers/records";
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithPatientHistoryPostgres =
+  process.env.PATIENT_HISTORY_DB_INTEGRATION === "1" ? describe : describe.skip;
+
+describeWithPatientHistoryPostgres(
+  "patient history PostgreSQL contract",
+  () => {
+    it("is literal, lifecycle-safe, paginated, role-gated, and tenant isolated", async () => {
+      const adminUrl = process.env.DATABASE_URL;
+      if (!adminUrl) throw new Error("DATABASE_URL is required");
+
+      const databaseName = `openpims_patient_history_${randomUUID().replaceAll("-", "")}`;
+      if (!/^openpims_patient_history_[a-f0-9]+$/.test(databaseName)) {
+        throw new Error("unsafe disposable database name");
+      }
+
+      const databaseUrl = new URL(adminUrl);
+      databaseUrl.pathname = `/${databaseName}`;
+      databaseUrl.search = "";
+      databaseUrl.hash = "";
+
+      const adminSql = postgres(adminUrl, { max: 1 });
+      let ownerSql: ReturnType<typeof postgres> | undefined;
+      await adminSql.unsafe(`create database "${databaseName}"`);
+
+      try {
+        for (const args of [
+          ["--filter", "@openpims/db", "db:migrate"],
+          ["--filter", "@openpims/db", "db:rls"],
+        ]) {
+          execFileSync("pnpm", args, {
+            cwd: repoRoot,
+            env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+            encoding: "utf8",
+            timeout: 45_000,
+          });
+        }
+
+        ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+        const ownerDb = drizzle(ownerSql, { schema });
+        const [practiceA, practiceB] = await ownerDb
+          .insert(schema.practices)
+          .values([
+            {
+              name: "Synthetic History Clinic A",
+              timezone: "America/New_York",
+            },
+            {
+              name: "Synthetic History Clinic B",
+              timezone: "America/Los_Angeles",
+            },
+          ])
+          .returning({ id: schema.practices.id });
+        if (!practiceA || !practiceB) throw new Error("practice seed failed");
+
+        const [clientA, clientB] = await ownerDb
+          .insert(schema.clients)
+          .values([
+            {
+              practiceId: practiceA.id,
+              firstName: "Synthetic",
+              lastName: "Owner A",
+            },
+            {
+              practiceId: practiceB.id,
+              firstName: "Synthetic",
+              lastName: "Owner B",
+            },
+          ])
+          .returning({ id: schema.clients.id });
+        if (!clientA || !clientB) throw new Error("client seed failed");
+
+        const [userA, userB] = await ownerDb
+          .insert(schema.users)
+          .values([
+            {
+              practiceId: practiceA.id,
+              email: "history-a@example.invalid",
+              passwordHash: "not-a-real-password-hash",
+              name: "Synthetic Clinician A",
+              role: "veterinarian",
+              isVeterinarian: true,
+            },
+            {
+              practiceId: practiceB.id,
+              email: "history-b@example.invalid",
+              passwordHash: "not-a-real-password-hash",
+              name: "Synthetic Clinician B",
+              role: "veterinarian",
+              isVeterinarian: true,
+            },
+          ])
+          .returning({ id: schema.users.id });
+        if (!userA || !userB) throw new Error("user seed failed");
+
+        const [patientA, unrelatedPatient, patientB, deletedPatient] =
+          await ownerDb
+            .insert(schema.patients)
+            .values([
+              {
+                practiceId: practiceA.id,
+                clientId: clientA.id,
+                name: "Long History Patient",
+                species: "canine",
+              },
+              {
+                practiceId: practiceA.id,
+                clientId: clientA.id,
+                name: "Unrelated High Cardinality Patient",
+                species: "canine",
+              },
+              {
+                practiceId: practiceB.id,
+                clientId: clientB.id,
+                name: "Cross Tenant Patient",
+                species: "canine",
+              },
+              {
+                practiceId: practiceA.id,
+                clientId: clientA.id,
+                name: "Deleted Patient",
+                species: "feline",
+                deletedAt: new Date("2026-08-20T00:00:00.000Z"),
+              },
+            ])
+            .returning({ id: schema.patients.id });
+        if (!patientA || !unrelatedPatient || !patientB || !deletedPatient) {
+          throw new Error("patient seed failed");
+        }
+
+        // Make the target chart realistically long while keeping a much larger
+        // unrelated population. This is PHI-free and is removed with the DB.
+        await ownerSql`
+          insert into soap_notes
+            (practice_id, patient_id, author_id, author_name, status,
+             finalized_at, finalized_by, finalizer_name, subjective, created_at)
+          select
+            ${practiceA.id}, ${unrelatedPatient.id}, ${userA.id},
+            'Synthetic Clinician A', 'finalized',
+            '2026-01-01T12:00:00Z'::timestamptz + (series || ' seconds')::interval,
+            ${userA.id}, 'Synthetic Clinician A',
+            'Unrelated population record ' || series,
+            '2026-01-01T12:00:00Z'::timestamptz + (series || ' seconds')::interval
+          from generate_series(1, 30000) series
+        `;
+        await ownerSql`
+          insert into soap_notes
+            (practice_id, patient_id, author_id, author_name, status,
+             finalized_at, finalized_by, finalizer_name, subjective, created_at)
+          select
+            ${practiceA.id}, ${patientA.id}, ${userA.id},
+            'Synthetic Clinician A', 'finalized',
+            '2026-02-01T12:00:00Z'::timestamptz + (series || ' seconds')::interval,
+            ${userA.id}, 'Synthetic Clinician A',
+            case when series <= 60 then 'routine tied history' else 'routine long history' end,
+            case when series <= 60
+              then '2026-07-01T12:00:00Z'::timestamptz
+              else '2026-02-01T12:00:00Z'::timestamptz + (series || ' seconds')::interval
+            end
+          from generate_series(1, 2050) series
+        `;
+
+        const [
+          correctedSoap,
+          addendumSoap,
+          literalSoap,
+          decoySoap,
+          dstBefore,
+          dstInside,
+          importedSoap,
+          deletedSoap,
+          draftSoap,
+        ] = await ownerDb
+          .insert(schema.soapNotes)
+          .values([
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2026-08-10T14:00:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              assessment: `<p>${"Long visible clinical context ".repeat(20)}<strong>Carprofen</strong> discussed for osteoarthritis</p>`,
+              createdAt: new Date("2026-08-10T14:00:00.000Z"),
+              imported: true,
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2026-08-12T14:00:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              subjective: "Owner called with an update",
+              createdAt: new Date("2026-08-12T14:00:00.000Z"),
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2026-08-13T14:00:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              plan: String.raw`Literal 50%_off\plan`,
+              createdAt: new Date("2026-08-13T14:00:00.000Z"),
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2026-08-13T13:00:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              plan: "Literal 50xxoffXplan wildcard decoy",
+              createdAt: new Date("2026-08-13T13:00:00.000Z"),
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2026-03-08T04:30:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              plan: "DST boundary marker",
+              createdAt: new Date("2026-03-08T04:30:00.000Z"),
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2026-03-08T05:30:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              plan: "DST boundary marker",
+              createdAt: new Date("2026-03-08T05:30:00.000Z"),
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2025-12-01T15:00:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              plan: "Imported history marker; unified surface marker",
+              imported: true,
+              createdAt: new Date("2025-12-01T15:00:00.000Z"),
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "finalized",
+              finalizedAt: new Date("2026-08-14T14:00:00.000Z"),
+              finalizedBy: userA.id,
+              finalizerName: "Synthetic Clinician A",
+              plan: "Deleted history marker",
+              createdAt: new Date("2026-08-14T14:00:00.000Z"),
+              deletedAt: new Date("2026-08-15T14:00:00.000Z"),
+            },
+            {
+              practiceId: practiceA.id,
+              patientId: patientA.id,
+              authorId: userA.id,
+              authorName: "Synthetic Clinician A",
+              status: "draft",
+              plan: "Draft-only carprofen should not be legal history",
+              createdAt: new Date("2026-08-15T14:00:00.000Z"),
+            },
+          ])
+          .returning({ id: schema.soapNotes.id });
+        if (
+          !correctedSoap ||
+          !addendumSoap ||
+          !literalSoap ||
+          !decoySoap ||
+          !dstBefore ||
+          !dstInside ||
+          !importedSoap ||
+          !deletedSoap ||
+          !draftSoap
+        ) {
+          throw new Error("SOAP evidence seed failed");
+        }
+
+        await ownerDb.transaction((tx) =>
+          addFinalizedSoapAddendum(tx as unknown as Database, {
+            practiceId: practiceA.id,
+            patientId: patientA.id,
+            noteId: addendumSoap.id,
+            operationId: randomUUID(),
+            content: "Addendum-only carprofen response",
+            actor: { id: userA.id, name: "Synthetic Clinician A" },
+          }),
+        );
+        const replacementResult = await ownerDb.transaction((tx) =>
+          replaceFinalizedSoapNote(tx as unknown as Database, {
+            practiceId: practiceA.id,
+            patientId: patientA.id,
+            sourceNoteId: correctedSoap.id,
+            operationId: randomUUID(),
+            reason: "Dose attribution corrected",
+            actor: { id: userA.id, name: "Synthetic Clinician A" },
+            sections: {
+              subjective: null,
+              objective: null,
+              assessment: null,
+              plan: "Carprofen corrected dose",
+            },
+          }),
+        );
+        const replacementSoap = replacementResult.note;
+
+        const [prescription] = await ownerDb
+          .insert(schema.prescriptions)
+          .values({
+            practiceId: practiceA.id,
+            patientId: patientA.id,
+            medicationName: "Carprofen",
+            dosage: "25 mg",
+            frequency: "Twice daily",
+            prescribedBy: userA.id,
+            startDate: "2026-08-09",
+            instructions: "Give with food; unified surface marker",
+          })
+          .returning({ id: schema.prescriptions.id });
+        if (!prescription) throw new Error("prescription seed failed");
+
+        await ownerDb.insert(schema.vaccinationRecords).values({
+          practiceId: practiceA.id,
+          patientId: patientA.id,
+          vaccineName: "Unified surface marker vaccine",
+          administeredBy: userA.id,
+          administeredAt: new Date("2026-08-08T14:00:00.000Z"),
+        });
+        await ownerDb.insert(schema.labResults).values({
+          practiceId: practiceA.id,
+          patientId: patientA.id,
+          testName: "Unified surface marker lab",
+          resultValue: "normal",
+          status: "completed",
+          orderedBy: userA.id,
+          completedAt: new Date("2026-08-07T14:00:00.000Z"),
+          followUpStatus: "open",
+          followUpAssignedTo: userA.id,
+          followUpNote: "PRIVATE_FOLLOW_UP_SENTINEL",
+        });
+        await ownerDb.insert(schema.procedures).values({
+          practiceId: practiceA.id,
+          patientId: patientA.id,
+          name: "Unified surface marker procedure",
+          performedBy: userA.id,
+        });
+        await ownerDb.insert(schema.problemList).values({
+          practiceId: practiceA.id,
+          patientId: patientA.id,
+          description: "Unified surface marker problem",
+        });
+        await ownerDb.insert(schema.vitalSigns).values({
+          practiceId: practiceA.id,
+          patientId: patientA.id,
+          recordedBy: userA.id,
+          notes: "Unified surface marker vital",
+          recordedAt: new Date("2026-08-06T14:00:00.000Z"),
+        });
+        await ownerDb.insert(schema.patientAllergies).values({
+          patientId: patientA.id,
+          allergen: "Unified surface marker allergy",
+          notedBy: userA.id,
+          notedAt: new Date("2026-08-05T14:00:00.000Z"),
+        });
+
+        await ownerDb.insert(schema.clinicalNotes).values({
+          practiceId: practiceA.id,
+          patientId: patientA.id,
+          authorId: userA.id,
+          noteType: "general",
+          content: "PRIVATE_WORKLIST_SENTINEL carprofen",
+        });
+        await ownerDb.insert(schema.soapNotes).values({
+          practiceId: practiceB.id,
+          patientId: patientB.id,
+          authorId: userB.id,
+          authorName: "Synthetic Clinician B",
+          status: "finalized",
+          finalizedAt: new Date("2026-08-20T14:00:00.000Z"),
+          finalizedBy: userB.id,
+          finalizerName: "Synthetic Clinician B",
+          assessment: "Cross-tenant carprofen secret",
+          createdAt: new Date("2026-08-20T14:00:00.000Z"),
+        });
+
+        // Historical attribution must survive ordinary staff deactivation.
+        await ownerDb
+          .update(schema.users)
+          .set({ deletedAt: new Date("2026-08-21T00:00:00.000Z") })
+          .where(eq(schema.users.id, userA.id));
+
+        const session = (role: string) => ({
+          user: {
+            id: randomUUID(),
+            email: `${role}@example.invalid`,
+            name: "Synthetic History User",
+            role,
+            practiceId: practiceA.id,
+          },
+        });
+        const caller = (role = "veterinarian") =>
+          recordsRouter.createCaller({
+            db: ownerDb,
+            session: session(role),
+          } as never);
+
+        await ownerSql`set role openpims_app`;
+        const [noContext] = await ownerSql<Array<{ count: number }>>`
+          select count(*)::int as count from soap_notes
+        `;
+        expect(noContext?.count).toBe(0);
+
+        await expect(
+          caller("front_desk").searchPatientHistory({ patientId: patientA.id }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+        for (const role of ["admin", "veterinarian", "technician", "viewer"]) {
+          await expect(
+            caller(role).searchPatientHistory({
+              patientId: patientA.id,
+              query: "carprofen",
+              recordTypes: ["soap_note", "prescription"],
+            }),
+          ).resolves.toMatchObject({ total: 4 });
+        }
+
+        const carprofen = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "CaRpRoFeN",
+          recordTypes: ["soap_note", "prescription"],
+        });
+        expect(carprofen.total).toBe(4);
+        expect(carprofen.items.map((item) => item.id).sort()).toEqual(
+          [
+            correctedSoap.id,
+            replacementSoap.id,
+            addendumSoap.id,
+            prescription.id,
+          ].sort(),
+        );
+        expect(
+          carprofen.items.find((item) => item.id === correctedSoap.id),
+        ).toMatchObject({
+          corrected: true,
+          imported: true,
+          replacementRecordId: replacementSoap.id,
+          authorLabel: "Imported by",
+          authorName: "Synthetic Clinician A",
+          finalizerName: "Synthetic Clinician A",
+        });
+        expect(
+          carprofen.items.find((item) => item.id === replacementSoap.id),
+        ).toMatchObject({
+          corrected: false,
+          replacesRecordId: correctedSoap.id,
+          authorLabel: "Authored by",
+          authorName: "Synthetic Clinician A",
+          finalizerName: "Synthetic Clinician A",
+        });
+        expect(
+          carprofen.items.find((item) => item.id === prescription.id),
+        ).toMatchObject({
+          authorLabel: "Prescribed by",
+          authorName: "Synthetic Clinician A",
+          finalizerName: null,
+        });
+        expect(JSON.stringify(carprofen)).not.toContain(
+          "PRIVATE_WORKLIST_SENTINEL",
+        );
+        expect(JSON.stringify(carprofen)).not.toContain("Cross-tenant");
+        expect(JSON.stringify(carprofen)).not.toContain("Draft-only");
+        for (const item of carprofen.items) {
+          expect(item.summary).toBeTruthy();
+          expect(item.summary).not.toContain("<");
+          expect(
+            item
+              .summary!.split("\n")
+              .every((line) => line.toLowerCase().includes("carprofen")),
+          ).toBe(true);
+        }
+
+        const markupOnly = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "<strong>",
+          recordTypes: ["soap_note"],
+        });
+        expect(markupOnly.total).toBe(0);
+
+        const unifiedSurface = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "unified surface marker",
+        });
+        expect(unifiedSurface.total).toBe(8);
+        expect(
+          new Set(unifiedSurface.items.map(({ recordType }) => recordType)),
+        ).toEqual(
+          new Set([
+            "soap_note",
+            "prescription",
+            "vaccination",
+            "lab_result",
+            "procedure",
+            "problem",
+            "vital_sign",
+            "allergy",
+          ]),
+        );
+        expect(
+          unifiedSurface.items
+            .filter((item) => item.authorLabel)
+            .every((item) => item.authorName === "Synthetic Clinician A"),
+        ).toBe(true);
+        const privateLabWork = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "PRIVATE_FOLLOW_UP_SENTINEL",
+        });
+        expect(privateLabWork.total).toBe(0);
+
+        const literal = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: String.raw`50%_off\plan`,
+          recordTypes: ["soap_note"],
+        });
+        expect(literal.items.map((item) => item.id)).toEqual([literalSoap.id]);
+        expect(literal.items.map((item) => item.id)).not.toContain(
+          decoySoap.id,
+        );
+
+        const correctedOnly = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "carprofen",
+          recordTypes: ["soap_note", "prescription"],
+          state: "corrected",
+        });
+        expect(correctedOnly.items.map((item) => item.id)).toEqual([
+          correctedSoap.id,
+        ]);
+
+        const dstDay = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "DST boundary marker",
+          recordTypes: ["soap_note"],
+          fromDate: "2026-03-08",
+          toDate: "2026-03-08",
+        });
+        expect(dstDay.items.map((item) => item.id)).toEqual([dstInside.id]);
+        expect(dstDay.items.map((item) => item.id)).not.toContain(dstBefore.id);
+
+        const firstPage = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "routine tied history",
+          recordTypes: ["soap_note"],
+          limit: 25,
+        });
+        expect(firstPage.total).toBe(60);
+        expect(firstPage.items).toHaveLength(25);
+        expect(firstPage.nextCursor).not.toBeNull();
+        await ownerSql`reset role`;
+        await ownerDb.insert(schema.soapNotes).values({
+          practiceId: practiceA.id,
+          patientId: patientA.id,
+          authorId: userA.id,
+          authorName: "Synthetic Clinician A",
+          status: "finalized",
+          finalizedAt: new Date("2026-08-22T14:00:00.000Z"),
+          finalizedBy: userA.id,
+          finalizerName: "Synthetic Clinician A",
+          subjective: "routine tied history newer insert",
+          createdAt: new Date("2026-08-22T14:00:00.000Z"),
+        });
+        await ownerSql`set role openpims_app`;
+        const secondPage = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "routine tied history",
+          recordTypes: ["soap_note"],
+          limit: 25,
+          cursor: firstPage.nextCursor!,
+        });
+        expect(secondPage.items).toHaveLength(25);
+        expect(
+          new Set([
+            ...firstPage.items.map((item) => item.id),
+            ...secondPage.items.map((item) => item.id),
+          ]).size,
+        ).toBe(50);
+
+        await expect(
+          caller().searchPatientHistory({ patientId: patientB.id }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+        await expect(
+          caller().searchPatientHistory({ patientId: deletedPatient.id }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+        const deletedRecord = await caller().searchPatientHistory({
+          patientId: patientA.id,
+          query: "Deleted history marker",
+          recordTypes: ["soap_note"],
+        });
+        expect(deletedRecord.total).toBe(0);
+
+        // Production tables have autovacuum statistics. The disposable test
+        // database needs an explicit analyze after its synthetic bulk load so
+        // EXPLAIN evaluates the patient and practice paths with real cardinality.
+        await ownerSql`reset role`;
+        await ownerSql`analyze soap_notes`;
+        await ownerSql`analyze prescriptions`;
+        await ownerSql`set role openpims_app`;
+        const plan = await withTenant(ownerDb, practiceA.id, async (tx) =>
+          tx.execute(
+            drizzleSql`explain (analyze, buffers, format json) ${buildPatientHistoryQuery(
+              {
+                practiceId: practiceA.id,
+                input: {
+                  patientId: patientA.id,
+                  query: "carprofen",
+                  recordTypes: ["soap_note", "prescription"],
+                  state: "all",
+                  limit: 25,
+                },
+              },
+            )}`,
+          ),
+        );
+        const planText = JSON.stringify(plan);
+        expect(planText).toContain("soap_notes_patient_idx");
+        expect(planText).not.toContain('"Rows Removed by Filter":30001');
+
+        const [contextAfterSearch] = await ownerSql<
+          Array<{ practiceId: string | null }>
+        >`
+          select nullif(current_setting('app.current_practice_id', true), '') as "practiceId"
+        `;
+        expect(contextAfterSearch?.practiceId).toBeNull();
+      } finally {
+        if (ownerSql) await ownerSql.end();
+        await adminSql.unsafe(
+          `drop database if exists "${databaseName}" with (force)`,
+        );
+        await adminSql.end();
+      }
+    }, 120_000);
+  },
+);

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -862,6 +862,57 @@ describe("records target safety", () => {
     expect(select).not.toHaveBeenCalled();
   });
 
+  it("blocks front desk from unified patient history before clinical query execution", async () => {
+    const { db, select } = createDb();
+    const execute = db.execute as ReturnType<typeof vi.fn>;
+
+    await expect(
+      callerWithDb(db, "front_desk").searchPatientHistory({
+        patientId: PATIENT_ID,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(select).not.toHaveBeenCalled();
+    // protectedProcedure establishes only its transaction-local tenant GUC.
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates bounded patient history filters before clinical query execution", async () => {
+    const { db, select } = createDb();
+    const execute = db.execute as ReturnType<typeof vi.fn>;
+    const caller = callerWithDb(db);
+
+    await expect(
+      caller.searchPatientHistory({
+        patientId: PATIENT_ID,
+        query: "x".repeat(121),
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller.searchPatientHistory({
+        patientId: PATIENT_ID,
+        recordTypes: [],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller.searchPatientHistory({
+        patientId: PATIENT_ID,
+        recordTypes: ["soap_note", "soap_note"],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller.searchPatientHistory({
+        patientId: PATIENT_ID,
+        fromDate: "2026-08-21",
+        toDate: "2026-08-20",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    // Each rejected call establishes only its transaction-local tenant GUC.
+    expect(execute).toHaveBeenCalledTimes(4);
+  });
+
   it("returns front desk only its assigned open follow-up with clinical values redacted", async () => {
     const assigned = {
       id: RECORD_ID,

--- a/apps/web/server/patient-history.ts
+++ b/apps/web/server/patient-history.ts
@@ -1,0 +1,525 @@
+import { sql, type SQL } from "drizzle-orm";
+import {
+  clinicalRecordCorrections,
+  labResultReplacements,
+  labResults,
+  patientAllergies,
+  patients,
+  practices,
+  prescriptions,
+  problemList,
+  procedures,
+  soapNoteAddenda,
+  soapNoteReplacements,
+  soapNotes,
+  users,
+  vaccinationRecords,
+  vitalSigns,
+} from "@openpims/db";
+import {
+  patientHistoryContainsPattern,
+  type PatientHistoryRecordType,
+  type PatientHistoryStateFilter,
+} from "@/lib/records/patient-history";
+
+export type PatientHistoryCursor = {
+  occurredAt: string;
+  recordType: PatientHistoryRecordType;
+  id: string;
+};
+
+export type PatientHistoryQuery = {
+  patientId: string;
+  query?: string;
+  recordTypes: PatientHistoryRecordType[];
+  state: PatientHistoryStateFilter;
+  fromDate?: string;
+  toDate?: string;
+  cursor?: PatientHistoryCursor;
+  limit: number;
+};
+
+export type PatientHistoryRawRow = {
+  id: string | null;
+  recordType: PatientHistoryRecordType | null;
+  displayDate: string | null;
+  occurredAt: Date | string | null;
+  title: string | null;
+  summary: string | null;
+  status: string | null;
+  corrected: boolean | null;
+  imported: boolean | null;
+  replacesRecordId: string | null;
+  replacementRecordId: string | null;
+  authorLabel: string | null;
+  authorName: string | null;
+  finalizerName: string | null;
+  totalCount: number;
+};
+
+const noRecordId = sql`null::uuid`;
+const noText = sql`null::text`;
+
+/**
+ * SOAP sections and addenda are stored as sanitized rich text. Search and
+ * excerpts must operate on what a clinician sees, never HTML tag names or a
+ * prefix that can omit a late literal match.
+ */
+function visibleClinicalText(value: SQL): SQL {
+  return sql`btrim(regexp_replace(
+    regexp_replace(
+      regexp_replace(
+        regexp_replace(
+          regexp_replace(
+            regexp_replace(
+              regexp_replace(
+                coalesce(${value}::text, ''),
+                '<[^>]*>', ' ', 'g'
+              ),
+              '&nbsp;|&#160;', ' ', 'gi'
+            ),
+            '&amp;', '&', 'gi'
+          ),
+          '&quot;', '"', 'gi'
+        ),
+        '&apos;|&#39;', '''', 'gi'
+      ),
+      '&lt;', '<', 'gi'
+    ),
+    '[[:space:]]+', ' ', 'g'
+  ))`;
+}
+
+function labeledClinicalText(label: string, value: SQL): SQL {
+  const visible = visibleClinicalText(value);
+  return sql`case
+    when nullif(${visible}, '') is not null then concat(${label}::text, ': ', ${visible})
+  end`;
+}
+
+/**
+ * Explicit allowlisted projection of client-exportable clinical chart data.
+ * Deliberately absent: clinical_notes, communications, appointment notes,
+ * worklists, documents, invoices, and every operational/private surface.
+ */
+export function buildPatientHistoryQuery(args: {
+  practiceId: string;
+  input: PatientHistoryQuery;
+}): SQL<PatientHistoryRawRow> {
+  const { practiceId, input } = args;
+  const recordTypes = sql.join(
+    input.recordTypes.map((recordType) => sql`${recordType}`),
+    sql`, `,
+  );
+  const includes = (recordType: PatientHistoryRecordType) =>
+    input.recordTypes.includes(recordType) ? sql`true` : sql`false`;
+  const query = input.query?.trim();
+  const searchPattern = query ? patientHistoryContainsPattern(query) : null;
+  const textPredicate = searchPattern
+    ? sql`history.search_text ilike ${searchPattern} escape '\\'`
+    : sql`true`;
+  const statePredicate =
+    input.state === "current"
+      ? sql`history.corrected = false`
+      : input.state === "corrected"
+        ? sql`history.corrected = true`
+        : sql`true`;
+  const fromPredicate = input.fromDate
+    ? sql`history.occurred_date >= ${input.fromDate}`
+    : sql`true`;
+  const toPredicate = input.toDate
+    ? sql`history.occurred_date <= ${input.toDate}`
+    : sql`true`;
+  const cursorPredicate = input.cursor
+    ? sql`(matched.occurred_at, matched.record_type, matched.id) <
+        (${input.cursor.occurredAt}::timestamptz, ${input.cursor.recordType}, ${input.cursor.id}::uuid)`
+    : sql`true`;
+
+  return sql<PatientHistoryRawRow>`
+    with practice_context as materialized (
+      select
+        ${practices.id} as practice_id,
+        coalesce(nullif(btrim(${practices.timezone}), ''), 'UTC') as time_zone
+      from ${practices}
+      where ${practices.id} = ${practiceId}
+        and ${practices.deletedAt} is null
+    ), history as materialized (
+      select
+        soap.id,
+        'soap_note'::text as record_type,
+        soap.created_at as occurred_at,
+        to_char(timezone(practice.time_zone, soap.created_at), 'YYYY-MM-DD') as occurred_date,
+        soap.created_at::text as display_date,
+        'SOAP note'::text as title,
+        soap.status::text as status,
+        correction.id is not null as corrected,
+        soap.imported as imported,
+        source_link.source_soap_note_id as replaces_record_id,
+        replacement_link.replacement_soap_note_id as replacement_record_id,
+        case when soap.imported then 'Imported by' else 'Authored by' end as author_label,
+        soap.author_name::text as author_name,
+        soap.finalizer_name::text as finalizer_name,
+        concat_ws(
+          E'\n',
+          ${labeledClinicalText("Subjective", sql`soap.subjective`)},
+          ${labeledClinicalText("Objective", sql`soap.objective`)},
+          ${labeledClinicalText("Assessment", sql`soap.assessment`)},
+          ${labeledClinicalText("Plan", sql`soap.plan`)},
+          ${labeledClinicalText("Addendum", sql`addenda.content`)},
+          case when nullif(correction.reason, '') is not null
+            then concat('Correction: ', correction.reason)
+          end
+        ) as search_text
+      from ${soapNotes} soap
+      join practice_context practice on practice.practice_id = soap.practice_id
+      left join ${clinicalRecordCorrections} correction
+        on correction.practice_id = soap.practice_id
+       and correction.soap_note_id = soap.id
+      left join ${soapNoteReplacements} source_link
+        on source_link.practice_id = soap.practice_id
+       and source_link.replacement_soap_note_id = soap.id
+      left join ${soapNoteReplacements} replacement_link
+        on replacement_link.practice_id = soap.practice_id
+       and replacement_link.source_soap_note_id = soap.id
+      left join lateral (
+        select string_agg(
+          ${visibleClinicalText(sql`addendum.content`)},
+          E'\n' order by addendum.created_at, addendum.id
+        ) as content
+        from ${soapNoteAddenda} addendum
+        where addendum.practice_id = soap.practice_id
+          and addendum.soap_note_id = soap.id
+      ) addenda on true
+      where soap.practice_id = ${practiceId}
+        and soap.patient_id = ${input.patientId}
+        and soap.status = 'finalized'
+        and soap.deleted_at is null
+        and ${includes("soap_note")}
+
+      union all
+
+      select
+        prescription.id,
+        'prescription'::text,
+        prescription.start_date::timestamp at time zone practice.time_zone,
+        prescription.start_date::text,
+        prescription.start_date::text,
+        prescription.medication_name::text,
+        case
+          when prescription.status = 'active'
+            and prescription.end_date is not null
+            and prescription.end_date < (now() at time zone practice.time_zone)::date
+          then 'expired'
+          else prescription.status::text
+        end,
+        false,
+        false,
+        ${noRecordId},
+        ${noRecordId},
+        'Prescribed by'::text,
+        prescriber.name::text,
+        ${noText},
+        concat_ws(
+          E'\n',
+          prescription.medication_name,
+          prescription.dosage,
+          prescription.frequency,
+          prescription.instructions,
+          prescription.quantity::text,
+          prescription.refills_remaining::text
+        )
+      from ${prescriptions} prescription
+      join practice_context practice on practice.practice_id = prescription.practice_id
+      left join ${users} prescriber
+        on prescriber.practice_id = prescription.practice_id
+       and prescriber.id = prescription.prescribed_by
+      where prescription.practice_id = ${practiceId}
+        and prescription.patient_id = ${input.patientId}
+        and prescription.deleted_at is null
+        and ${includes("prescription")}
+
+      union all
+
+      select
+        vaccination.id,
+        'vaccination'::text,
+        vaccination.administered_at,
+        to_char(timezone(practice.time_zone, vaccination.administered_at), 'YYYY-MM-DD'),
+        vaccination.administered_at::text,
+        vaccination.vaccine_name::text,
+        'recorded'::text,
+        correction.id is not null,
+        vaccination.import_fingerprint is not null,
+        ${noRecordId},
+        ${noRecordId},
+        'Administered by'::text,
+        administrator.name::text,
+        ${noText},
+        concat_ws(
+          E'\n',
+          vaccination.vaccine_name,
+          vaccination.manufacturer,
+          vaccination.lot_number,
+          vaccination.next_due_date::text,
+          correction.reason
+        )
+      from ${vaccinationRecords} vaccination
+      join practice_context practice on practice.practice_id = vaccination.practice_id
+      left join ${clinicalRecordCorrections} correction
+        on correction.practice_id = vaccination.practice_id
+       and correction.vaccination_record_id = vaccination.id
+      left join ${users} administrator
+        on administrator.practice_id = vaccination.practice_id
+       and administrator.id = vaccination.administered_by
+      where vaccination.practice_id = ${practiceId}
+        and vaccination.patient_id = ${input.patientId}
+        and vaccination.deleted_at is null
+        and ${includes("vaccination")}
+
+      union all
+
+      select
+        lab.id,
+        'lab_result'::text,
+        coalesce(lab.completed_at, lab.created_at),
+        to_char(timezone(practice.time_zone, coalesce(lab.completed_at, lab.created_at)), 'YYYY-MM-DD'),
+        coalesce(lab.completed_at, lab.created_at)::text,
+        lab.test_name::text,
+        lab.status::text,
+        correction.id is not null,
+        false,
+        source_link.source_lab_result_id,
+        replacement_link.replacement_lab_result_id,
+        'Ordered by'::text,
+        ordered_by.name::text,
+        ${noText},
+        concat_ws(
+          E'\n',
+          lab.test_name,
+          lab.result_value,
+          lab.unit,
+          lab.reference_range_low::text,
+          lab.reference_range_high::text,
+          lab.result_flag::text,
+          correction.reason
+        )
+      from ${labResults} lab
+      join practice_context practice on practice.practice_id = lab.practice_id
+      left join ${clinicalRecordCorrections} correction
+        on correction.practice_id = lab.practice_id
+       and correction.lab_result_id = lab.id
+      left join ${labResultReplacements} source_link
+        on source_link.practice_id = lab.practice_id
+       and source_link.replacement_lab_result_id = lab.id
+      left join ${labResultReplacements} replacement_link
+        on replacement_link.practice_id = lab.practice_id
+       and replacement_link.source_lab_result_id = lab.id
+      left join ${users} ordered_by
+        on ordered_by.practice_id = lab.practice_id
+       and ordered_by.id = lab.ordered_by
+      where lab.practice_id = ${practiceId}
+        and lab.patient_id = ${input.patientId}
+        and lab.deleted_at is null
+        and ${includes("lab_result")}
+
+      union all
+
+      select
+        procedure.id,
+        'procedure'::text,
+        procedure.created_at,
+        to_char(timezone(practice.time_zone, procedure.created_at), 'YYYY-MM-DD'),
+        procedure.created_at::text,
+        procedure.name::text,
+        'completed'::text,
+        false,
+        false,
+        ${noRecordId},
+        ${noRecordId},
+        'Performed by'::text,
+        performer.name::text,
+        ${noText},
+        concat_ws(
+          E'\n',
+          procedure.name,
+          procedure.description,
+          procedure.anesthesia_used,
+          procedure.duration_minutes::text,
+          procedure.notes
+        )
+      from ${procedures} procedure
+      join practice_context practice on practice.practice_id = procedure.practice_id
+      left join ${users} performer
+        on performer.practice_id = procedure.practice_id
+       and performer.id = procedure.performed_by
+      where procedure.practice_id = ${practiceId}
+        and procedure.patient_id = ${input.patientId}
+        and procedure.deleted_at is null
+        and ${includes("procedure")}
+
+      union all
+
+      select
+        problem.id,
+        'problem'::text,
+        coalesce(
+          problem.onset_date::timestamp at time zone practice.time_zone,
+          problem.created_at
+        ),
+        coalesce(
+          problem.onset_date::text,
+          to_char(timezone(practice.time_zone, problem.created_at), 'YYYY-MM-DD')
+        ),
+        coalesce(problem.onset_date::text, problem.created_at::text),
+        problem.description::text,
+        problem.status::text,
+        false,
+        false,
+        ${noRecordId},
+        ${noRecordId},
+        ${noText},
+        null::text,
+        ${noText},
+        concat_ws(E'\n', problem.description, problem.status::text, problem.resolved_date::text)
+      from ${problemList} problem
+      join practice_context practice on practice.practice_id = problem.practice_id
+      where problem.practice_id = ${practiceId}
+        and problem.patient_id = ${input.patientId}
+        and problem.deleted_at is null
+        and ${includes("problem")}
+
+      union all
+
+      select
+        vital.id,
+        'vital_sign'::text,
+        vital.recorded_at,
+        to_char(timezone(practice.time_zone, vital.recorded_at), 'YYYY-MM-DD'),
+        vital.recorded_at::text,
+        'Vital signs'::text,
+        'recorded'::text,
+        correction.id is not null,
+        false,
+        ${noRecordId},
+        ${noRecordId},
+        'Recorded by'::text,
+        recorder.name::text,
+        ${noText},
+        concat_ws(
+          E'\n',
+          vital.temperature_c::text,
+          vital.heart_rate_bpm::text,
+          vital.respiratory_rate_bpm::text,
+          vital.weight_kg::text,
+          vital.body_condition_score::text,
+          vital.pain_score::text,
+          vital.mucous_membrane,
+          vital.capillary_refill_sec::text,
+          vital.notes,
+          correction.reason
+        )
+      from ${vitalSigns} vital
+      join practice_context practice on practice.practice_id = vital.practice_id
+      left join ${clinicalRecordCorrections} correction
+        on correction.practice_id = vital.practice_id
+       and correction.vital_sign_id = vital.id
+      left join ${users} recorder
+        on recorder.practice_id = vital.practice_id
+       and recorder.id = vital.recorded_by
+      where vital.practice_id = ${practiceId}
+        and vital.patient_id = ${input.patientId}
+        and vital.deleted_at is null
+        and ${includes("vital_sign")}
+
+      union all
+
+      select
+        allergy.id,
+        'allergy'::text,
+        allergy.noted_at,
+        to_char(timezone(practice.time_zone, allergy.noted_at), 'YYYY-MM-DD'),
+        allergy.noted_at::text,
+        allergy.allergen::text,
+        allergy.severity::text,
+        correction.id is not null,
+        false,
+        ${noRecordId},
+        ${noRecordId},
+        'Recorded by'::text,
+        recorder.name::text,
+        ${noText},
+        concat_ws(E'\n', allergy.allergen, allergy.reaction, allergy.severity::text, correction.reason)
+      from ${patientAllergies} allergy
+      join ${patients} patient
+        on patient.id = allergy.patient_id
+       and patient.practice_id = ${practiceId}
+       and patient.deleted_at is null
+      join practice_context practice on practice.practice_id = patient.practice_id
+      left join ${clinicalRecordCorrections} correction
+        on correction.practice_id = patient.practice_id
+       and correction.patient_allergy_id = allergy.id
+      left join ${users} recorder
+        on recorder.practice_id = patient.practice_id
+       and recorder.id = allergy.noted_by
+      where allergy.patient_id = ${input.patientId}
+        and allergy.deleted_at is null
+        and ${includes("allergy")}
+    ), matched as materialized (
+      select history.*
+      from history
+      where history.record_type in (${recordTypes})
+        and ${textPredicate}
+        and ${statePredicate}
+        and ${fromPredicate}
+        and ${toPredicate}
+    )
+    select
+      page.id,
+      page.record_type as "recordType",
+      page.display_date as "displayDate",
+      page.occurred_at as "occurredAt",
+      page.title,
+      case
+        when ${searchPattern}::text is null then left(page.search_text, 500)
+        else coalesce((
+          select left(
+            string_agg(
+              substring(
+                match.line
+                from greatest(strpos(lower(match.line), lower(${query ?? ""})) - 80, 1)
+                for 200
+              ),
+              E'\n' order by match.position
+            ),
+            500
+          )
+          from (
+            select candidate.line, candidate.position
+            from unnest(string_to_array(page.search_text, E'\n'))
+              with ordinality as candidate(line, position)
+            where candidate.line ilike ${searchPattern ?? ""} escape '\\'
+            order by candidate.position
+            limit 3
+          ) match
+        ), '')
+      end as summary,
+      page.status,
+      page.corrected,
+      page.imported,
+      page.replaces_record_id as "replacesRecordId",
+      page.replacement_record_id as "replacementRecordId",
+      page.author_label as "authorLabel",
+      page.author_name as "authorName",
+      page.finalizer_name as "finalizerName",
+      totals.total_count as "totalCount"
+    from (select count(*)::int as total_count from matched) totals
+    left join lateral (
+      select matched.*
+      from matched
+      where ${cursorPredicate}
+      order by matched.occurred_at desc, matched.record_type desc, matched.id desc
+      limit ${input.limit + 1}
+    ) page on true
+    order by page.occurred_at desc, page.record_type desc, page.id desc
+  `;
+}

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -131,6 +131,19 @@ import {
   type PrescriptionEventType,
   type PrescriptionStatus,
 } from "@/lib/records/prescription-lifecycle";
+import { isValidClinicalDateInput } from "@/lib/records/date-input";
+import {
+  PATIENT_HISTORY_DEFAULT_PAGE_SIZE,
+  PATIENT_HISTORY_MAX_PAGE_SIZE,
+  PATIENT_HISTORY_QUERY_MAX_LENGTH,
+  PATIENT_HISTORY_RECORD_TYPES,
+  PATIENT_HISTORY_STATE_FILTERS,
+  type PatientHistoryRecordType,
+} from "@/lib/records/patient-history";
+import {
+  buildPatientHistoryQuery,
+  type PatientHistoryRawRow,
+} from "../patient-history";
 
 export { PRESCRIPTION_INSTRUCTIONS_MAX_LENGTH } from "@/lib/records/prescription-policy";
 export {
@@ -153,6 +166,58 @@ const labStatusValues = ["pending", "completed", "reviewed"] as const;
 type LabStatus = (typeof labStatusValues)[number];
 const labResultFlagValues = ["unknown", "normal", "abnormal", "critical"] as const;
 const labFollowUpStatusValues = ["not_required", "open", "completed"] as const;
+
+const patientHistoryDateInput = z.string().refine(isValidClinicalDateInput, {
+  message: "Use a valid date in YYYY-MM-DD format.",
+});
+
+const patientHistoryInput = z
+  .object({
+    patientId: z.string().uuid(),
+    query: z
+      .string()
+      .trim()
+      .min(1)
+      .max(PATIENT_HISTORY_QUERY_MAX_LENGTH)
+      .optional(),
+    recordTypes: z
+      .array(z.enum(PATIENT_HISTORY_RECORD_TYPES))
+      .min(1)
+      .max(PATIENT_HISTORY_RECORD_TYPES.length)
+      .default([...PATIENT_HISTORY_RECORD_TYPES]),
+    state: z.enum(PATIENT_HISTORY_STATE_FILTERS).default("all"),
+    fromDate: patientHistoryDateInput.optional(),
+    toDate: patientHistoryDateInput.optional(),
+    cursor: z
+      .object({
+        occurredAt: z.string().datetime({ offset: true }),
+        recordType: z.enum(PATIENT_HISTORY_RECORD_TYPES),
+        id: z.string().uuid(),
+      })
+      .optional(),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(PATIENT_HISTORY_MAX_PAGE_SIZE)
+      .default(PATIENT_HISTORY_DEFAULT_PAGE_SIZE),
+  })
+  .superRefine((input, ctx) => {
+    if (new Set(input.recordTypes).size !== input.recordTypes.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["recordTypes"],
+        message: "Choose each record type at most once.",
+      });
+    }
+    if (input.fromDate && input.toDate && input.fromDate > input.toDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["toDate"],
+        message: "To date must be on or after From date.",
+      });
+    }
+  });
 
 const labStatusTransitions: Record<LabStatus, readonly LabStatus[]> = {
   pending: ["pending", "completed"],
@@ -1137,6 +1202,77 @@ function rethrowSoapLifecycleError(error: unknown): never {
 
 export const recordsRouter = createRouter({
   settings: protectedProcedure.query(async ({ ctx }) => practiceSettings(ctx)),
+
+  // The client sends this query over POST so clinical terms stay out of URLs,
+  // while query semantics preserve viewer access and exclude mutation audits.
+  searchPatientHistory: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician", "viewer"))
+    .input(patientHistoryInput)
+    .query(async ({ ctx, input }) => {
+      await assertPatientBelongsToPractice(ctx, input.patientId);
+      const rows = await ctx.db.execute<PatientHistoryRawRow>(
+        buildPatientHistoryQuery({
+          practiceId: ctx.practiceId,
+          input,
+        }),
+      );
+      const populatedRows = rows.filter(
+        (
+          row,
+        ): row is PatientHistoryRawRow & {
+          id: string;
+          recordType: PatientHistoryRecordType;
+          occurredAt: Date | string;
+          displayDate: string;
+          title: string;
+          status: string;
+          corrected: boolean;
+          imported: boolean;
+        } =>
+          Boolean(
+            row.id &&
+            row.recordType &&
+            row.occurredAt &&
+            row.displayDate &&
+            row.title &&
+            row.status,
+          ),
+      );
+      const hasMore = populatedRows.length > input.limit;
+      const pageRows = populatedRows.slice(0, input.limit);
+      const lastRow = pageRows.at(-1);
+      const cursorInstant = lastRow
+        ? new Date(lastRow.occurredAt).toISOString()
+        : null;
+
+      return {
+        items: pageRows.map((row) => ({
+          id: row.id,
+          recordType: row.recordType,
+          occurredAt: row.displayDate,
+          title: row.title,
+          summary: row.summary?.trim() || null,
+          status: row.status,
+          corrected: row.corrected,
+          imported: row.imported,
+          replacesRecordId: row.replacesRecordId,
+          replacementRecordId: row.replacementRecordId,
+          authorLabel: row.authorLabel,
+          authorName: row.authorName,
+          finalizerName: row.finalizerName,
+          visibility: "clinical_chart" as const,
+        })),
+        total: Number(rows[0]?.totalCount ?? 0),
+        nextCursor:
+          hasMore && lastRow && cursorInstant
+            ? {
+                occurredAt: cursorInstant,
+                recordType: lastRow.recordType,
+                id: lastRow.id,
+              }
+            : null,
+      };
+    }),
 
   // SOAP Notes
   listSoapNotes: protectedProcedure


### PR DESCRIPTION
## Clinic outcome

Adds a read-only **Find in patient history** workflow modeled on Steven Dennis's Carprofen example. The existing SOAP timeline remains unchanged until filters are applied.

## Safety boundaries

- Clinical roles only: admin, veterinarian, technician, viewer; front desk is excluded.
- Patient- and practice-scoped RLS query across finalized SOAP/addenda, prescriptions, vaccines, labs, procedures, problems, vitals, and allergies.
- Explicitly excludes private staff notes, communications, worklists, appointment notes, documents, invoices, and lab follow-up work.
- Literal bounded search with HTML-visible excerpts, clinic-local dates, correction/replacement/import provenance, deterministic keyset pagination, and explicit clinician attribution.
- Search terms are sent by POST and are not stored in URLs or browser storage.
- No schema migration or write path.

## Verification

- 4,103 repository tests passed; 12 intentionally opt-in suites skipped in the general command.
- Dedicated real PostgreSQL/openpims_app contract passed after real migrations + RLS, including all 8 record types, cross-tenant/no-context isolation, deactivated-clinician attribution, rich-text/late-term matching, wildcard literals, DST, correction/replacement/import semantics, stable concurrent-insert pagination, and 30k-row plan evidence.
- Full workspace type-check passed.
- Production Next.js build and lint passed.
- Production dependency audit: no known vulnerabilities.
- OSS release verification: 1,343 tracked files passed.
- Migration history integrity: 82 passed, 1 opt-in skipped.
- Authenticated production-build browser gate passed at 1440, 768, and 375 widths; Carprofen POST privacy, provenance, clear/restore, overflow, and runtime/API checks passed.
- Two independent read-only reviews passed the frozen staged diff hash eb2b5a366b56956490f9fb04d519f032c353caed4b55b7898d66f6e18e2c3887.

Jira: OPENVPM-83
