### PR TITLE
OPENVPM-88: add dark staff treatment plan authoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,15 @@ jobs:
           pnpm --filter @openpims/db db:treatment-plan-evidence:test
           pnpm --filter @openpims/db db:treatment-plan-concurrency:test
 
+      # The staff authoring API is dark by default. Exercise the complete
+      # protected route with the least-privilege app role against disposable
+      # real PostgreSQL, including replay, rollback, RLS, and two-writer races.
+      - name: Execute treatment-plan staff authoring contract
+        env:
+          TREATMENT_PLAN_AUTHORING_DB_INTEGRATION: "1"
+          TREATMENT_PLAN_AUTHORING_ENABLED: "true"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/visit-treatment-plan-authoring.integration.test.ts
+
       # Recreate the exact staging-era 0093 state in a disposable database,
       # preserve existing settlement evidence through 0094, advance through
       # later migrations, and attack every finance tenant/privilege boundary

--- a/apps/web/lib/treatment-plan-authoring/policy.test.ts
+++ b/apps/web/lib/treatment-plan-authoring/policy.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  canonicalQuantity,
+  priceTreatmentPlanLines,
+  quantityToThousandths,
+  TREATMENT_PLAN_AUTHORING_ENABLED_ENV,
+  treatmentPlanAuthoringEnabled,
+  treatmentPlanOperationHash,
+} from "./policy";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("treatment-plan authoring policy", () => {
+  it("stays dark unless the launch flag is explicitly true", () => {
+    vi.stubEnv(TREATMENT_PLAN_AUTHORING_ENABLED_ENV, "");
+    expect(treatmentPlanAuthoringEnabled()).toBe(false);
+    vi.stubEnv(TREATMENT_PLAN_AUTHORING_ENABLED_ENV, "false");
+    expect(treatmentPlanAuthoringEnabled()).toBe(false);
+    vi.stubEnv(TREATMENT_PLAN_AUTHORING_ENABLED_ENV, " TRUE ");
+    expect(treatmentPlanAuthoringEnabled()).toBe(true);
+  });
+
+  it("normalizes positive quantities without floating-point arithmetic", () => {
+    expect(quantityToThousandths("12.345")).toBe(12_345n);
+    expect(canonicalQuantity("12.3")).toBe("12.300");
+    expect(() => canonicalQuantity("0")).toThrow(/greater than zero/i);
+    expect(() => canonicalQuantity("1.0001")).toThrow(/invalid/i);
+  });
+
+  it("matches aggregate tax and allocates rounding cents deterministically", () => {
+    const priced = priceTreatmentPlanLines(
+      [
+        {
+          sortOrder: 0,
+          description: "Exam",
+          offeredQuantity: "1",
+          unitPriceCents: 5,
+          taxable: true,
+          itemType: "service",
+          serviceId: "service-1",
+          productId: null,
+        },
+        {
+          sortOrder: 1,
+          description: "Medication",
+          offeredQuantity: "1",
+          unitPriceCents: 5,
+          taxable: true,
+          itemType: "product",
+          serviceId: null,
+          productId: "product-1",
+        },
+      ],
+      "10.00",
+    );
+
+    expect(priced).toMatchObject({
+      subtotalCents: 10,
+      taxCents: 1,
+      totalCents: 11,
+    });
+    expect(priced.lines.map((line) => line.taxAmountCents)).toEqual([1, 0]);
+    expect(priced.lines.map((line) => line.lineTotalCents)).toEqual([6, 5]);
+  });
+
+  it("rounds fractional quantities the same way as positive PostgreSQL numeric", () => {
+    const priced = priceTreatmentPlanLines(
+      [
+        {
+          sortOrder: 0,
+          description: "Medication",
+          offeredQuantity: "1.005",
+          unitPriceCents: 100,
+          taxable: false,
+          itemType: "product",
+          serviceId: null,
+          productId: "product-1",
+        },
+      ],
+      "8.00",
+    );
+    expect(priced.lines[0]).toMatchObject({
+      offeredQuantity: "1.005",
+      lineSubtotalCents: 101,
+      taxAmountCents: 0,
+      lineTotalCents: 101,
+    });
+  });
+
+  it("hashes canonical operation payloads deterministically", () => {
+    const payload = {
+      version: 1,
+      action: "create",
+      items: [{ itemType: "service", itemId: "id", quantity: "1.000" }],
+    };
+    expect(treatmentPlanOperationHash(payload)).toMatch(/^[0-9a-f]{64}$/);
+    expect(treatmentPlanOperationHash(payload)).toBe(
+      treatmentPlanOperationHash(structuredClone(payload)),
+    );
+    expect(treatmentPlanOperationHash(payload)).not.toBe(
+      treatmentPlanOperationHash({ ...payload, action: "revise" }),
+    );
+  });
+});

