### PR TITLE
OPENVPM-89: add dark encounter treatment plan composer

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import type { inferRouterOutputs } from "@trpc/server";
@@ -74,6 +75,14 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { EmptyState } from "@/components/common/empty-state";
 import type { AppRouter } from "@/server/routers/_app";
+
+const TreatmentPlanComposer = dynamic(
+  () =>
+    import("@/components/encounters/treatment-plan-composer").then(
+      (module) => module.TreatmentPlanComposer,
+    ),
+  { ssr: false, loading: () => null },
+);
 
 type RouterOutputs = inferRouterOutputs<AppRouter>;
 type CloseoutQueryState = {
@@ -798,6 +807,17 @@ export default function EncounterWorkspacePage() {
               visitStateReady={visitClinicalStateReady}
               visitOpen={visitOpenForClinicalEntry}
               timeZone={taxConfigQuery.data?.timezone}
+            />
+          ) : null}
+
+          {canRecordVitals(role) &&
+          appointment.patientId &&
+          appointment.clientId ? (
+            <TreatmentPlanComposer
+              appointmentId={appointment.id}
+              clientId={appointment.clientId}
+              patientId={appointment.patientId}
+              patientName={appointment.patientName ?? "Patient"}
             />
           ) : null}
 

--- a/apps/web/components/encounters/treatment-plan-composer.tsx
+++ b/apps/web/components/encounters/treatment-plan-composer.tsx
@@ -1,0 +1,608 @@
+"use client";
+
+import {
+  useDeferredValue,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  ChevronsUpDown,
+  ClipboardList,
+  Loader2,
+  Search,
+  Trash2,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { formatCurrency } from "@/lib/locale/format";
+import { TEMPLATE_CATALOG_SEARCH_MAX_LENGTH } from "@/lib/templates/catalog-search";
+import { trpc } from "@/lib/trpc";
+import { cn } from "@/lib/utils";
+
+type CatalogItem = {
+  id: string;
+  itemType: "service" | "product";
+  name: string;
+  code: string | null;
+  category: string | null;
+  unitPrice: string;
+};
+
+type DraftLine = CatalogItem & { quantity: string };
+
+const VALID_QUANTITY = /^(?:0|[1-9]\d{0,8})(?:\.\d{1,3})?$/;
+
+function validQuantity(value: string): boolean {
+  return VALID_QUANTITY.test(value.trim()) && Number(value) > 0;
+}
+
+function lineFingerprint(lines: DraftLine[]): string {
+  return JSON.stringify(
+    lines.map((line) => [line.itemType, line.id, line.quantity.trim()]),
+  );
+}
+
+function TreatmentPlanCatalogPicker({
+  excluded,
+  enabled,
+  currency,
+  onSelect,
+}: {
+  excluded: Set<string>;
+  enabled: boolean;
+  currency: string;
+  onSelect: (item: CatalogItem) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const deferredSearch = useDeferredValue(search);
+  const queryIsStale = search !== deferredSearch;
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
+  const catalogQuery = trpc.visitTreatmentPlans.searchCatalog.useQuery(
+    { search: deferredSearch },
+    { enabled: enabled && open, retry: false },
+  );
+  const results = useMemo(
+    () =>
+      (catalogQuery.data ?? []).filter(
+        (item) => !excluded.has(`${item.itemType}:${item.id}`),
+      ),
+    [catalogQuery.data, excluded],
+  );
+  const active =
+    !queryIsStale && !catalogQuery.isFetching && !catalogQuery.error
+      ? results[highlight]
+      : undefined;
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+        setSearch("");
+      }
+    };
+    document.addEventListener("pointerdown", close);
+    return () => document.removeEventListener("pointerdown", close);
+  }, [open]);
+
+  useEffect(() => setHighlight(0), [deferredSearch, open]);
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector<HTMLElement>(`[data-index="${highlight}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  const choose = (item: CatalogItem) => {
+    onSelect(item);
+    setOpen(false);
+    setSearch("");
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "ArrowDown") {
+      setHighlight((current) =>
+        Math.min(current + 1, Math.max(results.length - 1, 0)),
+      );
+      event.preventDefault();
+    } else if (event.key === "ArrowUp") {
+      setHighlight((current) => Math.max(current - 1, 0));
+      event.preventDefault();
+    } else if (event.key === "Enter") {
+      if (active) choose(active);
+      event.preventDefault();
+    } else if (event.key === "Escape") {
+      setOpen(false);
+      setSearch("");
+      event.preventDefault();
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="relative">
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full justify-between"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => {
+          setOpen((current) => !current);
+          setTimeout(() => inputRef.current?.focus(), 0);
+        }}
+      >
+        <span className="inline-flex items-center gap-2">
+          <Search className="h-4 w-4" /> Add a service or product
+        </span>
+        <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+      </Button>
+
+      {open ? (
+        <div className="absolute z-40 mt-1 w-full min-w-[18rem] rounded-md border border-border bg-popover shadow-lg">
+          <div className="flex min-h-11 items-center gap-2 border-b border-border px-3">
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              role="combobox"
+              aria-label="Search treatment plan catalog"
+              aria-autocomplete="list"
+              aria-expanded="true"
+              aria-controls={listboxId}
+              aria-activedescendant={
+                active
+                  ? `${listboxId}-option-${active.itemType}-${active.id}`
+                  : undefined
+              }
+              maxLength={TEMPLATE_CATALOG_SEARCH_MAX_LENGTH}
+              value={search}
+              placeholder="Search name, code, or category"
+              className="min-w-0 flex-1 bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
+              onChange={(event) => setSearch(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            {search ? (
+              <button
+                type="button"
+                aria-label="Clear search"
+                className="rounded p-2 text-muted-foreground hover:bg-accent"
+                onClick={() => {
+                  setSearch("");
+                  inputRef.current?.focus();
+                }}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            ) : null}
+          </div>
+          <div
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            aria-label="Available services and products"
+            aria-busy={queryIsStale || catalogQuery.isFetching}
+            className="max-h-72 overflow-y-auto p-1"
+          >
+            {queryIsStale || catalogQuery.isFetching ? (
+              <div className="flex items-center justify-center gap-2 px-3 py-6 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Searching...
+              </div>
+            ) : catalogQuery.error ? (
+              <div role="alert" className="px-3 py-6 text-sm text-destructive">
+                Catalog search failed. Edit the search to retry.
+              </div>
+            ) : results.length === 0 ? (
+              <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                No active catalog items match.
+              </p>
+            ) : (
+              results.map((item, index) => (
+                <button
+                  key={`${item.itemType}:${item.id}`}
+                  id={`${listboxId}-option-${item.itemType}-${item.id}`}
+                  type="button"
+                  role="option"
+                  aria-selected="false"
+                  data-index={index}
+                  className={cn(
+                    "flex min-h-11 w-full items-center gap-3 rounded-sm px-3 py-2 text-left text-sm",
+                    index === highlight && "bg-accent",
+                  )}
+                  onMouseEnter={() => setHighlight(index)}
+                  onClick={() => choose(item)}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium">
+                      {item.name}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {item.itemType === "service" ? "Service" : "Product"}
+                      {[item.code, item.category].filter(Boolean).length
+                        ? ` · ${[item.code, item.category].filter(Boolean).join(" · ")}`
+                        : ""}
+                    </span>
+                  </span>
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    {formatCurrency(item.unitPrice, currency)}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function TreatmentPlanComposer({
+  appointmentId,
+  clientId,
+  patientId,
+  patientName,
+}: {
+  appointmentId: string;
+  clientId: string;
+  patientId: string;
+  patientName: string;
+}) {
+  const utils = trpc.useUtils();
+  const [lines, setLines] = useState<DraftLine[]>([]);
+  const hydratedRevision = useRef<string | null>(null);
+  const savedFingerprint = useRef("");
+  const operation = useRef<{ fingerprint: string; id: string } | null>(null);
+  const context = { appointmentId, clientId, patientId };
+  const planQuery = trpc.visitTreatmentPlans.getForAppointment.useQuery(
+    context,
+    {
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  );
+  const plan = planQuery.data;
+
+  useEffect(() => {
+    if (!plan) {
+      if (planQuery.isSuccess && hydratedRevision.current === null) {
+        savedFingerprint.current = lineFingerprint([]);
+      }
+      return;
+    }
+    if (hydratedRevision.current === plan.revision.id) return;
+    const hydrated = plan.lines.map((line) => ({
+      id: line.serviceId ?? line.productId!,
+      itemType: line.itemType,
+      name: line.description,
+      code: null,
+      category: null,
+      unitPrice: line.unitPrice,
+      quantity: line.offeredQuantity,
+    }));
+    setLines(hydrated);
+    savedFingerprint.current = lineFingerprint(hydrated);
+    hydratedRevision.current = plan.revision.id;
+    operation.current = null;
+  }, [plan, planQuery.isSuccess]);
+
+  const deferredLines = useDeferredValue(lines);
+  const quantitiesValid = lines.every((line) => validQuantity(line.quantity));
+  const quoteQuery = trpc.visitTreatmentPlans.quote.useQuery(
+    {
+      ...context,
+      items: deferredLines.map((line) => ({
+        itemType: line.itemType,
+        itemId: line.id,
+        quantity: line.quantity,
+      })),
+    },
+    {
+      enabled:
+        planQuery.isSuccess && deferredLines.length > 0 && quantitiesValid,
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  );
+  const quote =
+    quantitiesValid && deferredLines === lines && !quoteQuery.isFetching
+      ? quoteQuery.data
+      : undefined;
+  const currency = quote?.currency ?? plan?.revision.currency ?? "USD";
+  const fingerprint = lineFingerprint(lines);
+  const hasChanges = fingerprint !== savedFingerprint.current;
+  const excluded = useMemo(
+    () => new Set(lines.map((line) => `${line.itemType}:${line.id}`)),
+    [lines],
+  );
+
+  const createPlan = trpc.visitTreatmentPlans.create.useMutation();
+  const revisePlan = trpc.visitTreatmentPlans.revise.useMutation();
+  const saving = createPlan.isPending || revisePlan.isPending;
+
+  const operationIdFor = (payloadFingerprint: string): string => {
+    if (operation.current?.fingerprint === payloadFingerprint) {
+      return operation.current.id;
+    }
+    const next = { fingerprint: payloadFingerprint, id: crypto.randomUUID() };
+    operation.current = next;
+    return next.id;
+  };
+
+  const save = async () => {
+    const items = lines.map((line) => ({
+      itemType: line.itemType,
+      itemId: line.id,
+      quantity: line.quantity.trim(),
+    }));
+    const payloadFingerprint = `${plan?.plan.id ?? "new"}:${fingerprint}`;
+    try {
+      if (plan) {
+        await revisePlan.mutateAsync({
+          operationId: operationIdFor(payloadFingerprint),
+          planId: plan.plan.id,
+          expectedRevisionNumber: plan.revision.revisionNumber,
+          items,
+        });
+      } else {
+        await createPlan.mutateAsync({
+          operationId: operationIdFor(payloadFingerprint),
+          ...context,
+          title: `${patientName} treatment plan`,
+          items,
+        });
+      }
+      operation.current = null;
+      await utils.visitTreatmentPlans.getForAppointment.invalidate(context);
+      toast.success(plan ? "Treatment plan updated" : "Treatment plan saved");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Save failed";
+      toast.error(message);
+      if (/changed in another session/i.test(message)) {
+        await planQuery.refetch();
+      }
+    }
+  };
+
+  if (planQuery.error?.data?.code === "NOT_FOUND") return null;
+  if (planQuery.isLoading) return null;
+
+  if (planQuery.error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Treatment plan</CardTitle>
+          <CardDescription>
+            Treatment plans are temporarily unavailable. Refresh before adding
+            one.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card id="treatment-plan" className="scroll-mt-4">
+      <CardHeader className="pb-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <ClipboardList className="h-5 w-5 text-primary" /> Treatment plan
+            </CardTitle>
+            <CardDescription className="mt-1.5">
+              Build the plan you’ll review with the client.
+            </CardDescription>
+          </div>
+          {plan ? (
+            <Badge variant="secondary">
+              Revision {plan.revision.revisionNumber}
+            </Badge>
+          ) : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <TreatmentPlanCatalogPicker
+          excluded={excluded}
+          enabled={planQuery.isSuccess}
+          currency={currency}
+          onSelect={(item) =>
+            setLines((current) => [...current, { ...item, quantity: "1" }])
+          }
+        />
+
+        {lines.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border px-4 py-8 text-center">
+            <p className="text-sm font-medium">No items yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Search your existing catalog to start this treatment plan.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y rounded-md border border-border">
+            {lines.map((line, index) => {
+              const quotedLine = quote?.lines[index];
+              return (
+                <div
+                  key={`${line.itemType}:${line.id}`}
+                  className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_5.5rem_6rem_auto] sm:items-center"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">{line.name}</p>
+                    <p className="text-xs capitalize text-muted-foreground">
+                      {line.itemType}
+                    </p>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`treatment-plan-quantity-${line.itemType}-${line.id}`}
+                      className="mb-1 block text-xs text-muted-foreground sm:sr-only"
+                    >
+                      Quantity
+                    </label>
+                    <Input
+                      id={`treatment-plan-quantity-${line.itemType}-${line.id}`}
+                      aria-label={`Quantity for ${line.name}`}
+                      inputMode="decimal"
+                      value={line.quantity}
+                      aria-invalid={!validQuantity(line.quantity)}
+                      onChange={(event) =>
+                        setLines((current) =>
+                          current.map((candidate, candidateIndex) =>
+                            candidateIndex === index
+                              ? { ...candidate, quantity: event.target.value }
+                              : candidate,
+                          ),
+                        )
+                      }
+                    />
+                  </div>
+                  <p className="text-right text-sm font-medium tabular-nums sm:text-left">
+                    {quotedLine
+                      ? formatCurrency(quotedLine.lineTotal, currency)
+                      : quoteQuery.isFetching
+                        ? "…"
+                        : "—"}
+                  </p>
+                  <div className="flex justify-end gap-1">
+                    {lines.length > 1 ? (
+                      <>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-9 w-9"
+                          aria-label={`Move ${line.name} up`}
+                          disabled={index === 0}
+                          onClick={() =>
+                            setLines((current) => {
+                              if (index === 0) return current;
+                              const next = [...current];
+                              [next[index - 1], next[index]] = [
+                                next[index]!,
+                                next[index - 1]!,
+                              ];
+                              return next;
+                            })
+                          }
+                        >
+                          <ArrowUp className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-9 w-9"
+                          aria-label={`Move ${line.name} down`}
+                          disabled={index === lines.length - 1}
+                          onClick={() =>
+                            setLines((current) => {
+                              if (index === current.length - 1) return current;
+                              const next = [...current];
+                              [next[index], next[index + 1]] = [
+                                next[index + 1]!,
+                                next[index]!,
+                              ];
+                              return next;
+                            })
+                          }
+                        >
+                          <ArrowDown className="h-4 w-4" />
+                        </Button>
+                      </>
+                    ) : null}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                      aria-label={`Remove ${line.name}`}
+                      onClick={() =>
+                        setLines((current) =>
+                          current.filter((_, row) => row !== index),
+                        )
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {lines.some((line) => !validQuantity(line.quantity)) ? (
+          <p role="alert" className="text-sm text-destructive">
+            Quantities must be greater than zero with up to three decimal
+            places.
+          </p>
+        ) : null}
+
+        {quoteQuery.error ? (
+          <p role="alert" className="text-sm text-destructive">
+            {quoteQuery.error.message}
+          </p>
+        ) : null}
+
+        <div className="flex flex-col gap-4 border-t border-border pt-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="grid grid-cols-3 gap-x-5 gap-y-1 text-sm">
+            <span className="text-muted-foreground">Subtotal</span>
+            <span className="text-muted-foreground">Tax</span>
+            <span className="font-medium">Total</span>
+            <span className="tabular-nums">
+              {quote ? formatCurrency(quote.subtotal, currency) : "—"}
+            </span>
+            <span className="tabular-nums">
+              {quote ? formatCurrency(quote.tax, currency) : "—"}
+            </span>
+            <span className="font-semibold tabular-nums">
+              {quote ? formatCurrency(quote.total, currency) : "—"}
+            </span>
+          </div>
+          <Button
+            type="button"
+            disabled={
+              saving ||
+              lines.length === 0 ||
+              !quantitiesValid ||
+              quoteQuery.isFetching ||
+              !quote ||
+              !hasChanges
+            }
+            onClick={save}
+          >
+            {saving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            {plan ? "Save new revision" : "Save treatment plan"}
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Saving this plan does not charge the client, adjust inventory, or
+          schedule care.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/lib/__tests__/patient-history-ui.test.ts
+++ b/apps/web/lib/__tests__/patient-history-ui.test.ts
@@ -38,9 +38,7 @@ describe("patient history search UI", () => {
     expect(recordsRouter).toContain(
       "The client sends this query over POST so clinical terms stay out of URLs",
     );
-    expect(providers).toContain(
-      'operation.path === "records.searchPatientHistory"',
-    );
+    expect(providers).toContain('"records.searchPatientHistory"');
     expect(providers).toContain('methodOverride: "POST"');
     expect(trpcRoute).toContain("allowMethodOverride: true");
     expect(component).not.toContain("useSearchParams");

--- a/apps/web/lib/__tests__/treatment-plan-composer-ui.test.ts
+++ b/apps/web/lib/__tests__/treatment-plan-composer-ui.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const composer = readFileSync(
+  "components/encounters/treatment-plan-composer.tsx",
+  "utf8",
+);
+const encounter = readFileSync(
+  "app/(dashboard)/encounters/[appointmentId]/page.tsx",
+  "utf8",
+);
+const providers = readFileSync("lib/providers.tsx", "utf8");
+
+describe("treatment-plan composer UI", () => {
+  it("stays inside the existing encounter and clinical-role boundary", () => {
+    expect(encounter).toContain("<TreatmentPlanComposer");
+    expect(encounter).toContain(
+      'import("@/components/encounters/treatment-plan-composer")',
+    );
+    expect(encounter).toContain("{ ssr: false, loading: () => null }");
+    expect(encounter).toContain("canRecordVitals(role) &&");
+    expect(encounter).toContain("appointment.patientId &&");
+    expect(encounter).toContain("appointment.clientId ?");
+  });
+
+  it("uses bounded server catalog search and server-authoritative quotes", () => {
+    expect(composer).toContain(
+      "trpc.visitTreatmentPlans.searchCatalog.useQuery",
+    );
+    expect(composer).toContain("useDeferredValue(search)");
+    expect(composer).toContain(
+      "maxLength={TEMPLATE_CATALOG_SEARCH_MAX_LENGTH}",
+    );
+    expect(composer).toContain("trpc.visitTreatmentPlans.quote.useQuery");
+    expect(composer).toContain("formatCurrency(quote.total, currency)");
+    expect(providers).toContain('"visitTreatmentPlans.searchCatalog"');
+    expect(providers).toContain('"visitTreatmentPlans.quote"');
+    expect(providers).toContain('methodOverride: "POST"');
+  });
+
+  it("supports a small keyboard and touch-friendly editing flow", () => {
+    expect(composer).toContain('event.key === "ArrowDown"');
+    expect(composer).toContain('event.key === "ArrowUp"');
+    expect(composer).toContain('event.key === "Enter"');
+    expect(composer).toContain('event.key === "Escape"');
+    expect(composer).toContain('role="listbox"');
+    expect(composer).toContain('role="option"');
+    expect(composer).toContain('role="combobox"');
+    expect(composer).toContain("Move ${line.name} up");
+    expect(composer).toContain("Remove ${line.name}");
+  });
+
+  it("keeps retries idempotent and refreshes stale revisions", () => {
+    expect(composer).toContain(
+      "useRef<{ fingerprint: string; id: string } | null>(null)",
+    );
+    expect(composer).toContain("operation.current?.fingerprint");
+    expect(composer).toContain("expectedRevisionNumber");
+    expect(composer).toContain("await planQuery.refetch()");
+  });
+
+  it("does not expose downstream execution actions", () => {
+    expect(composer).not.toMatch(
+      /charge client|send to client|reserve inventory/i,
+    );
+    expect(composer).not.toContain("trpc.billing");
+    expect(composer).not.toContain("trpc.inventory");
+    expect(composer).not.toContain("trpc.appointments.update");
+    expect(composer).toMatch(
+      /Saving this plan does not charge the client, adjust inventory, or\s+schedule care\./,
+    );
+  });
+});

--- a/apps/web/lib/providers.tsx
+++ b/apps/web/lib/providers.tsx
@@ -21,7 +21,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
       links: [
         splitLink({
           condition: (operation) =>
-            operation.path === "records.searchPatientHistory",
+            [
+              "records.searchPatientHistory",
+              "visitTreatmentPlans.searchCatalog",
+              "visitTreatmentPlans.quote",
+            ].includes(operation.path),
           true: httpBatchLink({
             url: "/api/trpc",
             transformer: superjson,

--- a/apps/web/server/__tests__/visit-treatment-plan-authoring.integration.test.ts
+++ b/apps/web/server/__tests__/visit-treatment-plan-authoring.integration.test.ts
@@ -251,6 +251,77 @@ describeWithAuthoringPostgres(
         const raceDbB = drizzle(raceSqlB, { schema });
         const caller = callerFor(appDb, practice.id, staff.id);
 
+        const composerContext = {
+          clientId: client.id,
+          patientId: patient.id,
+          appointmentId: appointment.id,
+        };
+        await expect(
+          caller.visitTreatmentPlans.getForAppointment(composerContext),
+        ).resolves.toBeNull();
+
+        const catalog = await caller.visitTreatmentPlans.searchCatalog({
+          search: "synthetic",
+        });
+        expect(catalog.map((item) => item.id)).toContain(medication.id);
+        expect(catalog.map((item) => item.id)).not.toContain(
+          otherMedication.id,
+        );
+        expect(catalog.length).toBeLessThanOrEqual(20);
+        await expect(
+          callerFor(
+            appDb,
+            practice.id,
+            staff.id,
+            "front_desk",
+          ).visitTreatmentPlans.searchCatalog({ search: "" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        const literalWildcard = await caller.visitTreatmentPlans.searchCatalog({
+          search: "%_\\",
+        });
+        expect(literalWildcard).toEqual([]);
+
+        const quote = await caller.visitTreatmentPlans.quote({
+          ...composerContext,
+          items: [
+            {
+              itemType: "service",
+              itemId: examService.id,
+              quantity: "1",
+            },
+            {
+              itemType: "product",
+              itemId: medication.id,
+              quantity: "2.5",
+            },
+          ],
+        });
+        expect(quote).toMatchObject({
+          currency: "USD",
+          subtotal: "80.85",
+          tax: "2.55",
+          total: "83.40",
+        });
+        expect(quote.lines).toHaveLength(2);
+        await expect(
+          caller.visitTreatmentPlans.quote({
+            ...composerContext,
+            items: [
+              {
+                itemType: "product",
+                itemId: otherMedication.id,
+                quantity: "1",
+              },
+            ],
+          }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+        const [plansAfterQuote] = await ownerDb
+          .select({ value: count() })
+          .from(schema.visitTreatmentPlans)
+          .where(eq(schema.visitTreatmentPlans.practiceId, practice.id));
+        expect(plansAfterQuote?.value).toBe(0);
+
         const createOperationId = randomUUID();
         const createInput = {
           operationId: createOperationId,
@@ -302,6 +373,18 @@ describeWithAuthoringPostgres(
           lineSubtotal: "30.85",
           taxAmount: "2.55",
         });
+        const reloaded =
+          await caller.visitTreatmentPlans.getForAppointment(composerContext);
+        expect(reloaded?.plan.id).toBe(created.plan.id);
+        expect(reloaded?.revision.id).toBe(created.revision.id);
+        expect(reloaded?.lines).toEqual(created.lines);
+
+        const otherClinicView = await callerFor(
+          appDb,
+          otherPractice.id,
+          otherStaff.id,
+        ).visitTreatmentPlans.getForAppointment(composerContext);
+        expect(otherClinicView).toBeNull();
 
         const replay = await caller.visitTreatmentPlans.create(createInput);
         expect(replay.plan.id).toBe(created.plan.id);

--- a/apps/web/server/__tests__/visit-treatment-plans-safety.test.ts
+++ b/apps/web/server/__tests__/visit-treatment-plans-safety.test.ts
@@ -22,6 +22,7 @@ const CLIENT_ID = "00000000-0000-0000-0000-000000000002";
 const PATIENT_ID = "00000000-0000-0000-0000-000000000003";
 const SERVICE_ID = "00000000-0000-0000-0000-000000000004";
 const OPERATION_ID = "00000000-0000-0000-0000-000000000005";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000006";
 
 function callerFor(role: string) {
   const tx = {
@@ -78,12 +79,41 @@ describe("visit treatment-plan authoring safety", () => {
     expect(db.transaction).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps composer reads and catalog pricing dark with the authoring flag off", async () => {
+    const { caller } = callerFor("admin");
+    const context = {
+      clientId: CLIENT_ID,
+      patientId: PATIENT_ID,
+      appointmentId: APPOINTMENT_ID,
+    };
+    await expect(caller.getForAppointment(context)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    await expect(
+      caller.searchCatalog({ search: "exam" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    await expect(
+      caller.quote({ ...context, items: validCreateInput.items }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
   it.each(["front_desk", "viewer"])(
     "rejects the %s role before authoring",
     async (role) => {
       vi.stubEnv("TREATMENT_PLAN_AUTHORING_ENABLED", "true");
       const { caller } = callerFor(role);
       await expect(caller.create(validCreateInput)).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+    },
+  );
+
+  it.each(["front_desk", "viewer"])(
+    "rejects the %s role before composer reads",
+    async (role) => {
+      vi.stubEnv("TREATMENT_PLAN_AUTHORING_ENABLED", "true");
+      const { caller } = callerFor(role);
+      await expect(caller.searchCatalog({ search: "" })).rejects.toMatchObject({
         code: "FORBIDDEN",
       });
     },
@@ -115,6 +145,11 @@ describe("visit treatment-plan authoring safety", () => {
     expect(ROUTER_SOURCE).toContain("eq(products.practiceId, practiceId)");
     expect(ROUTER_SOURCE).toContain("isNull(services.deletedAt)");
     expect(ROUTER_SOURCE).toContain("isNull(products.deletedAt)");
+    expect(ROUTER_SOURCE).toContain(
+      "eq(visitTreatmentPlans.appointmentId, input.appointmentId)",
+    );
+    expect(ROUTER_SOURCE).toContain("escapeTemplateCatalogLike(input.search)");
+    expect(ROUTER_SOURCE).toContain(".slice(0, TEMPLATE_CATALOG_RESULT_LIMIT)");
   });
 
   it("does not import or mutate downstream billing, inventory, queue, or consent surfaces", () => {

--- a/apps/web/server/routers/visit-treatment-plans.ts
+++ b/apps/web/server/routers/visit-treatment-plans.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { TRPCError } from "@trpc/server";
-import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -20,6 +20,11 @@ import type { Database } from "@openpims/db/client";
 import { centsToMoney, moneyToCents } from "@/lib/billing/invoice-balance";
 import { rowsFromExecute } from "@/lib/db/execute-rows";
 import { clinicalTextInput } from "@/lib/records/clinical-inputs";
+import {
+  escapeTemplateCatalogLike,
+  TEMPLATE_CATALOG_RESULT_LIMIT,
+  TEMPLATE_CATALOG_SEARCH_MAX_LENGTH,
+} from "@/lib/templates/catalog-search";
 import {
   canonicalQuantity,
   priceTreatmentPlanLines,
@@ -74,6 +79,20 @@ const revisePlanInput = z.object({
   expectedRevisionNumber: z.number().int().min(1),
   items: planItemsInput,
 });
+
+const planContextInput = z.object({
+  clientId: z.string().uuid(),
+  patientId: z.string().uuid(),
+  appointmentId: z.string().uuid(),
+});
+
+const quotePlanInput = planContextInput.extend({ items: planItemsInput });
+
+type TreatmentPlanContextInput = {
+  clientId: string;
+  patientId: string;
+  appointmentId?: string;
+};
 
 type TreatmentPlanTransaction = Parameters<
   Parameters<Database["transaction"]>[0]
@@ -265,7 +284,7 @@ function exactReplay(
 async function assertCreateContext(
   database: TreatmentPlanDatabase,
   practiceId: string,
-  input: z.infer<typeof createPlanInput>,
+  input: TreatmentPlanContextInput,
 ) {
   const [practice] = await database
     .select({
@@ -329,6 +348,65 @@ async function assertCreateContext(
   }
 
   return practice;
+}
+
+function catalogResultRank(
+  item: { name: string; code: string | null },
+  search: string,
+): number {
+  if (!search) return 4;
+  const query = search.toLowerCase();
+  const name = item.name.toLowerCase();
+  const code = item.code?.toLowerCase() ?? "";
+  if (name === query) return 0;
+  if (code === query) return 1;
+  if (name.startsWith(query)) return 2;
+  if (code.startsWith(query)) return 3;
+  return 4;
+}
+
+function compareCatalogResults(
+  left: { id: string; name: string; code: string | null },
+  right: { id: string; name: string; code: string | null },
+  search: string,
+): number {
+  const rank =
+    catalogResultRank(left, search) - catalogResultRank(right, search);
+  if (rank !== 0) return rank;
+  const name = left.name
+    .toLowerCase()
+    .localeCompare(right.name.toLowerCase(), "en");
+  if (name !== 0) return name;
+  const code = (left.code ?? "")
+    .toLowerCase()
+    .localeCompare((right.code ?? "").toLowerCase(), "en");
+  return code || left.id.localeCompare(right.id);
+}
+
+function serializeQuote(
+  lines: readonly PricedTreatmentPlanLine[],
+  taxRatePercent: string,
+  currency: string,
+) {
+  const priced = priceTreatmentPlanLines(lines, taxRatePercent);
+  return {
+    currency: currency.toUpperCase(),
+    subtotal: centsToMoney(priced.subtotalCents),
+    tax: centsToMoney(priced.taxCents),
+    total: centsToMoney(priced.totalCents),
+    lines: priced.lines.map((line) => ({
+      sortOrder: line.sortOrder,
+      description: line.description,
+      offeredQuantity: line.offeredQuantity,
+      unitPrice: centsToMoney(line.unitPriceCents),
+      lineSubtotal: centsToMoney(line.lineSubtotalCents),
+      taxAmount: centsToMoney(line.taxAmountCents),
+      lineTotal: centsToMoney(line.lineTotalCents),
+      itemType: line.itemType,
+      serviceId: line.serviceId,
+      productId: line.productId,
+    })),
+  };
 }
 
 async function resolveCatalogLines(
@@ -569,6 +647,119 @@ async function readPreview(
 }
 
 export const visitTreatmentPlansRouter = createRouter({
+  getForAppointment: protectedProcedure
+    .use(clinicalRole)
+    .input(planContextInput)
+    .query(async ({ ctx, input }) => {
+      assertAuthoringEnabled();
+      const [plan] = await ctx.db
+        .select({ id: visitTreatmentPlans.id })
+        .from(visitTreatmentPlans)
+        .where(
+          and(
+            eq(visitTreatmentPlans.practiceId, ctx.practiceId),
+            eq(visitTreatmentPlans.clientId, input.clientId),
+            eq(visitTreatmentPlans.patientId, input.patientId),
+            eq(visitTreatmentPlans.appointmentId, input.appointmentId),
+            eq(visitTreatmentPlans.status, "open"),
+            activePracticePredicate(ctx.practiceId),
+          ),
+        )
+        .orderBy(
+          desc(visitTreatmentPlans.createdAt),
+          desc(visitTreatmentPlans.id),
+        )
+        .limit(1);
+      return plan ? readPreview(ctx.db, ctx.practiceId, plan.id) : null;
+    }),
+
+  searchCatalog: protectedProcedure
+    .use(clinicalRole)
+    .input(
+      z.object({
+        search: z
+          .string()
+          .trim()
+          .max(TEMPLATE_CATALOG_SEARCH_MAX_LENGTH)
+          .default(""),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      assertAuthoringEnabled();
+      const escapedSearch = escapeTemplateCatalogLike(input.search);
+      const containsPattern = `%${escapedSearch}%`;
+      const serviceRows = await ctx.db
+        .select({
+          id: services.id,
+          name: services.name,
+          code: services.code,
+          category: services.category,
+          unitPrice: services.defaultPrice,
+        })
+        .from(services)
+        .where(
+          and(
+            eq(services.practiceId, ctx.practiceId),
+            isNull(services.deletedAt),
+            activePracticePredicate(ctx.practiceId),
+            input.search
+              ? or(
+                  sql`${services.name} ilike ${containsPattern} escape '\\'`,
+                  sql`${services.code} ilike ${containsPattern} escape '\\'`,
+                  sql`${services.category} ilike ${containsPattern} escape '\\'`,
+                )
+              : undefined,
+          ),
+        )
+        .orderBy(sql`lower(${services.name})`, asc(services.id))
+        .limit(TEMPLATE_CATALOG_RESULT_LIMIT);
+      const productRows = await ctx.db
+        .select({
+          id: products.id,
+          name: products.name,
+          code: products.sku,
+          category: products.category,
+          unitPrice: products.unitPrice,
+        })
+        .from(products)
+        .where(
+          and(
+            eq(products.practiceId, ctx.practiceId),
+            isNull(products.deletedAt),
+            activePracticePredicate(ctx.practiceId),
+            input.search
+              ? or(
+                  sql`${products.name} ilike ${containsPattern} escape '\\'`,
+                  sql`${products.sku} ilike ${containsPattern} escape '\\'`,
+                  sql`${products.category} ilike ${containsPattern} escape '\\'`,
+                )
+              : undefined,
+          ),
+        )
+        .orderBy(sql`lower(${products.name})`, asc(products.id))
+        .limit(TEMPLATE_CATALOG_RESULT_LIMIT);
+      return [
+        ...serviceRows.map((row) => ({ ...row, itemType: "service" as const })),
+        ...productRows.map((row) => ({ ...row, itemType: "product" as const })),
+      ]
+        .sort((left, right) => compareCatalogResults(left, right, input.search))
+        .slice(0, TEMPLATE_CATALOG_RESULT_LIMIT);
+    }),
+
+  quote: protectedProcedure
+    .use(clinicalRole)
+    .input(quotePlanInput)
+    .query(async ({ ctx, input }) => {
+      assertAuthoringEnabled();
+      const practice = await assertCreateContext(ctx.db, ctx.practiceId, input);
+      const lines = await resolveCatalogLines(
+        ctx.db,
+        ctx.practiceId,
+        input.items,
+      );
+      return serializeQuote(lines, practice.taxRatePercent, practice.currency);
+    }),
+
   preview: protectedProcedure
     .use(clinicalRole)
     .input(


### PR DESCRIPTION
## What changed
- add a compact, clinical-role-only treatment plan composer inside active encounters
- use one bounded catalog search and server-authoritative quoting
- save immutable revisions with stable retry operation IDs
- keep the feature dark behind `TREATMENT_PLAN_AUTHORING_ENABLED`
- keep treatment plans independent from charges, inventory, scheduling, and invoices
- send catalog/quote requests via POST so clinical search terms and quantities do not appear in URLs

## Safety and verification
- full web suite: 4,124 passed, 13 skipped opt-in integrations
- production build passed
- focused type and unit checks passed
- disposable real PostgreSQL/RLS integration passed
- browser-tested save, reload, revise, responsive layout, and zero console errors
- SQL-verified no invoice creation, no appointment-state change, and no inventory mutation

## Rollout
This merges dark. The feature remains unavailable until explicitly enabled for a controlled clinic rollout.