--- a/apps/web/lib/treatment-plan-authoring/policy.ts
+++ b/apps/web/lib/treatment-plan-authoring/policy.ts
@@ -1,0 +1,164 @@
+import { createHash } from "node:crypto";
+
+import { BILLING_MAX_MONEY_CENTS } from "@/lib/billing/policy";
+import { taxRateToBasisPoints } from "@/lib/billing/invoice-tax";
+
+export const TREATMENT_PLAN_AUTHORING_ENABLED_ENV =
+  "TREATMENT_PLAN_AUTHORING_ENABLED";
+export const TREATMENT_PLAN_MAX_ITEMS = 100;
+export const TREATMENT_PLAN_QUANTITY_PATTERN =
+  /^(?:0|[1-9]\d{0,8})(?:\.\d{1,3})?$/;
+
+export type TreatmentPlanCatalogItemInput = {
+  itemType: "service" | "product";
+  itemId: string;
+  quantity: string;
+};
+
+export type PricedTreatmentPlanLine = {
+  sortOrder: number;
+  description: string;
+  offeredQuantity: string;
+  unitPriceCents: number;
+  taxable: boolean;
+  itemType: "service" | "product";
+  serviceId: string | null;
+  productId: string | null;
+};
+
+export type TreatmentPlanStoredLine = PricedTreatmentPlanLine & {
+  lineSubtotalCents: number;
+  taxAmountCents: number;
+  lineTotalCents: number;
+};
+
+export function treatmentPlanAuthoringEnabled(): boolean {
+  return (
+    process.env[TREATMENT_PLAN_AUTHORING_ENABLED_ENV]?.trim().toLowerCase() ===
+    "true"
+  );
+}
+
+export function quantityToThousandths(value: string): bigint {
+  const normalized = value.trim();
+  if (!TREATMENT_PLAN_QUANTITY_PATTERN.test(normalized)) {
+    throw new Error("Invalid treatment-plan quantity.");
+  }
+  const [whole, fraction = ""] = normalized.split(".");
+  const thousandths = BigInt(whole) * 1000n + BigInt(fraction.padEnd(3, "0"));
+  if (thousandths <= 0n) {
+    throw new Error("Treatment-plan quantity must be greater than zero.");
+  }
+  return thousandths;
+}
+
+export function canonicalQuantity(value: string): string {
+  const thousandths = quantityToThousandths(value);
+  const whole = thousandths / 1000n;
+  const fraction = (thousandths % 1000n).toString().padStart(3, "0");
+  return `${whole}.${fraction}`;
+}
+
+function checkedCents(value: bigint, label: string): number {
+  if (value < 0n || value > BigInt(BILLING_MAX_MONEY_CENTS)) {
+    throw new Error(`${label} exceeds the supported currency range.`);
+  }
+  return Number(value);
+}
+
+function lineSubtotalCents(unitPriceCents: number, quantity: string): number {
+  if (!Number.isSafeInteger(unitPriceCents) || unitPriceCents < 0) {
+    throw new Error("Unit price must be a supported nonnegative amount.");
+  }
+  const numerator = BigInt(unitPriceCents) * quantityToThousandths(quantity);
+  return checkedCents((numerator + 500n) / 1000n, "Line subtotal");
+}
+
+/**
+ * Match invoice-level tax rounding, then allocate its cents deterministically
+ * across taxable lines by largest remainder and stable line order.
+ */
+export function priceTreatmentPlanLines(
+  lines: readonly PricedTreatmentPlanLine[],
+  taxRatePercent: string,
+): {
+  lines: TreatmentPlanStoredLine[];
+  subtotalCents: number;
+  taxCents: number;
+  totalCents: number;
+} {
+  const basisPoints = BigInt(taxRateToBasisPoints(taxRatePercent));
+  const denominator = 10_000n;
+  const calculated = lines.map((line) => {
+    const subtotal = lineSubtotalCents(
+      line.unitPriceCents,
+      line.offeredQuantity,
+    );
+    const taxNumerator = line.taxable ? BigInt(subtotal) * basisPoints : 0n;
+    return {
+      line,
+      subtotal,
+      baseTax: Number(taxNumerator / denominator),
+      remainder: taxNumerator % denominator,
+    };
+  });
+
+  const subtotalBig = calculated.reduce(
+    (sum, line) => sum + BigInt(line.subtotal),
+    0n,
+  );
+  const taxableBig = calculated.reduce(
+    (sum, line) => sum + (line.line.taxable ? BigInt(line.subtotal) : 0n),
+    0n,
+  );
+  const taxBig = (taxableBig * basisPoints + denominator / 2n) / denominator;
+  const baseTaxBig = calculated.reduce(
+    (sum, line) => sum + BigInt(line.baseTax),
+    0n,
+  );
+  const extraTaxCents = Number(taxBig - baseTaxBig);
+  const taxAwards = new Set(
+    calculated
+      .map((line, index) => ({
+        index,
+        remainder: line.remainder,
+        sortOrder: line.line.sortOrder,
+      }))
+      .filter((line) => line.remainder > 0n)
+      .sort((left, right) => {
+        if (left.remainder !== right.remainder) {
+          return left.remainder > right.remainder ? -1 : 1;
+        }
+        return left.sortOrder - right.sortOrder;
+      })
+      .slice(0, extraTaxCents)
+      .map((line) => line.index),
+  );
+
+  const subtotalCents = checkedCents(subtotalBig, "Treatment-plan subtotal");
+  const taxCents = checkedCents(taxBig, "Treatment-plan tax");
+  const totalCents = checkedCents(subtotalBig + taxBig, "Treatment-plan total");
+
+  return {
+    lines: calculated.map((calculatedLine, index) => {
+      const taxAmountCents =
+        calculatedLine.baseTax + (taxAwards.has(index) ? 1 : 0);
+      return {
+        ...calculatedLine.line,
+        offeredQuantity: canonicalQuantity(calculatedLine.line.offeredQuantity),
+        lineSubtotalCents: calculatedLine.subtotal,
+        taxAmountCents,
+        lineTotalCents: calculatedLine.subtotal + taxAmountCents,
+      };
+    }),
+    subtotalCents,
+    taxCents,
+    totalCents,
+  };
+}
+
+export function treatmentPlanOperationHash(payload: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(payload), "utf8")
+    .digest("hex");
+}

--- a/apps/web/server/__tests__/visit-treatment-plan-authoring.integration.test.ts
+++ b/apps/web/server/__tests__/visit-treatment-plan-authoring.integration.test.ts
@@ -1,0 +1,597 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+
+import { and, count, eq, max } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it, vi } from "vitest";
+
+import * as schema from "../../../../packages/db/schema/index";
+import { appRouter } from "../routers/_app";
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithAuthoringPostgres =
+  process.env.TREATMENT_PLAN_AUTHORING_DB_INTEGRATION === "1"
+    ? describe
+    : describe.skip;
+
+type AppDatabase = ReturnType<typeof drizzle<typeof schema>>;
+
+function callerFor(
+  database: AppDatabase,
+  practiceId: string,
+  userId: string,
+  role: "admin" | "veterinarian" | "technician" | "front_desk" = "admin",
+) {
+  return appRouter.createCaller({
+    db: database,
+    session: {
+      user: {
+        id: userId,
+        email: `${role}@synthetic.invalid`,
+        name: "Synthetic treatment-plan staff",
+        role,
+        practiceId,
+      },
+    },
+  } as never);
+}
+
+describeWithAuthoringPostgres(
+  "visit treatment-plan authoring PostgreSQL contract",
+  () => {
+    it("proves tenant safety, snapshot/replay/rollback semantics, and concurrent revision control", async () => {
+      const adminUrl = process.env.DATABASE_URL;
+      if (!adminUrl) throw new Error("DATABASE_URL is required");
+
+      const databaseName = `openpims_plan_authoring_${randomUUID().replaceAll("-", "")}`;
+      if (!/^openpims_plan_authoring_[a-f0-9]+$/.test(databaseName)) {
+        throw new Error("unsafe disposable database name");
+      }
+      const databaseUrl = new URL(adminUrl);
+      databaseUrl.pathname = `/${databaseName}`;
+      databaseUrl.search = "";
+      databaseUrl.hash = "";
+      const appUrl = new URL(databaseUrl);
+      appUrl.username = "openpims_app";
+      appUrl.password =
+        process.env.OPENPIMS_APP_DB_PASSWORD?.trim() || "openpims_app";
+
+      const adminSql = postgres(adminUrl, { max: 1 });
+      let ownerSql: ReturnType<typeof postgres> | undefined;
+      let appSql: ReturnType<typeof postgres> | undefined;
+      let raceSqlA: ReturnType<typeof postgres> | undefined;
+      let raceSqlB: ReturnType<typeof postgres> | undefined;
+      await adminSql.unsafe(`create database "${databaseName}"`);
+
+      const previousFlag = process.env.TREATMENT_PLAN_AUTHORING_ENABLED;
+      process.env.TREATMENT_PLAN_AUTHORING_ENABLED = "true";
+
+      try {
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:migrate"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+          timeout: 45_000,
+        });
+        execFileSync("pnpm", ["--filter", "@openpims/db", "db:rls"], {
+          cwd: repoRoot,
+          env: { ...process.env, DATABASE_URL: databaseUrl.toString() },
+          encoding: "utf8",
+          timeout: 45_000,
+        });
+
+        ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+        const ownerDb = drizzle(ownerSql, { schema });
+        const [practice, otherPractice] = await ownerDb
+          .insert(schema.practices)
+          .values([
+            {
+              name: "Synthetic Treatment Plan Clinic",
+              currency: "usd",
+              taxRatePercent: "8.25",
+            },
+            {
+              name: "Other Synthetic Clinic",
+              currency: "usd",
+              taxRatePercent: "7.00",
+            },
+          ])
+          .returning({ id: schema.practices.id });
+        if (!practice || !otherPractice) {
+          throw new Error("failed to seed practices");
+        }
+
+        const [location, otherLocation] = await ownerDb
+          .insert(schema.locations)
+          .values([
+            {
+              practiceId: practice.id,
+              name: "Main Clinic",
+              isPrimary: true,
+            },
+            {
+              practiceId: otherPractice.id,
+              name: "Other Clinic",
+              isPrimary: true,
+            },
+          ])
+          .returning({ id: schema.locations.id });
+        const [staff, otherStaff] = await ownerDb
+          .insert(schema.users)
+          .values([
+            {
+              practiceId: practice.id,
+              email: "plan-author@example.invalid",
+              passwordHash: "not-a-real-password-hash",
+              name: "Synthetic Plan Author",
+              role: "admin",
+              emailVerifiedAt: new Date(),
+            },
+            {
+              practiceId: otherPractice.id,
+              email: "other-plan-author@example.invalid",
+              passwordHash: "not-a-real-password-hash",
+              name: "Other Synthetic Author",
+              role: "admin",
+              emailVerifiedAt: new Date(),
+            },
+          ])
+          .returning({ id: schema.users.id });
+        const [client, otherClient] = await ownerDb
+          .insert(schema.clients)
+          .values([
+            {
+              practiceId: practice.id,
+              firstName: "Synthetic",
+              lastName: "Owner",
+            },
+            {
+              practiceId: otherPractice.id,
+              firstName: "Other",
+              lastName: "Owner",
+            },
+          ])
+          .returning({ id: schema.clients.id });
+        if (
+          !location ||
+          !otherLocation ||
+          !staff ||
+          !otherStaff ||
+          !client ||
+          !otherClient
+        ) {
+          throw new Error("failed to seed treatment-plan identities");
+        }
+
+        const [patient, otherPatient] = await ownerDb
+          .insert(schema.patients)
+          .values([
+            {
+              practiceId: practice.id,
+              clientId: client.id,
+              name: "Synthetic Patient",
+              species: "canine",
+            },
+            {
+              practiceId: otherPractice.id,
+              clientId: otherClient.id,
+              name: "Other Patient",
+              species: "feline",
+            },
+          ])
+          .returning({ id: schema.patients.id });
+        if (!patient || !otherPatient) {
+          throw new Error("failed to seed patients");
+        }
+
+        const start = new Date(Date.now() + 86_400_000);
+        const [appointment] = await ownerDb
+          .insert(schema.appointments)
+          .values({
+            practiceId: practice.id,
+            locationId: location.id,
+            clientId: client.id,
+            patientId: patient.id,
+            startTime: start,
+            endTime: new Date(start.getTime() + 1_800_000),
+          })
+          .returning({ id: schema.appointments.id });
+        if (!appointment) throw new Error("failed to seed appointment");
+
+        const [examService] = await ownerDb
+          .insert(schema.services)
+          .values({
+            practiceId: practice.id,
+            name: "Comprehensive exam",
+            code: "EXAM",
+            defaultPrice: "50.00",
+            taxable: false,
+          })
+          .returning({ id: schema.services.id });
+        const [medication, otherMedication] = await ownerDb
+          .insert(schema.products)
+          .values([
+            {
+              practiceId: practice.id,
+              locationId: location.id,
+              name: "Synthetic medication",
+              sku: "MED-1",
+              unitPrice: "12.34",
+              taxable: true,
+              inventoryTracked: true,
+              stockQuantity: 20,
+            },
+            {
+              practiceId: otherPractice.id,
+              locationId: otherLocation.id,
+              name: "Private other-clinic product",
+              sku: "PRIVATE-1",
+              unitPrice: "999.00",
+              taxable: true,
+              inventoryTracked: true,
+              stockQuantity: 99,
+            },
+          ])
+          .returning({ id: schema.products.id });
+        if (!examService || !medication || !otherMedication) {
+          throw new Error("failed to seed catalog");
+        }
+
+        appSql = postgres(appUrl.toString(), { max: 1 });
+        raceSqlA = postgres(appUrl.toString(), { max: 1 });
+        raceSqlB = postgres(appUrl.toString(), { max: 1 });
+        const appDb = drizzle(appSql, { schema });
+        const raceDbA = drizzle(raceSqlA, { schema });
+        const raceDbB = drizzle(raceSqlB, { schema });
+        const caller = callerFor(appDb, practice.id, staff.id);
+
+        const createOperationId = randomUUID();
+        const createInput = {
+          operationId: createOperationId,
+          clientId: client.id,
+          patientId: patient.id,
+          appointmentId: appointment.id,
+          title: "Dental treatment plan",
+          items: [
+            {
+              itemType: "service" as const,
+              itemId: examService.id,
+              quantity: "1",
+            },
+            {
+              itemType: "product" as const,
+              itemId: medication.id,
+              quantity: "2.5",
+            },
+          ],
+        };
+        const created = await caller.visitTreatmentPlans.create(createInput);
+        expect(created.plan).toMatchObject({
+          clientId: client.id,
+          patientId: patient.id,
+          appointmentId: appointment.id,
+          title: "Dental treatment plan",
+          status: "open",
+        });
+        expect(created.revision).toMatchObject({
+          revisionNumber: 1,
+          currency: "USD",
+          subtotal: "80.85",
+          tax: "2.55",
+          total: "83.40",
+        });
+        expect(created.revision.contentSha256).toMatch(/^[0-9a-f]{64}$/);
+        expect(created.lines).toHaveLength(2);
+        expect(created.lines[0]).toMatchObject({
+          description: "Comprehensive exam",
+          offeredQuantity: "1.000",
+          unitPrice: "50.00",
+          lineSubtotal: "50.00",
+          taxAmount: "0.00",
+        });
+        expect(created.lines[1]).toMatchObject({
+          description: "Synthetic medication",
+          offeredQuantity: "2.500",
+          unitPrice: "12.34",
+          lineSubtotal: "30.85",
+          taxAmount: "2.55",
+        });
+
+        const replay = await caller.visitTreatmentPlans.create(createInput);
+        expect(replay.plan.id).toBe(created.plan.id);
+        expect(replay.revision.id).toBe(created.revision.id);
+        await expect(
+          caller.visitTreatmentPlans.create({
+            ...createInput,
+            title: "Different payload",
+          }),
+        ).rejects.toMatchObject({ code: "CONFLICT" });
+
+        const concurrentCreateInput = {
+          ...createInput,
+          operationId: randomUUID(),
+          title: "Concurrent create treatment plan",
+        };
+        const concurrentCreates = await Promise.all([
+          callerFor(raceDbA, practice.id, staff.id).visitTreatmentPlans.create(
+            concurrentCreateInput,
+          ),
+          callerFor(raceDbB, practice.id, staff.id).visitTreatmentPlans.create(
+            concurrentCreateInput,
+          ),
+        ]);
+        expect(concurrentCreates[0]?.plan.id).toBe(
+          concurrentCreates[1]?.plan.id,
+        );
+        expect(concurrentCreates[0]?.revision.id).toBe(
+          concurrentCreates[1]?.revision.id,
+        );
+
+        await ownerDb
+          .update(schema.services)
+          .set({ name: "Renamed catalog service", defaultPrice: "75.00" })
+          .where(eq(schema.services.id, examService.id));
+        const preserved = await caller.visitTreatmentPlans.preview({
+          planId: created.plan.id,
+          revisionNumber: 1,
+        });
+        expect(preserved.lines[0]).toMatchObject({
+          description: "Comprehensive exam",
+          unitPrice: "50.00",
+        });
+
+        const revised = await caller.visitTreatmentPlans.revise({
+          operationId: randomUUID(),
+          planId: created.plan.id,
+          expectedRevisionNumber: 1,
+          items: [
+            {
+              itemType: "product",
+              itemId: medication.id,
+              quantity: "1",
+            },
+          ],
+        });
+        expect(revised.revision.revisionNumber).toBe(2);
+        expect(revised.lines).toHaveLength(1);
+        await expect(
+          caller.visitTreatmentPlans.revise({
+            operationId: randomUUID(),
+            planId: created.plan.id,
+            expectedRevisionNumber: 1,
+            items: [
+              {
+                itemType: "product",
+                itemId: medication.id,
+                quantity: "3",
+              },
+            ],
+          }),
+        ).rejects.toMatchObject({ code: "CONFLICT" });
+
+        const beforeCrossTenant = await ownerDb
+          .select({ value: count() })
+          .from(schema.visitTreatmentPlanRevisionLines)
+          .where(
+            eq(schema.visitTreatmentPlanRevisionLines.planId, created.plan.id),
+          );
+        await expect(
+          caller.visitTreatmentPlans.revise({
+            operationId: randomUUID(),
+            planId: created.plan.id,
+            expectedRevisionNumber: 2,
+            items: [
+              {
+                itemType: "product",
+                itemId: otherMedication.id,
+                quantity: "1",
+              },
+            ],
+          }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+        const afterCrossTenant = await ownerDb
+          .select({ value: count() })
+          .from(schema.visitTreatmentPlanRevisionLines)
+          .where(
+            eq(schema.visitTreatmentPlanRevisionLines.planId, created.plan.id),
+          );
+        expect(afterCrossTenant[0]?.value).toBe(beforeCrossTenant[0]?.value);
+
+        await expect(
+          caller.visitTreatmentPlans.create({
+            ...createInput,
+            operationId: randomUUID(),
+            clientId: otherClient.id,
+            patientId: otherPatient.id,
+            appointmentId: undefined,
+          }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+        const injectedFaultOperationId = randomUUID();
+        await ownerSql.unsafe(`
+            create or replace function public.inject_plan_authoring_fault()
+            returns trigger language plpgsql set search_path = '' as $$
+            begin
+              if new.operation_id = '${injectedFaultOperationId}'::uuid then
+                raise exception using errcode = '40001', message = 'synthetic post-line authoring fault';
+              end if;
+              return new;
+            end $$;
+            create trigger aaa_inject_plan_authoring_fault
+              before insert on public.visit_treatment_plan_revisions
+              for each row execute function public.inject_plan_authoring_fault();
+          `);
+        const [beforeFault] = await ownerDb
+          .select({
+            revisions: count(schema.visitTreatmentPlanRevisions.id),
+          })
+          .from(schema.visitTreatmentPlanRevisions)
+          .where(
+            eq(schema.visitTreatmentPlanRevisions.planId, created.plan.id),
+          );
+        const [beforeFaultLines] = await ownerDb
+          .select({ lines: count(schema.visitTreatmentPlanRevisionLines.id) })
+          .from(schema.visitTreatmentPlanRevisionLines)
+          .where(
+            eq(schema.visitTreatmentPlanRevisionLines.planId, created.plan.id),
+          );
+        await expect(
+          caller.visitTreatmentPlans.revise({
+            operationId: injectedFaultOperationId,
+            planId: created.plan.id,
+            expectedRevisionNumber: 2,
+            items: [
+              {
+                itemType: "service",
+                itemId: examService.id,
+                quantity: "4",
+              },
+            ],
+          }),
+        ).rejects.toMatchObject({ code: "CONFLICT" });
+        await ownerSql.unsafe(`
+            drop trigger aaa_inject_plan_authoring_fault
+              on public.visit_treatment_plan_revisions;
+            drop function public.inject_plan_authoring_fault();
+          `);
+        const [afterFault] = await ownerDb
+          .select({
+            revisions: count(schema.visitTreatmentPlanRevisions.id),
+          })
+          .from(schema.visitTreatmentPlanRevisions)
+          .where(
+            eq(schema.visitTreatmentPlanRevisions.planId, created.plan.id),
+          );
+        const [afterFaultLines] = await ownerDb
+          .select({ lines: count(schema.visitTreatmentPlanRevisionLines.id) })
+          .from(schema.visitTreatmentPlanRevisionLines)
+          .where(
+            eq(schema.visitTreatmentPlanRevisionLines.planId, created.plan.id),
+          );
+        expect(afterFault).toEqual(beforeFault);
+        expect(afterFaultLines).toEqual(beforeFaultLines);
+
+        const raceOperationA = randomUUID();
+        const raceOperationB = randomUUID();
+        const raceInputA = {
+          operationId: raceOperationA,
+          planId: created.plan.id,
+          expectedRevisionNumber: 2,
+          items: [
+            {
+              itemType: "service" as const,
+              itemId: examService.id,
+              quantity: "1",
+            },
+          ],
+        };
+        const raceInputB = {
+          operationId: raceOperationB,
+          planId: created.plan.id,
+          expectedRevisionNumber: 2,
+          items: [
+            {
+              itemType: "product" as const,
+              itemId: medication.id,
+              quantity: "2",
+            },
+          ],
+        };
+        const race = await Promise.allSettled([
+          callerFor(raceDbA, practice.id, staff.id).visitTreatmentPlans.revise(
+            raceInputA,
+          ),
+          callerFor(raceDbB, practice.id, staff.id).visitTreatmentPlans.revise(
+            raceInputB,
+          ),
+        ]);
+        const winners = race.filter(
+          (
+            result,
+          ): result is PromiseFulfilledResult<
+            Awaited<ReturnType<typeof caller.visitTreatmentPlans.revise>>
+          > => result.status === "fulfilled",
+        );
+        const losers = race.filter(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected",
+        );
+        expect(winners).toHaveLength(1);
+        expect(losers).toHaveLength(1);
+        expect(losers[0]?.reason).toMatchObject({ code: "CONFLICT" });
+        expect(winners[0]?.value.revision.revisionNumber).toBe(3);
+
+        const winningInput =
+          race[0]?.status === "fulfilled" ? raceInputA : raceInputB;
+        const replayedWinner =
+          await caller.visitTreatmentPlans.revise(winningInput);
+        expect(replayedWinner.revision.id).toBe(winners[0]?.value.revision.id);
+
+        const [revisionSummary] = await ownerDb
+          .select({
+            count: count(),
+            maxRevision: max(schema.visitTreatmentPlanRevisions.revisionNumber),
+          })
+          .from(schema.visitTreatmentPlanRevisions)
+          .where(
+            and(
+              eq(schema.visitTreatmentPlanRevisions.practiceId, practice.id),
+              eq(schema.visitTreatmentPlanRevisions.planId, created.plan.id),
+            ),
+          );
+        expect(revisionSummary).toMatchObject({ count: 3, maxRevision: 3 });
+
+        const [downstream] = await ownerDb
+          .select({ invoiceCount: count(schema.invoices.id) })
+          .from(schema.invoices)
+          .where(eq(schema.invoices.practiceId, practice.id));
+        expect(downstream?.invoiceCount).toBe(0);
+        const [appointmentAfter] = await ownerDb
+          .select({ status: schema.appointments.status })
+          .from(schema.appointments)
+          .where(eq(schema.appointments.id, appointment.id));
+        expect(appointmentAfter?.status).toBe("scheduled");
+        const [productAfter] = await ownerDb
+          .select({ stockQuantity: schema.products.stockQuantity })
+          .from(schema.products)
+          .where(eq(schema.products.id, medication.id));
+        expect(productAfter?.stockQuantity).toBe(20);
+
+        const otherCaller = callerFor(appDb, otherPractice.id, otherStaff.id);
+        await expect(
+          otherCaller.visitTreatmentPlans.preview({
+            planId: created.plan.id,
+          }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+        const noContextRows = await appDb
+          .select({ id: schema.visitTreatmentPlans.id })
+          .from(schema.visitTreatmentPlans);
+        expect(noContextRows).toEqual([]);
+      } finally {
+        if (previousFlag === undefined) {
+          delete process.env.TREATMENT_PLAN_AUTHORING_ENABLED;
+        } else {
+          process.env.TREATMENT_PLAN_AUTHORING_ENABLED = previousFlag;
+        }
+        await Promise.allSettled([
+          appSql?.end({ timeout: 2 }),
+          raceSqlA?.end({ timeout: 2 }),
+          raceSqlB?.end({ timeout: 2 }),
+          ownerSql?.end({ timeout: 2 }),
+        ]);
+        await adminSql.unsafe(
+          `select pg_terminate_backend(pid) from pg_stat_activity where datname = '${databaseName}' and pid <> pg_backend_pid()`,
+        );
+        await adminSql.unsafe(`drop database if exists "${databaseName}"`);
+        await adminSql.end({ timeout: 2 });
+      }
+    }, 120_000);
+  },
+);

--- a/apps/web/server/__tests__/visit-treatment-plans-safety.test.ts
+++ b/apps/web/server/__tests__/visit-treatment-plans-safety.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: mocks.recordAuditLog,
+}));
+
+const { visitTreatmentPlansRouter } =
+  await import("../routers/visit-treatment-plans");
+
+const ROUTER_SOURCE = readFileSync(
+  new URL("../routers/visit-treatment-plans.ts", import.meta.url),
+  "utf8",
+);
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+const CLIENT_ID = "00000000-0000-0000-0000-000000000002";
+const PATIENT_ID = "00000000-0000-0000-0000-000000000003";
+const SERVICE_ID = "00000000-0000-0000-0000-000000000004";
+const OPERATION_ID = "00000000-0000-0000-0000-000000000005";
+
+function callerFor(role: string) {
+  const tx = {
+    execute: vi.fn(async () => undefined),
+  };
+  const db = {
+    transaction: vi.fn(async (fn: (database: unknown) => unknown) => fn(tx)),
+  };
+  const session = {
+    user: {
+      id: USER_ID,
+      email: "staff@example.com",
+      name: "Staff",
+      role,
+      practiceId: PRACTICE_ID,
+    },
+  };
+  return {
+    caller: visitTreatmentPlansRouter.createCaller({ db, session } as never),
+    db,
+    tx,
+  };
+}
+
+const validCreateInput = {
+  operationId: OPERATION_ID,
+  clientId: CLIENT_ID,
+  patientId: PATIENT_ID,
+  title: "Dental treatment plan",
+  items: [
+    {
+      itemType: "service" as const,
+      itemId: SERVICE_ID,
+      quantity: "1",
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("visit treatment-plan authoring safety", () => {
+  it("keeps the registered production API dark by default", async () => {
+    const { caller, db } = callerFor("admin");
+    await expect(caller.create(validCreateInput)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Treatment plan authoring is not available.",
+    });
+
+    // Only protectedProcedure's tenant wrapper ran; no nested authoring
+    // transaction or write path was reached.
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["front_desk", "viewer"])(
+    "rejects the %s role before authoring",
+    async (role) => {
+      vi.stubEnv("TREATMENT_PLAN_AUTHORING_ENABLED", "true");
+      const { caller } = callerFor(role);
+      await expect(caller.create(validCreateInput)).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+    },
+  );
+
+  it("uses a nested savepoint and surfaces deferred constraints before returning", () => {
+    expect(ROUTER_SOURCE).toContain("await ctx.db.transaction(async (tx) =>");
+    expect(ROUTER_SOURCE).toContain(
+      "await database.execute(sql`set constraints all immediate`)",
+    );
+  });
+
+  it("locks the plan root before checking and staging a new revision", () => {
+    const reviseStart = ROUTER_SOURCE.indexOf("revise: protectedProcedure");
+    const reviseSource = ROUTER_SOURCE.slice(reviseStart);
+    const lock = reviseSource.indexOf('.for("update")');
+    const latest = reviseSource.indexOf("const [latest]");
+    const stage = reviseSource.indexOf("return stageAndSealRevision");
+    expect(lock).toBeGreaterThan(0);
+    expect(latest).toBeGreaterThan(lock);
+    expect(stage).toBeGreaterThan(latest);
+  });
+
+  it("requires active tenant-owned context and catalog rows", () => {
+    expect(ROUTER_SOURCE).toContain("eq(patients.practiceId, practiceId)");
+    expect(ROUTER_SOURCE).toContain("eq(patients.clientId, input.clientId)");
+    expect(ROUTER_SOURCE).toContain("eq(appointments.practiceId, practiceId)");
+    expect(ROUTER_SOURCE).toContain("eq(services.practiceId, practiceId)");
+    expect(ROUTER_SOURCE).toContain("eq(products.practiceId, practiceId)");
+    expect(ROUTER_SOURCE).toContain("isNull(services.deletedAt)");
+    expect(ROUTER_SOURCE).toContain("isNull(products.deletedAt)");
+  });
+
+  it("does not import or mutate downstream billing, inventory, queue, or consent surfaces", () => {
+    expect(ROUTER_SOURCE).not.toMatch(
+      /invoiceItems|invoices|whiteboard|consent/i,
+    );
+    expect(ROUTER_SOURCE).not.toMatch(/stockQuantity|inventoryTracked/);
+    expect(ROUTER_SOURCE).not.toContain("postCommitEffect");
+  });
+});

--- a/apps/web/server/routers/_app.ts
+++ b/apps/web/server/routers/_app.ts
@@ -33,6 +33,7 @@ import { messagingRouter } from "./messaging";
 import { bookingRouter } from "./booking";
 import { careRemindersRouter } from "./care-reminders";
 import { migrationArchiveRouter } from "./migration-archive";
+import { visitTreatmentPlansRouter } from "./visit-treatment-plans";
 
 export const appRouter = createRouter({
   auth: authRouter,
@@ -69,6 +70,7 @@ export const appRouter = createRouter({
   booking: bookingRouter,
   careReminders: careRemindersRouter,
   migrationArchive: migrationArchiveRouter,
+  visitTreatmentPlans: visitTreatmentPlansRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/server/routers/visit-treatment-plans.ts
+++ b/apps/web/server/routers/visit-treatment-plans.ts
@@ -1,0 +1,854 @@
+import { randomUUID } from "node:crypto";
+
+import { TRPCError } from "@trpc/server";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import {
+  appointments,
+  clients,
+  patients,
+  practices,
+  products,
+  services,
+  visitTreatmentPlanRevisionLines,
+  visitTreatmentPlanRevisions,
+  visitTreatmentPlans,
+} from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+
+import { centsToMoney, moneyToCents } from "@/lib/billing/invoice-balance";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import { clinicalTextInput } from "@/lib/records/clinical-inputs";
+import {
+  canonicalQuantity,
+  priceTreatmentPlanLines,
+  TREATMENT_PLAN_MAX_ITEMS,
+  TREATMENT_PLAN_QUANTITY_PATTERN,
+  treatmentPlanAuthoringEnabled,
+  treatmentPlanOperationHash,
+  type PricedTreatmentPlanLine,
+  type TreatmentPlanCatalogItemInput,
+} from "@/lib/treatment-plan-authoring/policy";
+import { createRouter, protectedProcedure, requireRole } from "../trpc";
+
+const clinicalRole = requireRole("admin", "veterinarian", "technician");
+
+const catalogItemInput = z.object({
+  itemType: z.enum(["service", "product"]),
+  itemId: z.string().uuid(),
+  quantity: z
+    .string()
+    .trim()
+    .regex(
+      TREATMENT_PLAN_QUANTITY_PATTERN,
+      "Quantity must be positive with at most three decimal places.",
+    )
+    .refine(
+      (value) => canonicalQuantity(value) !== "0.000",
+      "Quantity must be greater than zero.",
+    )
+    .transform(canonicalQuantity),
+});
+
+const planItemsInput = z
+  .array(catalogItemInput)
+  .min(1, "A treatment plan must contain at least one line.")
+  .max(
+    TREATMENT_PLAN_MAX_ITEMS,
+    `Treatment plans can contain at most ${TREATMENT_PLAN_MAX_ITEMS} lines.`,
+  );
+
+const createPlanInput = z.object({
+  operationId: z.string().uuid(),
+  clientId: z.string().uuid(),
+  patientId: z.string().uuid(),
+  appointmentId: z.string().uuid().optional(),
+  title: clinicalTextInput("Treatment plan title", 255),
+  items: planItemsInput,
+});
+
+const revisePlanInput = z.object({
+  operationId: z.string().uuid(),
+  planId: z.string().uuid(),
+  expectedRevisionNumber: z.number().int().min(1),
+  items: planItemsInput,
+});
+
+type TreatmentPlanTransaction = Parameters<
+  Parameters<Database["transaction"]>[0]
+>[0];
+type TreatmentPlanDatabase = Database | TreatmentPlanTransaction;
+
+type RevisionRow = {
+  id: string;
+  planId: string;
+  revisionNumber: number;
+  currency: string;
+  subtotal: string;
+  tax: string;
+  total: string;
+  authoredBy: string;
+  operationId: string;
+  operationPayloadHash: string;
+  contentSha256: string;
+  createdAt: Date;
+};
+
+function assertAuthoringEnabled(): void {
+  if (!treatmentPlanAuthoringEnabled()) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Treatment plan authoring is not available.",
+    });
+  }
+}
+
+function pgErrorDetails(error: unknown): {
+  code?: string;
+  message?: string;
+  constraint?: string;
+} {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 8 && current; depth += 1) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    if (typeof current !== "object") break;
+    const row = current as Record<string, unknown>;
+    if (typeof row.code === "string" && /^[0-9A-Z]{5}$/.test(row.code)) {
+      return {
+        code: row.code,
+        message: typeof row.message === "string" ? row.message : undefined,
+        constraint:
+          typeof row.constraint_name === "string"
+            ? row.constraint_name
+            : typeof row.constraint === "string"
+              ? row.constraint
+              : undefined,
+      };
+    }
+    current = row.cause;
+  }
+  return {};
+}
+
+function mapAuthoringDatabaseError(error: unknown): TRPCError | null {
+  const pg = pgErrorDetails(error);
+  if (pg.code === "40001") {
+    return new TRPCError({
+      code: "CONFLICT",
+      message:
+        "The treatment plan changed in another session. Refresh and retry.",
+      cause: error,
+    });
+  }
+  if (
+    pg.code === "23505" &&
+    pg.constraint?.startsWith("visit_treatment_plan")
+  ) {
+    return new TRPCError({
+      code: "CONFLICT",
+      message:
+        "The treatment plan changed in another session. Refresh and retry.",
+      cause: error,
+    });
+  }
+  if (
+    pg.code === "23514" &&
+    (pg.message ===
+      "Treatment plan revision number is stale or non-sequential" ||
+      pg.message === "Sealed treatment plan revision lines are immutable")
+  ) {
+    return new TRPCError({
+      code: "CONFLICT",
+      message:
+        "The treatment plan changed in another session. Refresh and retry.",
+      cause: error,
+    });
+  }
+  if (
+    pg.code === "23503" &&
+    pg.message ===
+      "Treatment plan is missing, closed, or outside the active practice"
+  ) {
+    return new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "This treatment plan is no longer open for revision.",
+      cause: error,
+    });
+  }
+  return null;
+}
+
+function activePracticePredicate(practiceId: string) {
+  return sql`exists (
+    select 1 from ${practices}
+    where ${practices.id} = ${practiceId}
+      and ${practices.deletedAt} is null
+  )`;
+}
+
+async function readRevisionByOperation(
+  database: TreatmentPlanDatabase,
+  practiceId: string,
+  operationId: string,
+): Promise<RevisionRow | undefined> {
+  const [revision] = await database
+    .select({
+      id: visitTreatmentPlanRevisions.id,
+      planId: visitTreatmentPlanRevisions.planId,
+      revisionNumber: visitTreatmentPlanRevisions.revisionNumber,
+      currency: visitTreatmentPlanRevisions.currency,
+      subtotal: visitTreatmentPlanRevisions.subtotal,
+      tax: visitTreatmentPlanRevisions.tax,
+      total: visitTreatmentPlanRevisions.total,
+      authoredBy: visitTreatmentPlanRevisions.authoredBy,
+      operationId: visitTreatmentPlanRevisions.operationId,
+      operationPayloadHash: visitTreatmentPlanRevisions.operationPayloadHash,
+      contentSha256: visitTreatmentPlanRevisions.contentSha256,
+      createdAt: visitTreatmentPlanRevisions.createdAt,
+    })
+    .from(visitTreatmentPlanRevisions)
+    .where(
+      and(
+        eq(visitTreatmentPlanRevisions.practiceId, practiceId),
+        eq(visitTreatmentPlanRevisions.operationId, operationId),
+        activePracticePredicate(practiceId),
+      ),
+    )
+    .limit(1);
+  return revision;
+}
+
+async function readPlanByOperation(
+  database: TreatmentPlanDatabase,
+  practiceId: string,
+  operationId: string,
+) {
+  const [plan] = await database
+    .select({
+      id: visitTreatmentPlans.id,
+      operationPayloadHash: visitTreatmentPlans.operationPayloadHash,
+    })
+    .from(visitTreatmentPlans)
+    .where(
+      and(
+        eq(visitTreatmentPlans.practiceId, practiceId),
+        eq(visitTreatmentPlans.operationId, operationId),
+        activePracticePredicate(practiceId),
+      ),
+    )
+    .limit(1);
+  return plan;
+}
+
+function exactReplay(
+  revision: RevisionRow | undefined,
+  planId: string,
+  payloadHash: string,
+): RevisionRow | null {
+  if (!revision) return null;
+  if (
+    revision.planId !== planId ||
+    revision.operationPayloadHash !== payloadHash
+  ) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message:
+        "This operation id was already used for different treatment-plan content.",
+    });
+  }
+  return revision;
+}
+
+async function assertCreateContext(
+  database: TreatmentPlanDatabase,
+  practiceId: string,
+  input: z.infer<typeof createPlanInput>,
+) {
+  const [practice] = await database
+    .select({
+      currency: practices.currency,
+      taxRatePercent: practices.taxRatePercent,
+    })
+    .from(practices)
+    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+    .limit(1);
+  if (!practice) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Practice not found" });
+  }
+
+  const [patient] = await database
+    .select({ id: patients.id })
+    .from(patients)
+    .innerJoin(
+      clients,
+      and(
+        eq(clients.id, patients.clientId),
+        eq(clients.practiceId, patients.practiceId),
+        isNull(clients.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(patients.id, input.patientId),
+        eq(patients.clientId, input.clientId),
+        eq(patients.practiceId, practiceId),
+        isNull(patients.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!patient) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Patient and client context not found.",
+    });
+  }
+
+  if (input.appointmentId) {
+    const [appointment] = await database
+      .select({ id: appointments.id })
+      .from(appointments)
+      .where(
+        and(
+          eq(appointments.id, input.appointmentId),
+          eq(appointments.practiceId, practiceId),
+          eq(appointments.patientId, input.patientId),
+          eq(appointments.clientId, input.clientId),
+          isNull(appointments.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (!appointment) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Appointment context not found.",
+      });
+    }
+  }
+
+  return practice;
+}
+
+async function resolveCatalogLines(
+  database: TreatmentPlanDatabase,
+  practiceId: string,
+  items: readonly TreatmentPlanCatalogItemInput[],
+): Promise<PricedTreatmentPlanLine[]> {
+  const serviceIds = [
+    ...new Set(
+      items
+        .filter((item) => item.itemType === "service")
+        .map((item) => item.itemId),
+    ),
+  ];
+  const productIds = [
+    ...new Set(
+      items
+        .filter((item) => item.itemType === "product")
+        .map((item) => item.itemId),
+    ),
+  ];
+  const serviceRows = serviceIds.length
+    ? await database
+        .select({
+          id: services.id,
+          name: services.name,
+          unitPrice: services.defaultPrice,
+          taxable: services.taxable,
+        })
+        .from(services)
+        .where(
+          and(
+            eq(services.practiceId, practiceId),
+            inArray(services.id, serviceIds),
+            isNull(services.deletedAt),
+            activePracticePredicate(practiceId),
+          ),
+        )
+    : [];
+  const productRows = productIds.length
+    ? await database
+        .select({
+          id: products.id,
+          name: products.name,
+          unitPrice: products.unitPrice,
+          taxable: products.taxable,
+        })
+        .from(products)
+        .where(
+          and(
+            eq(products.practiceId, practiceId),
+            inArray(products.id, productIds),
+            isNull(products.deletedAt),
+            activePracticePredicate(practiceId),
+          ),
+        )
+    : [];
+  const serviceById = new Map(serviceRows.map((row) => [row.id, row]));
+  const productById = new Map(productRows.map((row) => [row.id, row]));
+
+  return items.map((item, sortOrder) => {
+    const source =
+      item.itemType === "service"
+        ? serviceById.get(item.itemId)
+        : productById.get(item.itemId);
+    if (!source) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "A selected treatment-plan service or product is unavailable.",
+      });
+    }
+    return {
+      sortOrder,
+      description: source.name,
+      offeredQuantity: item.quantity,
+      unitPriceCents: moneyToCents(source.unitPrice),
+      taxable: source.taxable,
+      itemType: item.itemType,
+      serviceId: item.itemType === "service" ? item.itemId : null,
+      productId: item.itemType === "product" ? item.itemId : null,
+    };
+  });
+}
+
+async function stageAndSealRevision(
+  database: TreatmentPlanDatabase,
+  args: {
+    practiceId: string;
+    planId: string;
+    revisionNumber: number;
+    authoredBy: string;
+    operationId: string;
+    payloadHash: string;
+    currency: string;
+    taxRatePercent: string;
+    items: readonly TreatmentPlanCatalogItemInput[];
+  },
+): Promise<RevisionRow> {
+  const priced = priceTreatmentPlanLines(
+    await resolveCatalogLines(database, args.practiceId, args.items),
+    args.taxRatePercent,
+  );
+  const revisionId = randomUUID();
+  const lines = priced.lines.map((line) => ({
+    id: randomUUID(),
+    practiceId: args.practiceId,
+    planId: args.planId,
+    revisionId,
+    sortOrder: line.sortOrder,
+    description: line.description,
+    offeredQuantity: line.offeredQuantity,
+    unitPrice: centsToMoney(line.unitPriceCents),
+    lineSubtotal: centsToMoney(line.lineSubtotalCents),
+    taxAmount: centsToMoney(line.taxAmountCents),
+    lineTotal: centsToMoney(line.lineTotalCents),
+    taxable: line.taxable,
+    itemType: line.itemType,
+    serviceId: line.serviceId,
+    productId: line.productId,
+  }));
+  await database.insert(visitTreatmentPlanRevisionLines).values(lines);
+
+  const subtotal = centsToMoney(priced.subtotalCents);
+  const tax = centsToMoney(priced.taxCents);
+  const total = centsToMoney(priced.totalCents);
+  const currency = args.currency.toUpperCase();
+  const hashRows = rowsFromExecute<{ contentSha256: string }>(
+    await database.execute(sql`
+      select public.compute_visit_treatment_plan_revision_sha256(
+        ${args.practiceId}::uuid,
+        ${args.planId}::uuid,
+        ${revisionId}::uuid,
+        ${args.revisionNumber}::integer,
+        ${currency},
+        ${subtotal}::numeric,
+        ${tax}::numeric,
+        ${total}::numeric
+      ) as "contentSha256"
+    `),
+  );
+  const contentSha256 = hashRows[0]?.contentSha256;
+  if (!contentSha256) {
+    throw new Error("Treatment-plan content hash could not be computed.");
+  }
+
+  const [revision] = await database
+    .insert(visitTreatmentPlanRevisions)
+    .values({
+      id: revisionId,
+      practiceId: args.practiceId,
+      planId: args.planId,
+      revisionNumber: args.revisionNumber,
+      currency,
+      subtotal,
+      tax,
+      total,
+      authoredBy: args.authoredBy,
+      operationId: args.operationId,
+      operationPayloadHash: args.payloadHash,
+      contentSha256,
+    })
+    .returning();
+  if (!revision) {
+    throw new Error("Treatment-plan revision was not created.");
+  }
+  await database.execute(sql`set constraints all immediate`);
+  return revision;
+}
+
+async function readPreview(
+  database: TreatmentPlanDatabase,
+  practiceId: string,
+  planId: string,
+  revisionNumber?: number,
+) {
+  const [plan] = await database
+    .select({
+      id: visitTreatmentPlans.id,
+      clientId: visitTreatmentPlans.clientId,
+      patientId: visitTreatmentPlans.patientId,
+      appointmentId: visitTreatmentPlans.appointmentId,
+      title: visitTreatmentPlans.title,
+      status: visitTreatmentPlans.status,
+      createdBy: visitTreatmentPlans.createdBy,
+      createdAt: visitTreatmentPlans.createdAt,
+    })
+    .from(visitTreatmentPlans)
+    .where(
+      and(
+        eq(visitTreatmentPlans.id, planId),
+        eq(visitTreatmentPlans.practiceId, practiceId),
+        activePracticePredicate(practiceId),
+      ),
+    )
+    .limit(1);
+  if (!plan) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Treatment plan not found",
+    });
+  }
+
+  const [revision] = await database
+    .select()
+    .from(visitTreatmentPlanRevisions)
+    .where(
+      and(
+        eq(visitTreatmentPlanRevisions.practiceId, practiceId),
+        eq(visitTreatmentPlanRevisions.planId, planId),
+        revisionNumber === undefined
+          ? undefined
+          : eq(visitTreatmentPlanRevisions.revisionNumber, revisionNumber),
+      ),
+    )
+    .orderBy(desc(visitTreatmentPlanRevisions.revisionNumber))
+    .limit(1);
+  if (!revision) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Treatment plan revision not found",
+    });
+  }
+  const lines = await database
+    .select()
+    .from(visitTreatmentPlanRevisionLines)
+    .where(
+      and(
+        eq(visitTreatmentPlanRevisionLines.practiceId, practiceId),
+        eq(visitTreatmentPlanRevisionLines.planId, planId),
+        eq(visitTreatmentPlanRevisionLines.revisionId, revision.id),
+      ),
+    )
+    .orderBy(
+      asc(visitTreatmentPlanRevisionLines.sortOrder),
+      asc(visitTreatmentPlanRevisionLines.id),
+    );
+  return { plan, revision, lines };
+}
+
+export const visitTreatmentPlansRouter = createRouter({
+  preview: protectedProcedure
+    .use(clinicalRole)
+    .input(
+      z.object({
+        planId: z.string().uuid(),
+        revisionNumber: z.number().int().min(1).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      assertAuthoringEnabled();
+      return readPreview(
+        ctx.db,
+        ctx.practiceId,
+        input.planId,
+        input.revisionNumber,
+      );
+    }),
+
+  create: protectedProcedure
+    .use(clinicalRole)
+    .input(createPlanInput)
+    .mutation(async ({ ctx, input }) => {
+      assertAuthoringEnabled();
+      const canonicalItems = input.items.map((item) => ({
+        ...item,
+        quantity: canonicalQuantity(item.quantity),
+      }));
+      const payloadHash = treatmentPlanOperationHash({
+        version: 1,
+        action: "create",
+        practiceId: ctx.practiceId,
+        authoredBy: ctx.user.id,
+        clientId: input.clientId,
+        patientId: input.patientId,
+        appointmentId: input.appointmentId ?? null,
+        title: input.title,
+        items: canonicalItems,
+      });
+
+      try {
+        const revision = await ctx.db.transaction(async (tx) => {
+          const existingPlan = await readPlanByOperation(
+            tx,
+            ctx.practiceId,
+            input.operationId,
+          );
+          if (existingPlan) {
+            if (existingPlan.operationPayloadHash !== payloadHash) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message:
+                  "This operation id was already used for different treatment-plan content.",
+              });
+            }
+            const replay = exactReplay(
+              await readRevisionByOperation(
+                tx,
+                ctx.practiceId,
+                input.operationId,
+              ),
+              existingPlan.id,
+              payloadHash,
+            );
+            if (!replay) {
+              throw new TRPCError({
+                code: "PRECONDITION_FAILED",
+                message: "The existing treatment plan is incomplete.",
+              });
+            }
+            return replay;
+          }
+
+          const practice = await assertCreateContext(tx, ctx.practiceId, input);
+          const planId = randomUUID();
+          const [createdPlan] = await tx
+            .insert(visitTreatmentPlans)
+            .values({
+              id: planId,
+              practiceId: ctx.practiceId,
+              clientId: input.clientId,
+              patientId: input.patientId,
+              appointmentId: input.appointmentId,
+              createdBy: ctx.user.id,
+              title: input.title,
+              operationId: input.operationId,
+              operationPayloadHash: payloadHash,
+            })
+            .onConflictDoNothing({
+              target: [
+                visitTreatmentPlans.practiceId,
+                visitTreatmentPlans.operationId,
+              ],
+            })
+            .returning({ id: visitTreatmentPlans.id });
+          if (!createdPlan) {
+            const concurrentPlan = await readPlanByOperation(
+              tx,
+              ctx.practiceId,
+              input.operationId,
+            );
+            if (
+              !concurrentPlan ||
+              concurrentPlan.operationPayloadHash !== payloadHash
+            ) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message:
+                  "This operation id was already used for different treatment-plan content.",
+              });
+            }
+            const replay = exactReplay(
+              await readRevisionByOperation(
+                tx,
+                ctx.practiceId,
+                input.operationId,
+              ),
+              concurrentPlan.id,
+              payloadHash,
+            );
+            if (!replay) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message:
+                  "The treatment plan is still being created. Refresh and retry.",
+              });
+            }
+            return replay;
+          }
+
+          return stageAndSealRevision(tx, {
+            practiceId: ctx.practiceId,
+            planId,
+            revisionNumber: 1,
+            authoredBy: ctx.user.id,
+            operationId: input.operationId,
+            payloadHash,
+            currency: practice.currency,
+            taxRatePercent: practice.taxRatePercent,
+            items: canonicalItems,
+          });
+        });
+        return readPreview(ctx.db, ctx.practiceId, revision.planId, 1);
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        const mapped = mapAuthoringDatabaseError(error);
+        if (mapped) throw mapped;
+        throw error;
+      }
+    }),
+
+  revise: protectedProcedure
+    .use(clinicalRole)
+    .input(revisePlanInput)
+    .mutation(async ({ ctx, input }) => {
+      assertAuthoringEnabled();
+      const canonicalItems = input.items.map((item) => ({
+        ...item,
+        quantity: canonicalQuantity(item.quantity),
+      }));
+      const payloadHash = treatmentPlanOperationHash({
+        version: 1,
+        action: "revise",
+        practiceId: ctx.practiceId,
+        authoredBy: ctx.user.id,
+        planId: input.planId,
+        expectedRevisionNumber: input.expectedRevisionNumber,
+        items: canonicalItems,
+      });
+
+      try {
+        const revision = await ctx.db.transaction(async (tx) => {
+          const replayBeforeLock = exactReplay(
+            await readRevisionByOperation(
+              tx,
+              ctx.practiceId,
+              input.operationId,
+            ),
+            input.planId,
+            payloadHash,
+          );
+          if (replayBeforeLock) return replayBeforeLock;
+
+          const [plan] = await tx
+            .select({ id: visitTreatmentPlans.id })
+            .from(visitTreatmentPlans)
+            .where(
+              and(
+                eq(visitTreatmentPlans.id, input.planId),
+                eq(visitTreatmentPlans.practiceId, ctx.practiceId),
+                eq(visitTreatmentPlans.status, "open"),
+                activePracticePredicate(ctx.practiceId),
+              ),
+            )
+            .for("update")
+            .limit(1);
+          if (!plan) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "This treatment plan is no longer open for revision.",
+            });
+          }
+
+          const replayAfterLock = exactReplay(
+            await readRevisionByOperation(
+              tx,
+              ctx.practiceId,
+              input.operationId,
+            ),
+            input.planId,
+            payloadHash,
+          );
+          if (replayAfterLock) return replayAfterLock;
+
+          const [latest] = await tx
+            .select({
+              revisionNumber: visitTreatmentPlanRevisions.revisionNumber,
+            })
+            .from(visitTreatmentPlanRevisions)
+            .where(
+              and(
+                eq(visitTreatmentPlanRevisions.practiceId, ctx.practiceId),
+                eq(visitTreatmentPlanRevisions.planId, input.planId),
+              ),
+            )
+            .orderBy(desc(visitTreatmentPlanRevisions.revisionNumber))
+            .limit(1);
+          if (
+            !latest ||
+            latest.revisionNumber !== input.expectedRevisionNumber
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "The treatment plan changed in another session. Refresh and retry.",
+            });
+          }
+
+          const [practice] = await tx
+            .select({
+              currency: practices.currency,
+              taxRatePercent: practices.taxRatePercent,
+            })
+            .from(practices)
+            .where(
+              and(
+                eq(practices.id, ctx.practiceId),
+                isNull(practices.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!practice) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Practice not found",
+            });
+          }
+
+          return stageAndSealRevision(tx, {
+            practiceId: ctx.practiceId,
+            planId: input.planId,
+            revisionNumber: input.expectedRevisionNumber + 1,
+            authoredBy: ctx.user.id,
+            operationId: input.operationId,
+            payloadHash,
+            currency: practice.currency,
+            taxRatePercent: practice.taxRatePercent,
+            items: canonicalItems,
+          });
+        });
+        return readPreview(
+          ctx.db,
+          ctx.practiceId,
+          revision.planId,
+          revision.revisionNumber,
+        );
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        const mapped = mapAuthoringDatabaseError(error);
+        if (mapped) throw mapped;
+        throw error;
+      }
+    }),
+});


### PR DESCRIPTION
## Summary

- add a staff-only treatment-plan create/revise/preview API over the immutable evidence tables
- require active same-practice catalog services/products and snapshot exact descriptions, prices, tax, currency, and quantities
- add operation-id replay protection, expected-revision locking, typed concurrency failures, and nested-savepoint rollback
- keep the capability dark unless `TREATMENT_PLAN_AUTHORING_ENABLED=true`
- add a least-privilege, two-tenant real PostgreSQL CI contract

## Safety boundary

This is an additive API foundation only. The flag remains off by default and no production UI is exposed. It cannot sign, send, charge, reserve inventory, alter appointments, or enqueue work. Existing consult, estimate, invoice, clinical-plan, and whiteboard paths are unchanged.

## Verification

- full repository test suite: 406 files passed / 9 skipped; 4,116 tests passed / 13 skipped
- full production build: passed
- web and database type checks: passed
- migration history integrity: 82 passed / 1 skipped
- focused authoring policy/router safety: 12 passed
- disposable real PostgreSQL contract: passed with real migrations, least-privilege app role, two tenants, RLS/no-context refusal, exact replay, payload mismatch, immutable catalog snapshots, post-write rollback, concurrent create/revise races, and tenant-context cleanup
- formatting and diff checks: passed

Jira: OPENVPM-88