### PR TITLE
Add vaccination certificates and care-reminder controls

### DIFF
--- a/apps/web/app/(dashboard)/care-reminders/page.tsx
+++ b/apps/web/app/(dashboard)/care-reminders/page.tsx
@@ -25,12 +25,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/common/empty-state";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  COMMUNICATION_SUBJECT_MAX_LENGTH,
-  communicationContentMaxLength,
-  isCommunicationContentValid,
-  isCommunicationSubjectValid,
-} from "@/lib/communications/policy";
 
 type ReminderStatusFilter = "open" | "completed" | "dismissed";
 type ReminderDueFilter = "all" | "overdue" | "upcoming";
@@ -38,7 +32,7 @@ type OutreachChannel = "email" | "sms";
 const MAX_DISMISS_SELECTION = 100;
 
 type OutreachTarget = {
-  clientId: string;
+  reminderId: string;
   clientName: string;
   clientEmail: string | null;
   clientPhone: string | null;
@@ -86,8 +80,6 @@ export default function CareRemindersPage() {
   );
   const [outreachChannel, setOutreachChannel] =
     useState<OutreachChannel>("email");
-  const [outreachSubject, setOutreachSubject] = useState("");
-  const [outreachContent, setOutreachContent] = useState("");
   const outreachRequestId = useRef<string | null>(null);
   const query = trpc.careReminders.list.useQuery({ status, due, limit: 1000 });
   const patientSearch = trpc.patients.search.useQuery(
@@ -120,15 +112,21 @@ export default function CareRemindersPage() {
     },
     onError: (error) => toast.error(error.message),
   });
-  const sendOutreach = trpc.communications.create.useMutation({
-    onSuccess: () => {
+  const sendOutreach = trpc.careReminders.sendOutreach.useMutation({
+    onSuccess: (_, variables) => {
       outreachRequestId.current = null;
       setOutreachTarget(null);
-      toast.success("Client message sent and recorded in the inbox");
+      toast.success(
+        `Care reminder sent by ${variables.channel === "sms" ? "text" : "email"} and recorded in the inbox`,
+      );
       utils.communications.listConversations.invalidate();
     },
     onError: (error) => {
-      if (error.data?.code === "BAD_REQUEST") {
+      if (
+        error.data?.code === "BAD_REQUEST" ||
+        error.data?.code === "PRECONDITION_FAILED" ||
+        error.data?.code === "NOT_FOUND"
+      ) {
         outreachRequestId.current = null;
       }
       toast.error(error.message);
@@ -180,13 +178,20 @@ export default function CareRemindersPage() {
 
   const { counts, items, today } = query.data;
   const selectedItems = items.filter((item) => selectedIds.has(item.id));
-  const outreachContentMax = communicationContentMaxLength(outreachChannel);
   const canSendOutreach =
     Boolean(outreachTarget) &&
-    isCommunicationContentValid(outreachContent, outreachChannel) &&
-    (outreachChannel !== "email" ||
-      isCommunicationSubjectValid(outreachSubject)) &&
+    (outreachChannel === "email"
+      ? Boolean(outreachTarget?.clientEmail)
+      : Boolean(
+          outreachTarget?.clientPhone && outreachTarget.clientSmsConsent,
+        )) &&
     !sendOutreach.isPending;
+  const outreachSubject = outreachTarget
+    ? `Care Reminder for ${outreachTarget.patientName}`
+    : "";
+  const outreachContent = outreachTarget
+    ? `Hello ${outreachTarget.clientName},\n\nThis is a reminder from our veterinary team about ${outreachTarget.patientName}: ${outreachTarget.title}. The reminder date is ${displayDate(outreachTarget.dueDate)}. Please contact us if you have questions or would like to schedule.`
+    : "";
 
   function openOutreach(item: (typeof items)[number]) {
     const channel: OutreachChannel = item.clientEmail
@@ -195,7 +200,7 @@ export default function CareRemindersPage() {
         ? "sms"
         : "email";
     setOutreachTarget({
-      clientId: item.clientId,
+      reminderId: item.id,
       clientName: item.clientName,
       clientEmail: item.clientEmail,
       clientPhone: item.clientPhone,
@@ -205,10 +210,6 @@ export default function CareRemindersPage() {
       dueDate: item.dueDate,
     });
     setOutreachChannel(channel);
-    setOutreachSubject(`Care reminder for ${item.patientName}`);
-    setOutreachContent(
-      `Hello ${item.clientName},\n\nThis is a reminder from our veterinary team about ${item.patientName}: ${item.title}. The reminder date is ${displayDate(item.dueDate)}. Please contact us if you have questions or would like to schedule.`,
-    );
     outreachRequestId.current = null;
   }
 
@@ -230,12 +231,12 @@ export default function CareRemindersPage() {
           <Button variant="outline" asChild>
             <Link href="/schedule">Appointment reminders</Link>
           </Button>
-        {manageable ? (
-          <Button className="gap-2" onClick={() => setShowCreate(true)}>
-            <Plus className="h-4 w-4" /> Add reminder
-          </Button>
-        ) : null}
-      </div>
+          {manageable ? (
+            <Button className="gap-2" onClick={() => setShowCreate(true)}>
+              <Plus className="h-4 w-4" /> Add reminder
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       {showCreate ? (
@@ -527,12 +528,8 @@ export default function CareRemindersPage() {
                 if (!canSendOutreach) return;
                 outreachRequestId.current ??= crypto.randomUUID();
                 sendOutreach.mutate({
-                  clientId: outreachTarget.clientId,
+                  reminderId: outreachTarget.reminderId,
                   channel: outreachChannel,
-                  direction: "outbound",
-                  subject:
-                    outreachChannel === "email" ? outreachSubject : undefined,
-                  content: outreachContent,
                   requestId: outreachRequestId.current,
                 });
               }}
@@ -578,34 +575,23 @@ export default function CareRemindersPage() {
                 </p>
               ) : null}
               {outreachChannel === "email" ? (
-                <label className="block space-y-2 text-sm font-medium">
-                  Subject
-                  <Input
-                    value={outreachSubject}
-                    maxLength={COMMUNICATION_SUBJECT_MAX_LENGTH}
-                    onChange={(event) => {
-                      outreachRequestId.current = null;
-                      setOutreachSubject(event.target.value);
-                    }}
-                  />
-                </label>
+                <div className="space-y-2 text-sm font-medium">
+                  <p>Subject</p>
+                  <div className="rounded-md border border-border bg-muted/30 px-3 py-2 font-normal">
+                    {outreachSubject}
+                  </div>
+                </div>
               ) : null}
-              <label className="block space-y-2 text-sm font-medium">
-                Message
-                <Textarea
-                  value={outreachContent}
-                  maxLength={outreachContentMax}
-                  onChange={(event) => {
-                    outreachRequestId.current = null;
-                    setOutreachContent(event.target.value);
-                  }}
-                  className="min-h-36"
-                  required
-                />
-                <span className="block text-right text-xs font-normal text-muted-foreground">
-                  {outreachContent.length}/{outreachContentMax}
-                </span>
-              </label>
+              <div className="space-y-2 text-sm font-medium">
+                <p>Template preview</p>
+                <div className="min-h-36 whitespace-pre-wrap rounded-md border border-border bg-muted/30 px-3 py-2 font-normal">
+                  {outreachContent}
+                </div>
+                <p className="text-xs font-normal text-muted-foreground">
+                  Reminder wording is generated server-side and cannot be
+                  changed into free-form external email.
+                </p>
+              </div>
               <div className="flex justify-end">
                 <Button type="submit" disabled={!canSendOutreach}>
                   {sendOutreach.isPending ? (
@@ -881,27 +867,27 @@ export default function CareRemindersPage() {
                                   Restore
                                 </Button>
                               ) : (
-                            <Button
-                              size="sm"
-                              variant={
+                                <Button
+                                  size="sm"
+                                  variant={
                                     item.status === "open"
                                       ? "default"
                                       : "outline"
-                              }
-                              disabled={update.isPending}
-                              onClick={() =>
-                                update.mutate({
-                                  id: item.id,
-                                  completed: item.status === "open",
-                                  expectedUpdatedAt:
-                                    item.updatedAt.toISOString(),
-                                })
-                              }
-                            >
+                                  }
+                                  disabled={update.isPending}
+                                  onClick={() =>
+                                    update.mutate({
+                                      id: item.id,
+                                      completed: item.status === "open",
+                                      expectedUpdatedAt:
+                                        item.updatedAt.toISOString(),
+                                    })
+                                  }
+                                >
                                   {item.status === "open"
                                     ? "Complete"
                                     : "Reopen"}
-                            </Button>
+                                </Button>
                               )}
                               {item.status === "open" &&
                               item.patientStatus === "active" ? (

--- a/apps/web/app/(dashboard)/care-reminders/page.tsx
+++ b/apps/web/app/(dashboard)/care-reminders/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
@@ -9,7 +9,12 @@ import {
   CheckCircle2,
   Clock3,
   Loader2,
+  Mail,
+  MessageSquare,
   Plus,
+  RotateCcw,
+  Send,
+  Trash2,
   X,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -20,9 +25,28 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/common/empty-state";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  COMMUNICATION_SUBJECT_MAX_LENGTH,
+  communicationContentMaxLength,
+  isCommunicationContentValid,
+  isCommunicationSubjectValid,
+} from "@/lib/communications/policy";
 
-type ReminderStatusFilter = "open" | "completed";
+type ReminderStatusFilter = "open" | "completed" | "dismissed";
 type ReminderDueFilter = "all" | "overdue" | "upcoming";
+type OutreachChannel = "email" | "sms";
+const MAX_DISMISS_SELECTION = 100;
+
+type OutreachTarget = {
+  clientId: string;
+  clientName: string;
+  clientEmail: string | null;
+  clientPhone: string | null;
+  clientSmsConsent: boolean;
+  patientName: string;
+  title: string;
+  dueDate: string;
+};
 
 function canManage(role?: string | null): boolean {
   return ["admin", "veterinarian", "technician", "front_desk"].includes(
@@ -54,6 +78,17 @@ export default function CareRemindersPage() {
   const [title, setTitle] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [notes, setNotes] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [showDismiss, setShowDismiss] = useState(false);
+  const [dismissalReason, setDismissalReason] = useState("");
+  const [outreachTarget, setOutreachTarget] = useState<OutreachTarget | null>(
+    null,
+  );
+  const [outreachChannel, setOutreachChannel] =
+    useState<OutreachChannel>("email");
+  const [outreachSubject, setOutreachSubject] = useState("");
+  const [outreachContent, setOutreachContent] = useState("");
+  const outreachRequestId = useRef<string | null>(null);
   const query = trpc.careReminders.list.useQuery({ status, due, limit: 1000 });
   const patientSearch = trpc.patients.search.useQuery(
     { query: patientQuery, status: "active" },
@@ -71,6 +106,34 @@ export default function CareRemindersPage() {
     },
     onError: (error) => toast.error(error.message),
   });
+  const dismiss = trpc.careReminders.setDismissed.useMutation({
+    onSuccess: async (_, variables) => {
+      setSelectedIds(new Set());
+      setShowDismiss(false);
+      setDismissalReason("");
+      await utils.careReminders.list.invalidate();
+      toast.success(
+        variables.dismissed
+          ? `${variables.items.length} invalid reminder${variables.items.length === 1 ? "" : "s"} dismissed`
+          : "Reminder restored",
+      );
+    },
+    onError: (error) => toast.error(error.message),
+  });
+  const sendOutreach = trpc.communications.create.useMutation({
+    onSuccess: () => {
+      outreachRequestId.current = null;
+      setOutreachTarget(null);
+      toast.success("Client message sent and recorded in the inbox");
+      utils.communications.listConversations.invalidate();
+    },
+    onError: (error) => {
+      if (error.data?.code === "BAD_REQUEST") {
+        outreachRequestId.current = null;
+      }
+      toast.error(error.message);
+    },
+  });
   const manageable = canManage(session?.user?.role);
   const create = trpc.careReminders.create.useMutation({
     onSuccess: async () => {
@@ -87,6 +150,12 @@ export default function CareRemindersPage() {
     },
     onError: (error) => toast.error(error.message),
   });
+
+  useEffect(() => {
+    setSelectedIds(new Set());
+    setShowDismiss(false);
+    setDismissalReason("");
+  }, [status, due]);
 
   if (query.isLoading) {
     return (
@@ -110,6 +179,39 @@ export default function CareRemindersPage() {
   }
 
   const { counts, items, today } = query.data;
+  const selectedItems = items.filter((item) => selectedIds.has(item.id));
+  const outreachContentMax = communicationContentMaxLength(outreachChannel);
+  const canSendOutreach =
+    Boolean(outreachTarget) &&
+    isCommunicationContentValid(outreachContent, outreachChannel) &&
+    (outreachChannel !== "email" ||
+      isCommunicationSubjectValid(outreachSubject)) &&
+    !sendOutreach.isPending;
+
+  function openOutreach(item: (typeof items)[number]) {
+    const channel: OutreachChannel = item.clientEmail
+      ? "email"
+      : item.clientSmsConsent && item.clientPhone
+        ? "sms"
+        : "email";
+    setOutreachTarget({
+      clientId: item.clientId,
+      clientName: item.clientName,
+      clientEmail: item.clientEmail,
+      clientPhone: item.clientPhone,
+      clientSmsConsent: item.clientSmsConsent,
+      patientName: item.patientName,
+      title: item.title,
+      dueDate: item.dueDate,
+    });
+    setOutreachChannel(channel);
+    setOutreachSubject(`Care reminder for ${item.patientName}`);
+    setOutreachContent(
+      `Hello ${item.clientName},\n\nThis is a reminder from our veterinary team about ${item.patientName}: ${item.title}. The reminder date is ${displayDate(item.dueDate)}. Please contact us if you have questions or would like to schedule.`,
+    );
+    outreachRequestId.current = null;
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -121,11 +223,19 @@ export default function CareRemindersPage() {
             deliberate action with its own consent checks.
           </p>
         </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" asChild>
+            <Link href="/recalls">Vaccination recalls</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/schedule">Appointment reminders</Link>
+          </Button>
         {manageable ? (
           <Button className="gap-2" onClick={() => setShowCreate(true)}>
             <Plus className="h-4 w-4" /> Add reminder
           </Button>
         ) : null}
+      </div>
       </div>
 
       {showCreate ? (
@@ -312,10 +422,210 @@ export default function CareRemindersPage() {
         </Card>
       ) : null}
 
-      <div className="grid gap-4 sm:grid-cols-3">
+      {showDismiss && selectedItems.length > 0 ? (
+        <Card>
+          <CardHeader className="flex-row items-start justify-between space-y-0">
+            <div>
+              <CardTitle>Dismiss invalid reminders</CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {selectedItems.length} selected. They will leave the active
+                queue but remain in an auditable dismissed view.
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Close dismissal form"
+              onClick={() => setShowDismiss(false)}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <form
+              className="space-y-3"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (dismissalReason.trim().length < 3) return;
+                dismiss.mutate({
+                  dismissed: true,
+                  reason: dismissalReason,
+                  items: selectedItems.map((item) => ({
+                    id: item.id,
+                    expectedUpdatedAt: item.updatedAt.toISOString(),
+                  })),
+                });
+              }}
+            >
+              <label className="block space-y-2 text-sm font-medium">
+                Why are these reminders invalid?
+                <Textarea
+                  value={dismissalReason}
+                  onChange={(event) => setDismissalReason(event.target.value)}
+                  minLength={3}
+                  maxLength={500}
+                  required
+                  placeholder="For example: duplicate reminders from an import"
+                />
+              </label>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setShowDismiss(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  disabled={
+                    dismissalReason.trim().length < 3 || dismiss.isPending
+                  }
+                >
+                  {dismiss.isPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="mr-2 h-4 w-4" />
+                  )}
+                  Dismiss {selectedItems.length}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {outreachTarget ? (
+        <Card>
+          <CardHeader className="flex-row items-start justify-between space-y-0">
+            <div>
+              <CardTitle>Contact {outreachTarget.clientName}</CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Sending is deliberate and separate from completing the internal
+                reminder. Email suppression, SMS consent, sender, and quiet-hour
+                protections are applied before delivery.
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Close outreach composer"
+              onClick={() => {
+                outreachRequestId.current = null;
+                setOutreachTarget(null);
+              }}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <form
+              className="space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (!canSendOutreach) return;
+                outreachRequestId.current ??= crypto.randomUUID();
+                sendOutreach.mutate({
+                  clientId: outreachTarget.clientId,
+                  channel: outreachChannel,
+                  direction: "outbound",
+                  subject:
+                    outreachChannel === "email" ? outreachSubject : undefined,
+                  content: outreachContent,
+                  requestId: outreachRequestId.current,
+                });
+              }}
+            >
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={outreachChannel === "email" ? "default" : "outline"}
+                  disabled={!outreachTarget.clientEmail}
+                  onClick={() => {
+                    outreachRequestId.current = null;
+                    setOutreachChannel("email");
+                  }}
+                >
+                  <Mail className="mr-2 h-4 w-4" />
+                  Email
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={outreachChannel === "sms" ? "default" : "outline"}
+                  disabled={
+                    !outreachTarget.clientPhone ||
+                    !outreachTarget.clientSmsConsent
+                  }
+                  onClick={() => {
+                    outreachRequestId.current = null;
+                    setOutreachChannel("sms");
+                  }}
+                >
+                  <MessageSquare className="mr-2 h-4 w-4" />
+                  Text
+                </Button>
+              </div>
+              {!outreachTarget.clientEmail &&
+              (!outreachTarget.clientPhone ||
+                !outreachTarget.clientSmsConsent) ? (
+                <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                  This client has no deliverable email and no SMS-consented
+                  phone number. Update the client record before sending
+                  outreach.
+                </p>
+              ) : null}
+              {outreachChannel === "email" ? (
+                <label className="block space-y-2 text-sm font-medium">
+                  Subject
+                  <Input
+                    value={outreachSubject}
+                    maxLength={COMMUNICATION_SUBJECT_MAX_LENGTH}
+                    onChange={(event) => {
+                      outreachRequestId.current = null;
+                      setOutreachSubject(event.target.value);
+                    }}
+                  />
+                </label>
+              ) : null}
+              <label className="block space-y-2 text-sm font-medium">
+                Message
+                <Textarea
+                  value={outreachContent}
+                  maxLength={outreachContentMax}
+                  onChange={(event) => {
+                    outreachRequestId.current = null;
+                    setOutreachContent(event.target.value);
+                  }}
+                  className="min-h-36"
+                  required
+                />
+                <span className="block text-right text-xs font-normal text-muted-foreground">
+                  {outreachContent.length}/{outreachContentMax}
+                </span>
+              </label>
+              <div className="flex justify-end">
+                <Button type="submit" disabled={!canSendOutreach}>
+                  {sendOutreach.isPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Send className="mr-2 h-4 w-4" />
+                  )}
+                  Send {outreachChannel === "sms" ? "text" : "email"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Metric label="Open" value={counts.open} icon={BellRing} />
         <Metric label="Due or overdue" value={counts.overdue} icon={Clock3} />
         <Metric label="Upcoming" value={counts.upcoming} icon={CheckCircle2} />
+        <Metric label="Dismissed" value={counts.dismissed} icon={Trash2} />
       </div>
 
       <Card>
@@ -345,6 +655,16 @@ export default function CareRemindersPage() {
             >
               Completed
             </Button>
+            <Button
+              size="sm"
+              variant={status === "dismissed" ? "default" : "outline"}
+              onClick={() => {
+                setStatus("dismissed");
+                setDue("all");
+              }}
+            >
+              Dismissed
+            </Button>
             {status === "open" ? (
               <>
                 {(["all", "overdue", "upcoming"] as const).map((value) => (
@@ -363,18 +683,46 @@ export default function CareRemindersPage() {
           </div>
         </CardHeader>
         <CardContent>
+          {status === "open" && manageable && items.length > 0 ? (
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/30 p-3">
+              <span className="text-sm text-muted-foreground">
+                {selectedIds.size === 0
+                  ? "Select up to 100 invalid reminders to dismiss them safely."
+                  : `${selectedIds.size} reminder${selectedIds.size === 1 ? "" : "s"} selected`}
+              </span>
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={selectedIds.size === 0}
+                onClick={() => setShowDismiss(true)}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Dismiss selected
+              </Button>
+            </div>
+          ) : null}
           {items.length === 0 ? (
             <EmptyState
-              icon={status === "open" ? BellRing : CheckCircle2}
+              icon={
+                status === "open"
+                  ? BellRing
+                  : status === "completed"
+                    ? CheckCircle2
+                    : Trash2
+              }
               title={
                 status === "open"
                   ? "No reminders in this view"
-                  : "No completed reminders"
+                  : status === "completed"
+                    ? "No completed reminders"
+                    : "No dismissed reminders"
               }
               description={
                 status === "open"
                   ? "Try another due-date filter, or add a reminder from a patient record."
-                  : "Completed care reminders will remain available here for review."
+                  : status === "completed"
+                    ? "Completed care reminders will remain available here for review."
+                    : "Invalid reminders dismissed from the active queue will remain available here for audit and restoration."
               }
             />
           ) : (
@@ -382,6 +730,31 @@ export default function CareRemindersPage() {
               <table className="w-full min-w-[800px] text-sm">
                 <thead>
                   <tr className="border-b border-border text-left text-muted-foreground">
+                    {status === "open" && manageable ? (
+                      <th className="w-10 py-3 pr-3 font-medium">
+                        <input
+                          type="checkbox"
+                          aria-label="Select all reminders"
+                          checked={
+                            items.length > 0 &&
+                            selectedIds.size ===
+                              Math.min(items.length, MAX_DISMISS_SELECTION)
+                          }
+                          onChange={(event) =>
+                            setSelectedIds(
+                              event.target.checked
+                                ? new Set(
+                                    items
+                                      .slice(0, MAX_DISMISS_SELECTION)
+                                      .map((item) => item.id),
+                                  )
+                                : new Set(),
+                            )
+                          }
+                          className="h-4 w-4 rounded border-border"
+                        />
+                      </th>
+                    ) : null}
                     <th className="py-3 pr-4 font-medium">Due</th>
                     <th className="py-3 pr-4 font-medium">Patient / client</th>
                     <th className="py-3 pr-4 font-medium">Reminder</th>
@@ -398,6 +771,26 @@ export default function CareRemindersPage() {
                         key={item.id}
                         className="border-b border-border align-top last:border-0"
                       >
+                        {status === "open" && manageable ? (
+                          <td className="py-4 pr-3">
+                            <input
+                              type="checkbox"
+                              aria-label={`Select ${item.title} for ${item.patientName}`}
+                              checked={selectedIds.has(item.id)}
+                              disabled={
+                                !selectedIds.has(item.id) &&
+                                selectedIds.size >= MAX_DISMISS_SELECTION
+                              }
+                              onChange={(event) => {
+                                const next = new Set(selectedIds);
+                                if (event.target.checked) next.add(item.id);
+                                else next.delete(item.id);
+                                setSelectedIds(next);
+                              }}
+                              className="h-4 w-4 rounded border-border"
+                            />
+                          </td>
+                        ) : null}
                         <td className="py-4 pr-4">
                           <span
                             className={
@@ -440,6 +833,21 @@ export default function CareRemindersPage() {
                               {item.notes}
                             </p>
                           ) : null}
+                          {item.status === "dismissed" &&
+                          item.dismissalReason ? (
+                            <div className="mt-2 rounded-md border border-border bg-muted/40 p-2 text-xs text-muted-foreground">
+                              <span className="font-medium text-foreground">
+                                Dismissed:
+                              </span>{" "}
+                              {item.dismissalReason}
+                              <span className="mt-1 block">
+                                {item.dismissedByName ?? "Unknown staff member"}
+                                {item.dismissedAt
+                                  ? ` • ${item.dismissedAt.toLocaleString()}`
+                                  : ""}
+                              </span>
+                            </div>
+                          ) : null}
                         </td>
                         <td className="py-4 pr-4">
                           <Badge
@@ -450,10 +858,35 @@ export default function CareRemindersPage() {
                         </td>
                         <td className="py-4 text-right">
                           {manageable ? (
+                            <div className="flex flex-col items-end gap-2">
+                              {item.status === "dismissed" ? (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  disabled={dismiss.isPending}
+                                  onClick={() =>
+                                    dismiss.mutate({
+                                      dismissed: false,
+                                      items: [
+                                        {
+                                          id: item.id,
+                                          expectedUpdatedAt:
+                                            item.updatedAt.toISOString(),
+                                        },
+                                      ],
+                                    })
+                                  }
+                                >
+                                  <RotateCcw className="mr-2 h-4 w-4" />
+                                  Restore
+                                </Button>
+                              ) : (
                             <Button
                               size="sm"
                               variant={
-                                item.status === "open" ? "default" : "outline"
+                                    item.status === "open"
+                                      ? "default"
+                                      : "outline"
                               }
                               disabled={update.isPending}
                               onClick={() =>
@@ -465,8 +898,23 @@ export default function CareRemindersPage() {
                                 })
                               }
                             >
-                              {item.status === "open" ? "Complete" : "Reopen"}
+                                  {item.status === "open"
+                                    ? "Complete"
+                                    : "Reopen"}
                             </Button>
+                              )}
+                              {item.status === "open" &&
+                              item.patientStatus === "active" ? (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => openOutreach(item)}
+                                >
+                                  <Send className="mr-2 h-4 w-4" />
+                                  Contact client
+                                </Button>
+                              ) : null}
+                            </div>
                           ) : (
                             <span className="text-xs text-muted-foreground">
                               Read only

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -1673,7 +1673,6 @@ function VaccinationsTab({
         patientId,
         kind,
         vaccinationRecordId,
-        requestId: crypto.randomUUID(),
       });
       if (!certificate.ready) {
         toast.error(
@@ -1971,58 +1970,58 @@ function VaccinationsTab({
         </form>
       ) : null}
 
-    <div className="overflow-x-auto rounded-lg border border-border">
+      <div className="overflow-x-auto rounded-lg border border-border">
         <table className="w-full min-w-[960px] text-sm">
-        <thead>
-          <tr className="border-b border-border bg-muted/50">
-            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-              Vaccine Name
-            </th>
-            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-              Date Given
-            </th>
-            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-              Next Due
-            </th>
-            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Vaccine Name
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Date Given
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Next Due
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
                 Product / Lot
-            </th>
-            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-              Administered By
-            </th>
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Administered By
+              </th>
               <th className="px-4 py-3 text-left font-medium text-muted-foreground">
                 Certificate
               </th>
-            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-              Status
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {vaccinations.map((vax) => (
-            <tr
-              key={vax.id}
-              className={cn(
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {vaccinations.map((vax) => (
+              <tr
+                key={vax.id}
+                className={cn(
                   "border-b border-border align-top last:border-0",
-                vax.correctionId && "bg-destructive/5 text-muted-foreground",
-              )}
-            >
-              <td className="px-4 py-3 font-medium">{vax.vaccineName}</td>
-              <td className="px-4 py-3">
-                {formatClinicalDate(vax.administeredAt, timeZone, "\u2014")}
-              </td>
-              <td className="px-4 py-3">
-                {formatClinicalDate(vax.nextDueDate, timeZone, "\u2014")}
-              </td>
+                  vax.correctionId && "bg-destructive/5 text-muted-foreground",
+                )}
+              >
+                <td className="px-4 py-3 font-medium">{vax.vaccineName}</td>
+                <td className="px-4 py-3">
+                  {formatClinicalDate(vax.administeredAt, timeZone, "\u2014")}
+                </td>
+                <td className="px-4 py-3">
+                  {formatClinicalDate(vax.nextDueDate, timeZone, "\u2014")}
+                </td>
                 <td className="px-4 py-3">
                   <span>{vax.productName ?? "—"}</span>
                   <span className="block text-xs text-muted-foreground">
                     Lot {vax.lotNumber ?? "—"}
                   </span>
                 </td>
-              <td className="px-4 py-3 text-muted-foreground">
-                {vax.administeredByName ?? "\u2014"}
-              </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {vax.administeredByName ?? "\u2014"}
+                </td>
                 <td className="px-4 py-3">
                   {!vax.correctionId &&
                   canPrepareCertificate &&
@@ -2066,48 +2065,48 @@ function VaccinationsTab({
                     </Button>
                   ) : null}
                 </td>
-              <td className="px-4 py-3">
-                {vax.correctionId ? (
-                  <span className="inline-flex items-center rounded-full bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive">
-                    Entered in error
-                  </span>
-                ) : (
-                  <span className="text-xs text-muted-foreground">
-                    Recorded
-                  </span>
-                )}
-                <ClinicalCorrectionControl
-                  correction={
+                <td className="px-4 py-3">
+                  {vax.correctionId ? (
+                    <span className="inline-flex items-center rounded-full bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive">
+                      Entered in error
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      Recorded
+                    </span>
+                  )}
+                  <ClinicalCorrectionControl
+                    correction={
                       vax.correctionId &&
                       vax.correctionReason &&
                       vax.correctedAt
-                      ? {
-                          id: vax.correctionId,
-                          reason: vax.correctionReason,
-                          correctedAt: vax.correctedAt,
-                          correctedByName: vax.correctedByName,
-                        }
-                      : null
-                  }
-                  canCorrect={canCorrectClinicalRecords}
-                  isPending={
-                    correctVaccination.isPending &&
-                    correctVaccination.variables?.recordId === vax.id
-                  }
-                  onCorrect={(reason) =>
-                    correctVaccination.mutateAsync({
-                      patientId,
-                      recordId: vax.id,
-                      reason,
-                    })
-                  }
-                />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+                        ? {
+                            id: vax.correctionId,
+                            reason: vax.correctionReason,
+                            correctedAt: vax.correctedAt,
+                            correctedByName: vax.correctedByName,
+                          }
+                        : null
+                    }
+                    canCorrect={canCorrectClinicalRecords}
+                    isPending={
+                      correctVaccination.isPending &&
+                      correctVaccination.variables?.recordId === vax.id
+                    }
+                    onCorrect={(reason) =>
+                      correctVaccination.mutateAsync({
+                        patientId,
+                        recordId: vax.id,
+                        reason,
+                      })
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }
@@ -2165,219 +2164,219 @@ function MedicalRecordsTab({
           />
         ) : (
           notes.map((note) => {
-        const hasOtherCurrentAppointmentSoap = Boolean(
-          note.appointmentId &&
-          notes.some(
-            (candidate) =>
-              candidate.id !== note.id &&
-              candidate.appointmentId === note.appointmentId &&
-              candidate.status === "finalized" &&
-              !candidate.correctionId,
-          ),
-        );
-        const hasAppointmentSoapDraft = Boolean(
-          note.appointmentId &&
-          notes.some(
-            (candidate) =>
-              candidate.id !== note.id &&
-              candidate.appointmentId === note.appointmentId &&
-              candidate.status === "draft",
-          ),
-        );
-        return (
-          <div
-            key={note.id}
-            id={`soap-note-${note.id}`}
-            className={cn(
-              "rounded-lg border border-border bg-card p-4",
-              note.correctionId && "border-destructive/40 bg-destructive/5",
-            )}
-          >
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-medium">
-                  {note.createdAt
+            const hasOtherCurrentAppointmentSoap = Boolean(
+              note.appointmentId &&
+              notes.some(
+                (candidate) =>
+                  candidate.id !== note.id &&
+                  candidate.appointmentId === note.appointmentId &&
+                  candidate.status === "finalized" &&
+                  !candidate.correctionId,
+              ),
+            );
+            const hasAppointmentSoapDraft = Boolean(
+              note.appointmentId &&
+              notes.some(
+                (candidate) =>
+                  candidate.id !== note.id &&
+                  candidate.appointmentId === note.appointmentId &&
+                  candidate.status === "draft",
+              ),
+            );
+            return (
+              <div
+                key={note.id}
+                id={`soap-note-${note.id}`}
+                className={cn(
+                  "rounded-lg border border-border bg-card p-4",
+                  note.correctionId && "border-destructive/40 bg-destructive/5",
+                )}
+              >
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium">
+                      {note.createdAt
                         ? formatClinicalDate(
                             note.createdAt,
                             timeZone,
                             "Unknown",
                           )
-                    : "Unknown"}
-                </p>
-                {note.imported ? (
-                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
-                    Imported
-                  </span>
-                ) : null}
-                <span
-                  className={cn(
-                    "rounded-full px-2 py-0.5 text-[11px] font-medium",
-                    note.status === "draft"
-                      ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
-                      : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
-                  )}
-                >
-                  {note.status === "draft" ? "Draft" : "Finalized"}
-                </span>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {note.imported
-                  ? note.authorName
-                    ? `Imported by ${note.authorName}`
-                    : "Imported record"
-                  : (note.authorName ?? "Unknown author")}
-              </p>
-            </div>
-            {note.status === "finalized" ? (
-              <p className="mb-3 text-xs text-muted-foreground">
-                Finalized by {note.finalizerName ?? "Unknown clinician"}
-                {note.finalizedAt
-                  ? ` on ${formatClinicalDateTime(note.finalizedAt, timeZone)}`
-                  : ""}
-              </p>
-            ) : note.appointmentId && canCorrectClinicalRecords ? (
-              <a
-                href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
-                className="mb-3 inline-flex text-xs font-medium text-primary hover:underline"
-              >
-                Resume draft
-              </a>
-            ) : null}
-            {note.replacesSoapNoteId ? (
-              <div className="mb-3 rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
-                <p className="font-medium text-primary">
-                  Current replacement SOAP
-                </p>
-                <a
-                  href={`#soap-note-${note.replacesSoapNoteId}`}
-                  className="mt-1 inline-flex text-xs font-medium text-primary hover:underline"
-                >
-                  View retained original
-                </a>
-              </div>
-            ) : null}
-            <dl className="grid gap-3 sm:grid-cols-2">
-              {(
-                [
-                  ["Subjective", note.subjective],
-                  ["Objective", note.objective],
-                  ["Assessment", note.assessment],
-                  ["Plan", note.plan],
-                ] as const
-              ).map(([label, value]) =>
-                value ? (
-                  <div key={label}>
-                    <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      {label}
-                    </dt>
-                    <dd className="mt-1 whitespace-pre-wrap text-sm">
-                      {soapSectionText(value)}
-                    </dd>
+                        : "Unknown"}
+                    </p>
+                    {note.imported ? (
+                      <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                        Imported
+                      </span>
+                    ) : null}
+                    <span
+                      className={cn(
+                        "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                        note.status === "draft"
+                          ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                          : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+                      )}
+                    >
+                      {note.status === "draft" ? "Draft" : "Finalized"}
+                    </span>
                   </div>
-                ) : null,
-              )}
-            </dl>
-            {note.addenda.length > 0 ? (
-              <div className="mt-4 space-y-2 border-t border-border pt-3">
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Addenda
-                </p>
-                {note.addenda.map((addendum) => (
+                  <p className="text-xs text-muted-foreground">
+                    {note.imported
+                      ? note.authorName
+                        ? `Imported by ${note.authorName}`
+                        : "Imported record"
+                      : (note.authorName ?? "Unknown author")}
+                  </p>
+                </div>
+                {note.status === "finalized" ? (
+                  <p className="mb-3 text-xs text-muted-foreground">
+                    Finalized by {note.finalizerName ?? "Unknown clinician"}
+                    {note.finalizedAt
+                      ? ` on ${formatClinicalDateTime(note.finalizedAt, timeZone)}`
+                      : ""}
+                  </p>
+                ) : note.appointmentId && canCorrectClinicalRecords ? (
+                  <a
+                    href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+                    className="mb-3 inline-flex text-xs font-medium text-primary hover:underline"
+                  >
+                    Resume draft
+                  </a>
+                ) : null}
+                {note.replacesSoapNoteId ? (
+                  <div className="mb-3 rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+                    <p className="font-medium text-primary">
+                      Current replacement SOAP
+                    </p>
+                    <a
+                      href={`#soap-note-${note.replacesSoapNoteId}`}
+                      className="mt-1 inline-flex text-xs font-medium text-primary hover:underline"
+                    >
+                      View retained original
+                    </a>
+                  </div>
+                ) : null}
+                <dl className="grid gap-3 sm:grid-cols-2">
+                  {(
+                    [
+                      ["Subjective", note.subjective],
+                      ["Objective", note.objective],
+                      ["Assessment", note.assessment],
+                      ["Plan", note.plan],
+                    ] as const
+                  ).map(([label, value]) =>
+                    value ? (
+                      <div key={label}>
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          {label}
+                        </dt>
+                        <dd className="mt-1 whitespace-pre-wrap text-sm">
+                          {soapSectionText(value)}
+                        </dd>
+                      </div>
+                    ) : null,
+                  )}
+                </dl>
+                {note.addenda.length > 0 ? (
+                  <div className="mt-4 space-y-2 border-t border-border pt-3">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Addenda
+                    </p>
+                    {note.addenda.map((addendum) => (
                       <div
                         key={addendum.id}
                         className="rounded-md bg-muted/40 p-3"
                       >
-                    <p className="text-xs font-medium">
-                      {addendum.authorName} -{" "}
-                      {formatClinicalDateTime(addendum.createdAt, timeZone)}
-                    </p>
-                    <p className="mt-1 whitespace-pre-wrap text-sm">
-                      {soapSectionText(addendum.content)}
-                    </p>
+                        <p className="text-xs font-medium">
+                          {addendum.authorName} -{" "}
+                          {formatClinicalDateTime(addendum.createdAt, timeZone)}
+                        </p>
+                        <p className="mt-1 whitespace-pre-wrap text-sm">
+                          {soapSectionText(addendum.content)}
+                        </p>
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
-            ) : null}
-            {note.status === "finalized" && !note.correctionId ? (
-              <SoapAddendumControl
-                patientId={patientId}
-                noteId={note.id}
-                enabled={canCorrectClinicalRecords}
-              />
-            ) : null}
-            {note.status === "finalized" ? (
-              <>
-                <ClinicalCorrectionControl
-                  correction={
-                    note.correctionId &&
-                    note.correctionReason &&
-                    note.correctedAt
-                      ? {
-                          id: note.correctionId,
-                          reason: note.correctionReason,
-                          correctedAt: note.correctedAt,
-                          correctedByName: note.correctedByName,
-                        }
-                      : null
-                  }
-                  triggerLabel="Void without replacement"
-                  description="The original stays in permanent chart history but leaves current clinical summaries immediately. If its content needs correction, cancel and use Replace finalized SOAP. Use void alone only when no replacement belongs on this encounter; closeout will require a documented reason."
-                  canCorrect={canCorrectClinicalRecords}
-                  isPending={
-                    correctSoap.isPending &&
-                    correctSoap.variables?.recordId === note.id
-                  }
-                  onCorrect={(reason) =>
-                    correctSoap.mutateAsync({
-                      patientId,
-                      recordId: note.id,
-                      reason,
-                    })
-                  }
-                />
-                {note.replacementSoapNoteId ? (
-                  <div className="mt-3 flex justify-end">
-                    <a
-                      href={`#soap-note-${note.replacementSoapNoteId}`}
-                      className="text-sm font-medium text-primary hover:underline"
-                    >
-                      View signed replacement
-                    </a>
-                  </div>
-                ) : canCorrectClinicalRecords &&
-                  (!note.correctionId ||
-                    (!hasOtherCurrentAppointmentSoap &&
-                      !hasAppointmentSoapDraft)) ? (
-                  <div className="mt-3 flex justify-end">
-                    <Button asChild size="sm">
-                      <Link
-                        href={`/records/replace-soap/${encodeURIComponent(patientId)}?sourceNoteId=${encodeURIComponent(note.id)}&return=patient`}
-                      >
-                        {note.correctionId
-                          ? "Create missing replacement"
-                          : "Replace finalized SOAP"}
-                      </Link>
-                    </Button>
-                  </div>
-                ) : hasAppointmentSoapDraft && note.appointmentId ? (
-                  <div className="mt-3 flex justify-end">
-                    <Button asChild size="sm" variant="outline">
-                      <a
-                        href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
-                      >
-                        Review encounter SOAP draft
-                      </a>
-                    </Button>
-                  </div>
-                ) : note.correctionId && hasOtherCurrentAppointmentSoap ? (
-                  <p className="mt-3 text-right text-xs text-muted-foreground">
-                    This encounter already has a current finalized SOAP.
-                  </p>
                 ) : null}
-              </>
-            ) : null}
-          </div>
-        );
+                {note.status === "finalized" && !note.correctionId ? (
+                  <SoapAddendumControl
+                    patientId={patientId}
+                    noteId={note.id}
+                    enabled={canCorrectClinicalRecords}
+                  />
+                ) : null}
+                {note.status === "finalized" ? (
+                  <>
+                    <ClinicalCorrectionControl
+                      correction={
+                        note.correctionId &&
+                        note.correctionReason &&
+                        note.correctedAt
+                          ? {
+                              id: note.correctionId,
+                              reason: note.correctionReason,
+                              correctedAt: note.correctedAt,
+                              correctedByName: note.correctedByName,
+                            }
+                          : null
+                      }
+                      triggerLabel="Void without replacement"
+                      description="The original stays in permanent chart history but leaves current clinical summaries immediately. If its content needs correction, cancel and use Replace finalized SOAP. Use void alone only when no replacement belongs on this encounter; closeout will require a documented reason."
+                      canCorrect={canCorrectClinicalRecords}
+                      isPending={
+                        correctSoap.isPending &&
+                        correctSoap.variables?.recordId === note.id
+                      }
+                      onCorrect={(reason) =>
+                        correctSoap.mutateAsync({
+                          patientId,
+                          recordId: note.id,
+                          reason,
+                        })
+                      }
+                    />
+                    {note.replacementSoapNoteId ? (
+                      <div className="mt-3 flex justify-end">
+                        <a
+                          href={`#soap-note-${note.replacementSoapNoteId}`}
+                          className="text-sm font-medium text-primary hover:underline"
+                        >
+                          View signed replacement
+                        </a>
+                      </div>
+                    ) : canCorrectClinicalRecords &&
+                      (!note.correctionId ||
+                        (!hasOtherCurrentAppointmentSoap &&
+                          !hasAppointmentSoapDraft)) ? (
+                      <div className="mt-3 flex justify-end">
+                        <Button asChild size="sm">
+                          <Link
+                            href={`/records/replace-soap/${encodeURIComponent(patientId)}?sourceNoteId=${encodeURIComponent(note.id)}&return=patient`}
+                          >
+                            {note.correctionId
+                              ? "Create missing replacement"
+                              : "Replace finalized SOAP"}
+                          </Link>
+                        </Button>
+                      </div>
+                    ) : hasAppointmentSoapDraft && note.appointmentId ? (
+                      <div className="mt-3 flex justify-end">
+                        <Button asChild size="sm" variant="outline">
+                          <a
+                            href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+                          >
+                            Review encounter SOAP draft
+                          </a>
+                        </Button>
+                      </div>
+                    ) : note.correctionId && hasOtherCurrentAppointmentSoap ? (
+                      <p className="mt-3 text-right text-xs text-muted-foreground">
+                        This encounter already has a current finalized SOAP.
+                      </p>
+                    ) : null}
+                  </>
+                ) : null}
+              </div>
+            );
           })
         )
       ) : null}

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -57,6 +57,7 @@ import {
   formatClinicalDateTime,
 } from "@/lib/records/clinical-dates";
 import { soapSectionText } from "@/lib/records/soap-content";
+import { isRabiesVaccineName } from "@/lib/records/vaccination-policy";
 import {
   patientFileKind,
   patientFileLabel,
@@ -206,6 +207,10 @@ function canCorrectClinicalRecordRole(role?: string | null): boolean {
   return role === "admin" || role === "veterinarian";
 }
 
+function canEditVaccinationCertificateRole(role?: string | null): boolean {
+  return role === "admin" || role === "veterinarian" || role === "technician";
+}
+
 function canSearchPatientHistoryRole(role?: string | null): boolean {
   return (
     role === "admin" ||
@@ -274,6 +279,9 @@ export default function PatientDetailPage() {
   );
   const canRecordVitals = canRecordVitalsRole(session?.user?.role);
   const canCorrectClinicalRecords = canCorrectClinicalRecordRole(
+    session?.user?.role,
+  );
+  const canEditVaccinationCertificate = canEditVaccinationCertificateRole(
     session?.user?.role,
   );
   const canSearchPatientHistory = canSearchPatientHistoryRole(
@@ -1236,6 +1244,8 @@ export default function PatientDetailPage() {
             patientId={patient.id}
             timeZone={recordsTimeZone}
             canCorrectClinicalRecords={canCorrectClinicalRecords}
+            canPrepareCertificate={canManagePatientDetail}
+            canEditCertificate={canEditVaccinationCertificate}
           />
         )}
 
@@ -1593,21 +1603,57 @@ function VitalsTab({
   );
 }
 
+type VaccinationCertificateEditor = {
+  id: string;
+  expectedUpdatedAt: string;
+  productName: string;
+  manufacturer: string;
+  lotNumber: string;
+  productExpirationDate: string;
+  doseType: "" | "initial" | "booster";
+  licensedDurationMonths: string;
+  rabiesTagNumber: string;
+  supervisingVeterinarianId: string;
+  reason: string;
+};
+
 function VaccinationsTab({
   patientId,
   timeZone,
   canCorrectClinicalRecords,
+  canPrepareCertificate,
+  canEditCertificate,
 }: {
   patientId: string;
   timeZone?: string | null;
   canCorrectClinicalRecords: boolean;
+  canPrepareCertificate: boolean;
+  canEditCertificate: boolean;
 }) {
   const utils = trpc.useUtils();
+  const [editor, setEditor] = useState<VaccinationCertificateEditor | null>(
+    null,
+  );
   const {
     data: vaccinations,
     isLoading,
     error,
   } = trpc.records.listVaccinations.useQuery({ patientId });
+  const providers = trpc.records.listVaccinationProviders.useQuery(undefined, {
+    enabled: Boolean(editor),
+    staleTime: 5 * 60 * 1000,
+  });
+  const prepareCertificate =
+    trpc.records.prepareVaccinationCertificate.useMutation();
+  const updateCertificateDetails =
+    trpc.records.updateVaccinationCertificateDetails.useMutation({
+      onSuccess: async () => {
+        setEditor(null);
+        await utils.records.listVaccinations.invalidate({ patientId });
+        toast.success("Certificate details updated with an audit entry");
+      },
+      onError: (err) => toast.error(err.message),
+    });
   const correctVaccination =
     trpc.records.markVaccinationEnteredInError.useMutation({
       onSuccess: async () => {
@@ -1617,6 +1663,110 @@ function VaccinationsTab({
       onError: (err) => toast.error(err.message),
     });
   const vaccinationsMissing = !isLoading && !error && !vaccinations;
+
+  async function downloadCertificate(
+    kind: "vaccination_history" | "rabies",
+    vaccinationRecordId?: string,
+  ) {
+    try {
+      const certificate = await prepareCertificate.mutateAsync({
+        patientId,
+        kind,
+        vaccinationRecordId,
+        requestId: crypto.randomUUID(),
+      });
+      if (!certificate.ready) {
+        toast.error(
+          `Complete these details before issuing the certificate: ${certificate.missingFields.join(
+            ", ",
+          )}.`,
+        );
+        return;
+      }
+      const pdf = await import("@/lib/pdf");
+      const generatedDate = formatClinicalDate(
+        certificate.generatedAt,
+        certificate.practice.timezone,
+        "Unknown date",
+      );
+      const baseData = {
+        certificateId: certificate.certificateId,
+        generatedDate,
+        practice: certificate.practice,
+        owner: certificate.owner,
+        patient: {
+          ...certificate.patient,
+          sex: formatSex(certificate.patient.sex),
+          dob: formatClinicalDate(
+            certificate.patient.dob,
+            certificate.practice.timezone,
+            undefined,
+          ),
+        },
+      };
+      const safePatientName = certificate.patient.name.replace(
+        /[^a-z0-9]+/gi,
+        "_",
+      );
+      if (kind === "vaccination_history") {
+        pdf
+          .generateVaccinationHistoryCertificatePdf({
+            ...baseData,
+            vaccinations: certificate.vaccinations.map((vaccination) => ({
+              ...vaccination,
+              administeredAt: formatClinicalDate(
+                vaccination.administeredAt,
+                certificate.practice.timezone,
+                "Unknown",
+              ),
+              nextDueDate: formatClinicalDate(
+                vaccination.nextDueDate,
+                certificate.practice.timezone,
+                undefined,
+              ),
+            })),
+          })
+          .save(`${safePatientName}_vaccination_certificate.pdf`);
+      } else {
+        const rabies = certificate.vaccinations[0]!;
+        pdf
+          .generateRabiesVaccinationCertificatePdf({
+            ...baseData,
+            vaccination: {
+              ...rabies,
+              productName: rabies.productName!,
+              manufacturer: rabies.manufacturer!,
+              lotNumber: rabies.lotNumber!,
+              productExpirationDate: formatClinicalDate(
+                rabies.productExpirationDate,
+                certificate.practice.timezone,
+                "Unknown",
+              ),
+              doseType: rabies.doseType!,
+              licensedDurationMonths: rabies.licensedDurationMonths!,
+              administeredAt: formatClinicalDate(
+                rabies.administeredAt,
+                certificate.practice.timezone,
+                "Unknown",
+              ),
+              nextDueDate: formatClinicalDate(
+                rabies.nextDueDate,
+                certificate.practice.timezone,
+                "Unknown",
+              ),
+              veterinarianName: rabies.veterinarianName!,
+              veterinarianLicenseNumber: rabies.veterinarianLicenseNumber!,
+            },
+          })
+          .save(`${safePatientName}_rabies_vaccination_certificate.pdf`);
+      }
+      toast.success("Certificate downloaded");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Unable to create certificate",
+      );
+    }
+  }
 
   if (error) {
     return (
@@ -1641,8 +1791,188 @@ function VaccinationsTab({
   }
 
   return (
+    <div className="space-y-4">
+      {canPrepareCertificate ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-medium">Vaccination certificates</p>
+            <p className="text-xs text-muted-foreground">
+              Every prepared certificate receives a unique ID and an audit
+              entry. Rabies certificates must pass a required-field check.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            disabled={prepareCertificate.isPending}
+            onClick={() => downloadCertificate("vaccination_history")}
+          >
+            {prepareCertificate.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <FileDown className="mr-2 h-4 w-4" />
+            )}
+            Download vaccination certificate
+          </Button>
+        </div>
+      ) : null}
+
+      {editor ? (
+        <form
+          className="rounded-lg border border-border bg-card p-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (editor.reason.trim().length < 10) return;
+            updateCertificateDetails.mutate({
+              patientId,
+              recordId: editor.id,
+              expectedUpdatedAt: editor.expectedUpdatedAt,
+              reason: editor.reason,
+              productName: editor.productName || undefined,
+              manufacturer: editor.manufacturer || undefined,
+              lotNumber: editor.lotNumber || undefined,
+              productExpirationDate: editor.productExpirationDate || undefined,
+              doseType: editor.doseType || undefined,
+              licensedDurationMonths: editor.licensedDurationMonths
+                ? Number(editor.licensedDurationMonths)
+                : undefined,
+              rabiesTagNumber: editor.rabiesTagNumber || undefined,
+              supervisingVeterinarianId:
+                editor.supervisingVeterinarianId || undefined,
+            });
+          }}
+        >
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <p className="font-medium">Edit certificate details</p>
+              <p className="text-xs text-muted-foreground">
+                Clinical history is preserved. A reason is recorded with every
+                change.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setEditor(null)}
+            >
+              Cancel
+            </Button>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {(
+              [
+                ["Product name", "productName"],
+                ["Manufacturer", "manufacturer"],
+                ["Lot number", "lotNumber"],
+                ["Product expiration", "productExpirationDate"],
+                ["Rabies tag", "rabiesTagNumber"],
+              ] as const
+            ).map(([label, field]) => (
+              <label
+                key={field}
+                className="space-y-1 text-xs font-medium text-muted-foreground"
+              >
+                {label}
+                <input
+                  type={field === "productExpirationDate" ? "date" : "text"}
+                  value={editor[field]}
+                  onChange={(event) =>
+                    setEditor({ ...editor, [field]: event.target.value })
+                  }
+                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground"
+                />
+              </label>
+            ))}
+            <label className="space-y-1 text-xs font-medium text-muted-foreground">
+              Dose type
+              <select
+                value={editor.doseType}
+                onChange={(event) =>
+                  setEditor({
+                    ...editor,
+                    doseType: event.target.value as "" | "initial" | "booster",
+                  })
+                }
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground"
+              >
+                <option value="">Not recorded</option>
+                <option value="initial">Initial</option>
+                <option value="booster">Booster</option>
+              </select>
+            </label>
+            <label className="space-y-1 text-xs font-medium text-muted-foreground">
+              Licensed duration
+              <select
+                value={editor.licensedDurationMonths}
+                onChange={(event) =>
+                  setEditor({
+                    ...editor,
+                    licensedDurationMonths: event.target.value,
+                  })
+                }
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground"
+              >
+                <option value="">Not recorded</option>
+                <option value="12">1 year</option>
+                <option value="36">3 years</option>
+                <option value="48">4 years</option>
+              </select>
+            </label>
+            <label className="space-y-1 text-xs font-medium text-muted-foreground">
+              Supervising veterinarian
+              <select
+                value={editor.supervisingVeterinarianId}
+                onChange={(event) =>
+                  setEditor({
+                    ...editor,
+                    supervisingVeterinarianId: event.target.value,
+                  })
+                }
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground"
+              >
+                <option value="">Not recorded</option>
+                {providers.data?.map((provider) => (
+                  <option key={provider.id} value={provider.id}>
+                    {provider.name}
+                    {provider.licenseNumber
+                      ? ` — ${provider.licenseNumber}`
+                      : " — license missing"}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1 text-xs font-medium text-muted-foreground sm:col-span-2 lg:col-span-4">
+              Reason for change (required, at least 10 characters)
+              <textarea
+                value={editor.reason}
+                minLength={10}
+                maxLength={500}
+                required
+                onChange={(event) =>
+                  setEditor({ ...editor, reason: event.target.value })
+                }
+                className="min-h-20 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+              />
+            </label>
+          </div>
+          <div className="mt-3 flex justify-end">
+            <Button
+              type="submit"
+              disabled={
+                editor.reason.trim().length < 10 ||
+                updateCertificateDetails.isPending
+              }
+            >
+              {updateCertificateDetails.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              Save audited changes
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
     <div className="overflow-x-auto rounded-lg border border-border">
-      <table className="w-full text-sm">
+        <table className="w-full min-w-[960px] text-sm">
         <thead>
           <tr className="border-b border-border bg-muted/50">
             <th className="px-4 py-3 text-left font-medium text-muted-foreground">
@@ -1655,11 +1985,14 @@ function VaccinationsTab({
               Next Due
             </th>
             <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-              Lot Number
+                Product / Lot
             </th>
             <th className="px-4 py-3 text-left font-medium text-muted-foreground">
               Administered By
             </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Certificate
+              </th>
             <th className="px-4 py-3 text-left font-medium text-muted-foreground">
               Status
             </th>
@@ -1670,7 +2003,7 @@ function VaccinationsTab({
             <tr
               key={vax.id}
               className={cn(
-                "border-b border-border last:border-0",
+                  "border-b border-border align-top last:border-0",
                 vax.correctionId && "bg-destructive/5 text-muted-foreground",
               )}
             >
@@ -1681,10 +2014,58 @@ function VaccinationsTab({
               <td className="px-4 py-3">
                 {formatClinicalDate(vax.nextDueDate, timeZone, "\u2014")}
               </td>
-              <td className="px-4 py-3">{vax.lotNumber ?? "\u2014"}</td>
+                <td className="px-4 py-3">
+                  <span>{vax.productName ?? "—"}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Lot {vax.lotNumber ?? "—"}
+                  </span>
+                </td>
               <td className="px-4 py-3 text-muted-foreground">
                 {vax.administeredByName ?? "\u2014"}
               </td>
+                <td className="px-4 py-3">
+                  {!vax.correctionId &&
+                  canPrepareCertificate &&
+                  isRabiesVaccineName(vax.vaccineName) ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={prepareCertificate.isPending}
+                      onClick={() => downloadCertificate("rabies", vax.id)}
+                    >
+                      Rabies PDF
+                    </Button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">—</span>
+                  )}
+                  {!vax.correctionId && canEditCertificate ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="mt-1 block"
+                      onClick={() =>
+                        setEditor({
+                          id: vax.id,
+                          expectedUpdatedAt: vax.updatedAt.toISOString(),
+                          productName: vax.productName ?? "",
+                          manufacturer: vax.manufacturer ?? "",
+                          lotNumber: vax.lotNumber ?? "",
+                          productExpirationDate:
+                            vax.productExpirationDate ?? "",
+                          doseType: vax.doseType ?? "",
+                          licensedDurationMonths:
+                            vax.licensedDurationMonths?.toString() ?? "",
+                          rabiesTagNumber: vax.rabiesTagNumber ?? "",
+                          supervisingVeterinarianId:
+                            vax.supervisingVeterinarianId ?? "",
+                          reason: "",
+                        })
+                      }
+                    >
+                      Edit details
+                    </Button>
+                  ) : null}
+                </td>
               <td className="px-4 py-3">
                 {vax.correctionId ? (
                   <span className="inline-flex items-center rounded-full bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive">
@@ -1697,7 +2078,9 @@ function VaccinationsTab({
                 )}
                 <ClinicalCorrectionControl
                   correction={
-                    vax.correctionId && vax.correctionReason && vax.correctedAt
+                      vax.correctionId &&
+                      vax.correctionReason &&
+                      vax.correctedAt
                       ? {
                           id: vax.correctionId,
                           reason: vax.correctionReason,
@@ -1724,6 +2107,7 @@ function VaccinationsTab({
           ))}
         </tbody>
       </table>
+    </div>
     </div>
   );
 }
@@ -1813,7 +2197,11 @@ function MedicalRecordsTab({
               <div className="flex items-center gap-2">
                 <p className="text-sm font-medium">
                   {note.createdAt
-                    ? formatClinicalDate(note.createdAt, timeZone, "Unknown")
+                        ? formatClinicalDate(
+                            note.createdAt,
+                            timeZone,
+                            "Unknown",
+                          )
                     : "Unknown"}
                 </p>
                 {note.imported ? (
@@ -1895,7 +2283,10 @@ function MedicalRecordsTab({
                   Addenda
                 </p>
                 {note.addenda.map((addendum) => (
-                  <div key={addendum.id} className="rounded-md bg-muted/40 p-3">
+                      <div
+                        key={addendum.id}
+                        className="rounded-md bg-muted/40 p-3"
+                      >
                     <p className="text-xs font-medium">
                       {addendum.authorName} -{" "}
                       {formatClinicalDateTime(addendum.createdAt, timeZone)}

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -69,13 +69,11 @@ import {
   isLabRequiredTextInputValid,
 } from "@/lib/records/lab-policy";
 import {
-  VACCINATION_LOT_NUMBER_MAX_LENGTH,
-  VACCINATION_MANUFACTURER_MAX_LENGTH,
-  VACCINATION_NAME_MAX_LENGTH,
-  isVaccinationOptionalDateInputValid,
-  isVaccinationOptionalTextInputValid,
-  isVaccinationRequiredTextInputValid,
-} from "@/lib/records/vaccination-policy";
+  VaccinationFormFields,
+  initialVaccinationForm,
+  isVaccinationFormValid,
+  type VaccinationFormState,
+} from "@/components/records/vaccination-form-fields";
 import {
   PROBLEM_DESCRIPTION_MAX_LENGTH,
   PROBLEM_STATUSES,
@@ -298,13 +296,6 @@ type ReplacementPatientOption = {
   clientLastName: string | null;
 };
 
-type VaccinationFormState = {
-  vaccineName: string;
-  lotNumber: string;
-  manufacturer: string;
-  nextDueDate: string;
-};
-
 type ProblemFormState = {
   description: string;
   status: ProblemStatus;
@@ -340,15 +331,6 @@ function initialLabResultForm(): LabResultFormState {
     referenceRangeLow: "",
     referenceRangeHigh: "",
     resultFlag: "unknown",
-  };
-}
-
-function initialVaccinationForm(): VaccinationFormState {
-  return {
-    vaccineName: "",
-    lotNumber: "",
-    manufacturer: "",
-    nextDueDate: "",
   };
 }
 
@@ -740,6 +722,11 @@ function RecordsPageContent() {
   const recordsSettings = trpc.records.settings.useQuery(undefined, {
     staleTime: 5 * 60 * 1000,
   });
+  const vaccinationProviders =
+    trpc.records.listVaccinationProviders.useQuery(undefined, {
+      enabled: showVaccinationForm,
+      staleTime: 5 * 60 * 1000,
+    });
   const recordsSettingsError = recordsSettings.error;
   const recordsSettingsLoading = recordsSettings.isLoading;
   const recordsSettingsMissing =
@@ -1162,19 +1149,7 @@ function RecordsPageContent() {
     Boolean(patientId) &&
     isOnline &&
     visitContextMatchesPatient &&
-    isVaccinationRequiredTextInputValid(
-      vaccinationForm.vaccineName,
-      VACCINATION_NAME_MAX_LENGTH
-    ) &&
-    isVaccinationOptionalTextInputValid(
-      vaccinationForm.lotNumber,
-      VACCINATION_LOT_NUMBER_MAX_LENGTH
-    ) &&
-    isVaccinationOptionalTextInputValid(
-      vaccinationForm.manufacturer,
-      VACCINATION_MANUFACTURER_MAX_LENGTH
-    ) &&
-    isVaccinationOptionalDateInputValid(vaccinationForm.nextDueDate) &&
+    isVaccinationFormValid(vaccinationForm) &&
     !createVaccination.isPending;
   const canSubmitProblem =
     Boolean(patientId) &&
@@ -1901,90 +1876,35 @@ function RecordsPageContent() {
                         patientId,
                         appointmentId: linkedAppointmentId || undefined,
                         vaccineName: vaccinationForm.vaccineName.trim(),
+                        productName:
+                          vaccinationForm.productName.trim() || undefined,
                         lotNumber:
                           vaccinationForm.lotNumber.trim() || undefined,
                         manufacturer:
                           vaccinationForm.manufacturer.trim() || undefined,
+                        productExpirationDate:
+                          vaccinationForm.productExpirationDate || undefined,
+                        doseType: vaccinationForm.doseType || undefined,
+                        licensedDurationMonths:
+                          vaccinationForm.licensedDurationMonths
+                            ? Number(vaccinationForm.licensedDurationMonths)
+                            : undefined,
+                        rabiesTagNumber:
+                          vaccinationForm.rabiesTagNumber.trim() || undefined,
+                        supervisingVeterinarianId:
+                          vaccinationForm.supervisingVeterinarianId ||
+                          undefined,
                         nextDueDate:
                           vaccinationForm.nextDueDate.trim() || undefined,
                       });
                     }}
                   >
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                      <div>
-                        <label className="block text-xs font-medium text-muted-foreground mb-1">
-                          Vaccine *
-                        </label>
-                        <Input
-                          name="vaccineName"
-                          required
-                          value={vaccinationForm.vaccineName}
-                          maxLength={VACCINATION_NAME_MAX_LENGTH}
-                          onChange={(e) =>
-                            setVaccinationForm((form) => ({
-                              ...form,
-                              vaccineName: e.target.value,
-                            }))
-                          }
-                          placeholder="e.g. Rabies"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-muted-foreground mb-1">
-                          Next Due
-                        </label>
-                        <Input
-                          name="nextDueDate"
-                          type="date"
-                          value={vaccinationForm.nextDueDate}
-                          aria-invalid={
-                            !isVaccinationOptionalDateInputValid(
-                              vaccinationForm.nextDueDate
-                            )
-                          }
-                          onChange={(e) =>
-                            setVaccinationForm((form) => ({
-                              ...form,
-                              nextDueDate: e.target.value,
-                            }))
-                          }
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-muted-foreground mb-1">
-                          Lot Number
-                        </label>
-                        <Input
-                          name="lotNumber"
-                          value={vaccinationForm.lotNumber}
-                          maxLength={VACCINATION_LOT_NUMBER_MAX_LENGTH}
-                          onChange={(e) =>
-                            setVaccinationForm((form) => ({
-                              ...form,
-                              lotNumber: e.target.value,
-                            }))
-                          }
-                          placeholder="e.g. RAB-2026-04"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs font-medium text-muted-foreground mb-1">
-                          Manufacturer
-                        </label>
-                        <Input
-                          name="manufacturer"
-                          value={vaccinationForm.manufacturer}
-                          maxLength={VACCINATION_MANUFACTURER_MAX_LENGTH}
-                          onChange={(e) =>
-                            setVaccinationForm((form) => ({
-                              ...form,
-                              manufacturer: e.target.value,
-                            }))
-                          }
-                          placeholder="e.g. Zoetis"
-                        />
-                      </div>
-                    </div>
+                    <VaccinationFormFields
+                      form={vaccinationForm}
+                      setForm={setVaccinationForm}
+                      providers={vaccinationProviders.data}
+                      currentUserId={session?.user?.id}
+                    />
                     <div className="flex gap-2">
                       <Button
                         type="submit"

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -136,7 +136,7 @@ function canUpdateAppointmentStatusRole(role?: string | null): boolean {
 }
 
 function canSendAppointmentRemindersRole(role?: string | null): boolean {
-  return role === "admin" || role === "front_desk";
+  return role === "admin" || role === "veterinarian" || role === "front_desk";
 }
 
 // --- Helpers ---

--- a/apps/web/components/records/vaccination-form-fields.tsx
+++ b/apps/web/components/records/vaccination-form-fields.tsx
@@ -1,0 +1,298 @@
+import type { Dispatch, SetStateAction } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  isRabiesVaccineName,
+  VACCINATION_LICENSED_DURATION_MAX_MONTHS,
+  VACCINATION_LICENSED_DURATION_MIN_MONTHS,
+  VACCINATION_LOT_NUMBER_MAX_LENGTH,
+  VACCINATION_MANUFACTURER_MAX_LENGTH,
+  VACCINATION_NAME_MAX_LENGTH,
+  VACCINATION_PRODUCT_NAME_MAX_LENGTH,
+  VACCINATION_RABIES_TAG_MAX_LENGTH,
+  isVaccinationOptionalDateInputValid,
+  isVaccinationOptionalTextInputValid,
+  isVaccinationRequiredTextInputValid,
+} from "@/lib/records/vaccination-policy";
+
+export type VaccinationFormState = {
+  vaccineName: string;
+  productName: string;
+  lotNumber: string;
+  manufacturer: string;
+  productExpirationDate: string;
+  doseType: "" | "initial" | "booster";
+  licensedDurationMonths: string;
+  rabiesTagNumber: string;
+  supervisingVeterinarianId: string;
+  nextDueDate: string;
+};
+
+export type VaccinationProviderOption = {
+  id: string;
+  name: string;
+  licenseNumber: string | null;
+};
+
+export function initialVaccinationForm(): VaccinationFormState {
+  return {
+    vaccineName: "",
+    productName: "",
+    lotNumber: "",
+    manufacturer: "",
+    productExpirationDate: "",
+    doseType: "",
+    licensedDurationMonths: "",
+    rabiesTagNumber: "",
+    supervisingVeterinarianId: "",
+    nextDueDate: "",
+  };
+}
+
+export function isVaccinationFormValid(form: VaccinationFormState): boolean {
+  const duration = Number(form.licensedDurationMonths);
+  const baseValid =
+    isVaccinationRequiredTextInputValid(
+      form.vaccineName,
+      VACCINATION_NAME_MAX_LENGTH,
+    ) &&
+    isVaccinationOptionalTextInputValid(
+      form.productName,
+      VACCINATION_PRODUCT_NAME_MAX_LENGTH,
+    ) &&
+    isVaccinationOptionalTextInputValid(
+      form.lotNumber,
+      VACCINATION_LOT_NUMBER_MAX_LENGTH,
+    ) &&
+    isVaccinationOptionalTextInputValid(
+      form.manufacturer,
+      VACCINATION_MANUFACTURER_MAX_LENGTH,
+    ) &&
+    isVaccinationOptionalTextInputValid(
+      form.rabiesTagNumber,
+      VACCINATION_RABIES_TAG_MAX_LENGTH,
+    ) &&
+    isVaccinationOptionalDateInputValid(form.productExpirationDate) &&
+    isVaccinationOptionalDateInputValid(form.nextDueDate);
+  if (!baseValid || !isRabiesVaccineName(form.vaccineName)) return baseValid;
+
+  return (
+    isVaccinationRequiredTextInputValid(
+      form.productName,
+      VACCINATION_PRODUCT_NAME_MAX_LENGTH,
+    ) &&
+    isVaccinationRequiredTextInputValid(
+      form.manufacturer,
+      VACCINATION_MANUFACTURER_MAX_LENGTH,
+    ) &&
+    isVaccinationRequiredTextInputValid(
+      form.lotNumber,
+      VACCINATION_LOT_NUMBER_MAX_LENGTH,
+    ) &&
+    Boolean(form.productExpirationDate) &&
+    Boolean(form.nextDueDate) &&
+    Boolean(form.doseType) &&
+    Number.isInteger(duration) &&
+    duration >= VACCINATION_LICENSED_DURATION_MIN_MONTHS &&
+    duration <= VACCINATION_LICENSED_DURATION_MAX_MONTHS &&
+    Boolean(form.supervisingVeterinarianId)
+  );
+}
+
+export function VaccinationFormFields({
+  form,
+  setForm,
+  providers,
+  currentUserId,
+}: {
+  form: VaccinationFormState;
+  setForm: Dispatch<SetStateAction<VaccinationFormState>>;
+  providers?: VaccinationProviderOption[];
+  currentUserId?: string;
+}) {
+  const rabies = isRabiesVaccineName(form.vaccineName);
+  const update = <Field extends keyof VaccinationFormState>(
+    field: Field,
+    value: VaccinationFormState[Field],
+  ) => setForm((current) => ({ ...current, [field]: value }));
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div>
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          Vaccine *
+        </label>
+        <Input
+          name="vaccineName"
+          required
+          value={form.vaccineName}
+          maxLength={VACCINATION_NAME_MAX_LENGTH}
+          onChange={(event) => {
+            const vaccineName = event.target.value;
+            const currentProvider = providers?.find(
+              (provider) => provider.id === currentUserId,
+            );
+            setForm((current) => ({
+              ...current,
+              vaccineName,
+              supervisingVeterinarianId:
+                current.supervisingVeterinarianId ||
+                (isRabiesVaccineName(vaccineName)
+                  ? currentProvider?.id ?? ""
+                  : ""),
+            }));
+          }}
+          placeholder="e.g. Rabies"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          Product name{rabies ? " *" : ""}
+        </label>
+        <Input
+          name="productName"
+          required={rabies}
+          value={form.productName}
+          maxLength={VACCINATION_PRODUCT_NAME_MAX_LENGTH}
+          onChange={(event) => update("productName", event.target.value)}
+          placeholder="e.g. Defensor 3"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          Next due{rabies ? " *" : ""}
+        </label>
+        <Input
+          name="nextDueDate"
+          type="date"
+          required={rabies}
+          value={form.nextDueDate}
+          aria-invalid={!isVaccinationOptionalDateInputValid(form.nextDueDate)}
+          onChange={(event) => update("nextDueDate", event.target.value)}
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          Lot number{rabies ? " *" : ""}
+        </label>
+        <Input
+          name="lotNumber"
+          required={rabies}
+          value={form.lotNumber}
+          maxLength={VACCINATION_LOT_NUMBER_MAX_LENGTH}
+          onChange={(event) => update("lotNumber", event.target.value)}
+          placeholder="e.g. RAB-2026-04"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          Manufacturer{rabies ? " *" : ""}
+        </label>
+        <Input
+          name="manufacturer"
+          required={rabies}
+          value={form.manufacturer}
+          maxLength={VACCINATION_MANUFACTURER_MAX_LENGTH}
+          onChange={(event) => update("manufacturer", event.target.value)}
+          placeholder="e.g. Zoetis"
+        />
+      </div>
+      {rabies ? (
+        <>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Product expiration *
+            </label>
+            <Input
+              name="productExpirationDate"
+              type="date"
+              required
+              value={form.productExpirationDate}
+              onChange={(event) =>
+                update("productExpirationDate", event.target.value)
+              }
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Dose type *
+            </label>
+            <select
+              name="doseType"
+              required
+              value={form.doseType}
+              onChange={(event) =>
+                update(
+                  "doseType",
+                  event.target.value as VaccinationFormState["doseType"],
+                )
+              }
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="">Choose dose type</option>
+              <option value="initial">Initial dose</option>
+              <option value="booster">Booster dose</option>
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Licensed duration *
+            </label>
+            <select
+              name="licensedDurationMonths"
+              required
+              value={form.licensedDurationMonths}
+              onChange={(event) =>
+                update("licensedDurationMonths", event.target.value)
+              }
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="">Choose duration</option>
+              <option value="12">1 year</option>
+              <option value="36">3 years</option>
+              <option value="48">4 years</option>
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Rabies tag number
+            </label>
+            <Input
+              name="rabiesTagNumber"
+              value={form.rabiesTagNumber}
+              maxLength={VACCINATION_RABIES_TAG_MAX_LENGTH}
+              onChange={(event) => update("rabiesTagNumber", event.target.value)}
+            />
+          </div>
+          <div className="sm:col-span-2">
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Supervising veterinarian *
+            </label>
+            <select
+              name="supervisingVeterinarianId"
+              required
+              value={form.supervisingVeterinarianId}
+              onChange={(event) =>
+                update("supervisingVeterinarianId", event.target.value)
+              }
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="">Choose veterinarian</option>
+              {providers?.map((provider) => (
+                <option key={provider.id} value={provider.id}>
+                  {provider.name}
+                  {provider.licenseNumber
+                    ? ` — License ${provider.licenseNumber}`
+                    : " — license missing"}
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Rabies certificates require the veterinarian&apos;s license number
+              in Staff settings.
+            </p>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/__tests__/care-reminders-safety.test.ts
+++ b/apps/web/lib/__tests__/care-reminders-safety.test.ts
@@ -29,18 +29,35 @@ describe("care reminder safety contract", () => {
     expect(router).toContain("setDismissed");
     expect(router).toContain(".max(100)");
     expect(router).toContain('.for("update")');
-    expect(router).not.toMatch(/send(?:Email|Sms|Reminder)/);
+    expect(router).not.toContain(
+      "eq(careReminders.updatedAt, current.updatedAt)",
+    );
     expect(page).toMatch(/never sends an\s+email or text automatically/);
   });
 
-  it("keeps client outreach deliberate and delegates delivery safeguards", () => {
-    expect(page).toContain("trpc.communications.create.useMutation");
-    expect(page).toContain('direction: "outbound"');
+  it("keeps client outreach deliberate, templated, and safeguarded", () => {
+    expect(page).toContain("trpc.careReminders.sendOutreach.useMutation");
     expect(page).toContain("outreachRequestId.current ??= crypto.randomUUID()");
     expect(page).toContain("clientSmsConsent");
+    expect(page).toContain("Template preview");
+    expect(page).toContain("generated server-side");
     expect(page).toContain(
       "Email suppression, SMS consent, sender, and quiet-hour",
     );
+    expect(router).toContain("sendOutreach: manageProcedure");
+    expect(router).toContain('operation: "care_reminder"');
+    expect(router).toContain("sendCareReminder(");
+    expect(router).toContain("sendCareReminderSms(");
+    expect(router).toContain("withDurableSmsCommunication");
+    expect(router).toContain("ctx.db.transaction(async (tx)");
+    expect(router).toContain("lockPracticeForExternalSideEffects(db");
+    expect(router).toContain("emailSuppressionSendBlockMessage");
+    const outreachSchema = router.slice(
+      router.indexOf("const outreachInput"),
+      router.indexOf("const dismissalInput"),
+    );
+    expect(outreachSchema).not.toContain("content:");
+    expect(outreachSchema).not.toContain("subject:");
     expect(page).not.toContain("useEffect(() => sendOutreach");
   });
 

--- a/apps/web/lib/__tests__/care-reminders-safety.test.ts
+++ b/apps/web/lib/__tests__/care-reminders-safety.test.ts
@@ -15,16 +15,33 @@ describe("care reminder safety contract", () => {
     expect(schema).toContain("care_reminders_patient_tenant_fk");
     expect(schema).toContain("care_reminders_creator_tenant_fk");
     expect(schema).toContain("care_reminders_completer_tenant_fk");
+    expect(schema).toContain("care_reminders_dismisser_tenant_fk");
     expect(schema).toContain("care_reminders_external_id_uq");
     expect(schema).toContain("care_reminders_import_fingerprint_uq");
     expect(rls).toMatch(/'capture_sessions','care_reminders','cases'/);
   });
 
-  it("keeps completion coherent and never exposes a send mutation", () => {
+  it("keeps completion and dismissal states coherent", () => {
     expect(schema).toContain("care_reminders_state_check");
+    expect(schema).toContain("= 'dismissed'");
+    expect(schema).toContain("care_reminders_dismissal_reason_check");
     expect(router).toContain("setCompleted");
+    expect(router).toContain("setDismissed");
+    expect(router).toContain(".max(100)");
+    expect(router).toContain('.for("update")');
     expect(router).not.toMatch(/send(?:Email|Sms|Reminder)/);
     expect(page).toMatch(/never sends an\s+email or text automatically/);
+  });
+
+  it("keeps client outreach deliberate and delegates delivery safeguards", () => {
+    expect(page).toContain("trpc.communications.create.useMutation");
+    expect(page).toContain('direction: "outbound"');
+    expect(page).toContain("outreachRequestId.current ??= crypto.randomUUID()");
+    expect(page).toContain("clientSmsConsent");
+    expect(page).toContain(
+      "Email suppression, SMS consent, sender, and quiet-hour",
+    );
+    expect(page).not.toContain("useEffect(() => sendOutreach");
   });
 
   it("surfaces the reusable queue in primary navigation", () => {

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -110,13 +110,14 @@ describe("sendEmail", () => {
     consoleLog.mockRestore();
   });
 
-  it("keeps the console fallback available in demo mode", async () => {
+  it("forces the console provider in demo mode even when Resend is configured", async () => {
     vi.stubEnv("NEXT_PUBLIC_DEMO_MODE", " true ");
+    vi.stubEnv("RESEND_API_KEY", "re_preview_live_key");
     mocks.billingEnforced.mockReturnValue(true);
     const consoleLog = vi
       .spyOn(console, "log")
       .mockImplementation(() => undefined);
-    const { sendEmail } = await loadEmail();
+    const { sendEmail, verificationEmailProvider } = await loadEmail();
 
     await expect(
       sendEmail({
@@ -127,6 +128,9 @@ describe("sendEmail", () => {
     ).resolves.toEqual({ success: true, id: "dev-console" });
 
     expect(consoleLog).toHaveBeenCalled();
+    expect(verificationEmailProvider()).toBe("console");
+    expect(mocks.Resend).not.toHaveBeenCalled();
+    expect(mocks.resendSend).not.toHaveBeenCalled();
     consoleLog.mockRestore();
   });
 

--- a/apps/web/lib/__tests__/pdf-generation.test.ts
+++ b/apps/web/lib/__tests__/pdf-generation.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { generateMedicalSummaryPdf } from "../pdf";
+import {
+  generateMedicalSummaryPdf,
+  generateRabiesVaccinationCertificatePdf,
+  generateVaccinationHistoryCertificatePdf,
+} from "../pdf";
 
 describe("medical summary header", () => {
   const source = readFileSync("lib/pdf.ts", "utf8");
@@ -8,7 +12,7 @@ describe("medical summary header", () => {
   it("stacks logo, clinic name, then the title so long names cannot collide", () => {
     const headerSection = source.slice(
       source.indexOf("export function generateMedicalSummaryPdf"),
-      source.indexOf('sectionHeading("Patient Information")')
+      source.indexOf('sectionHeading("Patient Information")'),
     );
     const logoAt = headerSection.indexOf("drawPawMark");
     const nameAt = headerSection.indexOf("splitTextToSize(data.practiceName");
@@ -31,7 +35,9 @@ describe("medical summary header", () => {
       clientName: "Jordan Avery",
       allergies: [],
       problems: [],
-      vaccinations: [{ name: "Rabies", date: "2026-05-01", nextDue: "2027-05-01" }],
+      vaccinations: [
+        { name: "Rabies", date: "2026-05-01", nextDue: "2027-05-01" },
+      ],
       recentNotes: [],
       prescriptions: [],
       generatedDate: "7/11/2026",
@@ -93,26 +99,30 @@ describe("pdf generation date labels", () => {
     expect(source).toContain("generatedDate?: string;");
     expect(source).toContain("function formatGeneratedDateUtc()");
     expect(source).toContain(
-      'return new Date().toLocaleDateString("en-US", { timeZone: "UTC" })'
+      'return new Date().toLocaleDateString("en-US", { timeZone: "UTC" })',
     );
     expect(source).toContain(
-      "const generatedDate = data.generatedDate ?? formatGeneratedDateUtc()"
+      "const generatedDate = data.generatedDate ?? formatGeneratedDateUtc()",
     );
     expect(source).toContain("`Generated on ${generatedDate}");
-    expect(source).not.toContain("const today = new Date().toLocaleDateString()");
+    expect(source).not.toContain(
+      "const today = new Date().toLocaleDateString()",
+    );
   });
 
   it("generates vaccination certificates with caller-provided date labels", () => {
     expect(source).toContain("export interface VaccinationCertificateData");
-    expect(source).toContain("export function generateVaccinationCertificatePdf");
-    expect(source).toContain("VACCINATION CERTIFICATE");
-    expect(source).toContain("[\"Vaccine\", data.vaccineName]");
-    expect(source).toContain("[\"Administered\", data.administeredAt]");
-    expect(source).toContain("[\"Next due\", data.nextDueDate]");
-    expect(source).toContain("[\"Manufacturer\", data.manufacturer]");
-    expect(source).toContain("[\"Lot number\", data.lotNumber]");
     expect(source).toContain(
-      "const generatedDate = data.generatedDate ?? formatGeneratedDateUtc()"
+      "export function generateVaccinationCertificatePdf",
+    );
+    expect(source).toContain("VACCINATION CERTIFICATE");
+    expect(source).toContain('["Vaccine", data.vaccineName]');
+    expect(source).toContain('["Administered", data.administeredAt]');
+    expect(source).toContain('["Next due", data.nextDueDate]');
+    expect(source).toContain('["Manufacturer", data.manufacturer]');
+    expect(source).toContain('["Lot number", data.lotNumber]');
+    expect(source).toContain(
+      "const generatedDate = data.generatedDate ?? formatGeneratedDateUtc()",
     );
   });
 
@@ -120,12 +130,87 @@ describe("pdf generation date labels", () => {
     expect(source).toContain("export interface ReportPdfData");
     expect(source).toContain("export function generateReportPdf");
     expect(source).toContain(
-      'orientation: data.columns.length > 4 ? "landscape" : "portrait"'
+      'orientation: data.columns.length > 4 ? "landscape" : "portrait"',
     );
     expect(source).toContain("data.columns.forEach((column, index) =>");
     expect(source).toContain(
-      'doc.text(data.emptyMessage ?? "No report data available.", margin, y)'
+      'doc.text(data.emptyMessage ?? "No report data available.", margin, y)',
     );
     expect(source).toContain("doc.text(`Page ${i} of ${pageCount}`");
+  });
+});
+
+describe("staff vaccination certificate PDFs", () => {
+  const identity = {
+    certificateId: "00000000-0000-0000-0000-000000000001",
+    generatedDate: "Aug 24, 2026",
+    practice: {
+      name: "Neighborhood Veterinary",
+      address: "100 Clinic Way, Brooklyn, NY",
+      phone: "555-0100",
+      email: "care@example.test",
+    },
+    owner: {
+      name: "Alex Rivera",
+      address: "10 Main Street\nBrooklyn, NY, 11201",
+      phone: "555-0102",
+    },
+    patient: {
+      name: "Biscuit",
+      species: "Canine",
+      breed: "Mixed breed",
+      sex: "Female (Spayed)",
+      dob: "May 1, 2020",
+      color: "Brown",
+      microchipNumber: "985141000000001",
+      weightKg: "18.250",
+    },
+  };
+
+  it("renders a multi-page vaccination history with certificate identity", () => {
+    const doc = generateVaccinationHistoryCertificatePdf({
+      ...identity,
+      vaccinations: Array.from({ length: 60 }, (_, index) => ({
+        vaccineName: `Vaccination ${index + 1}`,
+        productName: `Product ${index + 1}`,
+        administeredAt: "Aug 24, 2026",
+        nextDueDate: "Aug 24, 2027",
+        lotNumber: `LOT-${index + 1}`,
+        administeredByName: "Dr. Rivera",
+      })),
+    });
+
+    expect(doc.getNumberOfPages()).toBeGreaterThan(1);
+    expect(doc.output("arraybuffer").byteLength).toBeGreaterThan(10_000);
+  });
+
+  it("renders all required routine rabies evidence and a wet-signature line", () => {
+    const doc = generateRabiesVaccinationCertificatePdf({
+      ...identity,
+      vaccination: {
+        vaccineName: "Rabies",
+        productName: "Defensor 3",
+        manufacturer: "Zoetis",
+        lotNumber: "LOT-123",
+        productExpirationDate: "May 1, 2027",
+        doseType: "booster",
+        licensedDurationMonths: 36,
+        rabiesTagNumber: "TAG-42",
+        administeredAt: "Aug 24, 2026",
+        nextDueDate: "Aug 24, 2029",
+        administeredByName: "Taylor Tech",
+        veterinarianName: "Dr. Rivera",
+        veterinarianLicenseNumber: "NY-12345",
+      },
+    });
+
+    expect(doc.getNumberOfPages()).toBe(1);
+    expect(doc.output("arraybuffer").byteLength).toBeGreaterThan(4_000);
+    const source = readFileSync("lib/pdf.ts", "utf8");
+    expect(source).toContain("Veterinarian signature");
+    expect(source).toContain(
+      "Routine vaccination record — not a travel health certificate",
+    );
+    expect(source).toContain("Certificate ID: ${data.certificateId}");
   });
 });

--- a/apps/web/lib/__tests__/s3.test.ts
+++ b/apps/web/lib/__tests__/s3.test.ts
@@ -50,6 +50,7 @@ const {
   deleteFile,
   getObject,
   normalizeS3VersionId,
+  normalizeBlobVersionId,
   readPrimaryObject,
   replicaStorageIncludesPractice,
   replicaStoragePracticeScope,
@@ -429,21 +430,21 @@ describe("private Blob storage", () => {
       blob: {
         size: body.byteLength,
         contentType: "application/pdf",
-        etag: "blob-etag-1",
+        etag: 'W/"blob-etag-1"',
       },
     });
 
     await expect(
       readReplicaObject("attachments/file", {
         maxBytes: 10,
-        versionId: "blob-etag-1",
+        versionId: '"blob-etag-1"',
       }),
     ).resolves.toMatchObject({
       status: "available",
       body,
       contentType: "application/pdf",
-      etag: "blob-etag-1",
-      versionId: "blob-etag-1",
+      etag: 'W/"blob-etag-1"',
+      versionId: '"blob-etag-1"',
     });
     expect(mocks.blobGet).toHaveBeenCalledWith(
       "attachments/file",
@@ -453,6 +454,7 @@ describe("private Blob storage", () => {
         useCache: false,
       }),
     );
+    expect(normalizeBlobVersionId('W/"blob-etag-1"')).toBe('"blob-etag-1"');
   });
 
   it("requires a distinct configured private Blob store for replica rollout", () => {

--- a/apps/web/lib/__tests__/schedule-ui.test.ts
+++ b/apps/web/lib/__tests__/schedule-ui.test.ts
@@ -231,7 +231,9 @@ describe("schedule appointment form UX", () => {
     expect(source).toContain("function canUpdateAppointmentStatusRole");
     expect(source).toContain('role === "technician"');
     expect(source).toContain("function canSendAppointmentRemindersRole");
-    expect(source).toContain('role === "admin" || role === "front_desk"');
+    expect(source).toContain(
+      'role === "admin" || role === "veterinarian" || role === "front_desk"'
+    );
     expect(source).toContain(
       "const canCreateAppointments = canCreateAppointmentsRole(userRole)"
     );

--- a/apps/web/lib/__tests__/soap-editor-ui.test.ts
+++ b/apps/web/lib/__tests__/soap-editor-ui.test.ts
@@ -407,6 +407,10 @@ describe("records lab result form UX", () => {
 describe("records vaccination form UX", () => {
   it("adds vaccinations through bounded controls aligned to shared policy", () => {
     const source = readFileSync("app/(dashboard)/records/page.tsx", "utf8");
+    const fieldsSource = readFileSync(
+      "components/records/vaccination-form-fields.tsx",
+      "utf8"
+    );
 
     expect(VACCINATION_NAME_MAX_LENGTH).toBe(255);
     expect(VACCINATION_LOT_NUMBER_MAX_LENGTH).toBe(64);
@@ -421,14 +425,14 @@ describe("records vaccination form UX", () => {
     expect(source).toContain("const canCreateVaccinations =");
     expect(source).toContain("const canSubmitVaccination =");
     expect(source).toContain("Add Vaccination");
-    expect(source).toContain("maxLength={VACCINATION_NAME_MAX_LENGTH}");
-    expect(source).toContain(
+    expect(fieldsSource).toContain("maxLength={VACCINATION_NAME_MAX_LENGTH}");
+    expect(fieldsSource).toContain(
       "maxLength={VACCINATION_LOT_NUMBER_MAX_LENGTH}"
     );
-    expect(source).toContain(
+    expect(fieldsSource).toContain(
       "maxLength={VACCINATION_MANUFACTURER_MAX_LENGTH}"
     );
-    expect(source).toContain("isVaccinationOptionalDateInputValid");
+    expect(fieldsSource).toContain("isVaccinationOptionalDateInputValid");
     expect(source).toContain("vaccinationForm.lotNumber.trim() || undefined");
     expect(source).toContain("disabled={!canSubmitVaccination}");
     expect(source).not.toContain("disabled={createVaccination.isPending}");

--- a/apps/web/lib/__tests__/staff-vaccination-certificates-ui.test.ts
+++ b/apps/web/lib/__tests__/staff-vaccination-certificates-ui.test.ts
@@ -28,7 +28,7 @@ describe("staff vaccination certificates", () => {
     expect(readyAt).toBeGreaterThan(prepareAt);
     expect(importAt).toBeGreaterThan(readyAt);
     expect(downloadSection).not.toMatch(/from ["']@\/lib\/pdf["']/);
-    expect(downloadSection).toContain("crypto.randomUUID()");
+    expect(downloadSection).not.toContain("crypto.randomUUID()");
     expect(downloadSection).toContain(
       "generateVaccinationHistoryCertificatePdf",
     );
@@ -45,15 +45,28 @@ describe("staff vaccination certificates", () => {
     expect(router).toContain('warnings.push("current patient weight")');
     expect(router).toContain('warnings.push("veterinarian license number")');
     expect(router).toContain("isNull(clinicalRecordCorrections.id)");
+    expect(router).toContain("const certificateId = randomUUID()");
+    expect(router).toContain('action: "vaccination_certificate_prepared"');
+    expect(router).toContain("vaccinationRecordIds:");
     expect(patientPage).toContain("Complete these details before issuing");
   });
 
   it("requires audited reasons for certificate-detail corrections", () => {
+    const updateSection = router.slice(
+      router.indexOf("updateVaccinationCertificateDetails"),
+      router.indexOf("prepareVaccinationCertificate"),
+    );
     expect(router).toContain("updateVaccinationCertificateDetails");
     expect(router).toContain('action: "certificate_details_updated"');
     expect(router).toContain("before:");
     expect(router).toContain("after: patch");
     expect(router).toContain("expectedUpdatedAt");
+    expect(updateSection).toContain("notExists(");
+    expect(updateSection).toContain('.for("update")');
+    expect(updateSection).not.toContain(".leftJoin(");
+    expect(updateSection).not.toContain(
+      "eq(vaccinationRecords.updatedAt, current.updatedAt)",
+    );
     expect(patientPage).toContain(
       "Reason for change (required, at least 10 characters)",
     );

--- a/apps/web/lib/__tests__/staff-vaccination-certificates-ui.test.ts
+++ b/apps/web/lib/__tests__/staff-vaccination-certificates-ui.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const patientPage = readFileSync(
+  "app/(dashboard)/patients/[id]/page.tsx",
+  "utf8",
+);
+const recordsPage = readFileSync("app/(dashboard)/records/page.tsx", "utf8");
+const vaccinationForm = readFileSync(
+  "components/records/vaccination-form-fields.tsx",
+  "utf8",
+);
+const router = readFileSync("server/routers/records.ts", "utf8");
+
+describe("staff vaccination certificates", () => {
+  it("prepares fresh server-authorized data before lazily loading PDF code", () => {
+    const downloadSection = patientPage.slice(
+      patientPage.indexOf("async function downloadCertificate"),
+      patientPage.indexOf(
+        "if (error)",
+        patientPage.indexOf("async function downloadCertificate"),
+      ),
+    );
+    const prepareAt = downloadSection.indexOf("prepareCertificate.mutateAsync");
+    const readyAt = downloadSection.indexOf("if (!certificate.ready)");
+    const importAt = downloadSection.indexOf('await import("@/lib/pdf")');
+    expect(prepareAt).toBeGreaterThan(0);
+    expect(readyAt).toBeGreaterThan(prepareAt);
+    expect(importAt).toBeGreaterThan(readyAt);
+    expect(downloadSection).not.toMatch(/from ["']@\/lib\/pdf["']/);
+    expect(downloadSection).toContain("crypto.randomUUID()");
+    expect(downloadSection).toContain(
+      "generateVaccinationHistoryCertificatePdf",
+    );
+    expect(downloadSection).toContain(
+      "generateRabiesVaccinationCertificatePdf",
+    );
+  });
+
+  it("fails rabies issuance closed and excludes corrected records", () => {
+    expect(router).toContain("prepareVaccinationCertificate");
+    expect(router).toContain("ready: warnings.length === 0");
+    expect(router).toContain('warnings.push("owner address")');
+    expect(router).toContain('warnings.push("microchip or rabies tag number")');
+    expect(router).toContain('warnings.push("current patient weight")');
+    expect(router).toContain('warnings.push("veterinarian license number")');
+    expect(router).toContain("isNull(clinicalRecordCorrections.id)");
+    expect(patientPage).toContain("Complete these details before issuing");
+  });
+
+  it("requires audited reasons for certificate-detail corrections", () => {
+    expect(router).toContain("updateVaccinationCertificateDetails");
+    expect(router).toContain('action: "certificate_details_updated"');
+    expect(router).toContain("before:");
+    expect(router).toContain("after: patch");
+    expect(router).toContain("expectedUpdatedAt");
+    expect(patientPage).toContain(
+      "Reason for change (required, at least 10 characters)",
+    );
+    expect(patientPage).toContain("Save audited changes");
+  });
+
+  it("captures complete rabies product and veterinarian details at entry", () => {
+    expect(recordsPage).toContain("isVaccinationFormValid(vaccinationForm)");
+    expect(vaccinationForm).toContain("Product expiration *");
+    expect(vaccinationForm).toContain("Dose type *");
+    expect(vaccinationForm).toContain("Licensed duration *");
+    expect(vaccinationForm).toContain("Supervising veterinarian *");
+    expect(vaccinationForm).toContain("license missing");
+    expect(vaccinationForm).toContain("Boolean(form.nextDueDate)");
+  });
+});

--- a/apps/web/lib/__tests__/vaccination-certificate-migration.test.ts
+++ b/apps/web/lib/__tests__/vaccination-certificate-migration.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(process.cwd(), "../..");
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "packages/db/drizzle/0096_vaccination_certificates_care_reminder_dismissal.sql",
+  ),
+  "utf8",
+);
+
+describe("vaccination certificate and reminder dismissal migration", () => {
+  it("replaces the care reminder enum transaction-safely", () => {
+    expect(migration).toContain(
+      "CREATE TYPE \"public\".\"care_reminder_status_v2\" AS ENUM('open', 'completed', 'dismissed')",
+    );
+    expect(migration).toContain(
+      'ALTER TABLE "care_reminders" ALTER COLUMN "status" TYPE "public"."care_reminder_status_v2" USING "status"::text::"public"."care_reminder_status_v2"',
+    );
+    expect(migration).not.toContain("ADD VALUE");
+    expect(
+      migration.indexOf('DROP CONSTRAINT "care_reminders_state_check"'),
+    ).toBeLessThan(
+      migration.indexOf('DROP TYPE "public"."care_reminder_status"'),
+    );
+  });
+
+  it("adds tenant-bound attribution and coherent state constraints", () => {
+    expect(migration).toContain("care_reminders_dismisser_tenant_fk");
+    expect(migration).toContain("care_reminders_dismissal_reason_check");
+    expect(migration).toContain("care_reminders_state_check");
+    expect(migration).toContain("\"status\" = 'dismissed'");
+    expect(migration).toContain('"dismissed_by" is not null');
+  });
+
+  it("adds bounded rabies evidence and a same-practice veterinarian reference", () => {
+    for (const column of [
+      "product_name",
+      "product_expiration_date",
+      "dose_type",
+      "licensed_duration_months",
+      "rabies_tag_number",
+      "supervising_veterinarian_id",
+    ]) {
+      expect(migration).toContain(`ADD COLUMN "${column}"`);
+    }
+    expect(migration).toContain("vaccination_records_supervisor_practice_fk");
+    expect(migration).toContain("vaccination_records_licensed_duration_check");
+    expect(migration).toContain("between 1 and 120");
+  });
+});

--- a/apps/web/lib/__tests__/vaccination-certificate-migration.test.ts
+++ b/apps/web/lib/__tests__/vaccination-certificate-migration.test.ts
@@ -25,6 +25,16 @@ describe("vaccination certificate and reminder dismissal migration", () => {
     ).toBeLessThan(
       migration.indexOf('DROP TYPE "public"."care_reminder_status"'),
     );
+    expect(
+      migration.indexOf('DROP INDEX "care_reminders_open_due_idx"'),
+    ).toBeLessThan(migration.indexOf('ALTER COLUMN "status" TYPE'));
+    expect(
+      migration.indexOf('CREATE INDEX "care_reminders_open_due_idx"'),
+    ).toBeGreaterThan(
+      migration.indexOf(
+        'ALTER TYPE "public"."care_reminder_status_v2" RENAME TO "care_reminder_status"',
+      ),
+    );
   });
 
   it("adds tenant-bound attribution and coherent state constraints", () => {

--- a/apps/web/lib/__tests__/vercel-ignore-build.test.ts
+++ b/apps/web/lib/__tests__/vercel-ignore-build.test.ts
@@ -8,6 +8,7 @@ function ignoredBuildStatus(overrides: Record<string, string>): number | null {
   return spawnSync("bash", [ignoreBuildScript], {
     cwd: process.cwd(),
     env: {
+      NODE_ENV: "test",
       PATH: process.env.PATH,
       VERCEL_ENV: "preview",
       NEXT_PUBLIC_DEMO_MODE: "true",

--- a/apps/web/lib/__tests__/vercel-ignore-build.test.ts
+++ b/apps/web/lib/__tests__/vercel-ignore-build.test.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ignoreBuildScript = resolve(process.cwd(), "scripts/vercel-ignore-build.sh");
+
+function ignoredBuildStatus(overrides: Record<string, string>): number | null {
+  return spawnSync("bash", [ignoreBuildScript], {
+    cwd: process.cwd(),
+    env: {
+      PATH: process.env.PATH,
+      VERCEL_ENV: "preview",
+      NEXT_PUBLIC_DEMO_MODE: "true",
+      ...overrides,
+    },
+    encoding: "utf8",
+  }).status;
+}
+
+describe("Vercel ignored build policy", () => {
+  it("lets an operator force a protected demo-mode preview rebuild", () => {
+    // Vercel interprets exit 1 as "continue building".
+    expect(
+      ignoredBuildStatus({ OPENVPM_FORCE_PREVIEW_BUILD: "true" }),
+    ).toBe(1);
+  });
+
+  it("continues skipping ordinary demo-mode preview builds", () => {
+    // Vercel interprets exit 0 as "skip this deployment".
+    expect(ignoredBuildStatus({})).toBe(0);
+  });
+});

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -523,6 +523,7 @@ describe("summarizePracticeExport", () => {
     expect(PRACTICE_EXPORT_SECTIONS).toContain("webhooks");
     expect(PRACTICE_EXPORT_SECTIONS).toContain("apiKeys");
     expect(PRACTICE_EXPORT_SECTIONS).toContain("auditLog");
+    expect(PRACTICE_EXPORT_SECTIONS).toContain("careReminders");
   });
 
   it("requires replacement lineage in current backups but accepts its legacy absence", () => {
@@ -1041,7 +1042,9 @@ describe("independent recovery metadata", () => {
 
     expect(
       validatePracticeExportRestore({ ...backup, practice: undefined }).errors,
-    ).toContain("practice recovery metadata is required in backup format v6.");
+    ).toContain(
+      `practice recovery metadata is required in backup format v${PRACTICE_EXPORT_FORMAT_VERSION}.`,
+    );
     expect(
       validatePracticeExportRestore({
         ...backup,
@@ -1066,7 +1069,9 @@ describe("independent recovery metadata", () => {
         ...backup,
         formatVersion: PRACTICE_EXPORT_FORMAT_VERSION + 1,
       }).errors,
-    ).toContain("backup format v8 is newer than this release supports.");
+    ).toContain(
+      `backup format v${PRACTICE_EXPORT_FORMAT_VERSION + 1} is newer than this release supports.`,
+    );
     expect(
       validatePracticeExportRestore({
         ...backup,
@@ -1078,13 +1083,76 @@ describe("independent recovery metadata", () => {
         ...backup,
         counts: undefined,
       }).errors,
-    ).toContain("canonical section counts are required in backup format v6.");
+    ).toContain(
+      `canonical section counts are required in backup format v${PRACTICE_EXPORT_FORMAT_VERSION}.`,
+    );
     expect(
       validatePracticeExportRestore({
         ...backup,
         counts: { ...backup.counts, unexpected: 0 },
       }).errors,
     ).toContain("backup counts contain unsupported sections: unexpected.");
+  });
+});
+
+describe("care reminder recovery", () => {
+  function backupWithReminder(reminder: Record<string, unknown>) {
+    const practiceId = "00000000-0000-4000-8000-000000000060";
+    const userId = "00000000-0000-4000-8000-000000000061";
+    const clientId = "00000000-0000-4000-8000-000000000062";
+    const patientId = "00000000-0000-4000-8000-000000000063";
+    return withCanonicalCounts({
+      formatVersion: PRACTICE_EXPORT_FORMAT_VERSION,
+      practiceId,
+      practice: { id: practiceId, name: "Recovery Clinic" },
+      ...emptyBackup(),
+      users: [{ id: userId, practiceId }],
+      clients: [{ id: clientId, practiceId }],
+      patients: [{ id: patientId, practiceId, clientId }],
+      careReminders: [
+        {
+          id: "00000000-0000-4000-8000-000000000064",
+          practiceId,
+          patientId,
+          title: "Review imported reminder",
+          dueDate: "2026-08-24",
+          createdBy: userId,
+          deletedAt: null,
+          ...reminder,
+        },
+      ],
+    });
+  }
+
+  it("accepts an attributed dismissed reminder", () => {
+    const backup = backupWithReminder({
+      status: "dismissed",
+      completedAt: null,
+      completedBy: null,
+      dismissedAt: "2026-08-24T18:00:00.000Z",
+      dismissedBy: "00000000-0000-4000-8000-000000000061",
+      dismissalReason: "Duplicate imported reminder",
+    });
+
+    expect(validatePracticeExportRestore(backup)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  it("rejects partial or contradictory reminder states before restore", () => {
+    const backup = backupWithReminder({
+      status: "dismissed",
+      completedAt: "2026-08-24T17:00:00.000Z",
+      completedBy: "00000000-0000-4000-8000-000000000061",
+      dismissedAt: "2026-08-24T18:00:00.000Z",
+      dismissedBy: null,
+      dismissalReason: "x",
+    });
+
+    expect(validatePracticeExportRestore(backup).errors).toContain(
+      "careReminders[00000000-0000-4000-8000-000000000064] must have a complete and mutually exclusive open, completed, or dismissed state.",
+    );
   });
 });
 

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -166,6 +166,15 @@ describe("backupKey", () => {
   });
 });
 
+describe("staff attribution retention", () => {
+  it("keeps all source staff rows so historical ledgers remain restorable", () => {
+    const source = readFileSync("lib/backup/export.ts", "utf8");
+
+    expect(source).toContain("const userRows = allUserRows;");
+    expect(source).not.toContain("user.deletedAt == null || referencedUserIds");
+  });
+});
+
 describe("attachment manifest restore safety", () => {
   function manifestBackup() {
     return {
@@ -1003,16 +1012,14 @@ describe("exportPracticeData query scoping", () => {
     expect(source).toContain("patientMergeEvents: patientMergeRows");
   });
 
-  it("exports append-only SMS consent evidence and referenced identities", () => {
+  it("exports append-only SMS consent evidence and its owned identities", () => {
     expect(source).toContain(
       "allPracticeRows(db, smsConsentEvents, practiceId)",
     );
     expect(source).toContain(
       "...smsConsentEventRows.map((event) => event.clientId)",
     );
-    expect(source).toContain(
-      "...smsConsentEventRows.map((event) => event.actorUserId)",
-    );
+    expect(source).toContain("const userRows = allUserRows;");
     expect(source).toContain(
       "...smsConsentEventRows.map((event) => event.locationId)",
     );

--- a/apps/web/lib/backup/__tests__/verify-evidence-cli.test.ts
+++ b/apps/web/lib/backup/__tests__/verify-evidence-cli.test.ts
@@ -42,7 +42,7 @@ function evidenceFixture(
       sections[section]!.length,
     ]),
   );
-  const formatVersion = options.formatVersion ?? 7;
+  const formatVersion = options.formatVersion ?? 8;
   const objectBody = Buffer.from(
     JSON.stringify({
       formatVersion,
@@ -139,10 +139,10 @@ describe("backup recovery evidence CLI", () => {
   });
 
   it("rejects artifacts outside the one canonical supported export format", () => {
-    const result = run(evidenceFixture({ formatVersion: 6 }));
+    const result = run(evidenceFixture({ formatVersion: 7 }));
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("exportFormatVersion must be 7");
+    expect(result.stderr).toContain("exportFormatVersion must be 8");
   });
 
   it("checks catalog counts against the actual canonical section arrays", () => {

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -1,4 +1,12 @@
-import { eq, and, isNull, inArray, or, sql, getTableColumns } from "drizzle-orm";
+import {
+  eq,
+  and,
+  isNull,
+  inArray,
+  or,
+  sql,
+  getTableColumns,
+} from "drizzle-orm";
 import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "@openpims/db/client";
 import { withSystem } from "@/lib/tenant-db";
@@ -18,6 +26,7 @@ import {
   auditLog,
   caseEntries,
   cases,
+  careReminders,
   clientContacts,
   clinicalRecordCorrections,
   clinicalNotes,
@@ -186,6 +195,7 @@ export const PRACTICE_EXPORT_SECTIONS = [
   "wellnessEnrollments",
   "patientWeights",
   "patientAllergies",
+  "careReminders",
   "appointments",
   "historicalAppointments",
   "appointmentWaitlist",
@@ -286,6 +296,9 @@ const PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS = [
   "visitTreatmentPlanRevisionLines",
   "visitTreatmentPlanResponses",
   "visitTreatmentPlanResponseLines",
+  // Backward compatibility for backups created before internal care reminders
+  // became a fully owned, auditable restore section.
+  "careReminders",
 ] as const satisfies readonly PracticeExportSection[];
 
 export type PracticeExport = {
@@ -298,7 +311,7 @@ export type PracticeExport = {
   counts: Record<PracticeExportSection, number>;
 } & Record<PracticeExportSection, unknown[]>;
 
-export const PRACTICE_EXPORT_FORMAT_VERSION = 7;
+export const PRACTICE_EXPORT_FORMAT_VERSION = 8;
 export const PRACTICE_RECOVERY_HOLD_REASON =
   "Practice data restore pending owner reconciliation";
 
@@ -510,6 +523,11 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   requiredRef("vaccinationRecords", "patientId", "patients"),
   optionalRef("vaccinationRecords", "appointmentId", "appointments"),
   optionalRef("vaccinationRecords", "administeredBy", "users"),
+  optionalRef("vaccinationRecords", "supervisingVeterinarianId", "users"),
+  requiredRef("careReminders", "patientId", "patients"),
+  optionalRef("careReminders", "createdBy", "users"),
+  optionalRef("careReminders", "completedBy", "users"),
+  optionalRef("careReminders", "dismissedBy", "users"),
   requiredRef("labResults", "patientId", "patients"),
   optionalRef("labResults", "appointmentId", "appointments"),
   optionalRef("labResults", "orderedBy", "users"),
@@ -917,7 +935,9 @@ export function validatePracticeExportRestore(data: unknown): {
   }
   if (exportRecord.formatVersion === PRACTICE_EXPORT_FORMAT_VERSION) {
     if (!isRecord(exportRecord.practice)) {
-      pushError("practice recovery metadata is required in backup format v6.");
+      pushError(
+        `practice recovery metadata is required in backup format v${PRACTICE_EXPORT_FORMAT_VERSION}.`,
+      );
     } else if (exportRecord.practice.id !== exportRecord.practiceId) {
       pushError("practice recovery metadata must match practiceId exactly.");
     } else {
@@ -939,7 +959,9 @@ export function validatePracticeExportRestore(data: unknown): {
     }
 
     if (!isRecord(exportRecord.counts)) {
-      pushError("canonical section counts are required in backup format v6.");
+      pushError(
+        `canonical section counts are required in backup format v${PRACTICE_EXPORT_FORMAT_VERSION}.`,
+      );
     } else {
       const countKeys = Object.keys(exportRecord.counts);
       const missingCountKeys = PRACTICE_EXPORT_SECTIONS.filter(
@@ -1001,6 +1023,58 @@ export function validatePracticeExportRestore(data: unknown): {
       }
     });
   }
+
+  rowsFor(data, "careReminders").forEach((row, index) => {
+    const label = `careReminders[${rowLabel(row, index)}]`;
+    const completedFieldsPresent =
+      row.completedAt != null && row.completedBy != null;
+    const completedFieldsClear =
+      row.completedAt == null && row.completedBy == null;
+    const dismissalFieldsPresent =
+      row.dismissedAt != null &&
+      row.dismissedBy != null &&
+      typeof row.dismissalReason === "string" &&
+      row.dismissalReason.trim().length >= 3 &&
+      row.dismissalReason.length <= 500;
+    const dismissalFieldsClear =
+      row.dismissedAt == null &&
+      row.dismissedBy == null &&
+      row.dismissalReason == null;
+    const validState =
+      (row.status === "open" && completedFieldsClear && dismissalFieldsClear) ||
+      (row.status === "completed" &&
+        completedFieldsPresent &&
+        dismissalFieldsClear) ||
+      (row.status === "dismissed" &&
+        completedFieldsClear &&
+        dismissalFieldsPresent);
+    if (!validState) {
+      pushError(
+        `${label} must have a complete and mutually exclusive open, completed, or dismissed state.`,
+      );
+    }
+  });
+
+  rowsFor(data, "vaccinationRecords").forEach((row, index) => {
+    const label = `vaccinationRecords[${rowLabel(row, index)}]`;
+    if (
+      row.doseType != null &&
+      row.doseType !== "initial" &&
+      row.doseType !== "booster"
+    ) {
+      pushError(`${label}.doseType must be initial, booster, or null.`);
+    }
+    if (
+      row.licensedDurationMonths != null &&
+      (!Number.isInteger(row.licensedDurationMonths) ||
+        Number(row.licensedDurationMonths) < 1 ||
+        Number(row.licensedDurationMonths) > 120)
+    ) {
+      pushError(
+        `${label}.licensedDurationMonths must be an integer from 1 through 120.`,
+      );
+    }
+  });
 
   const rowsById = (section: PracticeExportSection) =>
     new Map(
@@ -2543,6 +2617,7 @@ export async function exportPracticeData(
     clientContactRows,
     allPatientRows,
     patientMergeRows,
+    allCareReminderRows,
     allAppointmentRows,
     historicalAppointmentRows,
     appointmentWaitlistRows,
@@ -2611,6 +2686,7 @@ export async function exportPracticeData(
     allPracticeRows(db, clientContacts, practiceId),
     allPracticeRows(db, patients, practiceId),
     allPracticeRows(db, patientMergeEvents, practiceId),
+    allPracticeRows(db, careReminders, practiceId),
     allPracticeRows(db, appointments, practiceId),
     allPracticeRows(db, historicalAppointments, practiceId),
     activeRows(db, appointmentWaitlist, practiceId),
@@ -3025,6 +3101,7 @@ export async function exportPracticeData(
     clientContacts: clientContactRows,
     patients: patientRows,
     patientMergeEvents: patientMergeRows,
+    careReminders: allCareReminderRows,
     insurancePolicies: insurancePolicyRows,
     wellnessPlans: wellnessPlanRows,
     wellnessEnrollments: wellnessEnrollmentRows,
@@ -3319,6 +3396,7 @@ async function restorePracticeDataRows(
   );
   await restorePracticeRows("patients", patients);
   await restorePracticeRows("patientMergeEvents", patientMergeEvents);
+  await restorePracticeRows("careReminders", careReminders);
   await restorePracticeRows("insurancePolicies", insurancePolicies);
   await restorePracticeRows("wellnessPlans", wellnessPlans);
   await restorePracticeRows("wellnessEnrollments", wellnessEnrollments);
@@ -3374,10 +3452,7 @@ async function restorePracticeDataRows(
   );
   await restorePracticeRows("labResultEvents", labResultEvents);
   await restorePracticeRows("externalLabReports", externalLabReports);
-  await restorePracticeRows(
-    "externalLabObservations",
-    externalLabObservations,
-  );
+  await restorePracticeRows("externalLabObservations", externalLabObservations);
   await restorePracticeRows("procedures", procedures);
   await restorePracticeRows("clinicalNotes", clinicalNotes);
   await restorePracticeRows("vitalSigns", vitalSigns);
@@ -3498,10 +3573,7 @@ async function restorePracticeDataRows(
     "legacyFinancialLineItems",
     legacyFinancialLineItems,
   );
-  await restorePracticeRows(
-    "legacyFinancialPayments",
-    legacyFinancialPayments,
-  );
+  await restorePracticeRows("legacyFinancialPayments", legacyFinancialPayments);
   await restorePracticeRows(
     "legacyFinancialAllocations",
     legacyFinancialAllocations,

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -2863,40 +2863,12 @@ export async function exportPracticeData(
     (product) =>
       product.deletedAt == null || referencedProductIds.has(product.id),
   );
-  const referencedUserIds = new Set(
-    [
-      ...prescriptionEventRows.map((event) => event.actorId),
-      ...prescriptionRows.map((prescription) => prescription.prescribedBy),
-      ...clinicalCorrectionRows.map((correction) => correction.correctedBy),
-      ...labReplacementRows.map((replacement) => replacement.actorId),
-      ...soapNoteRows.map((note) => note.authorId),
-      ...soapNoteRows.map((note) => note.finalizedBy),
-      ...soapNoteAddendumRows.map((addendum) => addendum.authorId),
-      ...vitalRows.map((vital) => vital.recordedBy),
-      ...vaccinationRows.map((vaccination) => vaccination.administeredBy),
-      ...labRows.flatMap((result) => [
-        result.orderedBy,
-        result.reviewedBy,
-        result.followUpAssignedTo,
-        result.followUpCompletedBy,
-      ]),
-      ...labResultEventRows.flatMap((event) => [
-        event.actorId,
-        event.followUpAssignedTo,
-      ]),
-      ...appointmentRows.map((appointment) => appointment.doctorId),
-      ...patientMergeRows.map((event) => event.performedBy),
-      ...smsConsentEventRows.map((event) => event.actorUserId),
-      ...smsSendAttemptRows.map((attempt) => attempt.requestedByUserId),
-      ...smsSendAttemptEventRows.map((event) => event.actorUserId),
-      ...fileRows.map((file) => file.uploadedBy),
-      ...visitTreatmentPlanRows.map((plan) => plan.createdBy),
-      ...visitTreatmentPlanRevisionRows.map((revision) => revision.authoredBy),
-    ].filter((id): id is string => typeof id === "string"),
-  );
-  const userRows = allUserRows.filter(
-    (user) => user.deletedAt == null || referencedUserIds.has(user.id),
-  );
+  // Staff attribution is referenced throughout the clinical, financial,
+  // communication, and audit ledgers. Preserve every soft-deleted staff row
+  // already retained by the source practice so a future reference cannot make
+  // an otherwise complete backup unrestorable. Secrets are still sanitized in
+  // the users export section.
+  const userRows = allUserRows;
   const referencedClientIds = new Set(
     [
       ...patientRows.map((patient) => patient.clientId),

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -154,14 +154,17 @@ interface EmailDispatchOptions {
 async function dispatchEmail(
   options: EmailDispatchOptions,
 ): Promise<EmailProviderEvidence> {
-  const client = getResend();
+  const demoMode = emailDemoMode();
+  // Demo/QA environments must remain non-delivering even when Preview inherits
+  // a real provider key from the hosted project configuration.
+  const client = demoMode ? null : getResend();
   const provider: EmailProvider =
-    client || (billingEnforced() && !emailDemoMode()) ? "resend" : "console";
+    client || (billingEnforced() && !demoMode) ? "resend" : "console";
   const from = defaultEmailFrom(options.from);
   const replyTo = nonBlankEmailValue(options.replyTo);
 
   if (!client) {
-    if (billingEnforced() && !emailDemoMode()) {
+    if (billingEnforced() && !demoMode) {
       return {
         success: false,
         provider,
@@ -278,8 +281,9 @@ async function dispatchEmail(
  * configuration failure); only the explicit local/demo fallback is console.
  */
 export function verificationEmailProvider(): EmailProvider {
+  if (emailDemoMode()) return "console";
   if (getResend()) return "resend";
-  return billingEnforced() && !emailDemoMode() ? "resend" : "console";
+  return billingEnforced() ? "resend" : "console";
 }
 
 export async function sendEmail(

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -389,6 +389,55 @@ export async function sendVaccinationReminder(data: {
 }
 
 // ---------------------------------------------------------------------------
+// Care reminder
+// ---------------------------------------------------------------------------
+
+export async function sendCareReminder(data: {
+  to: string;
+  clientName: string;
+  patientName: string;
+  reminderTitle: string;
+  dueDate: string;
+  practiceName: string;
+  practicePhone?: string;
+  practiceAddress?: string;
+  idempotencyKey: string;
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  const body = `
+    <p style="margin:0 0 16px;color:#111827;font-size:15px;line-height:1.6;">Hi ${data.clientName},</p>
+    <p style="margin:0 0 24px;color:#111827;font-size:15px;line-height:1.6;">This is a reminder from our veterinary team about <strong>${data.patientName}</strong>.</p>
+    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;background-color:#f0fdfa;border:1px solid #ccfbf1;border-radius:8px;margin-bottom:24px;">
+      <tr>
+        <td style="padding:20px 24px;">
+          <p style="margin:0 0 4px;color:#6b7280;font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;">Reminder</p>
+          <p style="margin:0 0 16px;color:#0f172a;font-size:18px;font-weight:600;">${data.reminderTitle}</p>
+          <p style="margin:0 0 4px;color:#6b7280;font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em;">Reminder Date</p>
+          <p style="margin:0;color:#0f172a;font-size:18px;font-weight:600;">${data.dueDate}</p>
+        </td>
+      </tr>
+    </table>
+    <p style="margin:0;color:#111827;font-size:15px;line-height:1.6;">Please contact us${data.practicePhone ? ` at <strong>${data.practicePhone}</strong>` : ""} if you have questions or would like to schedule.</p>
+  `;
+
+  const html = emailLayout(
+    data.practiceName,
+    body,
+    practiceFooter({
+      practiceName: data.practiceName,
+      practicePhone: data.practicePhone,
+      practiceAddress: data.practiceAddress,
+    }),
+  );
+  const result = await sendEmail({
+    to: data.to,
+    subject: `Care Reminder for ${data.patientName}`,
+    html,
+    idempotencyKey: data.idempotencyKey,
+  });
+  return { success: result.success, id: result.id, error: result.error };
+}
+
+// ---------------------------------------------------------------------------
 // Invoice email
 // ---------------------------------------------------------------------------
 

--- a/apps/web/lib/messaging/__tests__/sms-provider-event-operations.test.ts
+++ b/apps/web/lib/messaging/__tests__/sms-provider-event-operations.test.ts
@@ -48,6 +48,17 @@ describe("SMS provider-event operational gates", () => {
     expect(queueSource).not.toContain('"toE164"');
   });
 
+  it("serializes raw SQL timestamps before they reach postgres-js", () => {
+    expect(source).toContain("input.unresolvedSince?.toISOString()");
+    expect(source).toContain("const nowIso = now.toISOString()");
+    expect(source).toContain(
+      "const staleBeforeIso = staleBefore.toISOString()",
+    );
+    expect(source).not.toContain("${input.unresolvedSince ?? null}");
+    expect(source).not.toContain("${staleBefore}");
+    expect(source).not.toContain("${now}");
+  });
+
   it("fails the final dispatch barrier on an exact durable STOP", async () => {
     const execute = vi.fn(async () => ({ rows: [{ blocked: true }] }));
 

--- a/apps/web/lib/messaging/sms-provider-event-operations.ts
+++ b/apps/web/lib/messaging/sms-provider-event-operations.ts
@@ -208,6 +208,7 @@ export async function loadSmsProviderEventGateSummaryInTransaction(
     unresolvedSince?: Date;
   },
 ): Promise<SmsProviderEventGateSummary> {
+  const unresolvedSince = input.unresolvedSince?.toISOString() ?? null;
   const result = await tx.execute(sql`
     with relevant_events as (
       select event.*,
@@ -225,8 +226,8 @@ export async function loadSmsProviderEventGateSummaryInTransaction(
           or (
             event.practice_id is null
             and (
-              ${input.unresolvedSince ?? null}::timestamptz is not null
-              and event.received_at >= ${input.unresolvedSince ?? null}::timestamptz
+              ${unresolvedSince}::timestamptz is not null
+              and event.received_at >= ${unresolvedSince}::timestamptz
             )
           )
           or (
@@ -289,8 +290,8 @@ export async function loadSmsProviderEventGateSummaryInTransaction(
           event.practice_id = ${input.practiceId}::uuid
           or (
             event.practice_id is null
-            and ${input.unresolvedSince ?? null}::timestamptz is not null
-            and conflict.received_at >= ${input.unresolvedSince ?? null}::timestamptz
+            and ${unresolvedSince}::timestamptz is not null
+            and conflict.received_at >= ${unresolvedSince}::timestamptz
           )
           or (
             event.practice_id is null
@@ -378,6 +379,8 @@ export async function loadSmsProviderEventQueue(
   const staleBefore = new Date(
     now.getTime() - SMS_PROVIDER_EVENT_STALE_MINUTES * 60 * 1000,
   );
+  const nowIso = now.toISOString();
+  const staleBeforeIso = staleBefore.toISOString();
 
   return withSystem(database, async (tx) => {
     const scope = options.practiceId
@@ -419,8 +422,8 @@ export async function loadSmsProviderEventQueue(
         (select count(*)::int from scoped_conflicts) as conflicts,
         count(*) filter (
           where state in ('pending', 'retry')
-            and received_at <= ${staleBefore}
-            and (next_attempt_at is null or next_attempt_at <= ${now})
+            and received_at <= ${staleBeforeIso}::timestamptz
+            and (next_attempt_at is null or next_attempt_at <= ${nowIso}::timestamptz)
         )::int as stale
       from scoped_events
     `);
@@ -445,8 +448,8 @@ export async function loadSmsProviderEventQueue(
           event.last_error_code as "lastErrorCode",
           (
             event.state in ('pending', 'retry')
-            and event.received_at <= ${staleBefore}
-            and (event.next_attempt_at is null or event.next_attempt_at <= ${now})
+            and event.received_at <= ${staleBeforeIso}::timestamptz
+            and (event.next_attempt_at is null or event.next_attempt_at <= ${nowIso}::timestamptz)
           ) as stale,
           case event.state
             when 'quarantined' then 0

--- a/apps/web/lib/messaging/sms-provider-events.ts
+++ b/apps/web/lib/messaging/sms-provider-events.ts
@@ -1629,6 +1629,7 @@ export async function getSmsProviderEventBacklogSummary(
   tx?: Database,
   opts: { practiceId?: string; since?: Date } = {},
 ): Promise<SmsProviderEventBacklogSummary> {
+  const since = opts.since?.toISOString() ?? null;
   const load = async (database: Database) => {
     const result = await database.execute(sql`
       with unresolved_conflicts as (
@@ -1649,7 +1650,7 @@ export async function getSmsProviderEventBacklogSummary(
             )
           )
           and (${opts.practiceId ?? null}::uuid is null or event.practice_id = ${opts.practiceId ?? null}::uuid)
-          and (${opts.since ?? null}::timestamptz is null or conflict.received_at >= ${opts.since ?? null}::timestamptz)
+          and (${since}::timestamptz is null or conflict.received_at >= ${since}::timestamptz)
       )
       select
         count(*) filter (where state = 'pending')::int as pending,
@@ -1668,7 +1669,7 @@ export async function getSmsProviderEventBacklogSummary(
           or not ${smsProviderEventQuarantineIsRemediatedSql}
         )
         and (${opts.practiceId ?? null}::uuid is null or event.practice_id = ${opts.practiceId ?? null}::uuid)
-        and (${opts.since ?? null}::timestamptz is null or event.received_at >= ${opts.since ?? null}::timestamptz)
+        and (${since}::timestamptz is null or event.received_at >= ${since}::timestamptz)
     `);
     const row = rowsFromExecute<BacklogRow>(result)[0];
     const oldest = row?.oldestUnresolvedAt;

--- a/apps/web/lib/outbound-email-security.ts
+++ b/apps/web/lib/outbound-email-security.ts
@@ -18,6 +18,7 @@ type OutboundEmailOperation =
   | "staff_invite"
   | "appointment_reminder"
   | "invoice"
+  | "care_reminder"
   | "vaccination_recall";
 
 type Quota = {

--- a/apps/web/lib/pdf.ts
+++ b/apps/web/lib/pdf.ts
@@ -279,7 +279,7 @@ export function generateInvoicePdf(data: InvoiceData): jsPDF {
   // Balance due — prefer the caller's region-formatted value; otherwise derive
   // it from total − paid (legacy callers without a currency context).
   const balanceParts = [data.total, data.paidAmount].map((v) =>
-    parseFloat(v.replace(/[^0-9.-]/g, ""))
+    parseFloat(v.replace(/[^0-9.-]/g, "")),
   );
   const balance =
     data.balanceDue ?? `$${(balanceParts[0]! - balanceParts[1]!).toFixed(2)}`;
@@ -297,7 +297,7 @@ export function generateInvoicePdf(data: InvoiceData): jsPDF {
     "Thank you for trusting us with your pet's care",
     PAGE_WIDTH / 2,
     pageHeight - 15,
-    { align: "center" }
+    { align: "center" },
   );
 
   return doc;
@@ -324,7 +324,7 @@ export interface PrescriptionLabelData {
 }
 
 export function generatePrescriptionLabelPdf(
-  data: PrescriptionLabelData
+  data: PrescriptionLabelData,
 ): jsPDF {
   // 4" x 2" landscape at 72 DPI  ➜  288 x 144 points
   const doc = new jsPDF({ format: [144, 288], orientation: "landscape" });
@@ -585,22 +585,14 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
     doc.setFont(FONT, "bold");
     doc.text("Phone: ", PAGE_MARGIN, y);
     doc.setFont(FONT, "normal");
-    doc.text(
-      data.clientPhone,
-      PAGE_MARGIN + doc.getTextWidth("Phone: "),
-      y
-    );
+    doc.text(data.clientPhone, PAGE_MARGIN + doc.getTextWidth("Phone: "), y);
     y += 6;
   }
   if (data.clientEmail) {
     doc.setFont(FONT, "bold");
     doc.text("Email: ", PAGE_MARGIN, y);
     doc.setFont(FONT, "normal");
-    doc.text(
-      data.clientEmail,
-      PAGE_MARGIN + doc.getTextWidth("Email: "),
-      y
-    );
+    doc.text(data.clientEmail, PAGE_MARGIN + doc.getTextWidth("Email: "), y);
     y += 6;
   }
 
@@ -621,7 +613,11 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
       doc.text(allergy.allergen, PAGE_MARGIN + 2, y);
       doc.setFont(FONT, "normal");
       setColor(doc, COLOR_GRAY);
-      doc.text(`(${allergy.severity})`, PAGE_MARGIN + 2 + doc.getTextWidth(allergy.allergen + " "), y);
+      doc.text(
+        `(${allergy.severity})`,
+        PAGE_MARGIN + 2 + doc.getTextWidth(allergy.allergen + " "),
+        y,
+      );
       y += 5;
       if (allergy.reaction) {
         doc.setFontSize(8);
@@ -706,7 +702,7 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
           ? `${note.date}  (Finalized imported record)`
           : `${note.date}  (Finalized)`,
         PAGE_MARGIN,
-        y
+        y,
       );
       y += 6;
 
@@ -863,11 +859,16 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
       `Generated on ${generatedDate} — This document is for reference only`,
       PAGE_WIDTH / 2,
       pageHeight - 10,
-      { align: "center" }
+      { align: "center" },
     );
-    doc.text(`Page ${i} of ${pageCount}`, PAGE_WIDTH - PAGE_MARGIN, pageHeight - 10, {
+    doc.text(
+      `Page ${i} of ${pageCount}`,
+      PAGE_WIDTH - PAGE_MARGIN,
+      pageHeight - 10,
+      {
       align: "right",
-    });
+      },
+    );
   }
 
   return doc;
@@ -898,7 +899,7 @@ export interface VaccinationCertificateData {
 }
 
 export function generateVaccinationCertificatePdf(
-  data: VaccinationCertificateData
+  data: VaccinationCertificateData,
 ): jsPDF {
   const doc = new jsPDF();
   let y = PAGE_MARGIN;
@@ -1006,6 +1007,372 @@ export function generateVaccinationCertificatePdf(
   return doc;
 }
 
+export interface StaffVaccinationCertificateData {
+  certificateId: string;
+  generatedDate: string;
+  practice: {
+    name: string;
+    address?: string | null;
+    phone?: string | null;
+    email?: string | null;
+  };
+  owner: {
+    name: string;
+    address?: string | null;
+    phone?: string | null;
+  };
+  patient: {
+    name: string;
+    species: string;
+    breed?: string | null;
+    sex?: string | null;
+    dob?: string | null;
+    color?: string | null;
+    microchipNumber?: string | null;
+    weightKg?: string | null;
+  };
+  vaccinations: Array<{
+    vaccineName: string;
+    productName?: string | null;
+    administeredAt: string;
+    nextDueDate?: string | null;
+    manufacturer?: string | null;
+    lotNumber?: string | null;
+    administeredByName?: string | null;
+  }>;
+}
+
+export interface RabiesVaccinationCertificateData extends Omit<
+  StaffVaccinationCertificateData,
+  "vaccinations"
+> {
+  vaccination: {
+    vaccineName: string;
+    productName: string;
+    manufacturer: string;
+    lotNumber: string;
+    productExpirationDate: string;
+    doseType: "initial" | "booster";
+    licensedDurationMonths: number;
+    rabiesTagNumber?: string | null;
+    administeredAt: string;
+    nextDueDate: string;
+    administeredByName?: string | null;
+    veterinarianName: string;
+    veterinarianLicenseNumber: string;
+  };
+}
+
+function drawCertificateHeader(
+  doc: jsPDF,
+  data: Pick<StaffVaccinationCertificateData, "practice" | "certificateId">,
+  title: string,
+): number {
+  let y = PAGE_MARGIN;
+  drawPawMark(doc, PAGE_MARGIN, y - 5, 13);
+  doc.setFont(FONT, "bold");
+  doc.setFontSize(18);
+  setColor(doc, COLOR_TEAL);
+  const practiceNameLines = doc.splitTextToSize(
+    data.practice.name || "Veterinary Practice",
+    CONTENT_WIDTH - 18,
+  );
+  doc.text(practiceNameLines, PAGE_MARGIN + 18, y);
+  y += Math.max(practiceNameLines.length, 1) * 6;
+  doc.setFont(FONT, "normal");
+  doc.setFontSize(8);
+  setColor(doc, COLOR_GRAY);
+  const practiceLines = [
+    data.practice.address,
+    [data.practice.phone, data.practice.email].filter(Boolean).join(" • "),
+  ].filter(Boolean) as string[];
+  if (practiceLines.length > 0) {
+    doc.text(practiceLines, PAGE_MARGIN + 18, y);
+  }
+  y += Math.max(practiceLines.length, 1) * 4 + 5;
+
+  doc.setFont(FONT, "bold");
+  doc.setFontSize(15);
+  setColor(doc, COLOR_DARK);
+  doc.text(title, PAGE_MARGIN, y);
+  doc.setFont(FONT, "normal");
+  doc.setFontSize(8);
+  setColor(doc, COLOR_GRAY);
+  doc.text(
+    `Certificate ID: ${data.certificateId}`,
+    PAGE_WIDTH - PAGE_MARGIN,
+    y,
+    { align: "right" },
+  );
+  y += 6;
+  drawLine(doc, y);
+  return y + 8;
+}
+
+function drawCertificateIdentity(
+  doc: jsPDF,
+  data: Pick<StaffVaccinationCertificateData, "owner" | "patient">,
+  y: number,
+): number {
+  const rightX = PAGE_MARGIN + CONTENT_WIDTH / 2 + 4;
+  doc.setFont(FONT, "bold");
+  doc.setFontSize(11);
+  setColor(doc, COLOR_TEAL);
+  doc.text("Patient", PAGE_MARGIN, y);
+  doc.text("Owner", rightX, y);
+  y += 5;
+
+  const patientLines = [
+    data.patient.name,
+    [data.patient.species, data.patient.breed].filter(Boolean).join(" / "),
+    data.patient.sex ? `Sex: ${data.patient.sex}` : undefined,
+    data.patient.dob ? `DOB: ${data.patient.dob}` : undefined,
+    data.patient.color ? `Color/markings: ${data.patient.color}` : undefined,
+    data.patient.microchipNumber
+      ? `Microchip: ${data.patient.microchipNumber}`
+      : undefined,
+    data.patient.weightKg ? `Weight: ${data.patient.weightKg} kg` : undefined,
+  ].filter(Boolean) as string[];
+  const ownerLines = [
+    data.owner.name,
+    ...(data.owner.address?.split("\n") ?? []),
+    data.owner.phone ? `Phone: ${data.owner.phone}` : undefined,
+  ].filter(Boolean) as string[];
+  doc.setFont(FONT, "normal");
+  doc.setFontSize(9);
+  setColor(doc, COLOR_DARK);
+  doc.text(patientLines, PAGE_MARGIN, y);
+  doc.text(ownerLines, rightX, y);
+  return y + Math.max(patientLines.length, ownerLines.length, 1) * 4.5 + 8;
+}
+
+function drawCertificateFooter(
+  doc: jsPDF,
+  certificateId: string,
+  generatedDate: string,
+): void {
+  const pageCount = doc.getNumberOfPages();
+  for (let page = 1; page <= pageCount; page += 1) {
+    doc.setPage(page);
+    const pageHeight = doc.internal.pageSize.getHeight();
+    doc.setFont(FONT, "italic");
+    doc.setFontSize(7.5);
+    setColor(doc, COLOR_GRAY);
+    doc.text(
+      `Generated ${generatedDate} • Certificate ${certificateId}`,
+      PAGE_MARGIN,
+      pageHeight - 9,
+    );
+    doc.text(
+      `Page ${page} of ${pageCount}`,
+      PAGE_WIDTH - PAGE_MARGIN,
+      pageHeight - 9,
+      {
+        align: "right",
+      },
+    );
+  }
+}
+
+export function generateVaccinationHistoryCertificatePdf(
+  data: StaffVaccinationCertificateData,
+): jsPDF {
+  const doc = new jsPDF();
+  let y = drawCertificateHeader(doc, data, "VACCINATION CERTIFICATE");
+  y = drawCertificateIdentity(doc, data, y);
+
+  doc.setFont(FONT, "bold");
+  doc.setFontSize(11);
+  setColor(doc, COLOR_TEAL);
+  doc.text("Vaccination history", PAGE_MARGIN, y);
+  y += 6;
+
+  const columns = [PAGE_MARGIN, 64, 94, 121, 148];
+  const widths = [42, 28, 25, 25, 42];
+  const drawTableHeader = (headerY: number) => {
+    const headings = [
+      "Vaccine / product",
+      "Given",
+      "Next due",
+      "Lot",
+      "Administered by",
+    ];
+    doc.setFillColor(...hexToRgb(COLOR_LIGHT_GRAY));
+    doc.rect(PAGE_MARGIN, headerY - 4, CONTENT_WIDTH, 7, "F");
+    doc.setFont(FONT, "bold");
+    doc.setFontSize(7.5);
+    setColor(doc, COLOR_DARK);
+    headings.forEach((heading, index) =>
+      doc.text(heading, columns[index]!, headerY),
+    );
+    return headerY + 6;
+  };
+  y = drawTableHeader(y);
+
+  doc.setFontSize(8);
+  for (const vaccination of data.vaccinations) {
+    const rowCells = [
+      [vaccination.vaccineName, vaccination.productName]
+        .filter(Boolean)
+        .join(" / "),
+      vaccination.administeredAt,
+      vaccination.nextDueDate || "—",
+      vaccination.lotNumber || "—",
+      vaccination.administeredByName || "—",
+    ];
+    const wrapped = rowCells.map((value, index) =>
+      doc.splitTextToSize(value, widths[index]!),
+    );
+    const rowHeight =
+      Math.max(...wrapped.map((lines) => lines.length), 1) * 3.8 + 3;
+    if (y + rowHeight + 3 > doc.internal.pageSize.getHeight() - 20) {
+      doc.addPage();
+      y = PAGE_MARGIN;
+      doc.setFont(FONT, "bold");
+      doc.setFontSize(11);
+      setColor(doc, COLOR_TEAL);
+      doc.text("Vaccination history (continued)", PAGE_MARGIN, y);
+      doc.setFont(FONT, "normal");
+      doc.setFontSize(8);
+      setColor(doc, COLOR_GRAY);
+      doc.text(
+        `Certificate ID: ${data.certificateId}`,
+        PAGE_WIDTH - PAGE_MARGIN,
+        y,
+        { align: "right" },
+      );
+      y += 6;
+      drawLine(doc, y);
+      y = drawTableHeader(y + 8);
+    }
+    doc.setFont(FONT, "normal");
+    setColor(doc, COLOR_DARK);
+    wrapped.forEach((lines, index) => doc.text(lines, columns[index]!, y));
+    y += rowHeight;
+    drawLine(doc, y - 2);
+  }
+
+  y = ensureSpace(doc, y + 5, 14);
+  doc.setFont(FONT, "normal");
+  doc.setFontSize(8);
+  setColor(doc, COLOR_GRAY);
+  doc.text(
+    doc.splitTextToSize(
+      "This document is a record of vaccinations entered in the patient's chart as of the generated date.",
+      CONTENT_WIDTH,
+    ),
+    PAGE_MARGIN,
+    y,
+  );
+  drawCertificateFooter(doc, data.certificateId, data.generatedDate);
+  return doc;
+}
+
+export function generateRabiesVaccinationCertificatePdf(
+  data: RabiesVaccinationCertificateData,
+): jsPDF {
+  const doc = new jsPDF();
+  let y = drawCertificateHeader(doc, data, "RABIES VACCINATION CERTIFICATE");
+  y = drawCertificateIdentity(doc, data, y);
+
+  doc.setFont(FONT, "bold");
+  doc.setFontSize(11);
+  setColor(doc, COLOR_TEAL);
+  doc.text("Rabies vaccination", PAGE_MARGIN, y);
+  y += 6;
+
+  const durationLabel =
+    data.vaccination.licensedDurationMonths % 12 === 0
+      ? `${data.vaccination.licensedDurationMonths / 12} year`
+      : `${data.vaccination.licensedDurationMonths} months`;
+  const details: Array<[string, string]> = [
+    ["Vaccine", data.vaccination.vaccineName],
+    ["Product", data.vaccination.productName],
+    ["Manufacturer", data.vaccination.manufacturer],
+    ["Lot number", data.vaccination.lotNumber],
+    ["Product expiration", data.vaccination.productExpirationDate],
+    ["Dose", data.vaccination.doseType === "initial" ? "Initial" : "Booster"],
+    ["Licensed duration", durationLabel],
+    ["Date administered", data.vaccination.administeredAt],
+    ["Next due", data.vaccination.nextDueDate],
+    [
+      "Rabies tag",
+      data.vaccination.rabiesTagNumber ||
+        "Not assigned (microchip listed above)",
+    ],
+    ["Administered by", data.vaccination.administeredByName || "Not recorded"],
+  ];
+  const half = Math.ceil(details.length / 2);
+  const rightX = PAGE_MARGIN + CONTENT_WIDTH / 2 + 4;
+  const drawDetailsColumn = (
+    rows: Array<[string, string]>,
+    x: number,
+    startY: number,
+  ) => {
+    let columnY = startY;
+    rows.forEach(([label, value]) => {
+      doc.setFont(FONT, "bold");
+      doc.setFontSize(7.5);
+      setColor(doc, COLOR_GRAY);
+      doc.text(label.toUpperCase(), x, columnY);
+      columnY += 3.8;
+      doc.setFont(FONT, "normal");
+      doc.setFontSize(9);
+      setColor(doc, COLOR_DARK);
+      const lines = doc.splitTextToSize(value, CONTENT_WIDTH / 2 - 8);
+      doc.text(lines, x, columnY);
+      columnY += Math.max(lines.length, 1) * 4 + 3;
+    });
+    return columnY;
+  };
+  y = Math.max(
+    drawDetailsColumn(details.slice(0, half), PAGE_MARGIN, y),
+    drawDetailsColumn(details.slice(half), rightX, y),
+  );
+
+  y = ensureSpace(doc, y + 6, 40);
+  drawLine(doc, y);
+  y += 8;
+  doc.setFont(FONT, "bold");
+  doc.setFontSize(10);
+  setColor(doc, COLOR_DARK);
+  doc.text(data.vaccination.veterinarianName, PAGE_MARGIN, y);
+  doc.setFont(FONT, "normal");
+  doc.setFontSize(8.5);
+  doc.text(
+    `Veterinarian • License ${data.vaccination.veterinarianLicenseNumber}`,
+    PAGE_MARGIN,
+    y + 5,
+  );
+  doc.line(PAGE_MARGIN + 94, y + 4, PAGE_WIDTH - PAGE_MARGIN, y + 4);
+  doc.setFontSize(7.5);
+  setColor(doc, COLOR_GRAY);
+  doc.text("Veterinarian signature", PAGE_MARGIN + 94, y + 8);
+
+  y += 18;
+  doc.setFont(FONT, "bold");
+  doc.setFontSize(8);
+  setColor(doc, COLOR_DARK);
+  doc.text(
+    "Routine vaccination record — not a travel health certificate",
+    PAGE_MARGIN,
+    y,
+  );
+  doc.setFont(FONT, "normal");
+  doc.setFontSize(7.5);
+  setColor(doc, COLOR_GRAY);
+  doc.text(
+    doc.splitTextToSize(
+      "A handwritten veterinarian signature may be required by the receiving authority. Travel and import documents can require separate accreditation, endorsement, and submission workflows.",
+      CONTENT_WIDTH,
+    ),
+    PAGE_MARGIN,
+    y + 4,
+  );
+  drawCertificateFooter(doc, data.certificateId, data.generatedDate);
+  return doc;
+}
+
 // ---------------------------------------------------------------------------
 // 5. Generic Report PDF
 // ---------------------------------------------------------------------------
@@ -1084,7 +1451,7 @@ export function generateReportPdf(data: ReportPdfData): jsPDF {
 
     for (const row of data.rows) {
       const cellLines = data.columns.map((_, index) =>
-        doc.splitTextToSize(String(row[index] ?? ""), colWidth - 4)
+        doc.splitTextToSize(String(row[index] ?? ""), colWidth - 4),
       );
       const rowHeight =
         Math.max(...cellLines.map((lines) => lines.length), 1) * 4 + 4;
@@ -1142,7 +1509,7 @@ export interface DischargeInstructionsData {
 }
 
 export function generateDischargeInstructions(
-  data: DischargeInstructionsData
+  data: DischargeInstructionsData,
 ): jsPDF {
   const doc = new jsPDF();
   let y = PAGE_MARGIN;
@@ -1237,7 +1604,10 @@ export function generateDischargeInstructions(
       doc.text(`Frequency: ${med.frequency}`, PAGE_MARGIN + 4, y);
       y += 5;
       if (med.instructions) {
-        const instrLines = doc.splitTextToSize(med.instructions, CONTENT_WIDTH - 8);
+        const instrLines = doc.splitTextToSize(
+          med.instructions,
+          CONTENT_WIDTH - 8,
+        );
         setColor(doc, COLOR_DARK);
         doc.text(instrLines, PAGE_MARGIN + 4, y);
         y += instrLines.length * 5;
@@ -1345,7 +1715,7 @@ export function generateDischargeInstructions(
     "If you have any questions or concerns, please contact our office.",
     PAGE_WIDTH / 2,
     pageHeight - 15,
-    { align: "center" }
+    { align: "center" },
   );
   if (data.practicePhone) {
     doc.text(data.practicePhone, PAGE_WIDTH / 2, pageHeight - 10, {

--- a/apps/web/lib/records/__tests__/vaccination-policy.test.ts
+++ b/apps/web/lib/records/__tests__/vaccination-policy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isRabiesVaccineName } from "../vaccination-policy";
+
+describe("rabies vaccine identification", () => {
+  it.each([
+    "Rabies",
+    "Canine Rabies 3 Year",
+    "RABIES-BOOSTER",
+    "rabies_vaccine",
+    "Rabies/Feline",
+  ])("recognizes %s", (name) => {
+    expect(isRabiesVaccineName(name)).toBe(true);
+  });
+
+  it.each(["Parvovirus", "Coronavirus", "Crabies", "Rabieslike"])(
+    "does not classify %s as rabies",
+    (name) => {
+      expect(isRabiesVaccineName(name)).toBe(false);
+    },
+  );
+});

--- a/apps/web/lib/records/vaccination-policy.ts
+++ b/apps/web/lib/records/vaccination-policy.ts
@@ -1,12 +1,20 @@
 export const VACCINATION_NAME_MAX_LENGTH = 255;
+export const VACCINATION_PRODUCT_NAME_MAX_LENGTH = 255;
 export const VACCINATION_LOT_NUMBER_MAX_LENGTH = 64;
 export const VACCINATION_MANUFACTURER_MAX_LENGTH = 128;
+export const VACCINATION_RABIES_TAG_MAX_LENGTH = 64;
+export const VACCINATION_LICENSED_DURATION_MIN_MONTHS = 1;
+export const VACCINATION_LICENSED_DURATION_MAX_MONTHS = 120;
+
+export function isRabiesVaccineName(value: string): boolean {
+  return /(^|\s|[-_/])rabies($|\s|[-_/])/i.test(value.trim());
+}
 
 const DATE_INPUT_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export function isVaccinationRequiredTextInputValid(
   value: string,
-  maxLength: number
+  maxLength: number,
 ): boolean {
   const trimmed = value.trim();
   return trimmed.length > 0 && trimmed.length <= maxLength;
@@ -14,7 +22,7 @@ export function isVaccinationRequiredTextInputValid(
 
 export function isVaccinationOptionalTextInputValid(
   value: string,
-  maxLength: number
+  maxLength: number,
 ): boolean {
   return value.trim().length <= maxLength;
 }

--- a/apps/web/lib/s3.ts
+++ b/apps/web/lib/s3.ts
@@ -66,6 +66,17 @@ export function normalizeS3VersionId(value: unknown): string | undefined {
     : undefined;
 }
 
+/**
+ * Private Blob origin reads may expose the same entity tag in weak form
+ * (`W/"hash"`) even when put/list returned the strong form (`"hash"`). The
+ * opaque tag still identifies the same immutable bytes, so compare and retain
+ * a canonical strong representation for exact-version evidence.
+ */
+export function normalizeBlobVersionId(value: unknown): string | undefined {
+  const normalized = normalizeS3VersionId(value);
+  return normalized?.startsWith("W/") ? normalized.slice(2) : normalized;
+}
+
 export type ObjectReadResult =
   | {
       status: "available";
@@ -333,7 +344,7 @@ async function putObject(
         etag: result.etag,
         // Private Blob pathnames are immutable because overwrite is disabled.
         // The provider ETag is therefore the exact immutable version evidence.
-        versionId: result.etag,
+        versionId: normalizeBlobVersionId(result.etag),
       };
     }
 
@@ -445,7 +456,11 @@ async function readObject(
       });
       if (!res) return { status: "missing" };
       if (res.statusCode !== 200 || !res.stream) return { status: "failed" };
-      if (requestedVersionId && res.blob.etag !== requestedVersionId) {
+      const responseVersionId = normalizeBlobVersionId(res.blob.etag);
+      if (
+        requestedVersionId &&
+        responseVersionId !== normalizeBlobVersionId(requestedVersionId)
+      ) {
         return { status: "failed" };
       }
       if (
@@ -467,7 +482,7 @@ async function readObject(
         body,
         contentType: res.blob.contentType,
         etag: res.blob.etag,
-        versionId: res.blob.etag,
+        ...(responseVersionId ? { versionId: responseVersionId } : {}),
       };
     }
 

--- a/apps/web/lib/sms.ts
+++ b/apps/web/lib/sms.ts
@@ -1,7 +1,4 @@
-import {
-  sendSms,
-  type SmsDispatchResult,
-} from "@/lib/sms-dispatch";
+import { sendSms, type SmsDispatchResult } from "@/lib/sms-dispatch";
 
 export {
   prepareCampaignSmsBody,
@@ -100,4 +97,38 @@ export async function sendVaccinationReminderSms(data: {
     idempotencyKey: data.idempotencyKey,
   });
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Care reminder SMS
+// ---------------------------------------------------------------------------
+
+export async function sendCareReminderSms(data: {
+  to: string;
+  patientName: string;
+  reminderTitle: string;
+  dueDate: string;
+  practiceName: string;
+  practicePhone?: string;
+  practiceId: string;
+  locationId: string;
+  clientId: string;
+  communicationId: string;
+  sourceId: string;
+  idempotencyKey: string;
+}): Promise<SmsDispatchResult> {
+  const contact = data.practicePhone
+    ? `Call ${data.practicePhone} with questions.`
+    : "Contact us with questions.";
+  return sendSms({
+    to: data.to,
+    body: `Reminder for ${data.patientName}: ${data.reminderTitle}. Reminder date: ${data.dueDate}. ${contact}`,
+    practiceId: data.practiceId,
+    locationId: data.locationId,
+    clientId: data.clientId,
+    communicationId: data.communicationId,
+    source: "care_reminder",
+    sourceId: data.sourceId,
+    idempotencyKey: data.idempotencyKey,
+  });
 }

--- a/apps/web/scripts/vercel-ignore-build.sh
+++ b/apps/web/scripts/vercel-ignore-build.sh
@@ -3,6 +3,7 @@
 # Exit 0 skips the build; exit 1 lets it proceed.
 #
 # - Production deployments always build.
+# - An explicit operator-only override can force a protected preview rebuild.
 # - The public demo deployment (NEXT_PUBLIC_DEMO_MODE=true) tracks
 #   production only; its preview builds are skipped as duplicates.
 # - Preview builds are skipped when nothing that ships in the web app
@@ -12,6 +13,10 @@
 set -u
 
 if [ "${VERCEL_ENV:-}" = "production" ]; then
+  exit 1
+fi
+
+if [ "${OPENVPM_FORCE_PREVIEW_BUILD:-}" = "true" ]; then
   exit 1
 fi
 

--- a/apps/web/scripts/verify-backup-evidence.mjs
+++ b/apps/web/scripts/verify-backup-evidence.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 
 const MAX_CATALOG_BYTES = 1_000_000;
 const MAX_BACKUP_BYTES = 50_000_000;
-const SUPPORTED_EXPORT_FORMAT_VERSION = 7;
+const SUPPORTED_EXPORT_FORMAT_VERSION = 8;
 const PRACTICE_EXPORT_SECTIONS = [
   "locations",
   "locationMessaging",
@@ -34,6 +34,7 @@ const PRACTICE_EXPORT_SECTIONS = [
   "wellnessEnrollments",
   "patientWeights",
   "patientAllergies",
+  "careReminders",
   "appointments",
   "historicalAppointments",
   "appointmentWaitlist",

--- a/apps/web/server/__tests__/care-reminders-dismissal.test.ts
+++ b/apps/web/server/__tests__/care-reminders-dismissal.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { careRemindersRouter } from "../routers/care-reminders";
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+const REMINDER_ID = "00000000-0000-0000-0000-000000000002";
+const SECOND_REMINDER_ID = "00000000-0000-0000-0000-000000000003";
+const UPDATED_AT = new Date("2026-08-24T16:00:00.000Z");
+
+function callerWithDb(db: Record<string, unknown>) {
+  return careRemindersRouter.createCaller({
+    db,
+    session: {
+      user: {
+        id: USER_ID,
+        email: "doctor@example.test",
+        name: "Dr. Rivera",
+        role: "veterinarian",
+        practiceId: PRACTICE_ID,
+      },
+    },
+  } as never);
+}
+
+function createDb(options?: {
+  current?: Array<{ id: string; status: string; updatedAt: Date }>;
+  updated?: Array<{ id: string }>;
+}) {
+  const selectResults: unknown[][] = [
+    [{ id: PRACTICE_ID, timezone: "America/New_York" }],
+    options?.current ?? [],
+  ];
+  const select = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const afterWhere = {
+      limit: vi.fn(async () => result),
+      orderBy: vi.fn(() => afterWhere),
+      for: vi.fn(async () => result),
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (error: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject),
+    };
+    const builder = {
+      from: vi.fn(() => builder),
+      leftJoin: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
+      where: vi.fn(() => afterWhere),
+    };
+    return builder;
+  });
+  const updateReturning = vi.fn(async () => options?.updated ?? []);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+  const db: Record<string, unknown> = {
+    execute: vi.fn(async () => undefined),
+    select,
+    update,
+    insert: vi.fn(() => ({
+      values: vi.fn(async () => undefined),
+    })),
+    transaction: async (fn: (tx: unknown) => unknown) => fn(db),
+  };
+  return { db, select, updateSet };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("care reminder dismissal", () => {
+  it("requires an explanatory reason and unique bounded targets before DB work", async () => {
+    const { db, select } = createDb();
+    const caller = callerWithDb(db);
+
+    await expect(
+      caller.setDismissed({
+        dismissed: true,
+        reason: "x",
+        items: [
+          { id: REMINDER_ID, expectedUpdatedAt: UPDATED_AT.toISOString() },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(
+      caller.setDismissed({
+        dismissed: true,
+        reason: "Duplicate import",
+        items: [
+          { id: REMINDER_ID, expectedUpdatedAt: UPDATED_AT.toISOString() },
+          { id: REMINDER_ID, expectedUpdatedAt: UPDATED_AT.toISOString() },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("atomically dismisses all selected open reminders with attribution", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-24T18:30:00.000Z"));
+    const { db, updateSet } = createDb({
+      current: [
+        { id: REMINDER_ID, status: "open", updatedAt: UPDATED_AT },
+        { id: SECOND_REMINDER_ID, status: "open", updatedAt: UPDATED_AT },
+      ],
+      updated: [{ id: REMINDER_ID }, { id: SECOND_REMINDER_ID }],
+    });
+
+    await expect(
+      callerWithDb(db).setDismissed({
+        dismissed: true,
+        reason: "Duplicate reminders from legacy import",
+        items: [
+          { id: REMINDER_ID, expectedUpdatedAt: UPDATED_AT.toISOString() },
+          {
+            id: SECOND_REMINDER_ID,
+            expectedUpdatedAt: UPDATED_AT.toISOString(),
+          },
+        ],
+      }),
+    ).resolves.toEqual({
+      id: REMINDER_ID,
+      ids: [REMINDER_ID, SECOND_REMINDER_ID],
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      status: "dismissed",
+      dismissedAt: new Date("2026-08-24T18:30:00.000Z"),
+      dismissedBy: USER_ID,
+      dismissalReason: "Duplicate reminders from legacy import",
+      completedAt: null,
+      completedBy: null,
+      updatedAt: new Date("2026-08-24T18:30:00.000Z"),
+    });
+  });
+
+  it("fails the whole batch on a stale timestamp or non-open source", async () => {
+    const { db, updateSet } = createDb({
+      current: [
+        {
+          id: REMINDER_ID,
+          status: "completed",
+          updatedAt: UPDATED_AT,
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).setDismissed({
+        dismissed: true,
+        reason: "Duplicate reminder",
+        items: [
+          { id: REMINDER_ID, expectedUpdatedAt: UPDATED_AT.toISOString() },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "One or more reminders changed. Refresh before updating them.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("restores only an unchanged dismissed reminder and clears dismissal evidence", async () => {
+    const { db, updateSet } = createDb({
+      current: [
+        { id: REMINDER_ID, status: "dismissed", updatedAt: UPDATED_AT },
+      ],
+      updated: [{ id: REMINDER_ID }],
+    });
+
+    await callerWithDb(db).setDismissed({
+      dismissed: false,
+      items: [{ id: REMINDER_ID, expectedUpdatedAt: UPDATED_AT.toISOString() }],
+    });
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "open",
+        dismissedAt: null,
+        dismissedBy: null,
+        dismissalReason: null,
+        completedAt: null,
+        completedBy: null,
+      }),
+    );
+  });
+});

--- a/apps/web/server/__tests__/notifications-safety.test.ts
+++ b/apps/web/server/__tests__/notifications-safety.test.ts
@@ -58,8 +58,7 @@ vi.mock("@/lib/messaging/durable-sms-communication", () => ({
 
 vi.mock("@/lib/recovery-hold", () => ({
   RECOVERY_HOLD_BLOCK_MESSAGE: "recovery hold",
-  lockPracticeForExternalSideEffects:
-    mocks.lockPracticeForExternalSideEffects,
+  lockPracticeForExternalSideEffects: mocks.lockPracticeForExternalSideEffects,
 }));
 
 vi.mock("@/lib/outbound-email-security", () => ({
@@ -1547,6 +1546,16 @@ describe("notification query scoping", () => {
     "utf8",
   );
   const source = `${routerSource}\n${recallSource}`;
+
+  it("allows the operational veterinarian role to send one-off appointment reminders", () => {
+    const procedure = routerSource.slice(
+      routerSource.indexOf("sendAppointmentReminder: protectedProcedure"),
+      routerSource.indexOf("sendInvoiceEmail: protectedProcedure"),
+    );
+    expect(procedure).toContain(
+      'requireRole("admin", "veterinarian", "front_desk")',
+    );
+  });
 
   function expectScopedJoin(
     joinKind: "leftJoin" | "innerJoin",

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -45,6 +45,7 @@ const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000003";
 const RECORD_ID = "00000000-0000-0000-0000-000000000004";
 const FORM_ID = "00000000-0000-0000-0000-000000000005";
 const OTHER_USER_ID = "00000000-0000-0000-0000-000000000006";
+const CERTIFICATE_ID = "00000000-0000-0000-0000-000000000007";
 
 function operationHash(payload: Record<string, unknown>): string {
   return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
@@ -77,7 +78,7 @@ function createDb(opts?: {
       orderBy: vi.fn(() => afterWhere),
       then: (
         resolve: (value: unknown[]) => unknown,
-        reject?: (error: unknown) => unknown
+        reject?: (error: unknown) => unknown,
       ) => Promise.resolve(result).then(resolve, reject),
     };
     const builder = {
@@ -135,7 +136,7 @@ describe("records target safety", () => {
       callerWithDb(db).createSoapNote({
         patientId: PATIENT_ID,
         subjective: "Eating well",
-      } as never)
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -148,7 +149,9 @@ describe("records target safety", () => {
         [
           {
             name: "Neighborhood Veterinary",
+            address: "100 Clinic Way",
             phone: "555-0100",
+            email: "care@example.test",
             timezone: "America/Los_Angeles",
           },
         ],
@@ -157,7 +160,9 @@ describe("records target safety", () => {
 
     await expect(callerWithDb(db).settings()).resolves.toEqual({
       name: "Neighborhood Veterinary",
+      address: "100 Clinic Way",
       phone: "555-0100",
+      email: "care@example.test",
       timezone: "America/Los_Angeles",
     });
 
@@ -186,19 +191,19 @@ describe("records target safety", () => {
     expect(source).not.toContain("practice?.phone");
     expect(source).not.toContain("practice?.timezone");
     expect(
-      source.match(/activePracticePredicate\(ctx\.practiceId\)/g)?.length ?? 0
+      source.match(/activePracticePredicate\(ctx\.practiceId\)/g)?.length ?? 0,
     ).toBeGreaterThanOrEqual(15);
     expect(source).toMatch(
-      /eq\(patients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(patients\.deletedAt\)/
+      /eq\(patients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(patients\.deletedAt\)/,
     );
     expect(source).toMatch(
-      /eq\(appointments\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointments\.deletedAt\)/
+      /eq\(appointments\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(appointments\.deletedAt\)/,
     );
     expect(source).toMatch(
-      /eq\(problemList\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(problemList\.deletedAt\)/
+      /eq\(problemList\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(problemList\.deletedAt\)/,
     );
     expect(source).toMatch(
-      /eq\(labResults\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(labResults\.deletedAt\)/
+      /eq\(labResults\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(labResults\.deletedAt\)/,
     );
   });
 
@@ -210,7 +215,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         subjective: "Eating well",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -226,7 +231,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         name: "Dental cleaning",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -249,7 +254,7 @@ describe("records target safety", () => {
       callerWithDb(db).createVaccination({
         patientId: PATIENT_ID,
         vaccineName: "Rabies",
-      })
+      }),
     ).resolves.toMatchObject({ id: RECORD_ID, vaccineName: "Rabies" });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -257,7 +262,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         practiceId: PRACTICE_ID,
         administeredBy: USER_ID,
-      })
+      }),
     );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
@@ -268,7 +273,151 @@ describe("records target safety", () => {
         vaccineName: "Rabies",
         administeredBy: USER_ID,
         source: "dashboard",
-      }
+      },
+    );
+  });
+
+  it("prepares a complete, uniquely identified rabies certificate for staff", async () => {
+    const { db } = createDb({
+      selectResults: [
+        [
+          {
+            practiceName: "Neighborhood Veterinary",
+            practiceAddress: "100 Clinic Way",
+            practicePhone: "555-0100",
+            practiceEmail: "care@example.test",
+            practiceTimezone: "America/New_York",
+            patientId: PATIENT_ID,
+            patientName: "Biscuit",
+            species: "canine",
+            breed: "Mixed breed",
+            sex: "female_spayed",
+            dob: "2020-05-01",
+            color: "Brown",
+            microchipNumber: "985141000000001",
+            clientId: "00000000-0000-0000-0000-000000000008",
+            clientFirstName: "Alex",
+            clientLastName: "Rivera",
+            clientAddress: "10 Main Street",
+            clientCity: "Brooklyn",
+            clientState: "NY",
+            clientZip: "11201",
+            clientPhone: "555-0102",
+          },
+        ],
+        [
+          {
+            id: RECORD_ID,
+            vaccineName: "Rabies",
+            productName: "Defensor 3",
+            lotNumber: "LOT-1",
+            manufacturer: "Zoetis",
+            productExpirationDate: "2027-05-01",
+            doseType: "booster",
+            licensedDurationMonths: 36,
+            rabiesTagNumber: "TAG-9",
+            administeredAt: new Date("2026-08-24T14:00:00.000Z"),
+            nextDueDate: "2029-08-24",
+            administeredByName: "Taylor Tech",
+            administeredByIsVeterinarian: false,
+            administeredByLicenseNumber: null,
+            supervisingVeterinarianName: "Dr. Rivera",
+            supervisingVeterinarianLicenseNumber: "NY-12345",
+          },
+        ],
+        [{ weightKg: "18.250" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db, "front_desk").prepareVaccinationCertificate({
+        patientId: PATIENT_ID,
+        kind: "rabies",
+        vaccinationRecordId: RECORD_ID,
+        requestId: CERTIFICATE_ID,
+      }),
+    ).resolves.toMatchObject({
+      id: RECORD_ID,
+      certificateId: CERTIFICATE_ID,
+      kind: "rabies",
+      ready: true,
+      missingFields: [],
+      owner: {
+        name: "Alex Rivera",
+        address: "10 Main Street\nBrooklyn, NY, 11201",
+      },
+      vaccinations: [
+        {
+          id: RECORD_ID,
+          veterinarianName: "Dr. Rivera",
+          veterinarianLicenseNumber: "NY-12345",
+        },
+      ],
+    });
+  });
+
+  it("fails rabies certificate preflight closed when required evidence is missing", async () => {
+    const { db } = createDb({
+      selectResults: [
+        [
+          {
+            practiceName: "Neighborhood Veterinary",
+            practiceTimezone: "America/New_York",
+            patientId: PATIENT_ID,
+            patientName: "Biscuit",
+            species: "canine",
+            breed: null,
+            sex: null,
+            dob: null,
+            color: null,
+            microchipNumber: null,
+            clientId: "00000000-0000-0000-0000-000000000008",
+            clientFirstName: "Alex",
+            clientLastName: "Rivera",
+            clientAddress: null,
+            clientCity: null,
+            clientState: null,
+            clientZip: null,
+            clientPhone: null,
+          },
+        ],
+        [
+          {
+            id: RECORD_ID,
+            vaccineName: "Rabies",
+            administeredAt: new Date("2026-08-24T14:00:00.000Z"),
+            administeredByName: "Taylor Tech",
+            administeredByIsVeterinarian: false,
+          },
+        ],
+        [],
+      ],
+    });
+
+    const result = await callerWithDb(
+      db,
+      "veterinarian",
+    ).prepareVaccinationCertificate({
+      patientId: PATIENT_ID,
+      kind: "rabies",
+      vaccinationRecordId: RECORD_ID,
+      requestId: CERTIFICATE_ID,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.missingFields).toEqual(
+      expect.arrayContaining([
+        "owner address",
+        "owner phone",
+        "patient breed",
+        "current patient weight",
+        "microchip or rabies tag number",
+        "vaccine product name",
+        "vaccine lot number",
+        "next vaccination due date",
+        "supervising veterinarian",
+        "veterinarian license number",
+      ]),
     );
   });
 
@@ -280,7 +429,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         vaccineName: "Rabies",
         nextDueDate: "2026-02-31",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -288,7 +437,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         description: "Chronic otitis",
         onsetDate: "not-a-date",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -328,7 +477,7 @@ describe("records target safety", () => {
       callerWithDb(db).createVaccination({
         patientId: PATIENT_ID,
         vaccineName: "A".repeat(VACCINATION_NAME_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -336,7 +485,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         vaccineName: "Rabies",
         lotNumber: "A".repeat(VACCINATION_LOT_NUMBER_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -344,14 +493,14 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         vaccineName: "Rabies",
         manufacturer: "A".repeat(VACCINATION_MANUFACTURER_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).createProblem({
         patientId: PATIENT_ID,
         description: "A".repeat(PROBLEM_DESCRIPTION_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -359,7 +508,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         testName: "A".repeat(LAB_TEST_NAME_MAX_LENGTH + 1),
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -368,7 +517,7 @@ describe("records target safety", () => {
         testName: "CBC",
         resultValue: "A".repeat(LAB_RESULT_VALUE_MAX_LENGTH + 1),
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -377,14 +526,14 @@ describe("records target safety", () => {
         testName: "CBC",
         unit: "A".repeat(LAB_UNIT_MAX_LENGTH + 1),
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).createProcedure({
         patientId: PATIENT_ID,
         name: "A".repeat(PROCEDURE_NAME_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -399,7 +548,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         name: "Dental cleaning",
         description: "A".repeat(PROCEDURE_DESCRIPTION_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -407,7 +556,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         name: "Dental cleaning",
         anesthesiaUsed: "A".repeat(PROCEDURE_ANESTHESIA_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -415,7 +564,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         name: "Dental cleaning",
         durationMinutes: PROCEDURE_DURATION_MAX_MINUTES + 1,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -423,7 +572,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         name: "Dental cleaning",
         notes: "A".repeat(PROCEDURE_NOTES_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -448,7 +597,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         subjective: "Eating well",
-      })
+      }),
     ).resolves.toMatchObject({ id: RECORD_ID, patientId: PATIENT_ID });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -472,7 +621,7 @@ describe("records target safety", () => {
         appointmentId: APPOINTMENT_ID,
         authorId: USER_ID,
         source: "dashboard",
-      }
+      },
     );
   });
 
@@ -487,7 +636,7 @@ describe("records target safety", () => {
         appointmentId: APPOINTMENT_ID,
         subjective: "<p><br></p>",
         objective: "<ul><li>&nbsp;</li></ul>",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -502,7 +651,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         subjective: SOAP_NOTE_TEMPLATES[0]!.sections.subjective,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message:
@@ -522,7 +671,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         subjective: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -530,7 +679,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         objective: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -538,7 +687,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         assessment: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -546,7 +695,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         plan: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -570,7 +719,7 @@ describe("records target safety", () => {
       callerWithDb(db).createProblem({
         patientId: PATIENT_ID,
         description: "Chronic otitis",
-      })
+      }),
     ).resolves.toMatchObject({ id: RECORD_ID, status: "active" });
 
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
@@ -581,7 +730,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         status: "active",
         source: "dashboard",
-      }
+      },
     );
   });
 
@@ -610,7 +759,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         testName: "CBC",
         operationId: FORM_ID,
-      })
+      }),
     ).resolves.toMatchObject({ id: RECORD_ID, testName: "CBC" });
 
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
@@ -623,7 +772,7 @@ describe("records target safety", () => {
         status: "pending",
         orderedBy: USER_ID,
         source: "dashboard",
-      }
+      },
     );
   });
 
@@ -636,7 +785,7 @@ describe("records target safety", () => {
         testName: "CBC",
         referenceRangeLow: "not numeric",
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -646,7 +795,7 @@ describe("records target safety", () => {
         referenceRangeLow: "30.000",
         referenceRangeHigh: "7.000",
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -676,7 +825,7 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         name: "Dental cleaning",
-      })
+      }),
     ).resolves.toMatchObject({ id: RECORD_ID, name: "Dental cleaning" });
 
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
@@ -689,7 +838,7 @@ describe("records target safety", () => {
         name: "Dental cleaning",
         performedBy: USER_ID,
         source: "dashboard",
-      }
+      },
     );
   });
 
@@ -715,7 +864,7 @@ describe("records target safety", () => {
       callerWithDb(db).updateProblemStatus({
         id: RECORD_ID,
         status: "resolved",
-      })
+      }),
     ).resolves.toMatchObject({
       id: RECORD_ID,
       status: "resolved",
@@ -735,7 +884,7 @@ describe("records target safety", () => {
       callerWithDb(db).updateProblemStatus({
         id: RECORD_ID,
         status: "resolved",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -757,19 +906,17 @@ describe("records target safety", () => {
       callerWithDb(db).updateProblemStatus({
         id: RECORD_ID,
         status: "resolved",
-      })
+      }),
     ).resolves.toMatchObject({
       id: RECORD_ID,
       status: "resolved",
       resolvedDate: "2026-07-01",
     });
 
-    expect(updateSet).toHaveBeenCalledWith(
-      {
+    expect(updateSet).toHaveBeenCalledWith({
         status: "resolved",
         resolvedDate: "2026-07-01",
-      }
-    );
+    });
   });
 
   it("rejects problem status updates that lose a concurrent race", async () => {
@@ -782,7 +929,7 @@ describe("records target safety", () => {
       callerWithDb(db).updateProblemStatus({
         id: RECORD_ID,
         status: "resolved",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Problem changed while updating. Refresh and try again.",
@@ -791,7 +938,7 @@ describe("records target safety", () => {
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         status: "resolved",
-      })
+      }),
     );
   });
 
@@ -803,7 +950,7 @@ describe("records target safety", () => {
         id: RECORD_ID,
         status: "reviewed",
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -819,13 +966,12 @@ describe("records target safety", () => {
         id: RECORD_ID,
         status: "reviewed",
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Cannot change lab result status from pending to reviewed.",
     });
     expect(pending.updateSet).not.toHaveBeenCalled();
-
   });
 
   it("returns tenant-scoped immutable lab evidence with value snapshots", async () => {
@@ -937,11 +1083,13 @@ describe("records target safety", () => {
       followUpOutcome: null,
     };
     const { db } = createDb({
-      selectResults: [[
+      selectResults: [
+        [
         assigned,
         { ...assigned, id: FORM_ID, followUpAssignedTo: OTHER_USER_ID },
         { ...assigned, id: APPOINTMENT_ID, followUpStatus: "completed" },
-      ]],
+        ],
+      ],
     });
 
     const result = await callerWithDb(db, "front_desk").listLabReviewInbox({
@@ -995,12 +1143,14 @@ describe("records target safety", () => {
     const { db, updateSet, insertValues } = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           status: "completed",
           resultValue: "12.5",
           resultFlag: "abnormal",
           followUpStatus: "not_required",
-        }],
+          },
+        ],
       ],
       updatedRows: [
         {
@@ -1025,7 +1175,7 @@ describe("records target safety", () => {
         id: RECORD_ID,
         status: "reviewed",
         operationId: FORM_ID,
-      })
+      }),
     ).resolves.toMatchObject({
       id: RECORD_ID,
       status: "reviewed",
@@ -1038,7 +1188,7 @@ describe("records target safety", () => {
         reviewedBy: USER_ID,
         reviewedAt: expect.any(Date),
         updatedAt: expect.any(Date),
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1051,7 +1201,7 @@ describe("records target safety", () => {
         referenceRangeLow: "8.000",
         referenceRangeHigh: "18.000",
         actorId: USER_ID,
-      })
+      }),
     );
   });
 
@@ -1059,12 +1209,14 @@ describe("records target safety", () => {
     const { db, updateSet, insertValues } = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           status: "completed",
           resultValue: "2.1",
           resultFlag: "critical",
           followUpStatus: "not_required",
-        }],
+          },
+        ],
       ],
     });
 
@@ -1076,7 +1228,8 @@ describe("records target safety", () => {
       }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message: "Assign owned follow-up for this critical result before recording clinical review.",
+      message:
+        "Assign owned follow-up for this critical result before recording clinical review.",
     });
     expect(updateSet).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
@@ -1098,11 +1251,13 @@ describe("records target safety", () => {
     };
     const { db, updateSet, insertValues } = createDb({
       selectResults: [
-        [{
+        [
+          {
           labResultId: RECORD_ID,
           eventType: "reviewed",
           operationPayloadHash: payloadHash,
-        }],
+          },
+        ],
         [reviewed],
       ],
     });
@@ -1120,11 +1275,15 @@ describe("records target safety", () => {
 
   it("rejects reuse of a lab operation id for different evidence", async () => {
     const { db, updateSet, insertValues } = createDb({
-      selectResults: [[{
+      selectResults: [
+        [
+          {
         labResultId: RECORD_ID,
         eventType: "reviewed",
         operationPayloadHash: "f".repeat(64),
-      }]],
+          },
+        ],
+      ],
     });
 
     await expect(
@@ -1179,7 +1338,7 @@ describe("records target safety", () => {
         unit: "mmol/L",
         resultFlag: "critical",
         operationId: FORM_ID,
-      })
+      }),
     ).resolves.toMatchObject({ status: "completed", resultFlag: "critical" });
 
     expect(updateSet).toHaveBeenCalledWith(
@@ -1188,7 +1347,7 @@ describe("records target safety", () => {
         status: "completed",
         completedAt: expect.any(Date),
         updatedAt: expect.any(Date),
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1200,7 +1359,7 @@ describe("records target safety", () => {
         resultValue: "2.1",
         unit: "mmol/L",
         actorId: USER_ID,
-      })
+      }),
     );
   });
 
@@ -1208,7 +1367,8 @@ describe("records target safety", () => {
     const { db, updateSet, insertValues } = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           id: RECORD_ID,
           patientId: PATIENT_ID,
           appointmentId: null,
@@ -1218,7 +1378,8 @@ describe("records target safety", () => {
           followUpStatus: "open",
           followUpAssignedTo: OTHER_USER_ID,
           followUpDueAt: null,
-        }],
+          },
+        ],
       ],
     });
 
@@ -1231,7 +1392,8 @@ describe("records target safety", () => {
       }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message: "Set a due date on the open follow-up before recording this result as critical.",
+      message:
+        "Set a due date on the open follow-up before recording this result as critical.",
     });
     expect(updateSet).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
@@ -1266,7 +1428,7 @@ describe("records target safety", () => {
         dueAt: "2026-08-10T18:00:00.000Z",
         note: "Call the owner today.",
         operationId: FORM_ID,
-      })
+      }),
     ).resolves.toMatchObject({
       followUpStatus: "open",
       followUpAssignedTo: USER_ID,
@@ -1279,7 +1441,7 @@ describe("records target safety", () => {
         followUpDueAt: new Date("2026-08-10T18:00:00.000Z"),
         followUpNote: "Call the owner today.",
         updatedAt: expect.any(Date),
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1288,7 +1450,7 @@ describe("records target safety", () => {
         resultFlag: "critical",
         followUpAssignedTo: USER_ID,
         actorId: USER_ID,
-      })
+      }),
     );
   });
 
@@ -1296,14 +1458,16 @@ describe("records target safety", () => {
     const pending = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           id: RECORD_ID,
           status: "pending",
           resultValue: null,
           resultFlag: "unknown",
           followUpStatus: "not_required",
           followUpAssignedTo: null,
-        }],
+          },
+        ],
       ],
     });
     await expect(
@@ -1322,13 +1486,15 @@ describe("records target safety", () => {
     const laterCritical = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           id: RECORD_ID,
           status: "completed",
           resultValue: "2.1",
           resultFlag: "critical",
           followUpStatus: "not_required",
-        }],
+          },
+        ],
       ],
     });
     await expect(
@@ -1338,7 +1504,8 @@ describe("records target safety", () => {
         operationId: FORM_ID,
       }),
     ).rejects.toMatchObject({
-      message: "Assign owned follow-up for this critical result before recording clinical review.",
+      message:
+        "Assign owned follow-up for this critical result before recording clinical review.",
     });
     expect(laterCritical.updateSet).not.toHaveBeenCalled();
   });
@@ -1404,7 +1571,8 @@ describe("records target safety", () => {
       }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message: "Front desk follow-up requires actionable instructions from the clinical team.",
+      message:
+        "Front desk follow-up requires actionable instructions from the clinical team.",
     });
     expect(updateSet).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
@@ -1427,11 +1595,13 @@ describe("records target safety", () => {
     };
     const { db, updateSet, insertValues } = createDb({
       selectResults: [[], [existing]],
-      updatedRows: [{
+      updatedRows: [
+        {
         ...existing,
         followUpStatus: "completed",
         followUpOutcome: "Owner reached; repeat test booked.",
-      }],
+        },
+      ],
     });
 
     const result = await callerWithDb(db, "front_desk").completeLabFollowUp({
@@ -1439,12 +1609,14 @@ describe("records target safety", () => {
       outcome: "Owner reached; repeat test booked.",
       operationId: FORM_ID,
     });
-    expect(result).toEqual(expect.objectContaining({
+    expect(result).toEqual(
+      expect.objectContaining({
       id: RECORD_ID,
       patientId: PATIENT_ID,
       followUpStatus: "completed",
       followUpAssignedTo: USER_ID,
-    }));
+      }),
+    );
     expect(result).not.toHaveProperty("resultValue");
     expect(result).not.toHaveProperty("referenceRangeLow");
     expect(result).not.toHaveProperty("resultFlag");
@@ -1493,11 +1665,13 @@ describe("records target safety", () => {
     };
     const { db, updateSet, insertValues } = createDb({
       selectResults: [
-        [{
+        [
+          {
           labResultId: RECORD_ID,
           eventType: "follow_up_completed",
           operationPayloadHash: payloadHash,
-        }],
+          },
+        ],
         [completed],
       ],
     });
@@ -1523,14 +1697,16 @@ describe("records target safety", () => {
     const { db, updateSet, insertValues } = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           id: RECORD_ID,
           status: "pending",
           resultValue: null,
           resultFlag: "unknown",
           followUpStatus: "open",
           followUpAssignedTo: USER_ID,
-        }],
+          },
+        ],
       ],
     });
 
@@ -1542,7 +1718,8 @@ describe("records target safety", () => {
       }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message: "Lab follow-up cannot be completed before result values are available.",
+      message:
+        "Lab follow-up cannot be completed before result values are available.",
     });
     expect(updateSet).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
@@ -1552,14 +1729,16 @@ describe("records target safety", () => {
     const { db, updateSet, insertValues } = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           id: RECORD_ID,
           resultValue: "2.1",
           resultFlag: "critical",
           status: "reviewed",
           followUpStatus: "open",
           followUpAssignedTo: OTHER_USER_ID,
-        }],
+          },
+        ],
       ],
     });
 
@@ -1596,7 +1775,7 @@ describe("records target safety", () => {
         id: RECORD_ID,
         status: "reviewed",
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -1606,12 +1785,14 @@ describe("records target safety", () => {
     const { db, updateSet } = createDb({
       selectResults: [
         [],
-        [{
+        [
+          {
           status: "completed",
           resultValue: "12.5",
           resultFlag: "normal",
           followUpStatus: "not_required",
-        }],
+          },
+        ],
       ],
       updatedRows: [],
     });
@@ -1621,7 +1802,7 @@ describe("records target safety", () => {
         id: RECORD_ID,
         status: "reviewed",
         operationId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Lab result changed while updating. Refresh and try again.",
@@ -1631,7 +1812,7 @@ describe("records target safety", () => {
       expect.objectContaining({
         status: "reviewed",
         reviewedBy: USER_ID,
-      })
+      }),
     );
   });
 });
@@ -1652,12 +1833,8 @@ describe("capture sessions", () => {
     });
 
     expect(result.token).toMatch(/^[0-9a-f]{64}$/);
-    expect(result.url).toMatch(
-      new RegExp(`/capture/${result.token}$`)
-    );
-    expect(result.expiresAt).toEqual(
-      new Date("2026-07-10T12:30:00.000Z")
-    );
+    expect(result.url).toMatch(new RegExp(`/capture/${result.token}$`));
+    expect(result.expiresAt).toEqual(new Date("2026-07-10T12:30:00.000Z"));
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: PRACTICE_ID,
@@ -1665,7 +1842,7 @@ describe("capture sessions", () => {
         createdBy: USER_ID,
         token: result.token,
         expiresAt: result.expiresAt,
-      })
+      }),
     );
   });
 
@@ -1681,7 +1858,7 @@ describe("capture sessions", () => {
 
     expect(result.appointmentId).toBe(APPOINTMENT_ID);
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ appointmentId: APPOINTMENT_ID })
+      expect.objectContaining({ appointmentId: APPOINTMENT_ID }),
     );
   });
 
@@ -1698,7 +1875,7 @@ describe("capture sessions", () => {
 
     expect(result.appointmentId).toBe(APPOINTMENT_ID);
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ appointmentId: APPOINTMENT_ID })
+      expect.objectContaining({ appointmentId: APPOINTMENT_ID }),
     );
   });
 
@@ -1711,7 +1888,7 @@ describe("capture sessions", () => {
       callerWithDb(db).createCaptureSession({
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -1729,23 +1906,18 @@ describe("capture sessions", () => {
 
     expect(result.appointmentId).toBeNull();
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ appointmentId: null })
+      expect.objectContaining({ appointmentId: null }),
     );
   });
 
   it("keeps capture links restricted to non-viewer staff roles", async () => {
-    for (const role of [
-      "admin",
-      "veterinarian",
-      "technician",
-      "front_desk",
-    ]) {
+    for (const role of ["admin", "veterinarian", "technician", "front_desk"]) {
       const { db } = createDb({
         selectResults: [patientRow],
         insertedRows: [{ id: RECORD_ID }],
       });
       await expect(
-        callerWithDb(db, role).createCaptureSession({ patientId: PATIENT_ID })
+        callerWithDb(db, role).createCaptureSession({ patientId: PATIENT_ID }),
       ).resolves.toMatchObject({ token: expect.any(String) });
     }
 
@@ -1753,7 +1925,7 @@ describe("capture sessions", () => {
     await expect(
       callerWithDb(db, "viewer").createCaptureSession({
         patientId: PATIENT_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -1762,7 +1934,7 @@ describe("capture sessions", () => {
     const { db, insertValues } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).createCaptureSession({ patientId: PATIENT_ID })
+      callerWithDb(db).createCaptureSession({ patientId: PATIENT_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -1772,7 +1944,7 @@ describe("capture sessions", () => {
     const { db } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).listCaptureFiles({ patientId: PATIENT_ID })
+      callerWithDb(db).listCaptureFiles({ patientId: PATIENT_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });
@@ -1855,7 +2027,7 @@ describe("consent requests", () => {
         expiresAt: result.expiresAt,
         title: "Consent to treatment",
         bodyText: expect.stringContaining("I give this clinic permission"),
-      })
+      }),
     );
   });
 
@@ -1872,7 +2044,7 @@ describe("consent requests", () => {
 
     expect(result.appointmentId).toBe(APPOINTMENT_ID);
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ appointmentId: APPOINTMENT_ID })
+      expect.objectContaining({ appointmentId: APPOINTMENT_ID }),
     );
   });
 
@@ -1890,7 +2062,7 @@ describe("consent requests", () => {
 
     expect(result.appointmentId).toBe(APPOINTMENT_ID);
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ appointmentId: APPOINTMENT_ID })
+      expect.objectContaining({ appointmentId: APPOINTMENT_ID }),
     );
   });
 
@@ -1904,7 +2076,7 @@ describe("consent requests", () => {
         patientId: PATIENT_ID,
         appointmentId: APPOINTMENT_ID,
         formId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -1928,7 +2100,7 @@ describe("consent requests", () => {
         formId: FORM_ID,
         title: "Dental cleaning consent",
         bodyText: "I agree to the dental cleaning we talked about.",
-      })
+      }),
     );
   });
 
@@ -1950,7 +2122,7 @@ describe("consent requests", () => {
       callerWithDb(db).createConsentRequest({
         patientId: PATIENT_ID,
         formId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: expect.stringContaining("Fill in every blank"),
@@ -1979,13 +2151,13 @@ describe("consent requests", () => {
         patientId: PATIENT_ID,
         formId: FORM_ID,
         bodyText: "I approve dental extractions up to $850.",
-      })
+      }),
     ).resolves.toMatchObject({ id: RECORD_ID });
 
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         bodyText: "I approve dental extractions up to $850.",
-      })
+      }),
     );
   });
 
@@ -1998,7 +2170,7 @@ describe("consent requests", () => {
       callerWithDb(db).createConsentRequest({
         patientId: PATIENT_ID,
         formId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -2019,7 +2191,7 @@ describe("consent requests", () => {
         callerWithDb(db, role).createConsentRequest({
           patientId: PATIENT_ID,
           formId: FORM_ID,
-        })
+        }),
       ).resolves.toMatchObject({ token: expect.any(String) });
     }
 
@@ -2028,7 +2200,7 @@ describe("consent requests", () => {
       callerWithDb(db, "viewer").createConsentRequest({
         patientId: PATIENT_ID,
         formId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -2040,7 +2212,7 @@ describe("consent requests", () => {
       callerWithDb(db).createConsentRequest({
         patientId: PATIENT_ID,
         formId: FORM_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -2050,7 +2222,7 @@ describe("consent requests", () => {
     const { db } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).listConsents({ patientId: PATIENT_ID })
+      callerWithDb(db).listConsents({ patientId: PATIENT_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -45,7 +45,6 @@ const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000003";
 const RECORD_ID = "00000000-0000-0000-0000-000000000004";
 const FORM_ID = "00000000-0000-0000-0000-000000000005";
 const OTHER_USER_ID = "00000000-0000-0000-0000-000000000006";
-const CERTIFICATE_ID = "00000000-0000-0000-0000-000000000007";
 
 function operationHash(payload: Record<string, unknown>): string {
   return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
@@ -334,11 +333,10 @@ describe("records target safety", () => {
         patientId: PATIENT_ID,
         kind: "rabies",
         vaccinationRecordId: RECORD_ID,
-        requestId: CERTIFICATE_ID,
       }),
     ).resolves.toMatchObject({
       id: RECORD_ID,
-      certificateId: CERTIFICATE_ID,
+      certificateId: expect.any(String),
       kind: "rabies",
       ready: true,
       missingFields: [],
@@ -401,7 +399,6 @@ describe("records target safety", () => {
       patientId: PATIENT_ID,
       kind: "rabies",
       vaccinationRecordId: RECORD_ID,
-      requestId: CERTIFICATE_ID,
     });
 
     expect(result.ready).toBe(false);
@@ -914,8 +911,8 @@ describe("records target safety", () => {
     });
 
     expect(updateSet).toHaveBeenCalledWith({
-        status: "resolved",
-        resolvedDate: "2026-07-01",
+      status: "resolved",
+      resolvedDate: "2026-07-01",
     });
   });
 
@@ -1085,9 +1082,9 @@ describe("records target safety", () => {
     const { db } = createDb({
       selectResults: [
         [
-        assigned,
-        { ...assigned, id: FORM_ID, followUpAssignedTo: OTHER_USER_ID },
-        { ...assigned, id: APPOINTMENT_ID, followUpStatus: "completed" },
+          assigned,
+          { ...assigned, id: FORM_ID, followUpAssignedTo: OTHER_USER_ID },
+          { ...assigned, id: APPOINTMENT_ID, followUpStatus: "completed" },
         ],
       ],
     });
@@ -1145,10 +1142,10 @@ describe("records target safety", () => {
         [],
         [
           {
-          status: "completed",
-          resultValue: "12.5",
-          resultFlag: "abnormal",
-          followUpStatus: "not_required",
+            status: "completed",
+            resultValue: "12.5",
+            resultFlag: "abnormal",
+            followUpStatus: "not_required",
           },
         ],
       ],
@@ -1211,10 +1208,10 @@ describe("records target safety", () => {
         [],
         [
           {
-          status: "completed",
-          resultValue: "2.1",
-          resultFlag: "critical",
-          followUpStatus: "not_required",
+            status: "completed",
+            resultValue: "2.1",
+            resultFlag: "critical",
+            followUpStatus: "not_required",
           },
         ],
       ],
@@ -1253,9 +1250,9 @@ describe("records target safety", () => {
       selectResults: [
         [
           {
-          labResultId: RECORD_ID,
-          eventType: "reviewed",
-          operationPayloadHash: payloadHash,
+            labResultId: RECORD_ID,
+            eventType: "reviewed",
+            operationPayloadHash: payloadHash,
           },
         ],
         [reviewed],
@@ -1278,9 +1275,9 @@ describe("records target safety", () => {
       selectResults: [
         [
           {
-        labResultId: RECORD_ID,
-        eventType: "reviewed",
-        operationPayloadHash: "f".repeat(64),
+            labResultId: RECORD_ID,
+            eventType: "reviewed",
+            operationPayloadHash: "f".repeat(64),
           },
         ],
       ],
@@ -1369,15 +1366,15 @@ describe("records target safety", () => {
         [],
         [
           {
-          id: RECORD_ID,
-          patientId: PATIENT_ID,
-          appointmentId: null,
-          resultValue: null,
-          resultFlag: "unknown",
-          status: "pending",
-          followUpStatus: "open",
-          followUpAssignedTo: OTHER_USER_ID,
-          followUpDueAt: null,
+            id: RECORD_ID,
+            patientId: PATIENT_ID,
+            appointmentId: null,
+            resultValue: null,
+            resultFlag: "unknown",
+            status: "pending",
+            followUpStatus: "open",
+            followUpAssignedTo: OTHER_USER_ID,
+            followUpDueAt: null,
           },
         ],
       ],
@@ -1460,12 +1457,12 @@ describe("records target safety", () => {
         [],
         [
           {
-          id: RECORD_ID,
-          status: "pending",
-          resultValue: null,
-          resultFlag: "unknown",
-          followUpStatus: "not_required",
-          followUpAssignedTo: null,
+            id: RECORD_ID,
+            status: "pending",
+            resultValue: null,
+            resultFlag: "unknown",
+            followUpStatus: "not_required",
+            followUpAssignedTo: null,
           },
         ],
       ],
@@ -1488,11 +1485,11 @@ describe("records target safety", () => {
         [],
         [
           {
-          id: RECORD_ID,
-          status: "completed",
-          resultValue: "2.1",
-          resultFlag: "critical",
-          followUpStatus: "not_required",
+            id: RECORD_ID,
+            status: "completed",
+            resultValue: "2.1",
+            resultFlag: "critical",
+            followUpStatus: "not_required",
           },
         ],
       ],
@@ -1597,9 +1594,9 @@ describe("records target safety", () => {
       selectResults: [[], [existing]],
       updatedRows: [
         {
-        ...existing,
-        followUpStatus: "completed",
-        followUpOutcome: "Owner reached; repeat test booked.",
+          ...existing,
+          followUpStatus: "completed",
+          followUpOutcome: "Owner reached; repeat test booked.",
         },
       ],
     });
@@ -1611,10 +1608,10 @@ describe("records target safety", () => {
     });
     expect(result).toEqual(
       expect.objectContaining({
-      id: RECORD_ID,
-      patientId: PATIENT_ID,
-      followUpStatus: "completed",
-      followUpAssignedTo: USER_ID,
+        id: RECORD_ID,
+        patientId: PATIENT_ID,
+        followUpStatus: "completed",
+        followUpAssignedTo: USER_ID,
       }),
     );
     expect(result).not.toHaveProperty("resultValue");
@@ -1667,9 +1664,9 @@ describe("records target safety", () => {
       selectResults: [
         [
           {
-          labResultId: RECORD_ID,
-          eventType: "follow_up_completed",
-          operationPayloadHash: payloadHash,
+            labResultId: RECORD_ID,
+            eventType: "follow_up_completed",
+            operationPayloadHash: payloadHash,
           },
         ],
         [completed],
@@ -1699,12 +1696,12 @@ describe("records target safety", () => {
         [],
         [
           {
-          id: RECORD_ID,
-          status: "pending",
-          resultValue: null,
-          resultFlag: "unknown",
-          followUpStatus: "open",
-          followUpAssignedTo: USER_ID,
+            id: RECORD_ID,
+            status: "pending",
+            resultValue: null,
+            resultFlag: "unknown",
+            followUpStatus: "open",
+            followUpAssignedTo: USER_ID,
           },
         ],
       ],
@@ -1731,12 +1728,12 @@ describe("records target safety", () => {
         [],
         [
           {
-          id: RECORD_ID,
-          resultValue: "2.1",
-          resultFlag: "critical",
-          status: "reviewed",
-          followUpStatus: "open",
-          followUpAssignedTo: OTHER_USER_ID,
+            id: RECORD_ID,
+            resultValue: "2.1",
+            resultFlag: "critical",
+            status: "reviewed",
+            followUpStatus: "open",
+            followUpAssignedTo: OTHER_USER_ID,
           },
         ],
       ],
@@ -1787,10 +1784,10 @@ describe("records target safety", () => {
         [],
         [
           {
-          status: "completed",
-          resultValue: "12.5",
-          resultFlag: "normal",
-          followUpStatus: "not_required",
+            status: "completed",
+            resultValue: "12.5",
+            resultFlag: "normal",
+            followUpStatus: "not_required",
           },
         ],
       ],

--- a/apps/web/server/routers/care-reminders.ts
+++ b/apps/web/server/routers/care-reminders.ts
@@ -5,6 +5,10 @@ import { alias } from "drizzle-orm/pg-core";
 import {
   careReminders,
   clients,
+  communications,
+  emailSuppressions,
+  locationMessaging,
+  locations,
   patients,
   practices,
   users,
@@ -15,6 +19,21 @@ import {
   clinicalDateInput,
   clinicalTextInput,
 } from "@/lib/records/clinical-inputs";
+import { formatClinicalDate } from "@/lib/records/clinical-dates";
+import { sendCareReminder } from "@/lib/email";
+import { sendCareReminderSms } from "@/lib/sms";
+import {
+  emailSuppressionSendBlockMessage,
+  normalizeEmailSuppressionAddress,
+} from "@/lib/email-suppression";
+import { assertOutboundEmailAllowed } from "@/lib/outbound-email-security";
+import { hasNonBlankMessagingSender } from "@/lib/messaging/sender-query";
+import { isQuietHours } from "@/lib/messaging/reminders";
+import { withDurableSmsCommunication } from "@/lib/messaging/durable-sms-communication";
+import {
+  lockPracticeForExternalSideEffects,
+  RECOVERY_HOLD_BLOCK_MESSAGE,
+} from "@/lib/recovery-hold";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 
 const manageProcedure = protectedProcedure.use(
@@ -29,6 +48,11 @@ const reminderNotesInput = z
   .transform((value) => value || undefined);
 const expectedUpdatedAtInput = z.string().datetime();
 const careReminderDismisser = alias(users, "care_reminder_dismisser");
+const outreachInput = z.object({
+  reminderId: z.string().uuid(),
+  channel: z.enum(["email", "sms"]),
+  requestId: z.string().uuid(),
+});
 const dismissalInput = z
   .object({
     items: z
@@ -75,6 +99,42 @@ async function activePractice(
     throw new TRPCError({ code: "NOT_FOUND", message: "Practice not found" });
   }
   return practice;
+}
+
+function careReminderOutreachDedupeKey(
+  practiceId: string,
+  channel: "email" | "sms",
+  requestId: string,
+): string {
+  return `${channel}:care-reminder:${practiceId}:${requestId}`;
+}
+
+async function activeCareReminderSmsSender(
+  db: Pick<Database, "select">,
+  practiceId: string,
+): Promise<{ locationId: string } | null> {
+  const senders = await db
+    .select({ locationId: locationMessaging.locationId })
+    .from(locationMessaging)
+    .innerJoin(
+      locations,
+      and(
+        eq(locations.id, locationMessaging.locationId),
+        eq(locations.practiceId, practiceId),
+        isNull(locations.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        eq(locationMessaging.practiceId, practiceId),
+        isNull(locationMessaging.deletedAt),
+        eq(locationMessaging.enabled, true),
+        eq(locationMessaging.registrationStatus, "active"),
+        hasNonBlankMessagingSender(),
+      ),
+    )
+    .limit(2);
+  return senders.length === 1 ? senders[0]! : null;
 }
 
 export const careRemindersRouter = createRouter({
@@ -153,7 +213,7 @@ export const careRemindersRouter = createRouter({
             ? desc(careReminders.completedAt)
             : status === "dismissed"
               ? desc(careReminders.dismissedAt)
-            : asc(careReminders.dueDate),
+              : asc(careReminders.dueDate),
           asc(careReminders.id),
         )
         .limit(input?.limit ?? 500);
@@ -229,6 +289,313 @@ export const careRemindersRouter = createRouter({
       return reminder!;
     }),
 
+  sendOutreach: manageProcedure
+    .input(outreachInput)
+    .mutation(async ({ ctx, input }) => {
+      const outcome = await ctx.db.transaction(async (tx) => {
+        const db = tx as unknown as Database;
+        if (!(await lockPracticeForExternalSideEffects(db, ctx.practiceId))) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: RECOVERY_HOLD_BLOCK_MESSAGE,
+          });
+        }
+
+        const [reminder] = await db
+          .select({
+            id: careReminders.id,
+            title: careReminders.title,
+            dueDate: careReminders.dueDate,
+            status: careReminders.status,
+            patientName: patients.name,
+            clientId: clients.id,
+            clientFirstName: clients.firstName,
+            clientLastName: clients.lastName,
+            clientEmail: clients.email,
+            clientPhone: clients.phone,
+            clientSmsConsent: clients.smsConsent,
+            emailSuppressionReason: emailSuppressions.reason,
+            practiceName: practices.name,
+            practicePhone: practices.phone,
+            practiceAddress: practices.address,
+            practiceTimezone: practices.timezone,
+          })
+          .from(careReminders)
+          .innerJoin(
+            patients,
+            and(
+              eq(careReminders.patientId, patients.id),
+              eq(patients.practiceId, ctx.practiceId),
+              isNull(patients.deletedAt),
+            ),
+          )
+          .innerJoin(
+            clients,
+            and(
+              eq(patients.clientId, clients.id),
+              eq(clients.practiceId, ctx.practiceId),
+              isNull(clients.deletedAt),
+            ),
+          )
+          .innerJoin(
+            practices,
+            and(eq(practices.id, ctx.practiceId), isNull(practices.deletedAt)),
+          )
+          .leftJoin(
+            emailSuppressions,
+            and(
+              eq(emailSuppressions.practiceId, ctx.practiceId),
+              sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
+              isNull(emailSuppressions.deletedAt),
+            ),
+          )
+          .where(
+            and(
+              eq(careReminders.id, input.reminderId),
+              eq(careReminders.practiceId, ctx.practiceId),
+              isNull(careReminders.deletedAt),
+            ),
+          )
+          .limit(1);
+        if (!reminder) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Care reminder not found",
+          });
+        }
+        if (reminder.status !== "open") {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Only open care reminders can be sent to a client.",
+          });
+        }
+
+        const clientName =
+          [reminder.clientFirstName, reminder.clientLastName]
+            .filter(Boolean)
+            .join(" ") || "Client";
+        const dueDate = formatClinicalDate(
+          reminder.dueDate,
+          reminder.practiceTimezone,
+          reminder.dueDate,
+        );
+        const subject = `Care Reminder for ${reminder.patientName}`;
+        const content = `Hello ${clientName},\n\nThis is a reminder from our veterinary team about ${reminder.patientName}: ${reminder.title}. The reminder date is ${dueDate}. Please contact us if you have questions or would like to schedule.`;
+        const dedupeKey = careReminderOutreachDedupeKey(
+          ctx.practiceId,
+          input.channel,
+          input.requestId,
+        );
+
+        let email: string | null = null;
+        let smsSender: { locationId: string } | null = null;
+        if (input.channel === "email") {
+          email = normalizeEmailSuppressionAddress(reminder.clientEmail);
+          if (!email) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Client does not have an email address on file",
+            });
+          }
+          if (reminder.emailSuppressionReason) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: emailSuppressionSendBlockMessage(
+                reminder.emailSuppressionReason,
+              ),
+            });
+          }
+          await assertOutboundEmailAllowed({
+            practiceId: ctx.practiceId,
+            practiceCreatedAt: ctx.user.practiceCreatedAt,
+            userId: ctx.user.id,
+            userEmailVerifiedAt: ctx.user.emailVerifiedAt,
+            ip: ctx.ip,
+            operation: "care_reminder",
+          });
+        } else {
+          if (!reminder.clientPhone || !reminder.clientSmsConsent) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Client does not have an SMS-consented phone number on file",
+            });
+          }
+          if (isQuietHours(new Date(), reminder.practiceTimezone)) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                "SMS reminders cannot be sent during quiet hours (9 PM–8 AM local time). Try again after 8 AM.",
+            });
+          }
+          smsSender = await activeCareReminderSmsSender(db, ctx.practiceId);
+          if (!smsSender) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Set up exactly one active clinic texting number before sending care reminders by SMS",
+            });
+          }
+        }
+
+        const insertCommunication = async (
+          db: Pick<Database, "insert" | "select">,
+        ) => {
+          const [inserted] = await db
+            .insert(communications)
+            .values({
+              practiceId: ctx.practiceId,
+              clientId: reminder.clientId,
+              channel: input.channel,
+              direction: "outbound",
+              subject: input.channel === "email" ? subject : null,
+              content,
+              status: "pending",
+              dedupeKey,
+            })
+            .onConflictDoNothing({ target: communications.dedupeKey })
+            .returning();
+          if (inserted) return { communication: inserted, replayed: false };
+
+          const [existing] = await db
+            .select()
+            .from(communications)
+            .where(
+              and(
+                eq(communications.practiceId, ctx.practiceId),
+                eq(communications.dedupeKey, dedupeKey),
+                eq(communications.clientId, reminder.clientId),
+                eq(communications.channel, input.channel),
+                eq(communications.direction, "outbound"),
+                isNull(communications.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!existing) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Reminder request ID is already in use.",
+            });
+          }
+          if (
+            existing.content !== content ||
+            (existing.subject ?? null) !==
+              (input.channel === "email" ? subject : null)
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "Reminder request ID was already used for different reminder data.",
+            });
+          }
+          return { communication: existing, replayed: true };
+        };
+
+        const durableSms = input.channel === "sms";
+        const claim = durableSms
+          ? await withDurableSmsCommunication(
+              ctx.practiceId,
+              insertCommunication,
+            )
+          : await insertCommunication(db);
+        const communication = claim.communication;
+        if (
+          claim.replayed &&
+          new Set(["sent", "delivered", "read"]).has(communication.status)
+        ) {
+          return { success: true, channel: input.channel, replayed: true };
+        }
+        if (claim.replayed) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              communication.status === "failed"
+                ? "This reminder delivery failed. Start a new send to retry it."
+                : "This reminder delivery is already being processed.",
+          });
+        }
+
+        const result =
+          input.channel === "email"
+            ? await sendCareReminder({
+                to: email!,
+                clientName,
+                patientName: reminder.patientName,
+                reminderTitle: reminder.title,
+                dueDate,
+                practiceName: reminder.practiceName,
+                practicePhone: reminder.practicePhone ?? undefined,
+                practiceAddress: reminder.practiceAddress ?? undefined,
+                idempotencyKey: dedupeKey,
+              })
+            : await sendCareReminderSms({
+                to: reminder.clientPhone!,
+                patientName: reminder.patientName,
+                reminderTitle: reminder.title,
+                dueDate,
+                practiceName: reminder.practiceName,
+                practicePhone: reminder.practicePhone ?? undefined,
+                practiceId: ctx.practiceId,
+                locationId: smsSender!.locationId,
+                clientId: reminder.clientId,
+                communicationId: communication.id,
+                sourceId: reminder.id,
+                idempotencyKey: dedupeKey,
+              });
+
+        if (
+          input.channel === "sms" &&
+          !result.success &&
+          "outcome" in result &&
+          result.outcome === "outcome_unknown"
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "The texting provider outcome is unknown. Do not resend until support confirms the outcome.",
+          });
+        }
+
+        const project = (db: Pick<Database, "update">) =>
+          db
+            .update(communications)
+            .set({
+              status: result.success ? "sent" : "failed",
+              providerMessageId: result.success
+                ? "sid" in result
+                  ? result.sid
+                  : result.id
+                : undefined,
+            })
+            .where(
+              and(
+                eq(communications.id, communication.id),
+                eq(communications.practiceId, ctx.practiceId),
+                eq(communications.status, "pending"),
+                isNull(communications.deletedAt),
+              ),
+            );
+        if (durableSms) {
+          await withDurableSmsCommunication(ctx.practiceId, project);
+        } else {
+          await project(db);
+        }
+        if (!result.success) {
+          return {
+            deliveryError: result.error ?? "Could not send care reminder",
+          } as const;
+        }
+        return { success: true, channel: input.channel, replayed: false };
+      });
+      if ("deliveryError" in outcome) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: outcome.deliveryError,
+        });
+      }
+      return outcome;
+    }),
+
   setCompleted: manageProcedure
     .input(
       z.object({
@@ -292,7 +659,6 @@ export const careRemindersRouter = createRouter({
             and(
               eq(careReminders.id, current.id),
               eq(careReminders.practiceId, ctx.practiceId),
-              eq(careReminders.updatedAt, current.updatedAt),
               isNull(careReminders.deletedAt),
             ),
           )

--- a/apps/web/server/routers/care-reminders.ts
+++ b/apps/web/server/routers/care-reminders.ts
@@ -1,7 +1,14 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { and, asc, desc, eq, gt, isNull, lte, sql } from "drizzle-orm";
-import { careReminders, clients, patients, practices } from "@openpims/db";
+import { and, asc, desc, eq, gt, inArray, isNull, lte, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import {
+  careReminders,
+  clients,
+  patients,
+  practices,
+  users,
+} from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
 import {
@@ -21,6 +28,39 @@ const reminderNotesInput = z
   .optional()
   .transform((value) => value || undefined);
 const expectedUpdatedAtInput = z.string().datetime();
+const careReminderDismisser = alias(users, "care_reminder_dismisser");
+const dismissalInput = z
+  .object({
+    items: z
+      .array(
+        z.object({
+          id: z.string().uuid(),
+          expectedUpdatedAt: expectedUpdatedAtInput,
+        }),
+      )
+      .min(1)
+      .max(100),
+    dismissed: z.boolean(),
+    reason: z.string().trim().max(500).optional(),
+  })
+  .superRefine((input, ctx) => {
+    if (input.dismissed && (!input.reason || input.reason.length < 3)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["reason"],
+        message: "Explain why these reminders are invalid.",
+      });
+    }
+    if (
+      new Set(input.items.map((item) => item.id)).size !== input.items.length
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["items"],
+        message: "Choose each reminder at most once.",
+      });
+    }
+  });
 
 async function activePractice(
   db: Pick<Database, "select">,
@@ -42,7 +82,9 @@ export const careRemindersRouter = createRouter({
     .input(
       z
         .object({
-          status: z.enum(["open", "completed", "all"]).default("open"),
+          status: z
+            .enum(["open", "completed", "dismissed", "all"])
+            .default("open"),
           due: z.enum(["all", "overdue", "upcoming"]).default("all"),
           patientId: z.string().uuid().optional(),
           limit: z.number().int().min(1).max(1000).default(500),
@@ -80,22 +122,37 @@ export const careRemindersRouter = createRouter({
           patientStatus: patients.status,
           clientId: clients.id,
           clientName: sql<string>`${clients.firstName} || ' ' || ${clients.lastName}`,
+          clientEmail: clients.email,
+          clientPhone: clients.phone,
+          clientSmsConsent: clients.smsConsent,
           title: careReminders.title,
           notes: careReminders.notes,
           dueDate: careReminders.dueDate,
           status: careReminders.status,
           imported: sql<boolean>`${careReminders.externalSource} is not null`,
           completedAt: careReminders.completedAt,
+          dismissedAt: careReminders.dismissedAt,
+          dismissalReason: careReminders.dismissalReason,
+          dismissedByName: careReminderDismisser.name,
           createdAt: careReminders.createdAt,
           updatedAt: careReminders.updatedAt,
         })
         .from(careReminders)
         .innerJoin(patients, eq(careReminders.patientId, patients.id))
         .innerJoin(clients, eq(patients.clientId, clients.id))
+        .leftJoin(
+          careReminderDismisser,
+          and(
+            eq(careReminders.dismissedBy, careReminderDismisser.id),
+            eq(careReminderDismisser.practiceId, ctx.practiceId),
+          ),
+        )
         .where(and(...conditions))
         .orderBy(
           status === "completed"
             ? desc(careReminders.completedAt)
+            : status === "dismissed"
+              ? desc(careReminders.dismissedAt)
             : asc(careReminders.dueDate),
           asc(careReminders.id),
         )
@@ -107,6 +164,7 @@ export const careRemindersRouter = createRouter({
           overdue: sql<number>`count(*) filter (where ${careReminders.status} = 'open' and ${careReminders.dueDate} <= ${today})::int`,
           upcoming: sql<number>`count(*) filter (where ${careReminders.status} = 'open' and ${careReminders.dueDate} > ${today})::int`,
           completed: sql<number>`count(*) filter (where ${careReminders.status} = 'completed')::int`,
+          dismissed: sql<number>`count(*) filter (where ${careReminders.status} = 'dismissed')::int`,
         })
         .from(careReminders)
         .where(
@@ -118,7 +176,13 @@ export const careRemindersRouter = createRouter({
 
       return {
         today,
-        counts: counts ?? { open: 0, overdue: 0, upcoming: 0, completed: 0 },
+        counts: counts ?? {
+          open: 0,
+          overdue: 0,
+          upcoming: 0,
+          completed: 0,
+          dismissed: 0,
+        },
         items,
       };
     }),
@@ -199,6 +263,12 @@ export const careRemindersRouter = createRouter({
           });
         }
         const targetStatus = input.completed ? "completed" : "open";
+        if (current.status === "dismissed") {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Restore this dismissed reminder before completing it.",
+          });
+        }
         if (current.status === targetStatus) return current;
         if (
           current.updatedAt.getTime() !==
@@ -236,4 +306,78 @@ export const careRemindersRouter = createRouter({
         return updated;
       });
     }),
+
+  setDismissed: manageProcedure
+    .input(dismissalInput)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        await activePractice(tx as unknown as Database, ctx.practiceId);
+        const ids = input.items.map((item) => item.id);
+        const expectedById = new Map(
+          input.items.map((item) => [
+            item.id,
+            new Date(item.expectedUpdatedAt).getTime(),
+          ]),
+        );
+        const current = await tx
+          .select({
+            id: careReminders.id,
+            status: careReminders.status,
+            updatedAt: careReminders.updatedAt,
+          })
+          .from(careReminders)
+          .where(
+            and(
+              inArray(careReminders.id, ids),
+              eq(careReminders.practiceId, ctx.practiceId),
+              isNull(careReminders.deletedAt),
+            ),
+          )
+          .orderBy(asc(careReminders.id))
+          .for("update");
+        if (
+          current.length !== ids.length ||
+          current.some(
+            (row) =>
+              row.updatedAt.getTime() !== expectedById.get(row.id) ||
+              row.status !== (input.dismissed ? "open" : "dismissed"),
+          )
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "One or more reminders changed. Refresh before updating them.",
+          });
+        }
+        const now = new Date();
+        const updated = await tx
+          .update(careReminders)
+          .set({
+            status: input.dismissed ? "dismissed" : "open",
+            dismissedAt: input.dismissed ? now : null,
+            dismissedBy: input.dismissed ? ctx.user.id : null,
+            dismissalReason: input.dismissed ? input.reason! : null,
+            completedAt: null,
+            completedBy: null,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              inArray(careReminders.id, ids),
+              eq(careReminders.practiceId, ctx.practiceId),
+              eq(careReminders.status, input.dismissed ? "open" : "dismissed"),
+              isNull(careReminders.deletedAt),
+            ),
+          )
+          .returning({ id: careReminders.id });
+        if (updated.length !== ids.length) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "One or more reminders changed. Refresh before updating them.",
+          });
+        }
+        return { id: updated[0]!.id, ids: updated.map((row) => row.id) };
+      }),
+    ),
 });

--- a/apps/web/server/routers/notifications.ts
+++ b/apps/web/server/routers/notifications.ts
@@ -285,7 +285,7 @@ async function activeReminderSmsSender(
 
 export const notificationsRouter = createRouter({
   sendAppointmentReminder: protectedProcedure
-    .use(requireRole("admin", "front_desk"))
+    .use(requireRole("admin", "veterinarian", "front_desk"))
     .input(z.object({ appointmentId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -27,9 +27,12 @@ import {
   problemList,
   prescriptions,
   prescriptionEvents,
+  auditLog,
+  clients,
   dispenseChargeQueue,
   drugInteractions,
   patients,
+  patientWeights,
   patientAllergies,
   products,
   users,
@@ -76,9 +79,14 @@ import {
   LAB_UNIT_MAX_LENGTH,
 } from "@/lib/records/lab-policy";
 import {
+  isRabiesVaccineName,
+  VACCINATION_LICENSED_DURATION_MAX_MONTHS,
+  VACCINATION_LICENSED_DURATION_MIN_MONTHS,
   VACCINATION_LOT_NUMBER_MAX_LENGTH,
   VACCINATION_MANUFACTURER_MAX_LENGTH,
   VACCINATION_NAME_MAX_LENGTH,
+  VACCINATION_PRODUCT_NAME_MAX_LENGTH,
+  VACCINATION_RABIES_TAG_MAX_LENGTH,
 } from "@/lib/records/vaccination-policy";
 import {
   PROBLEM_DESCRIPTION_MAX_LENGTH,
@@ -164,7 +172,12 @@ type ProblemStatus = (typeof PROBLEM_STATUSES)[number];
 
 const labStatusValues = ["pending", "completed", "reviewed"] as const;
 type LabStatus = (typeof labStatusValues)[number];
-const labResultFlagValues = ["unknown", "normal", "abnormal", "critical"] as const;
+const labResultFlagValues = [
+  "unknown",
+  "normal",
+  "abnormal",
+  "critical",
+] as const;
 const labFollowUpStatusValues = ["not_required", "open", "completed"] as const;
 
 const patientHistoryDateInput = z.string().refine(isValidClinicalDateInput, {
@@ -245,13 +258,17 @@ function activeLabResultPredicate(practiceId: string) {
 
 async function practiceSettings(ctx: RecordsContext): Promise<{
   name: string;
+  address: string | null;
   phone: string | null;
+  email: string | null;
   timezone: string | null;
 }> {
   const [practice] = await ctx.db
     .select({
       name: practices.name,
+      address: practices.address,
       phone: practices.phone,
+      email: practices.email,
       timezone: practices.timezone,
     })
     .from(practices)
@@ -267,7 +284,9 @@ async function practiceSettings(ctx: RecordsContext): Promise<{
 
   return {
     name: practice.name?.trim() || "Veterinary Practice",
+    address: practice.address ?? null,
     phone: practice.phone ?? null,
+    email: practice.email ?? null,
     timezone: practice.timezone ?? null,
   };
 }
@@ -308,22 +327,81 @@ const createVaccinationInput = z.object({
   patientId: z.string().uuid(),
   appointmentId: z.string().uuid().optional(),
   vaccineName: clinicalTextInput("Vaccine name", VACCINATION_NAME_MAX_LENGTH),
+  productName: optionalClinicalTextInput(
+    "Product name",
+    VACCINATION_PRODUCT_NAME_MAX_LENGTH,
+  ),
   lotNumber: optionalClinicalTextInput(
     "Lot number",
-    VACCINATION_LOT_NUMBER_MAX_LENGTH
+    VACCINATION_LOT_NUMBER_MAX_LENGTH,
   ),
   manufacturer: optionalClinicalTextInput(
     "Manufacturer",
-    VACCINATION_MANUFACTURER_MAX_LENGTH
+    VACCINATION_MANUFACTURER_MAX_LENGTH,
   ),
+  productExpirationDate: clinicalDateInput(
+    "Product expiration date",
+  ).optional(),
+  doseType: z.enum(["initial", "booster"]).optional(),
+  licensedDurationMonths: z
+    .number()
+    .int()
+    .min(VACCINATION_LICENSED_DURATION_MIN_MONTHS)
+    .max(VACCINATION_LICENSED_DURATION_MAX_MONTHS)
+    .optional(),
+  rabiesTagNumber: optionalClinicalTextInput(
+    "Rabies tag number",
+    VACCINATION_RABIES_TAG_MAX_LENGTH,
+  ),
+  supervisingVeterinarianId: z.string().uuid().optional(),
   nextDueDate: clinicalDateInput("Next due date").optional(),
 });
+
+const vaccinationCertificateDetailsInput = z.object({
+  patientId: z.string().uuid(),
+  recordId: z.string().uuid(),
+  expectedUpdatedAt: z.string().datetime(),
+  reason: z.string().trim().min(10).max(500),
+  productName: optionalClinicalTextInput(
+    "Product name",
+    VACCINATION_PRODUCT_NAME_MAX_LENGTH,
+  ),
+  manufacturer: optionalClinicalTextInput(
+    "Manufacturer",
+    VACCINATION_MANUFACTURER_MAX_LENGTH,
+  ),
+  lotNumber: optionalClinicalTextInput(
+    "Lot number",
+    VACCINATION_LOT_NUMBER_MAX_LENGTH,
+  ),
+  productExpirationDate: clinicalDateInput(
+    "Product expiration date",
+  ).optional(),
+  doseType: z.enum(["initial", "booster"]).optional(),
+  licensedDurationMonths: z
+    .number()
+    .int()
+    .min(VACCINATION_LICENSED_DURATION_MIN_MONTHS)
+    .max(VACCINATION_LICENSED_DURATION_MAX_MONTHS)
+    .optional(),
+  rabiesTagNumber: optionalClinicalTextInput(
+    "Rabies tag number",
+    VACCINATION_RABIES_TAG_MAX_LENGTH,
+  ),
+  supervisingVeterinarianId: z.string().uuid().optional(),
+});
+
+const vaccinationSupervisorUsers = alias(users, "vaccination_supervisor_users");
+const vaccinationAdministratorUsers = alias(
+  users,
+  "vaccination_administrator_users",
+);
 
 const createProblemInput = z.object({
   patientId: z.string().uuid(),
   description: clinicalTextInput(
     "Problem description",
-    PROBLEM_DESCRIPTION_MAX_LENGTH
+    PROBLEM_DESCRIPTION_MAX_LENGTH,
   ),
   status: z.enum(PROBLEM_STATUSES).default("active"),
   onsetDate: clinicalDateInput("Onset date").optional(),
@@ -336,12 +414,12 @@ const createPrescriptionInput = z
     operationId: z.string().uuid(),
     medicationName: clinicalTextInput(
       "Medication name",
-      PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH
+      PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH,
     ),
     dosage: clinicalTextInput("Dosage", PRESCRIPTION_DOSAGE_MAX_LENGTH),
     frequency: clinicalTextInput(
       "Frequency",
-      PRESCRIPTION_FREQUENCY_MAX_LENGTH
+      PRESCRIPTION_FREQUENCY_MAX_LENGTH,
     ),
     quantity: z
       .number()
@@ -360,7 +438,7 @@ const createPrescriptionInput = z
     endDate: clinicalDateInput("End date").optional(),
     instructions: optionalClinicalTextInput(
       "Prescription instructions",
-      PRESCRIPTION_INSTRUCTIONS_MAX_LENGTH
+      PRESCRIPTION_INSTRUCTIONS_MAX_LENGTH,
     ),
     acknowledgeSafetyWarnings: z.boolean().default(false),
   })
@@ -384,7 +462,7 @@ const createLabResultInput = z
     testName: clinicalTextInput("Test name", LAB_TEST_NAME_MAX_LENGTH),
     resultValue: optionalClinicalTextInput(
       "Result value",
-      LAB_RESULT_VALUE_MAX_LENGTH
+      LAB_RESULT_VALUE_MAX_LENGTH,
     ),
     unit: optionalClinicalTextInput("Unit", LAB_UNIT_MAX_LENGTH),
     referenceRangeLow: labReferenceInput("Reference range low").optional(),
@@ -398,7 +476,7 @@ const createLabResultInput = z
     if (
       !isOrderedLabReferenceRange(
         input.referenceRangeLow,
-        input.referenceRangeHigh
+        input.referenceRangeHigh,
       )
     ) {
       ctx.addIssue({
@@ -411,7 +489,8 @@ const createLabResultInput = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["resultValue"],
-        message: "A result value is required before a lab result can be completed.",
+        message:
+          "A result value is required before a lab result can be completed.",
       });
     }
     if (input.replacesLabResultId && !input.resultValue?.trim()) {
@@ -433,7 +512,8 @@ const createLabResultInput = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["status"],
-        message: "Pending lab results cannot carry partial values. Complete the result when values are available.",
+        message:
+          "Pending lab results cannot carry partial values. Complete the result when values are available.",
       });
     }
   });
@@ -545,7 +625,8 @@ async function getLabOperationReplay(
   ) {
     throw new TRPCError({
       code: "CONFLICT",
-      message: "This lab operation id was already used for different clinical evidence.",
+      message:
+        "This lab operation id was already used for different clinical evidence.",
     });
   }
   return getLabStatusForUpdate(ctx, event.labResultId);
@@ -567,7 +648,7 @@ function labMutationResultForRole(
 
 async function assertPatientBelongsToPractice(
   ctx: RecordsContext,
-  patientId: string
+  patientId: string,
 ) {
   const [patient] = await ctx.db
     .select({ id: patients.id })
@@ -577,8 +658,8 @@ async function assertPatientBelongsToPractice(
         eq(patients.id, patientId),
         eq(patients.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(patients.deletedAt)
-      )
+        isNull(patients.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -589,10 +670,40 @@ async function assertPatientBelongsToPractice(
   return patient;
 }
 
+async function assertVaccinationSupervisor(
+  ctx: RecordsContext,
+  supervisorId: string | undefined,
+) {
+  if (!supervisorId) return null;
+  const [supervisor] = await ctx.db
+    .select({
+      id: users.id,
+      name: users.name,
+      licenseNumber: users.licenseNumber,
+    })
+    .from(users)
+    .where(
+      and(
+        eq(users.id, supervisorId),
+        eq(users.practiceId, ctx.practiceId),
+        eq(users.isVeterinarian, true),
+        isNull(users.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!supervisor) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Choose an active veterinarian from this practice.",
+    });
+  }
+  return supervisor;
+}
+
 async function assertAppointmentBelongsToPatient(
   ctx: RecordsContext,
   appointmentId: string,
-  patientId: string
+  patientId: string,
 ) {
   const [appointment] = await ctx.db
     .select({ id: appointments.id })
@@ -603,8 +714,8 @@ async function assertAppointmentBelongsToPatient(
         eq(appointments.patientId, patientId),
         eq(appointments.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(appointments.deletedAt)
-      )
+        isNull(appointments.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -622,7 +733,7 @@ async function lockOpenAppointmentForClinicalWork(
   ctx: RecordsContext,
   appointmentId: string,
   patientId: string,
-  workLabel: string
+  workLabel: string,
 ) {
   const visit = await lockOpenVisitForClinicalAppend(ctx.db as Database, {
     practiceId: ctx.practiceId,
@@ -630,7 +741,10 @@ async function lockOpenAppointmentForClinicalWork(
     patientId,
   });
   if (!visit.ok && visit.reason === "appointment_not_found") {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Appointment not found",
+    });
   }
   if (!visit.ok && visit.reason === "visit_not_open") {
     throw new TRPCError({
@@ -657,7 +771,7 @@ type VisitWorkSource =
 async function registerVisitWorkItem(
   ctx: RecordsContext,
   appointmentId: string,
-  source: VisitWorkSource
+  source: VisitWorkSource,
 ) {
   if ("vaccinationRecordId" in source) {
     await ctx.db.execute(sql`
@@ -698,7 +812,7 @@ async function registerVisitWorkItem(
  */
 async function findActiveVisitId(
   ctx: RecordsContext,
-  patientId: string
+  patientId: string,
 ): Promise<string | null> {
   const [visit] = await ctx.db
     .select({ id: appointments.id })
@@ -708,8 +822,8 @@ async function findActiveVisitId(
         eq(appointments.practiceId, ctx.practiceId),
         eq(appointments.patientId, patientId),
         inArray(appointments.status, ["checked_in", "in_exam"]),
-        isNull(appointments.deletedAt)
-      )
+        isNull(appointments.deletedAt),
+      ),
     )
     .orderBy(desc(appointments.startTime))
     .limit(1);
@@ -719,7 +833,7 @@ async function findActiveVisitId(
 async function assessPrescriptionSafety(
   ctx: RecordsContext,
   patientId: string,
-  medicationName: string
+  medicationName: string,
 ) {
   const [allergies, activePrescriptions, interactions] = await Promise.all([
     ctx.db
@@ -746,8 +860,8 @@ async function assessPrescriptionSafety(
             where allergy_correction.practice_id = ${ctx.practiceId}
               and allergy_correction.patient_allergy_id = ${patientAllergies.id}
           )`,
-          isNull(patientAllergies.deletedAt)
-        )
+          isNull(patientAllergies.deletedAt),
+        ),
       ),
     ctx.db
       .select({
@@ -761,14 +875,11 @@ async function assessPrescriptionSafety(
           eq(prescriptions.status, "active"),
           or(
             isNull(prescriptions.endDate),
-            gte(
-              prescriptions.endDate,
-              practiceTodayExpression(ctx.practiceId),
-            )
+            gte(prescriptions.endDate, practiceTodayExpression(ctx.practiceId)),
           ),
           activePracticePredicate(ctx.practiceId),
-          isNull(prescriptions.deletedAt)
-        )
+          isNull(prescriptions.deletedAt),
+        ),
       ),
     ctx.db
       .select({
@@ -791,7 +902,7 @@ async function assessPrescriptionSafety(
 
 async function assertDispensedProductBelongsToPractice(
   ctx: RecordsContext,
-  productId: string
+  productId: string,
 ) {
   const [product] = await ctx.db
     .select({
@@ -807,8 +918,8 @@ async function assertDispensedProductBelongsToPractice(
         eq(products.id, productId),
         eq(products.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(products.deletedAt)
-      )
+        isNull(products.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -873,7 +984,7 @@ async function createDispenseChargeWork(
 async function deductDispensedProductStock(
   ctx: RecordsContext,
   productId: string,
-  quantity: number
+  quantity: number,
 ) {
   const [product] = await ctx.db
     .update(products)
@@ -887,8 +998,8 @@ async function deductDispensedProductStock(
         eq(products.inventoryTracked, true),
         activePracticePredicate(ctx.practiceId),
         isNull(products.deletedAt),
-        sql`${products.stockQuantity} >= ${quantity}`
-      )
+        sql`${products.stockQuantity} >= ${quantity}`,
+      ),
     )
     .returning({ id: products.id, stockQuantity: products.stockQuantity });
 
@@ -913,7 +1024,7 @@ type LockedPrescription = {
 
 async function lockPrescriptionForLifecycle(
   ctx: RecordsContext,
-  prescriptionId: string
+  prescriptionId: string,
 ): Promise<LockedPrescription> {
   const [prescription] = await ctx.db
     .select({
@@ -932,14 +1043,17 @@ async function lockPrescriptionForLifecycle(
         eq(prescriptions.id, prescriptionId),
         eq(prescriptions.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(prescriptions.deletedAt)
-      )
+        isNull(prescriptions.deletedAt),
+      ),
     )
     .limit(1)
     .for("update");
 
   if (!prescription) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Prescription not found" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Prescription not found",
+    });
   }
   return prescription;
 }
@@ -952,7 +1066,7 @@ async function lifecycleOperationReplay(
     eventTypes: PrescriptionEventType[];
     reason: string | null;
     appointmentId?: string | null;
-  }
+  },
 ) {
   const [event] = await ctx.db
     .select()
@@ -960,15 +1074,16 @@ async function lifecycleOperationReplay(
     .where(
       and(
         eq(prescriptionEvents.practiceId, ctx.practiceId),
-        eq(prescriptionEvents.operationId, input.operationId)
-      )
+        eq(prescriptionEvents.operationId, input.operationId),
+      ),
     )
     .limit(1);
   if (!event) return null;
   if (event.prescriptionId !== input.prescriptionId) {
     throw new TRPCError({
       code: "CONFLICT",
-      message: "This prescription operation ID was already used for another change.",
+      message:
+        "This prescription operation ID was already used for another change.",
     });
   }
 
@@ -979,12 +1094,15 @@ async function lifecycleOperationReplay(
       and(
         eq(prescriptions.id, input.prescriptionId),
         eq(prescriptions.practiceId, ctx.practiceId),
-        isNull(prescriptions.deletedAt)
-      )
+        isNull(prescriptions.deletedAt),
+      ),
     )
     .limit(1);
   if (!prescription) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Prescription not found" });
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Prescription not found",
+    });
   }
   const expectedEventType =
     input.eventTypes.length === 2
@@ -1029,7 +1147,7 @@ const prescriptionLifecycleReasonInput = z
   .trim()
   .min(
     PRESCRIPTION_LIFECYCLE_REASON_MIN_LENGTH,
-    "Explain the prescription lifecycle change."
+    "Explain the prescription lifecycle change.",
   )
   .max(PRESCRIPTION_LIFECYCLE_REASON_MAX_LENGTH);
 
@@ -1040,14 +1158,14 @@ async function transitionPrescription(
     operationId: string;
     reason: string;
     targetStatus: "completed" | "cancelled";
-  }
+  },
 ) {
   const eventType = input.targetStatus;
   return (ctx.db as Database).transaction(async (tx) => {
     const txCtx = { db: tx, practiceId: ctx.practiceId };
     const operationKey = `prescription-lifecycle:${ctx.practiceId}:${input.operationId}`;
     await tx.execute(
-      sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+      sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
     );
     const replay = await lifecycleOperationReplay(txCtx, {
       prescriptionId: input.id,
@@ -1079,8 +1197,8 @@ async function transitionPrescription(
           eq(prescriptions.id, prescription.id),
           eq(prescriptions.practiceId, ctx.practiceId),
           eq(prescriptions.status, "active"),
-          isNull(prescriptions.deletedAt)
-        )
+          isNull(prescriptions.deletedAt),
+        ),
       )
       .returning();
     if (!updated) {
@@ -1115,7 +1233,7 @@ async function transitionPrescription(
 
 async function getProblemStatusForUpdate(
   ctx: RecordsContext,
-  id: string
+  id: string,
 ): Promise<{ status: ProblemStatus; resolvedDate: string | null }> {
   const [problem] = await ctx.db
     .select({
@@ -1128,8 +1246,8 @@ async function getProblemStatusForUpdate(
         eq(problemList.id, id),
         eq(problemList.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(problemList.deletedAt)
-      )
+        isNull(problemList.deletedAt),
+      ),
     )
     .limit(1);
 
@@ -1140,10 +1258,7 @@ async function getProblemStatusForUpdate(
   return problem;
 }
 
-async function getLabStatusForUpdate(
-  ctx: RecordsContext,
-  id: string
-) {
+async function getLabStatusForUpdate(ctx: RecordsContext, id: string) {
   const [result] = await ctx.db
     .select(getTableColumns(labResults))
     .from(labResults)
@@ -1310,8 +1425,7 @@ export const recordsRouter = createRouter({
           correctedAt: clinicalRecordCorrections.createdAt,
           correctedBy: clinicalRecordCorrections.correctedBy,
           correctedByName: clinicalRecordCorrections.correctedByName,
-          replacementSoapNoteId:
-            replacementFromSource.replacementSoapNoteId,
+          replacementSoapNoteId: replacementFromSource.replacementSoapNoteId,
           replacementCreatedAt: replacementFromSource.createdAt,
           replacementActorName: replacementFromSource.actorName,
           replacesSoapNoteId: sourceFromReplacement.sourceSoapNoteId,
@@ -1321,8 +1435,8 @@ export const recordsRouter = createRouter({
           clinicalRecordCorrections,
           and(
             eq(clinicalRecordCorrections.soapNoteId, soapNotes.id),
-            eq(clinicalRecordCorrections.practiceId, ctx.practiceId)
-          )
+            eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           replacementFromSource,
@@ -1343,8 +1457,8 @@ export const recordsRouter = createRouter({
             eq(soapNotes.patientId, input.patientId),
             eq(soapNotes.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(soapNotes.deletedAt)
-          )
+            isNull(soapNotes.deletedAt),
+          ),
         )
         .orderBy(desc(soapNotes.createdAt));
 
@@ -1392,7 +1506,7 @@ export const recordsRouter = createRouter({
           .trim()
           .min(CLINICAL_CORRECTION_REASON_MIN_LENGTH)
           .max(CLINICAL_CORRECTION_REASON_MAX_LENGTH),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) =>
       ctx.db.transaction(async (tx) => {
@@ -1479,8 +1593,8 @@ export const recordsRouter = createRouter({
           .where(
             and(
               eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
-              eq(clinicalRecordCorrections.soapNoteId, source.id)
-            )
+              eq(clinicalRecordCorrections.soapNoteId, source.id),
+            ),
           )
           .limit(1);
         if (existing) {
@@ -1498,7 +1612,7 @@ export const recordsRouter = createRouter({
           code: "CONFLICT",
           message: "Clinical correction changed; refresh and retry.",
         });
-      })
+      }),
     ),
 
   replaceSoapNote: protectedProcedure
@@ -1723,6 +1837,25 @@ export const recordsRouter = createRouter({
     }),
 
   // Vaccinations
+  listVaccinationProviders: protectedProcedure.query(async ({ ctx }) =>
+    ctx.db
+      .select({
+        id: users.id,
+        name: users.name,
+        licenseNumber: users.licenseNumber,
+      })
+      .from(users)
+      .where(
+        and(
+          eq(users.practiceId, ctx.practiceId),
+          eq(users.isVeterinarian, true),
+          isNull(users.deletedAt),
+          activePracticePredicate(ctx.practiceId),
+        ),
+      )
+      .orderBy(asc(users.name), asc(users.id)),
+  ),
+
   listVaccinations: protectedProcedure
     .input(z.object({ patientId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
@@ -1730,11 +1863,22 @@ export const recordsRouter = createRouter({
         .select({
           id: vaccinationRecords.id,
           vaccineName: vaccinationRecords.vaccineName,
+          productName: vaccinationRecords.productName,
           lotNumber: vaccinationRecords.lotNumber,
           manufacturer: vaccinationRecords.manufacturer,
+          productExpirationDate: vaccinationRecords.productExpirationDate,
+          doseType: vaccinationRecords.doseType,
+          licensedDurationMonths: vaccinationRecords.licensedDurationMonths,
+          rabiesTagNumber: vaccinationRecords.rabiesTagNumber,
+          supervisingVeterinarianId:
+            vaccinationRecords.supervisingVeterinarianId,
+          supervisingVeterinarianName: vaccinationSupervisorUsers.name,
+          supervisingVeterinarianLicenseNumber:
+            vaccinationSupervisorUsers.licenseNumber,
           administeredAt: vaccinationRecords.administeredAt,
           nextDueDate: vaccinationRecords.nextDueDate,
           administeredByName: users.name,
+          updatedAt: vaccinationRecords.updatedAt,
           correctionId: clinicalRecordCorrections.id,
           correctionAction: clinicalRecordCorrections.action,
           correctionReason: clinicalRecordCorrections.reason,
@@ -1747,28 +1891,449 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(vaccinationRecords.administeredBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
+            eq(users.practiceId, ctx.practiceId),
+          ),
           )
+        .leftJoin(
+          vaccinationSupervisorUsers,
+          and(
+            eq(
+              vaccinationRecords.supervisingVeterinarianId,
+              vaccinationSupervisorUsers.id,
+            ),
+            eq(vaccinationSupervisorUsers.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           clinicalRecordCorrections,
           and(
             eq(
               clinicalRecordCorrections.vaccinationRecordId,
-              vaccinationRecords.id
+              vaccinationRecords.id,
             ),
-            eq(clinicalRecordCorrections.practiceId, ctx.practiceId)
-          )
+            eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+            ),
         )
         .where(
           and(
             eq(vaccinationRecords.patientId, input.patientId),
             eq(vaccinationRecords.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(vaccinationRecords.deletedAt)
-          )
+            isNull(vaccinationRecords.deletedAt),
+          ),
         )
         .orderBy(desc(vaccinationRecords.administeredAt));
+    }),
+
+  updateVaccinationCertificateDetails: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician"))
+    .input(vaccinationCertificateDetailsInput)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const txCtx: RecordsContext = { db: tx, practiceId: ctx.practiceId };
+        await assertPatientBelongsToPractice(txCtx, input.patientId);
+        await assertVaccinationSupervisor(
+          txCtx,
+          input.supervisingVeterinarianId,
+        );
+        const [current] = await tx
+          .select({
+            id: vaccinationRecords.id,
+            productName: vaccinationRecords.productName,
+            manufacturer: vaccinationRecords.manufacturer,
+            lotNumber: vaccinationRecords.lotNumber,
+            productExpirationDate: vaccinationRecords.productExpirationDate,
+            doseType: vaccinationRecords.doseType,
+            licensedDurationMonths: vaccinationRecords.licensedDurationMonths,
+            rabiesTagNumber: vaccinationRecords.rabiesTagNumber,
+            supervisingVeterinarianId:
+              vaccinationRecords.supervisingVeterinarianId,
+            updatedAt: vaccinationRecords.updatedAt,
+          })
+          .from(vaccinationRecords)
+          .leftJoin(
+            clinicalRecordCorrections,
+            and(
+              eq(
+                clinicalRecordCorrections.vaccinationRecordId,
+                vaccinationRecords.id,
+              ),
+              eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+            ),
+          )
+          .where(
+            and(
+              eq(vaccinationRecords.id, input.recordId),
+              eq(vaccinationRecords.patientId, input.patientId),
+              eq(vaccinationRecords.practiceId, ctx.practiceId),
+              isNull(vaccinationRecords.deletedAt),
+              isNull(clinicalRecordCorrections.id),
+            ),
+          )
+          .limit(1)
+          .for("update");
+        if (!current) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Current vaccination record not found.",
+          });
+        }
+        if (
+          current.updatedAt.getTime() !==
+          new Date(input.expectedUpdatedAt).getTime()
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "This vaccination changed. Refresh before updating certificate details.",
+          });
+        }
+
+        const now = new Date();
+        const patch = {
+          productName: input.productName ?? null,
+          manufacturer: input.manufacturer ?? null,
+          lotNumber: input.lotNumber ?? null,
+          productExpirationDate: input.productExpirationDate ?? null,
+          doseType: input.doseType ?? null,
+          licensedDurationMonths: input.licensedDurationMonths ?? null,
+          rabiesTagNumber: input.rabiesTagNumber ?? null,
+          supervisingVeterinarianId: input.supervisingVeterinarianId ?? null,
+          updatedAt: now,
+        };
+        const [updated] = await tx
+          .update(vaccinationRecords)
+          .set(patch)
+          .where(
+            and(
+              eq(vaccinationRecords.id, current.id),
+              eq(vaccinationRecords.practiceId, ctx.practiceId),
+              eq(vaccinationRecords.updatedAt, current.updatedAt),
+              isNull(vaccinationRecords.deletedAt),
+            ),
+          )
+          .returning();
+        if (!updated) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "This vaccination changed. Refresh before updating certificate details.",
+          });
+        }
+        await tx.insert(auditLog).values({
+          practiceId: ctx.practiceId,
+          userId: ctx.user.id,
+          action: "certificate_details_updated",
+          entityType: "vaccination_record",
+          entityId: current.id,
+          changes: {
+            reason: input.reason,
+            before: {
+              productName: current.productName,
+              manufacturer: current.manufacturer,
+              lotNumber: current.lotNumber,
+              productExpirationDate: current.productExpirationDate,
+              doseType: current.doseType,
+              licensedDurationMonths: current.licensedDurationMonths,
+              rabiesTagNumber: current.rabiesTagNumber,
+              supervisingVeterinarianId: current.supervisingVeterinarianId,
+            },
+            after: patch,
+          },
+        });
+        return updated;
+      }),
+    ),
+
+  prepareVaccinationCertificate: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician", "front_desk"))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        kind: z.enum(["vaccination_history", "rabies"]),
+        vaccinationRecordId: z.string().uuid().optional(),
+        requestId: z.string().uuid(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (input.kind === "rabies" && !input.vaccinationRecordId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Choose the rabies vaccination for this certificate.",
+        });
+      }
+
+      const [identityRows, vaccinationRows, weightRows] = await Promise.all([
+        ctx.db
+          .select({
+            practiceName: practices.name,
+            practiceAddress: practices.address,
+            practicePhone: practices.phone,
+            practiceEmail: practices.email,
+            practiceTimezone: practices.timezone,
+            patientId: patients.id,
+            patientName: patients.name,
+            species: patients.species,
+            breed: patients.breed,
+            sex: patients.sex,
+            dob: patients.dob,
+            color: patients.color,
+            microchipNumber: patients.microchipNumber,
+            clientId: clients.id,
+            clientFirstName: clients.firstName,
+            clientLastName: clients.lastName,
+            clientAddress: clients.address,
+            clientCity: clients.city,
+            clientState: clients.state,
+            clientZip: clients.zip,
+            clientPhone: clients.phone,
+          })
+          .from(patients)
+          .innerJoin(
+            clients,
+            and(
+              eq(patients.clientId, clients.id),
+              eq(clients.practiceId, ctx.practiceId),
+              isNull(clients.deletedAt),
+            ),
+          )
+          .innerJoin(
+            practices,
+            and(eq(practices.id, ctx.practiceId), isNull(practices.deletedAt)),
+          )
+          .where(
+            and(
+              eq(patients.id, input.patientId),
+              eq(patients.practiceId, ctx.practiceId),
+              isNull(patients.deletedAt),
+            ),
+          )
+          .limit(1),
+        ctx.db
+          .select({
+            id: vaccinationRecords.id,
+            vaccineName: vaccinationRecords.vaccineName,
+            productName: vaccinationRecords.productName,
+            lotNumber: vaccinationRecords.lotNumber,
+            manufacturer: vaccinationRecords.manufacturer,
+            productExpirationDate: vaccinationRecords.productExpirationDate,
+            doseType: vaccinationRecords.doseType,
+            licensedDurationMonths: vaccinationRecords.licensedDurationMonths,
+            rabiesTagNumber: vaccinationRecords.rabiesTagNumber,
+            administeredAt: vaccinationRecords.administeredAt,
+            nextDueDate: vaccinationRecords.nextDueDate,
+            administeredByName: vaccinationAdministratorUsers.name,
+            administeredByIsVeterinarian:
+              vaccinationAdministratorUsers.isVeterinarian,
+            administeredByLicenseNumber:
+              vaccinationAdministratorUsers.licenseNumber,
+            supervisingVeterinarianName: vaccinationSupervisorUsers.name,
+            supervisingVeterinarianLicenseNumber:
+              vaccinationSupervisorUsers.licenseNumber,
+          })
+          .from(vaccinationRecords)
+          .leftJoin(
+            vaccinationAdministratorUsers,
+            and(
+              eq(
+                vaccinationRecords.administeredBy,
+                vaccinationAdministratorUsers.id,
+              ),
+              eq(vaccinationAdministratorUsers.practiceId, ctx.practiceId),
+              isNull(vaccinationAdministratorUsers.deletedAt),
+            ),
+          )
+          .leftJoin(
+            vaccinationSupervisorUsers,
+            and(
+              eq(
+                vaccinationRecords.supervisingVeterinarianId,
+                vaccinationSupervisorUsers.id,
+              ),
+              eq(vaccinationSupervisorUsers.practiceId, ctx.practiceId),
+              isNull(vaccinationSupervisorUsers.deletedAt),
+            ),
+          )
+          .leftJoin(
+            clinicalRecordCorrections,
+            and(
+              eq(
+                clinicalRecordCorrections.vaccinationRecordId,
+                vaccinationRecords.id,
+              ),
+              eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+            ),
+          )
+          .where(
+            and(
+              eq(vaccinationRecords.patientId, input.patientId),
+              eq(vaccinationRecords.practiceId, ctx.practiceId),
+              isNull(vaccinationRecords.deletedAt),
+              isNull(clinicalRecordCorrections.id),
+              input.vaccinationRecordId
+                ? eq(vaccinationRecords.id, input.vaccinationRecordId)
+                : undefined,
+            ),
+          )
+          .orderBy(desc(vaccinationRecords.administeredAt)),
+        ctx.db
+          .select({ weightKg: patientWeights.weightKg })
+          .from(patientWeights)
+          .innerJoin(
+            patients,
+            and(
+              eq(patientWeights.patientId, patients.id),
+              eq(patients.practiceId, ctx.practiceId),
+              isNull(patients.deletedAt),
+            ),
+          )
+          .where(
+            and(
+              eq(patientWeights.patientId, input.patientId),
+              isNull(patientWeights.deletedAt),
+              activePracticePredicate(ctx.practiceId),
+            ),
+          )
+          .orderBy(desc(patientWeights.recordedAt), desc(patientWeights.id))
+          .limit(1),
+      ]);
+
+      const identity = identityRows[0];
+      if (!identity) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Patient not found",
+        });
+      }
+      const certificateVaccinations =
+        input.kind === "rabies"
+          ? vaccinationRows.filter((row) =>
+              isRabiesVaccineName(row.vaccineName),
+            )
+          : vaccinationRows;
+      if (certificateVaccinations.length === 0) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            input.kind === "rabies"
+              ? "The selected record is not an active rabies vaccination."
+              : "No current vaccination records are available for a certificate.",
+        });
+      }
+
+      const ownerAddress = [
+        identity.clientAddress,
+        [identity.clientCity, identity.clientState, identity.clientZip]
+          .filter(Boolean)
+          .join(", "),
+      ]
+        .filter(Boolean)
+        .join("\n");
+      const vaccinationsForCertificate = certificateVaccinations.map((row) => {
+        const useAdministratorAsVeterinarian =
+          !row.supervisingVeterinarianName &&
+          row.administeredByIsVeterinarian === true;
+        return {
+          id: row.id,
+          vaccineName: row.vaccineName,
+          productName: row.productName,
+          lotNumber: row.lotNumber,
+          manufacturer: row.manufacturer,
+          productExpirationDate: row.productExpirationDate,
+          doseType: row.doseType,
+          licensedDurationMonths: row.licensedDurationMonths,
+          rabiesTagNumber: row.rabiesTagNumber,
+          administeredAt: row.administeredAt,
+          nextDueDate: row.nextDueDate,
+          administeredByName: row.administeredByName,
+          veterinarianName: useAdministratorAsVeterinarian
+            ? row.administeredByName
+            : row.supervisingVeterinarianName,
+          veterinarianLicenseNumber: useAdministratorAsVeterinarian
+            ? row.administeredByLicenseNumber
+            : row.supervisingVeterinarianLicenseNumber,
+        };
+      });
+
+      const warnings: string[] = [];
+      if (input.kind === "rabies") {
+        const rabies = vaccinationsForCertificate[0]!;
+        if (!ownerAddress) warnings.push("owner address");
+        if (!identity.clientPhone) warnings.push("owner phone");
+        if (!identity.breed) warnings.push("patient breed");
+        if (!identity.sex) warnings.push("patient sex");
+        if (!identity.dob) warnings.push("patient date of birth");
+        if (!identity.color) warnings.push("patient color or markings");
+        if (!weightRows[0]?.weightKg) warnings.push("current patient weight");
+        if (!identity.microchipNumber && !rabies.rabiesTagNumber) {
+          warnings.push("microchip or rabies tag number");
+        }
+        if (!rabies.productName) warnings.push("vaccine product name");
+        if (!rabies.manufacturer) warnings.push("vaccine manufacturer");
+        if (!rabies.lotNumber) warnings.push("vaccine lot number");
+        if (!rabies.productExpirationDate) {
+          warnings.push("vaccine product expiration date");
+        }
+        if (!rabies.doseType) warnings.push("initial or booster dose");
+        if (!rabies.licensedDurationMonths) {
+          warnings.push("licensed vaccine duration");
+        }
+        if (!rabies.nextDueDate) warnings.push("next vaccination due date");
+        const administeredDate = formatDateInputForTimeZone(
+          new Date(rabies.administeredAt),
+          identity.practiceTimezone,
+        );
+        if (
+          rabies.productExpirationDate &&
+          rabies.productExpirationDate < administeredDate
+        ) {
+          warnings.push("product expiration on or after administration");
+        }
+        if (rabies.nextDueDate && rabies.nextDueDate <= administeredDate) {
+          warnings.push("next due date after administration");
+        }
+        if (!rabies.veterinarianName) {
+          warnings.push("supervising veterinarian");
+        }
+        if (!rabies.veterinarianLicenseNumber) {
+          warnings.push("veterinarian license number");
+        }
+      }
+
+      return {
+        id:
+          input.kind === "rabies"
+            ? certificateVaccinations[0]!.id
+            : identity.patientId,
+        certificateId: input.requestId,
+        kind: input.kind,
+        generatedAt: new Date(),
+        ready: warnings.length === 0,
+        missingFields: warnings,
+        practice: {
+          name: identity.practiceName?.trim() || "Veterinary Practice",
+          address: identity.practiceAddress,
+          phone: identity.practicePhone,
+          email: identity.practiceEmail,
+          timezone: identity.practiceTimezone,
+        },
+        owner: {
+          name: `${identity.clientFirstName} ${identity.clientLastName}`.trim(),
+          address: ownerAddress || null,
+          phone: identity.clientPhone,
+        },
+        patient: {
+          name: identity.patientName,
+          species: identity.species,
+          breed: identity.breed,
+          sex: identity.sex,
+          dob: identity.dob,
+          color: identity.color,
+          microchipNumber: identity.microchipNumber,
+          weightKg: weightRows[0]?.weightKg ?? null,
+        },
+        vaccinations: vaccinationsForCertificate,
+      };
     }),
 
   markVaccinationEnteredInError: protectedProcedure
@@ -1782,7 +2347,7 @@ export const recordsRouter = createRouter({
           .trim()
           .min(CLINICAL_CORRECTION_REASON_MIN_LENGTH)
           .max(CLINICAL_CORRECTION_REASON_MAX_LENGTH),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) =>
       ctx.db.transaction(async (tx) => {
@@ -1799,8 +2364,8 @@ export const recordsRouter = createRouter({
               eq(vaccinationRecords.patientId, input.patientId),
               eq(vaccinationRecords.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(vaccinationRecords.deletedAt)
-            )
+              isNull(vaccinationRecords.deletedAt),
+            ),
           )
           .limit(1)
           .for("update", { of: vaccinationRecords });
@@ -1847,8 +2412,8 @@ export const recordsRouter = createRouter({
                 eq(visitWorkItems.status, "unresolved"),
                 isNull(visitWorkItems.invoiceId),
                 isNull(visitWorkItems.invoiceItemId),
-                isNull(visitWorkItems.deletedAt)
-              )
+                isNull(visitWorkItems.deletedAt),
+              ),
             );
           return created;
         }
@@ -1859,8 +2424,8 @@ export const recordsRouter = createRouter({
           .where(
             and(
               eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
-              eq(clinicalRecordCorrections.vaccinationRecordId, source.id)
-            )
+              eq(clinicalRecordCorrections.vaccinationRecordId, source.id),
+            ),
           )
           .limit(1);
         if (existing) return existing;
@@ -1869,7 +2434,7 @@ export const recordsRouter = createRouter({
           code: "CONFLICT",
           message: "Clinical correction changed; refresh and retry.",
         });
-      })
+      }),
     ),
 
   createVaccination: protectedProcedure
@@ -1879,12 +2444,16 @@ export const recordsRouter = createRouter({
       const record = await ctx.db.transaction(async (tx) => {
         const txCtx: RecordsContext = { db: tx, practiceId: ctx.practiceId };
         await assertPatientBelongsToPractice(txCtx, input.patientId);
+        await assertVaccinationSupervisor(
+          txCtx,
+          input.supervisingVeterinarianId,
+        );
         if (input.appointmentId) {
           await lockOpenAppointmentForClinicalWork(
             txCtx,
             input.appointmentId,
             input.patientId,
-            "vaccination"
+            "vaccination",
           );
         }
         const [created] = await tx
@@ -1924,8 +2493,8 @@ export const recordsRouter = createRouter({
             eq(problemList.patientId, input.patientId),
             eq(problemList.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(problemList.deletedAt)
-          )
+            isNull(problemList.deletedAt),
+          ),
         )
         .orderBy(desc(problemList.createdAt));
     }),
@@ -1957,7 +2526,7 @@ export const recordsRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         status: z.enum(PROBLEM_STATUSES),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const existing = await getProblemStatusForUpdate(ctx, input.id);
@@ -1980,8 +2549,8 @@ export const recordsRouter = createRouter({
             eq(problemList.status, existing.status),
             activePracticePredicate(ctx.practiceId),
             sql`${problemList.resolvedDate} is not distinct from ${existing.resolvedDate}`,
-            isNull(problemList.deletedAt)
-          )
+            isNull(problemList.deletedAt),
+          ),
         )
         .returning();
       if (!problem) {
@@ -2025,24 +2594,24 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(prescriptions.prescribedBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
-          )
+            eq(users.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           products,
           and(
             eq(prescriptions.productId, products.id),
             eq(products.practiceId, ctx.practiceId),
-            isNull(products.deletedAt)
-          )
+            isNull(products.deletedAt),
+          ),
         )
         .where(
           and(
             eq(prescriptions.patientId, input.patientId),
             eq(prescriptions.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(prescriptions.deletedAt)
-          )
+            isNull(prescriptions.deletedAt),
+          ),
         )
         .orderBy(desc(prescriptions.createdAt));
     }),
@@ -2072,17 +2641,20 @@ export const recordsRouter = createRouter({
           dispenseChargeQueue,
           and(
             eq(dispenseChargeQueue.prescriptionEventId, prescriptionEvents.id),
-            eq(dispenseChargeQueue.practiceId, ctx.practiceId)
-          )
+            eq(dispenseChargeQueue.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
             eq(prescriptionEvents.practiceId, ctx.practiceId),
             eq(prescriptionEvents.prescriptionId, input.prescriptionId),
-            activePracticePredicate(ctx.practiceId)
-          )
+            activePracticePredicate(ctx.practiceId),
+          ),
         )
-        .orderBy(desc(prescriptionEvents.createdAt), desc(prescriptionEvents.id));
+        .orderBy(
+          desc(prescriptionEvents.createdAt),
+          desc(prescriptionEvents.id),
+        );
     }),
 
   checkPrescriptionSafety: protectedProcedure
@@ -2092,16 +2664,16 @@ export const recordsRouter = createRouter({
         patientId: z.string().uuid(),
         medicationName: clinicalTextInput(
           "Medication name",
-          PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH
+          PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH,
         ),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
       return assessPrescriptionSafety(
         ctx,
         input.patientId,
-        input.medicationName
+        input.medicationName,
       );
     }),
 
@@ -2113,7 +2685,7 @@ export const recordsRouter = createRouter({
         const txCtx: RecordsContext = { db: tx, practiceId: ctx.practiceId };
         const operationKey = `dashboard-prescription:${ctx.practiceId}:${input.operationId}`;
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
         );
 
         const [existing] = await tx
@@ -2140,8 +2712,8 @@ export const recordsRouter = createRouter({
           .where(
             and(
               eq(prescriptions.practiceId, ctx.practiceId),
-              eq(prescriptions.operationId, input.operationId)
-            )
+              eq(prescriptions.operationId, input.operationId),
+            ),
           )
           .limit(1);
         if (existing) {
@@ -2161,7 +2733,8 @@ export const recordsRouter = createRouter({
           if (
             !createdEvent ||
             existing.patientId !== input.patientId ||
-            (existing.appointmentId ?? null) !== (input.appointmentId ?? null) ||
+            (existing.appointmentId ?? null) !==
+              (input.appointmentId ?? null) ||
             existing.medicationName !== input.medicationName ||
             existing.dosage !== input.dosage ||
             existing.frequency !== input.frequency ||
@@ -2191,18 +2764,18 @@ export const recordsRouter = createRouter({
           await assertAppointmentBelongsToPatient(
             txCtx,
             input.appointmentId,
-            input.patientId
+            input.patientId,
           );
         }
         const safety = await assessPrescriptionSafety(
           txCtx,
           input.patientId,
-          input.medicationName
+          input.medicationName,
         );
         if (input.productId) {
           const product = await assertDispensedProductBelongsToPractice(
             txCtx,
-            input.productId
+            input.productId,
           );
           if (!input.quantity || input.quantity <= 0) {
             throw new TRPCError({
@@ -2233,7 +2806,7 @@ export const recordsRouter = createRouter({
             txCtx,
             input.appointmentId,
             input.patientId,
-            "prescriptions"
+            "prescriptions",
           );
         }
 
@@ -2241,7 +2814,7 @@ export const recordsRouter = createRouter({
           await deductDispensedProductStock(
             txCtx,
             input.productId,
-            input.quantity
+            input.quantity,
           );
         }
 
@@ -2327,14 +2900,14 @@ export const recordsRouter = createRouter({
           .trim()
           .max(PRESCRIPTION_LIFECYCLE_REASON_MAX_LENGTH)
           .optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db.transaction(async (tx) => {
         const txCtx = { db: tx, practiceId: ctx.practiceId };
         const operationKey = `prescription-lifecycle:${ctx.practiceId}:${input.operationId}`;
         await tx.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`,
         );
         const replay = await lifecycleOperationReplay(txCtx, {
           prescriptionId: input.id,
@@ -2345,7 +2918,10 @@ export const recordsRouter = createRouter({
         });
         if (replay) return replay;
 
-        const prescription = await lockPrescriptionForLifecycle(txCtx, input.id);
+        const prescription = await lockPrescriptionForLifecycle(
+          txCtx,
+          input.id,
+        );
         if (input.appointmentId) {
           await assertAppointmentBelongsToPatient(
             txCtx,
@@ -2391,12 +2967,12 @@ export const recordsRouter = createRouter({
         if (prescription.productId && prescription.quantity) {
           await assertDispensedProductBelongsToPractice(
             txCtx,
-            prescription.productId
+            prescription.productId,
           );
           await deductDispensedProductStock(
             txCtx,
             prescription.productId,
-            prescription.quantity
+            prescription.quantity,
           );
         }
         const [updated] = await tx
@@ -2411,14 +2987,15 @@ export const recordsRouter = createRouter({
               eq(prescriptions.practiceId, ctx.practiceId),
               eq(prescriptions.status, "active"),
               eq(prescriptions.refillsRemaining, prescription.refillsRemaining),
-              isNull(prescriptions.deletedAt)
-            )
+              isNull(prescriptions.deletedAt),
+            ),
           )
           .returning();
         if (!updated) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Prescription changed while dispensing. Refresh and try again.",
+            message:
+              "Prescription changed while dispensing. Refresh and try again.",
           });
         }
         const [event] = await tx
@@ -2455,7 +3032,11 @@ export const recordsRouter = createRouter({
             medicationName: prescription.medicationName,
           });
         }
-        return { prescription: updated, event: event!, replayed: false as const };
+        return {
+          prescription: updated,
+          event: event!,
+          replayed: false as const,
+        };
       });
       if (!result.replayed) {
         const webhookEvent =
@@ -2481,12 +3062,12 @@ export const recordsRouter = createRouter({
         id: z.string().uuid(),
         operationId: z.string().uuid(),
         reason: prescriptionLifecycleReasonInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await transitionPrescription(
         { db: ctx.db, practiceId: ctx.practiceId, user: ctx.user },
-        { ...input, targetStatus: "completed" }
+        { ...input, targetStatus: "completed" },
       );
       if (!result.replayed) {
         await dispatchWebhookEvent(ctx.practiceId, "prescription.completed", {
@@ -2505,12 +3086,12 @@ export const recordsRouter = createRouter({
         id: z.string().uuid(),
         operationId: z.string().uuid(),
         reason: prescriptionLifecycleReasonInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const result = await transitionPrescription(
         { db: ctx.db, practiceId: ctx.practiceId, user: ctx.user },
-        { ...input, targetStatus: "cancelled" }
+        { ...input, targetStatus: "cancelled" },
       );
       if (!result.replayed) {
         await dispatchWebhookEvent(ctx.practiceId, "prescription.cancelled", {
@@ -2609,22 +3190,22 @@ export const recordsRouter = createRouter({
           orderedBy,
           and(
             eq(labResults.orderedBy, orderedBy.id),
-            eq(orderedBy.practiceId, ctx.practiceId)
-          )
+            eq(orderedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           reviewedBy,
           and(
             eq(labResults.reviewedBy, reviewedBy.id),
-            eq(reviewedBy.practiceId, ctx.practiceId)
-          )
+            eq(reviewedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           followUpAssignee,
           and(
             eq(labResults.followUpAssignedTo, followUpAssignee.id),
-            eq(followUpAssignee.practiceId, ctx.practiceId)
-          )
+            eq(followUpAssignee.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           clinicalRecordCorrections,
@@ -2638,8 +3219,8 @@ export const recordsRouter = createRouter({
             eq(labResults.patientId, input.patientId),
             eq(labResults.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(labResults.deletedAt)
-          )
+            isNull(labResults.deletedAt),
+          ),
         )
         .orderBy(desc(labResults.createdAt));
       return rows;
@@ -2701,10 +3282,17 @@ export const recordsRouter = createRouter({
       z.object({
         resultId: z.string().uuid().optional(),
         filter: z
-          .enum(["action_required", "awaiting_results", "awaiting_review", "critical", "follow_up", "all"])
+          .enum([
+            "action_required",
+            "awaiting_results",
+            "awaiting_review",
+            "critical",
+            "follow_up",
+            "all",
+          ])
           .default("action_required"),
         limit: z.number().int().min(1).max(100).default(50),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const orderedBy = alias(users, "inbox_lab_ordered_by");
@@ -2729,7 +3317,10 @@ export const recordsRouter = createRouter({
         );
       } else if (!input.resultId && input.filter === "action_required") {
         conditions.push(
-          or(ne(labResults.status, "reviewed"), eq(labResults.followUpStatus, "open"))!
+          or(
+            ne(labResults.status, "reviewed"),
+            eq(labResults.followUpStatus, "open"),
+          )!,
         );
       } else if (!input.resultId && input.filter === "awaiting_results") {
         conditions.push(eq(labResults.status, "pending"));
@@ -2787,43 +3378,43 @@ export const recordsRouter = createRouter({
           patients,
           and(
             eq(labResults.patientId, patients.id),
-            eq(patients.practiceId, ctx.practiceId)
-          )
+            eq(patients.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           appointments,
           and(
             eq(labResults.appointmentId, appointments.id),
-            eq(appointments.practiceId, ctx.practiceId)
-          )
+            eq(appointments.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           clinician,
           and(
             eq(appointments.doctorId, clinician.id),
-            eq(clinician.practiceId, ctx.practiceId)
-          )
+            eq(clinician.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           orderedBy,
           and(
             eq(labResults.orderedBy, orderedBy.id),
-            eq(orderedBy.practiceId, ctx.practiceId)
-          )
+            eq(orderedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           reviewedBy,
           and(
             eq(labResults.reviewedBy, reviewedBy.id),
-            eq(reviewedBy.practiceId, ctx.practiceId)
-          )
+            eq(reviewedBy.practiceId, ctx.practiceId),
+          ),
         )
         .leftJoin(
           assignee,
           and(
             eq(labResults.followUpAssignedTo, assignee.id),
-            eq(assignee.practiceId, ctx.practiceId)
-          )
+            eq(assignee.practiceId, ctx.practiceId),
+          ),
         )
         .where(and(...conditions))
         .orderBy(
@@ -2836,8 +3427,10 @@ export const recordsRouter = createRouter({
             else 'infinity'::timestamptz end`),
           asc(sql`case ${labResults.status}
             when 'completed' then 0 when 'pending' then 1 else 2 end`),
-          asc(sql`coalesce(${labResults.completedAt}, ${labResults.createdAt})`),
-          asc(labResults.id)
+          asc(
+            sql`coalesce(${labResults.completedAt}, ${labResults.createdAt})`,
+          ),
+          asc(labResults.id),
         )
         .limit(input.resultId ? 2 : input.limit + 1);
       const visibleRows = frontDeskMode
@@ -2879,8 +3472,8 @@ export const recordsRouter = createRouter({
             eq(users.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             ne(users.role, "viewer"),
-            isNull(users.deletedAt)
-          )
+            isNull(users.deletedAt),
+          ),
         )
         .orderBy(asc(users.name));
     }),
@@ -3084,7 +3677,8 @@ export const recordsRouter = createRouter({
           if (existingReplay[0].creationPayloadHash !== creationPayloadHash) {
             throw new TRPCError({
               code: "CONFLICT",
-              message: "This lab creation id was already used for different result data.",
+              message:
+                "This lab creation id was already used for different result data.",
             });
           }
           if (input.replacesLabResultId) {
@@ -3275,7 +3869,10 @@ export const recordsRouter = createRouter({
           followUpStatus: created.followUpStatus,
           actorId: ctx.user.id,
           actorName: ctx.user.name,
-          note: created.status === "completed" ? "Result values available at entry." : null,
+          note:
+            created.status === "completed"
+              ? "Result values available at entry."
+              : null,
           operationId,
           operationPayloadHash: creationPayloadHash,
         });
@@ -3318,11 +3915,14 @@ export const recordsRouter = createRouter({
         id: z.string().uuid(),
         status: z.literal("reviewed"),
         operationId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       if (input.status === "reviewed" && ctx.user.role === "technician") {
-        throw new TRPCError({ code: "FORBIDDEN", message: "A veterinarian or administrator must review lab results." });
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "A veterinarian or administrator must review lab results.",
+        });
       }
       const payloadHash = labOperationHash({
         kind: "review",
@@ -3342,7 +3942,10 @@ export const recordsRouter = createRouter({
         const existing = await getLabStatusForUpdate(txCtx, input.id);
         assertLabStatusTransition(existing.status, input.status);
         if (!existing.resultValue?.trim()) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "A lab result cannot be reviewed without recorded values." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "A lab result cannot be reviewed without recorded values.",
+          });
         }
         if (
           existing.resultFlag === "critical" &&
@@ -3350,7 +3953,8 @@ export const recordsRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Assign owned follow-up for this critical result before recording clinical review.",
+            message:
+              "Assign owned follow-up for this critical result before recording clinical review.",
           });
         }
         const occurredAt = new Date();
@@ -3376,7 +3980,8 @@ export const recordsRouter = createRouter({
         if (!updated) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Lab result changed while updating. Refresh and try again.",
+            message:
+              "Lab result changed while updating. Refresh and try again.",
           });
         }
         await tx.insert(labResultEvents).values({
@@ -3412,22 +4017,35 @@ export const recordsRouter = createRouter({
       z
         .object({
           id: z.string().uuid(),
-          resultValue: clinicalTextInput("Result value", LAB_RESULT_VALUE_MAX_LENGTH),
+          resultValue: clinicalTextInput(
+            "Result value",
+            LAB_RESULT_VALUE_MAX_LENGTH,
+          ),
           unit: optionalClinicalTextInput("Unit", LAB_UNIT_MAX_LENGTH),
-          referenceRangeLow: labReferenceInput("Reference range low").optional(),
-          referenceRangeHigh: labReferenceInput("Reference range high").optional(),
+          referenceRangeLow: labReferenceInput(
+            "Reference range low",
+          ).optional(),
+          referenceRangeHigh: labReferenceInput(
+            "Reference range high",
+          ).optional(),
           resultFlag: z.enum(labResultFlagValues).default("unknown"),
           operationId: z.string().uuid(),
         })
         .superRefine((input, refineCtx) => {
-          if (!isOrderedLabReferenceRange(input.referenceRangeLow, input.referenceRangeHigh)) {
+          if (
+            !isOrderedLabReferenceRange(
+              input.referenceRangeLow,
+              input.referenceRangeHigh,
+            )
+          ) {
             refineCtx.addIssue({
               code: z.ZodIssueCode.custom,
               path: ["referenceRangeHigh"],
-              message: "Reference range high must be greater than or equal to low.",
+              message:
+                "Reference range high must be greater than or equal to low.",
             });
           }
-        })
+        }),
     )
     .mutation(async ({ ctx, input }) => {
       const payloadHash = labOperationHash({
@@ -3451,7 +4069,11 @@ export const recordsRouter = createRouter({
         if (replay) return replay;
         const existing = await getLabStatusForUpdate(txCtx, input.id);
         if (existing.status !== "pending") {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending lab results can be completed with new values." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Only pending lab results can be completed with new values.",
+          });
         }
         if (
           input.resultFlag === "critical" &&
@@ -3460,7 +4082,8 @@ export const recordsRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Set a due date on the open follow-up before recording this result as critical.",
+            message:
+              "Set a due date on the open follow-up before recording this result as critical.",
           });
         }
         const occurredAt = new Date();
@@ -3488,7 +4111,11 @@ export const recordsRouter = createRouter({
           )
           .returning();
         if (!updated) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Lab result changed while completing. Refresh and try again." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Lab result changed while completing. Refresh and try again.",
+          });
         }
         await tx.insert(labResultEvents).values({
           practiceId: ctx.practiceId,
@@ -3525,7 +4152,7 @@ export const recordsRouter = createRouter({
         dueAt: z.string().datetime().optional(),
         note: z.string().trim().max(1000).optional(),
         operationId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const dueAt = input.dueAt ? new Date(input.dueAt).toISOString() : null;
@@ -3551,7 +4178,8 @@ export const recordsRouter = createRouter({
         if (existing.status === "pending") {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Enter and complete the lab values before assigning follow-up.",
+            message:
+              "Enter and complete the lab values before assigning follow-up.",
           });
         }
         const [assignee] = await tx
@@ -3562,12 +4190,15 @@ export const recordsRouter = createRouter({
               eq(users.id, input.assigneeId),
               eq(users.practiceId, ctx.practiceId),
               ne(users.role, "viewer"),
-              isNull(users.deletedAt)
-            )
+              isNull(users.deletedAt),
+            ),
           )
           .limit(1);
         if (!assignee) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Choose an active clinic teammate." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Choose an active clinic teammate.",
+          });
         }
         if (existing.resultFlag === "critical" && !dueAt) {
           throw new TRPCError({
@@ -3578,7 +4209,8 @@ export const recordsRouter = createRouter({
         if (assignee.role === "front_desk" && !note) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Front desk follow-up requires actionable instructions from the clinical team.",
+            message:
+              "Front desk follow-up requires actionable instructions from the clinical team.",
           });
         }
         const occurredAt = new Date();
@@ -3608,14 +4240,21 @@ export const recordsRouter = createRouter({
           )
           .returning();
         if (!updated) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Lab result changed while assigning follow-up. Refresh and try again." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Lab result changed while assigning follow-up. Refresh and try again.",
+          });
         }
         await tx.insert(labResultEvents).values({
           practiceId: ctx.practiceId,
           labResultId: updated.id,
           patientId: updated.patientId,
           appointmentId: updated.appointmentId,
-          eventType: existing.followUpStatus === "not_required" ? "follow_up_assigned" : "follow_up_reassigned",
+          eventType:
+            existing.followUpStatus === "not_required"
+              ? "follow_up_assigned"
+              : "follow_up_reassigned",
           createdAt: occurredAt,
           statusBefore: updated.status,
           statusAfter: updated.status,
@@ -3666,11 +4305,18 @@ export const recordsRouter = createRouter({
         if (existing.status === "pending") {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Lab follow-up cannot be completed before result values are available.",
+            message:
+              "Lab follow-up cannot be completed before result values are available.",
           });
         }
-        if (existing.followUpStatus !== "open" || !existing.followUpAssignedTo) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "This lab result has no open follow-up." });
+        if (
+          existing.followUpStatus !== "open" ||
+          !existing.followUpAssignedTo
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "This lab result has no open follow-up.",
+          });
         }
         if (
           ctx.user.role === "front_desk" &&
@@ -3678,7 +4324,8 @@ export const recordsRouter = createRouter({
         ) {
           throw new TRPCError({
             code: "FORBIDDEN",
-            message: "Front desk staff can complete only lab follow-up assigned to them.",
+            message:
+              "Front desk staff can complete only lab follow-up assigned to them.",
           });
         }
         const occurredAt = new Date();
@@ -3704,7 +4351,11 @@ export const recordsRouter = createRouter({
           )
           .returning();
         if (!updated) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Lab follow-up changed while completing. Refresh and try again." });
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Lab follow-up changed while completing. Refresh and try again.",
+          });
         }
         await tx.insert(labResultEvents).values({
           practiceId: ctx.practiceId,
@@ -3754,16 +4405,16 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(procedures.performedBy, users.id),
-            eq(users.practiceId, ctx.practiceId)
-          )
+            eq(users.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
             eq(procedures.patientId, input.patientId),
             eq(procedures.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(procedures.deletedAt)
-          )
+            isNull(procedures.deletedAt),
+          ),
         )
         .orderBy(desc(procedures.createdAt));
     }),
@@ -3777,20 +4428,20 @@ export const recordsRouter = createRouter({
         name: clinicalTextInput("Procedure name", PROCEDURE_NAME_MAX_LENGTH),
         description: optionalClinicalTextInput(
           "Procedure description",
-          PROCEDURE_DESCRIPTION_MAX_LENGTH
+          PROCEDURE_DESCRIPTION_MAX_LENGTH,
         ),
         anesthesiaUsed: optionalClinicalTextInput(
           "Anesthesia used",
-          PROCEDURE_ANESTHESIA_MAX_LENGTH
+          PROCEDURE_ANESTHESIA_MAX_LENGTH,
         ),
         durationMinutes: positiveIntegerColumnInput
           .max(PROCEDURE_DURATION_MAX_MINUTES)
           .optional(),
         notes: optionalClinicalTextInput(
           "Procedure notes",
-          PROCEDURE_NOTES_MAX_LENGTH
+          PROCEDURE_NOTES_MAX_LENGTH,
         ),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const procedure = await ctx.db.transaction(async (tx) => {
@@ -3801,7 +4452,7 @@ export const recordsRouter = createRouter({
             txCtx,
             input.appointmentId,
             input.patientId,
-            "procedures"
+            "procedures",
           );
         }
         const [created] = await tx
@@ -3840,7 +4491,7 @@ export const recordsRouter = createRouter({
       z.object({
         patientId: z.string().uuid(),
         appointmentId: z.string().uuid().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
@@ -3849,7 +4500,7 @@ export const recordsRouter = createRouter({
             await assertAppointmentBelongsToPatient(
               ctx,
               input.appointmentId,
-              input.patientId
+              input.patientId,
             )
           ).id
         : await findActiveVisitId(ctx, input.patientId);
@@ -3901,8 +4552,8 @@ export const recordsRouter = createRouter({
             like(files.mimeType, "image/%"),
             eq(files.storageStatus, "available"),
             activePracticePredicate(ctx.practiceId),
-            isNull(files.deletedAt)
-          )
+            isNull(files.deletedAt),
+          ),
         )
         .orderBy(desc(files.createdAt))
         .limit(50);
@@ -3919,7 +4570,7 @@ export const recordsRouter = createRouter({
       z.object({
         patientId: z.string().uuid(),
         appointmentId: z.string().uuid().optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
@@ -3927,7 +4578,7 @@ export const recordsRouter = createRouter({
         await assertAppointmentBelongsToPatient(
           ctx,
           input.appointmentId,
-          input.patientId
+          input.patientId,
         );
       }
       return ctx.db
@@ -3951,8 +4602,8 @@ export const recordsRouter = createRouter({
             eq(consentRequests.fileId, files.id),
             eq(consentRequests.practiceId, ctx.practiceId),
             eq(consentRequests.status, "signed"),
-            isNull(consentRequests.deletedAt)
-          )
+            isNull(consentRequests.deletedAt),
+          ),
         )
         .where(
           and(
@@ -3966,11 +4617,11 @@ export const recordsRouter = createRouter({
             or(
               isNull(files.category),
               ne(files.category, CONSENT_FILE_CATEGORY),
-              eq(consentRequests.status, "signed")
+              eq(consentRequests.status, "signed"),
             ),
             activePracticePredicate(ctx.practiceId),
-            isNull(files.deletedAt)
-          )
+            isNull(files.deletedAt),
+          ),
         )
         .orderBy(desc(files.createdAt))
         .limit(200);
@@ -3999,8 +4650,8 @@ export const recordsRouter = createRouter({
             eq(consentForms.practiceId, ctx.practiceId),
             eq(consentForms.isActive, true),
             activePracticePredicate(ctx.practiceId),
-            isNull(consentForms.deletedAt)
-          )
+            isNull(consentForms.deletedAt),
+          ),
         )
         .orderBy(consentForms.sortOrder)
         .limit(100);
@@ -4017,7 +4668,7 @@ export const recordsRouter = createRouter({
           title: form.title,
           body: form.body,
           sortOrder: form.sortOrder,
-        }))
+        })),
       )
       .onConflictDoNothing();
     return listForms();
@@ -4037,9 +4688,19 @@ export const recordsRouter = createRouter({
         patientId: z.string().uuid(),
         appointmentId: z.string().uuid().optional(),
         formId: z.string().uuid(),
-        title: z.string().trim().min(1).max(CONSENT_TITLE_MAX_LENGTH).optional(),
-        bodyText: z.string().trim().min(1).max(CONSENT_BODY_MAX_LENGTH).optional(),
-      })
+        title: z
+          .string()
+          .trim()
+          .min(1)
+          .max(CONSENT_TITLE_MAX_LENGTH)
+          .optional(),
+        bodyText: z
+          .string()
+          .trim()
+          .min(1)
+          .max(CONSENT_BODY_MAX_LENGTH)
+          .optional(),
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
@@ -4055,8 +4716,8 @@ export const recordsRouter = createRouter({
             eq(consentForms.id, input.formId),
             eq(consentForms.practiceId, ctx.practiceId),
             eq(consentForms.isActive, true),
-            isNull(consentForms.deletedAt)
-          )
+            isNull(consentForms.deletedAt),
+          ),
         )
         .limit(1);
       if (!form) {
@@ -4082,7 +4743,7 @@ export const recordsRouter = createRouter({
             await assertAppointmentBelongsToPatient(
               ctx,
               input.appointmentId,
-              input.patientId
+              input.patientId,
             )
           ).id
         : await findActiveVisitId(ctx, input.patientId);
@@ -4137,8 +4798,8 @@ export const recordsRouter = createRouter({
             eq(files.patientId, input.patientId),
             eq(files.category, CONSENT_FILE_CATEGORY),
             eq(files.storageStatus, "available"),
-            isNull(files.deletedAt)
-          )
+            isNull(files.deletedAt),
+          ),
         )
         .where(
           and(
@@ -4146,8 +4807,8 @@ export const recordsRouter = createRouter({
             eq(consentRequests.patientId, input.patientId),
             eq(consentRequests.status, "signed"),
             activePracticePredicate(ctx.practiceId),
-            isNull(consentRequests.deletedAt)
-          )
+            isNull(consentRequests.deletedAt),
+          ),
         )
         .orderBy(desc(consentRequests.createdAt))
         .limit(50);

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   eq,
   and,
@@ -13,6 +13,7 @@ import {
   ne,
   asc,
   getTableColumns,
+  notExists,
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { TRPCError } from "@trpc/server";
@@ -1893,7 +1894,7 @@ export const recordsRouter = createRouter({
             eq(vaccinationRecords.administeredBy, users.id),
             eq(users.practiceId, ctx.practiceId),
           ),
-          )
+        )
         .leftJoin(
           vaccinationSupervisorUsers,
           and(
@@ -1912,7 +1913,7 @@ export const recordsRouter = createRouter({
               vaccinationRecords.id,
             ),
             eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
-            ),
+          ),
         )
         .where(
           and(
@@ -1951,23 +1952,26 @@ export const recordsRouter = createRouter({
             updatedAt: vaccinationRecords.updatedAt,
           })
           .from(vaccinationRecords)
-          .leftJoin(
-            clinicalRecordCorrections,
-            and(
-              eq(
-                clinicalRecordCorrections.vaccinationRecordId,
-                vaccinationRecords.id,
-              ),
-              eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
-            ),
-          )
           .where(
             and(
               eq(vaccinationRecords.id, input.recordId),
               eq(vaccinationRecords.patientId, input.patientId),
               eq(vaccinationRecords.practiceId, ctx.practiceId),
               isNull(vaccinationRecords.deletedAt),
-              isNull(clinicalRecordCorrections.id),
+              notExists(
+                tx
+                  .select({ id: clinicalRecordCorrections.id })
+                  .from(clinicalRecordCorrections)
+                  .where(
+                    and(
+                      eq(
+                        clinicalRecordCorrections.vaccinationRecordId,
+                        vaccinationRecords.id,
+                      ),
+                      eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+                    ),
+                  ),
+              ),
             ),
           )
           .limit(1)
@@ -2008,7 +2012,6 @@ export const recordsRouter = createRouter({
             and(
               eq(vaccinationRecords.id, current.id),
               eq(vaccinationRecords.practiceId, ctx.practiceId),
-              eq(vaccinationRecords.updatedAt, current.updatedAt),
               isNull(vaccinationRecords.deletedAt),
             ),
           )
@@ -2052,7 +2055,6 @@ export const recordsRouter = createRouter({
         patientId: z.string().uuid(),
         kind: z.enum(["vaccination_history", "rabies"]),
         vaccinationRecordId: z.string().uuid().optional(),
-        requestId: z.string().uuid(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -2300,12 +2302,36 @@ export const recordsRouter = createRouter({
         }
       }
 
+      const certificateId = randomUUID();
+      if (warnings.length === 0) {
+        await ctx.db.insert(auditLog).values({
+          practiceId: ctx.practiceId,
+          userId: ctx.user.id,
+          action: "vaccination_certificate_prepared",
+          entityType:
+            input.kind === "rabies" ? "vaccination_record" : "patient",
+          entityId:
+            input.kind === "rabies"
+              ? certificateVaccinations[0]!.id
+              : identity.patientId,
+          changes: {
+            certificateId,
+            kind: input.kind,
+            patientId: identity.patientId,
+            vaccinationRecordIds: certificateVaccinations.map(
+              (vaccination) => vaccination.id,
+            ),
+          },
+          ipAddress: ctx.ip,
+        });
+      }
+
       return {
         id:
           input.kind === "rabies"
             ? certificateVaccinations[0]!.id
             : identity.patientId,
-        certificateId: input.requestId,
+        certificateId,
         kind: input.kind,
         generatedAt: new Date(),
         ready: warnings.length === 0,

--- a/packages/db/drizzle/0096_vaccination_certificates_care_reminder_dismissal.sql
+++ b/packages/db/drizzle/0096_vaccination_certificates_care_reminder_dismissal.sql
@@ -1,0 +1,44 @@
+CREATE TYPE "public"."vaccination_dose_type" AS ENUM('initial', 'booster');--> statement-breakpoint
+ALTER TABLE "care_reminders" DROP CONSTRAINT "care_reminders_state_check";--> statement-breakpoint
+ALTER TABLE "care_reminders" ALTER COLUMN "status" DROP DEFAULT;--> statement-breakpoint
+CREATE TYPE "public"."care_reminder_status_v2" AS ENUM('open', 'completed', 'dismissed');--> statement-breakpoint
+ALTER TABLE "care_reminders" ALTER COLUMN "status" TYPE "public"."care_reminder_status_v2" USING "status"::text::"public"."care_reminder_status_v2";--> statement-breakpoint
+DROP TYPE "public"."care_reminder_status";--> statement-breakpoint
+ALTER TYPE "public"."care_reminder_status_v2" RENAME TO "care_reminder_status";--> statement-breakpoint
+ALTER TABLE "care_reminders" ALTER COLUMN "status" SET DEFAULT 'open';--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD COLUMN "product_name" varchar(255);--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD COLUMN "product_expiration_date" date;--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD COLUMN "dose_type" "vaccination_dose_type";--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD COLUMN "licensed_duration_months" integer;--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD COLUMN "rabies_tag_number" varchar(64);--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD COLUMN "supervising_veterinarian_id" uuid;--> statement-breakpoint
+ALTER TABLE "care_reminders" ADD COLUMN "dismissed_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "care_reminders" ADD COLUMN "dismissed_by" uuid;--> statement-breakpoint
+ALTER TABLE "care_reminders" ADD COLUMN "dismissal_reason" varchar(500);--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD CONSTRAINT "vaccination_records_supervising_veterinarian_id_users_id_fk" FOREIGN KEY ("supervising_veterinarian_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD CONSTRAINT "vaccination_records_supervisor_practice_fk" FOREIGN KEY ("practice_id","supervising_veterinarian_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "care_reminders" ADD CONSTRAINT "care_reminders_dismisser_tenant_fk" FOREIGN KEY ("practice_id","dismissed_by") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD CONSTRAINT "vaccination_records_licensed_duration_check" CHECK ("vaccination_records"."licensed_duration_months" is null or "vaccination_records"."licensed_duration_months" between 1 and 120);--> statement-breakpoint
+ALTER TABLE "care_reminders" ADD CONSTRAINT "care_reminders_dismissal_reason_check" CHECK ("care_reminders"."dismissal_reason" is null or char_length(btrim("care_reminders"."dismissal_reason")) between 3 and 500);--> statement-breakpoint
+ALTER TABLE "care_reminders" ADD CONSTRAINT "care_reminders_state_check" CHECK ((
+          "care_reminders"."status" = 'open'
+          and "care_reminders"."completed_at" is null
+          and "care_reminders"."completed_by" is null
+          and "care_reminders"."dismissed_at" is null
+          and "care_reminders"."dismissed_by" is null
+          and "care_reminders"."dismissal_reason" is null
+        ) or (
+          "care_reminders"."status" = 'completed'
+          and "care_reminders"."completed_at" is not null
+          and "care_reminders"."completed_by" is not null
+          and "care_reminders"."dismissed_at" is null
+          and "care_reminders"."dismissed_by" is null
+          and "care_reminders"."dismissal_reason" is null
+        ) or (
+          "care_reminders"."status" = 'dismissed'
+          and "care_reminders"."completed_at" is null
+          and "care_reminders"."completed_by" is null
+          and "care_reminders"."dismissed_at" is not null
+          and "care_reminders"."dismissed_by" is not null
+          and char_length(btrim("care_reminders"."dismissal_reason")) between 3 and 500
+        ));

--- a/packages/db/drizzle/0096_vaccination_certificates_care_reminder_dismissal.sql
+++ b/packages/db/drizzle/0096_vaccination_certificates_care_reminder_dismissal.sql
@@ -1,11 +1,13 @@
 CREATE TYPE "public"."vaccination_dose_type" AS ENUM('initial', 'booster');--> statement-breakpoint
 ALTER TABLE "care_reminders" DROP CONSTRAINT "care_reminders_state_check";--> statement-breakpoint
+DROP INDEX "care_reminders_open_due_idx";--> statement-breakpoint
 ALTER TABLE "care_reminders" ALTER COLUMN "status" DROP DEFAULT;--> statement-breakpoint
 CREATE TYPE "public"."care_reminder_status_v2" AS ENUM('open', 'completed', 'dismissed');--> statement-breakpoint
 ALTER TABLE "care_reminders" ALTER COLUMN "status" TYPE "public"."care_reminder_status_v2" USING "status"::text::"public"."care_reminder_status_v2";--> statement-breakpoint
 DROP TYPE "public"."care_reminder_status";--> statement-breakpoint
 ALTER TYPE "public"."care_reminder_status_v2" RENAME TO "care_reminder_status";--> statement-breakpoint
 ALTER TABLE "care_reminders" ALTER COLUMN "status" SET DEFAULT 'open';--> statement-breakpoint
+CREATE INDEX "care_reminders_open_due_idx" ON "care_reminders" USING btree ("practice_id","due_date","id") WHERE "care_reminders"."status" = 'open' and "care_reminders"."deleted_at" is null;--> statement-breakpoint
 ALTER TABLE "vaccination_records" ADD COLUMN "product_name" varchar(255);--> statement-breakpoint
 ALTER TABLE "vaccination_records" ADD COLUMN "product_expiration_date" date;--> statement-breakpoint
 ALTER TABLE "vaccination_records" ADD COLUMN "dose_type" "vaccination_dose_type";--> statement-breakpoint

--- a/packages/db/drizzle/meta/0096_snapshot.json
+++ b/packages/db/drizzle/meta/0096_snapshot.json
@@ -1,0 +1,30995 @@
+{
+  "id": "b7d4cb0f-503e-4764-90f7-c83c70e664b9",
+  "prevId": "c40a4158-1da3-45f4-9aa7-0305e5300577",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_reminders_enabled": {
+          "name": "appointment_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appointment_reminder_lead_hours": {
+          "name": "appointment_reminder_lead_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "recovery_hold": {
+          "name": "recovery_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recovery_hold_reason": {
+          "name": "recovery_hold_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_hold_set_at": {
+          "name": "recovery_hold_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_hold_released_at": {
+          "name": "recovery_hold_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practices_appointment_reminder_lead_hours_check": {
+          "name": "practices_appointment_reminder_lead_hours_check",
+          "value": "\"practices\".\"appointment_reminder_lead_hours\" in (24, 48, 72)"
+        },
+        "practices_recovery_hold_evidence_check": {
+          "name": "practices_recovery_hold_evidence_check",
+          "value": "not \"practices\".\"recovery_hold\" or (\"practices\".\"recovery_hold_set_at\" is not null and \"practices\".\"recovery_hold_reason\" is not null and \"practices\".\"recovery_hold_reason\" ~ '[^[:space:]]')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "is_veterinarian": {
+          "name": "is_veterinarian",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_veterinarian_idx": {
+          "name": "users_veterinarian_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_veterinarian",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_id_patient_uq": {
+          "name": "patient_allergies_id_patient_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_client_id_uq": {
+          "name": "patients_practice_client_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_client_id_uq": {
+          "name": "appointments_practice_patient_client_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_location_time_idx": {
+          "name": "appointments_location_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_id_locations_id_fk": {
+          "name": "appointments_location_id_locations_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_location_tenant_fk": {
+          "name": "appointments_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_location_tenant_fk": {
+          "name": "appointments_room_location_tenant_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "practice_id",
+            "location_id",
+            "room_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "location_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "appointments_time_range_check": {
+          "name": "appointments_time_range_check",
+          "value": "\"appointments\".\"start_time\" < \"appointments\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_practice_location_id_uq": {
+          "name": "rooms_practice_location_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_tenant_fk": {
+          "name": "rooms_location_tenant_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_active_day_idx": {
+          "name": "staff_schedules_active_day_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"staff_schedules\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_window_uq": {
+          "name": "staff_schedules_active_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_active_null_location_window_uq": {
+          "name": "staff_schedules_active_null_location_window_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"staff_schedules\".\"deleted_at\" is null and \"staff_schedules\".\"location_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_tenant_fk": {
+          "name": "staff_schedules_user_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_tenant_fk": {
+          "name": "staff_schedules_location_tenant_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "staff_schedules_day_of_week_check": {
+          "name": "staff_schedules_day_of_week_check",
+          "value": "\"staff_schedules\".\"day_of_week\" between 0 and 6"
+        },
+        "staff_schedules_time_range_check": {
+          "name": "staff_schedules_time_range_check",
+          "value": "\"staff_schedules\".\"start_time\" < \"staff_schedules\".\"end_time\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "finalized_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_expiration_date": {
+          "name": "product_expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dose_type": {
+          "name": "dose_type",
+          "type": "vaccination_dose_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licensed_duration_months": {
+          "name": "licensed_duration_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rabies_tag_number": {
+          "name": "rabies_tag_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supervising_veterinarian_id": {
+          "name": "supervising_veterinarian_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_supervising_veterinarian_id_users_id_fk": {
+          "name": "vaccination_records_supervising_veterinarian_id_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "supervising_veterinarian_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_supervisor_practice_fk": {
+          "name": "vaccination_records_supervisor_practice_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "supervising_veterinarian_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "vaccination_records_licensed_duration_check": {
+          "name": "vaccination_records_licensed_duration_check",
+          "value": "\"vaccination_records\".\"licensed_duration_months\" is null or \"vaccination_records\".\"licensed_duration_months\" between 1 and 120"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_allergy_id": {
+          "name": "patient_allergy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_patient_allergy_uq": {
+          "name": "clinical_record_corrections_patient_allergy_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_allergy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"patient_allergy_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_soap_source_uq": {
+          "name": "clinical_record_corrections_practice_record_soap_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_allergy_id_patient_allergies_id_fk": {
+          "name": "clinical_record_corrections_patient_allergy_id_patient_allergies_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patient_allergies",
+          "columnsFrom": [
+            "patient_allergy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_allergy_source_fk": {
+          "name": "clinical_record_corrections_patient_allergy_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patient_allergies",
+          "columnsFrom": [
+            "patient_allergy_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'patient_allergy'\n        and \"clinical_record_corrections\".\"patient_allergy_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n        and \"clinical_record_corrections\".\"appointment_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "lab_result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_note_replacements": {
+      "name": "soap_note_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_soap_note_id": {
+          "name": "source_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_soap_note_id": {
+          "name": "replacement_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_replacements_source_history_idx": {
+          "name": "soap_note_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_source_uq": {
+          "name": "soap_note_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_replacement_uq": {
+          "name": "soap_note_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_operation_uq": {
+          "name": "soap_note_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_replacements_practice_id_practices_id_fk": {
+          "name": "soap_note_replacements_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "soap_note_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_source_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_id_users_id_fk": {
+          "name": "soap_note_replacements_actor_id_users_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_tenant_fk": {
+          "name": "soap_note_replacements_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_tenant_fk": {
+          "name": "soap_note_replacements_replacement_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_source_tenant_fk": {
+          "name": "soap_note_replacements_correction_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "soap_note_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_tenant_fk": {
+          "name": "soap_note_replacements_actor_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_replacements_shape_check": {
+          "name": "soap_note_replacements_shape_check",
+          "value": "\"soap_note_replacements\".\"source_soap_note_id\" <> \"soap_note_replacements\".\"replacement_soap_note_id\"\n        and \"soap_note_replacements\".\"actor_name\" = btrim(\"soap_note_replacements\".\"actor_name\")\n        and length(btrim(\"soap_note_replacements\".\"actor_name\")) between 1 and 255\n        and \"soap_note_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_practice_id_uq": {
+          "name": "invoices_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_invoice_id_uq": {
+          "name": "payments_invoice_id_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_tenant_provider_account_uq": {
+          "name": "practice_payment_accounts_tenant_provider_account_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory_tracked": {
+          "name": "inventory_tracked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_external_id_uq": {
+          "name": "products_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"products\".\"external_source\" is not null and \"products\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_import_fingerprint_uq": {
+          "name": "products_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"products\".\"import_fingerprint\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "products_import_identity_check": {
+          "name": "products_import_identity_check",
+          "value": "(\"products\".\"external_source\" is null and \"products\".\"external_id\" is null and \"products\".\"import_fingerprint\" is null)\n        or (\"products\".\"external_source\" is not null and \"products\".\"external_id\" is not null and \"products\".\"import_fingerprint\" is not null)"
+        },
+        "products_import_fingerprint_check": {
+          "name": "products_import_fingerprint_check",
+          "value": "\"products\".\"import_fingerprint\" is null or \"products\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "products_external_source_check": {
+          "name": "products_external_source_check",
+          "value": "\"products\".\"external_source\" is null or \"products\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "products_inventory_tracking_check": {
+          "name": "products_inventory_tracking_check",
+          "value": "\"products\".\"inventory_tracked\" or (\n        \"products\".\"stock_quantity\" = 0\n        and \"products\".\"reorder_point\" is null\n        and \"products\".\"lot_number\" is null\n        and \"products\".\"expiration_date\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "services_practice_id_uq": {
+          "name": "services_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "services_external_id_uq": {
+          "name": "services_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"services\".\"external_source\" is not null and \"services\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "services_import_fingerprint_uq": {
+          "name": "services_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"services\".\"import_fingerprint\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        },
+        "services_import_identity_check": {
+          "name": "services_import_identity_check",
+          "value": "(\"services\".\"external_source\" is null and \"services\".\"external_id\" is null and \"services\".\"import_fingerprint\" is null)\n        or (\"services\".\"external_source\" is not null and \"services\".\"external_id\" is not null and \"services\".\"import_fingerprint\" is not null)"
+        },
+        "services_import_fingerprint_check": {
+          "name": "services_import_fingerprint_check",
+          "value": "\"services\".\"import_fingerprint\" is null or \"services\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "services_external_source_check": {
+          "name": "services_external_source_check",
+          "value": "\"services\".\"external_source\" is null or \"services\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.financial_closes": {
+      "name": "financial_closes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_date": {
+          "name": "business_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cutoff_at": {
+          "name": "cutoff_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_count": {
+          "name": "payment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross_receipts_cents": {
+          "name": "gross_receipts_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refunds_cents": {
+          "name": "refunds_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "net_receipts_cents": {
+          "name": "net_receipts_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cash_cents": {
+          "name": "cash_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_cents": {
+          "name": "check_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_and_online_cents": {
+          "name": "card_and_online_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "other_cents": {
+          "name": "other_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_gross_cents": {
+          "name": "processor_gross_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_fee_cents": {
+          "name": "processor_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_fee_cents": {
+          "name": "application_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_net_cents": {
+          "name": "clinic_net_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_out_cents": {
+          "name": "paid_out_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_dispute_cents": {
+          "name": "open_dispute_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unreconciled_count": {
+          "name": "unreconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "financial_closes_practice_day_uq": {
+          "name": "financial_closes_practice_day_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "business_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "financial_closes_practice_cutoff_idx": {
+          "name": "financial_closes_practice_cutoff_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cutoff_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "financial_closes_practice_id_practices_id_fk": {
+          "name": "financial_closes_practice_id_practices_id_fk",
+          "tableFrom": "financial_closes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "financial_closes_closed_by_users_id_fk": {
+          "name": "financial_closes_closed_by_users_id_fk",
+          "tableFrom": "financial_closes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "closed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "financial_closes_actor_tenant_fk": {
+          "name": "financial_closes_actor_tenant_fk",
+          "tableFrom": "financial_closes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "closed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "financial_closes_counts_check": {
+          "name": "financial_closes_counts_check",
+          "value": "\"financial_closes\".\"payment_count\" >= 0 and \"financial_closes\".\"unreconciled_count\" >= 0"
+        },
+        "financial_closes_nonnegative_check": {
+          "name": "financial_closes_nonnegative_check",
+          "value": "\"financial_closes\".\"gross_receipts_cents\" >= 0\n        and \"financial_closes\".\"refunds_cents\" >= 0\n        and \"financial_closes\".\"processor_gross_cents\" >= 0\n        and \"financial_closes\".\"processor_fee_cents\" >= 0\n        and \"financial_closes\".\"application_fee_cents\" >= 0\n        and \"financial_closes\".\"clinic_net_cents\" >= 0\n        and \"financial_closes\".\"paid_out_cents\" >= 0\n        and \"financial_closes\".\"open_dispute_cents\" >= 0"
+        },
+        "financial_closes_receipt_identity_check": {
+          "name": "financial_closes_receipt_identity_check",
+          "value": "\"financial_closes\".\"net_receipts_cents\" = \"financial_closes\".\"gross_receipts_cents\" - \"financial_closes\".\"refunds_cents\""
+        },
+        "financial_closes_processor_identity_check": {
+          "name": "financial_closes_processor_identity_check",
+          "value": "\"financial_closes\".\"processor_gross_cents\" = \"financial_closes\".\"processor_fee_cents\" + \"financial_closes\".\"application_fee_cents\" + \"financial_closes\".\"clinic_net_cents\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_disputes": {
+      "name": "payment_disputes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settlement_id": {
+          "name": "settlement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "external_dispute_id": {
+          "name": "external_dispute_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_due_by": {
+          "name": "evidence_due_by",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payment_disputes_external_uq": {
+          "name": "payment_disputes_external_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_dispute_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_disputes_practice_status_idx": {
+          "name": "payment_disputes_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_disputes_practice_id_practices_id_fk": {
+          "name": "payment_disputes_practice_id_practices_id_fk",
+          "tableFrom": "payment_disputes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_disputes_settlement_id_payment_processor_settlements_id_fk": {
+          "name": "payment_disputes_settlement_id_payment_processor_settlements_id_fk",
+          "tableFrom": "payment_disputes",
+          "tableTo": "payment_processor_settlements",
+          "columnsFrom": [
+            "settlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_disputes_settlement_tenant_fk": {
+          "name": "payment_disputes_settlement_tenant_fk",
+          "tableFrom": "payment_disputes",
+          "tableTo": "payment_processor_settlements",
+          "columnsFrom": [
+            "practice_id",
+            "settlement_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_disputes_amount_check": {
+          "name": "payment_disputes_amount_check",
+          "value": "\"payment_disputes\".\"amount_cents\" > 0 and \"payment_disputes\".\"currency\" ~ '^[a-z]{3}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_processor_payouts": {
+      "name": "payment_processor_payouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_payout_id": {
+          "name": "external_payout_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automatic": {
+          "name": "automatic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconciliation_complete": {
+          "name": "reconciliation_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "arrival_at": {
+          "name": "arrival_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payment_processor_payouts_external_uq": {
+          "name": "payment_processor_payouts_external_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connected_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_payout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_payouts_practice_date_idx": {
+          "name": "payment_processor_payouts_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_processor_payouts_practice_id_practices_id_fk": {
+          "name": "payment_processor_payouts_practice_id_practices_id_fk",
+          "tableFrom": "payment_processor_payouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_payouts_account_tenant_fk": {
+          "name": "payment_processor_payouts_account_tenant_fk",
+          "tableFrom": "payment_processor_payouts",
+          "tableTo": "practice_payment_accounts",
+          "columnsFrom": [
+            "practice_id",
+            "provider",
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "provider",
+            "stripe_account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_processor_payouts_amount_check": {
+          "name": "payment_processor_payouts_amount_check",
+          "value": "\"payment_processor_payouts\".\"amount_cents\" > 0 and \"payment_processor_payouts\".\"currency\" ~ '^[a-z]{3}$'"
+        },
+        "payment_processor_payouts_status_check": {
+          "name": "payment_processor_payouts_status_check",
+          "value": "\"payment_processor_payouts\".\"status\" in ('pending', 'in_transit', 'paid', 'failed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_processor_refunds": {
+      "name": "payment_processor_refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settlement_id": {
+          "name": "settlement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_payment_id": {
+          "name": "original_payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refund_payment_id": {
+          "name": "refund_payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_refund_id": {
+          "name": "external_refund_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_transaction_id": {
+          "name": "balance_transaction_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_amount_cents": {
+          "name": "balance_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_fee_cents": {
+          "name": "balance_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_net_cents": {
+          "name": "balance_net_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payment_processor_refunds_payment_uq": {
+          "name": "payment_processor_refunds_payment_uq",
+          "columns": [
+            {
+              "expression": "refund_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_refunds_external_uq": {
+          "name": "payment_processor_refunds_external_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_refund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_refunds_practice_date_idx": {
+          "name": "payment_processor_refunds_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_processor_refunds_practice_id_practices_id_fk": {
+          "name": "payment_processor_refunds_practice_id_practices_id_fk",
+          "tableFrom": "payment_processor_refunds",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_refunds_settlement_id_payment_processor_settlements_id_fk": {
+          "name": "payment_processor_refunds_settlement_id_payment_processor_settlements_id_fk",
+          "tableFrom": "payment_processor_refunds",
+          "tableTo": "payment_processor_settlements",
+          "columnsFrom": [
+            "settlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_refunds_original_payment_id_payments_id_fk": {
+          "name": "payment_processor_refunds_original_payment_id_payments_id_fk",
+          "tableFrom": "payment_processor_refunds",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "original_payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_refunds_refund_payment_id_payments_id_fk": {
+          "name": "payment_processor_refunds_refund_payment_id_payments_id_fk",
+          "tableFrom": "payment_processor_refunds",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "refund_payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_refunds_settlement_payment_tenant_fk": {
+          "name": "payment_processor_refunds_settlement_payment_tenant_fk",
+          "tableFrom": "payment_processor_refunds",
+          "tableTo": "payment_processor_settlements",
+          "columnsFrom": [
+            "practice_id",
+            "settlement_id",
+            "original_payment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "payment_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_refunds_account_tenant_fk": {
+          "name": "payment_processor_refunds_account_tenant_fk",
+          "tableFrom": "payment_processor_refunds",
+          "tableTo": "practice_payment_accounts",
+          "columnsFrom": [
+            "practice_id",
+            "provider",
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "provider",
+            "stripe_account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_processor_refunds_amount_check": {
+          "name": "payment_processor_refunds_amount_check",
+          "value": "\"payment_processor_refunds\".\"amount_cents\" > 0\n        and \"payment_processor_refunds\".\"currency\" ~ '^[a-z]{3}$'\n        and (\"payment_processor_refunds\".\"balance_amount_cents\" is null or \"payment_processor_refunds\".\"balance_amount_cents\" <= 0)\n        and (\"payment_processor_refunds\".\"balance_fee_cents\" is null or \"payment_processor_refunds\".\"balance_fee_cents\" >= 0)\n        and (\"payment_processor_refunds\".\"balance_net_cents\" is null or \"payment_processor_refunds\".\"balance_net_cents\" <= 0)"
+        },
+        "payment_processor_refunds_status_check": {
+          "name": "payment_processor_refunds_status_check",
+          "value": "\"payment_processor_refunds\".\"status\" in ('pending', 'requires_action', 'succeeded', 'failed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_processor_settlements": {
+      "name": "payment_processor_settlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkout_session_id": {
+          "name": "checkout_session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_intent_id": {
+          "name": "payment_intent_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_transaction_id": {
+          "name": "balance_transaction_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross_amount_cents": {
+          "name": "gross_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_fee_cents": {
+          "name": "processor_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_fee_cents": {
+          "name": "application_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clinic_net_cents": {
+          "name": "clinic_net_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_status": {
+          "name": "balance_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_on": {
+          "name": "available_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payout_id": {
+          "name": "payout_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payout_status": {
+          "name": "payout_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unassigned'"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payment_processor_settlements_payment_uq": {
+          "name": "payment_processor_settlements_payment_uq",
+          "columns": [
+            {
+              "expression": "payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_settlements_checkout_uq": {
+          "name": "payment_processor_settlements_checkout_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connected_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_settlements_charge_uq": {
+          "name": "payment_processor_settlements_charge_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connected_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_settlements_balance_transaction_uq": {
+          "name": "payment_processor_settlements_balance_transaction_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connected_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "balance_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_settlements_practice_date_idx": {
+          "name": "payment_processor_settlements_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reconciled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_settlements_payout_idx": {
+          "name": "payment_processor_settlements_payout_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payout_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_settlements_practice_id_uq": {
+          "name": "payment_processor_settlements_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_processor_settlements_tenant_payment_uq": {
+          "name": "payment_processor_settlements_tenant_payment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_processor_settlements_practice_id_practices_id_fk": {
+          "name": "payment_processor_settlements_practice_id_practices_id_fk",
+          "tableFrom": "payment_processor_settlements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_settlements_invoice_id_invoices_id_fk": {
+          "name": "payment_processor_settlements_invoice_id_invoices_id_fk",
+          "tableFrom": "payment_processor_settlements",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_settlements_payment_id_payments_id_fk": {
+          "name": "payment_processor_settlements_payment_id_payments_id_fk",
+          "tableFrom": "payment_processor_settlements",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_settlements_invoice_tenant_fk": {
+          "name": "payment_processor_settlements_invoice_tenant_fk",
+          "tableFrom": "payment_processor_settlements",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_settlements_payment_invoice_fk": {
+          "name": "payment_processor_settlements_payment_invoice_fk",
+          "tableFrom": "payment_processor_settlements",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "invoice_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_processor_settlements_account_tenant_fk": {
+          "name": "payment_processor_settlements_account_tenant_fk",
+          "tableFrom": "payment_processor_settlements",
+          "tableTo": "practice_payment_accounts",
+          "columnsFrom": [
+            "practice_id",
+            "provider",
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "provider",
+            "stripe_account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_processor_settlements_currency_check": {
+          "name": "payment_processor_settlements_currency_check",
+          "value": "\"payment_processor_settlements\".\"currency\" ~ '^[a-z]{3}$'"
+        },
+        "payment_processor_settlements_amounts_check": {
+          "name": "payment_processor_settlements_amounts_check",
+          "value": "\"payment_processor_settlements\".\"gross_amount_cents\" > 0\n        and \"payment_processor_settlements\".\"processor_fee_cents\" >= 0\n        and \"payment_processor_settlements\".\"application_fee_cents\" >= 0\n        and \"payment_processor_settlements\".\"clinic_net_cents\" >= 0\n        and \"payment_processor_settlements\".\"gross_amount_cents\" = \"payment_processor_settlements\".\"processor_fee_cents\" + \"payment_processor_settlements\".\"application_fee_cents\" + \"payment_processor_settlements\".\"clinic_net_cents\""
+        },
+        "payment_processor_settlements_status_check": {
+          "name": "payment_processor_settlements_status_check",
+          "value": "\"payment_processor_settlements\".\"balance_status\" in ('pending', 'available')\n        and \"payment_processor_settlements\".\"payout_status\" in ('unassigned', 'pending', 'paid', 'failed', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_tenant_fk": {
+          "name": "capture_sessions_patient_tenant_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_creator_tenant_fk": {
+          "name": "capture_sessions_creator_tenant_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "created_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_patient_tenant_fk": {
+          "name": "capture_sessions_appointment_patient_tenant_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_object_replicas": {
+      "name": "file_object_replicas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replica_target": {
+          "name": "replica_target",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_etag": {
+          "name": "object_etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_version_id": {
+          "name": "object_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "file_replica_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "replicated_at": {
+          "name": "replicated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_class": {
+          "name": "last_error_class",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_object_replicas_file_target_uq": {
+          "name": "file_object_replicas_file_target_uq",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replica_target",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_object_replicas_practice_status_idx": {
+          "name": "file_object_replicas_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_object_replicas_due_idx": {
+          "name": "file_object_replicas_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_object_replicas_practice_id_practices_id_fk": {
+          "name": "file_object_replicas_practice_id_practices_id_fk",
+          "tableFrom": "file_object_replicas",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_object_replicas_file_tenant_fk": {
+          "name": "file_object_replicas_file_tenant_fk",
+          "tableFrom": "file_object_replicas",
+          "tableTo": "files",
+          "columnsFrom": [
+            "practice_id",
+            "file_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_object_replicas_attempt_count_check": {
+          "name": "file_object_replicas_attempt_count_check",
+          "value": "\"file_object_replicas\".\"attempt_count\" >= 0"
+        },
+        "file_object_replicas_checksum_sha256_format_check": {
+          "name": "file_object_replicas_checksum_sha256_format_check",
+          "value": "\"file_object_replicas\".\"checksum_sha256\" is null or \"file_object_replicas\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "file_object_replicas_file_size_bytes_check": {
+          "name": "file_object_replicas_file_size_bytes_check",
+          "value": "\"file_object_replicas\".\"file_size_bytes\" is null or \"file_object_replicas\".\"file_size_bytes\" >= 0"
+        },
+        "file_object_replicas_available_evidence_check": {
+          "name": "file_object_replicas_available_evidence_check",
+          "value": "\"file_object_replicas\".\"status\" <> 'available' or (\"file_object_replicas\".\"checksum_sha256\" is not null and \"file_object_replicas\".\"file_size_bytes\" is not null and \"file_object_replicas\".\"replicated_at\" is not null and \"file_object_replicas\".\"verified_at\" is not null)"
+        },
+        "file_object_replicas_independent_object_key_check": {
+          "name": "file_object_replicas_independent_object_key_check",
+          "value": "\"file_object_replicas\".\"replica_target\" <> 'independent-v1' or (\"file_object_replicas\".\"object_key\" ~ ('^attachments/v1/' || \"file_object_replicas\".\"practice_id\"::text || '/' || \"file_object_replicas\".\"file_id\"::text || '/(pending|[0-9a-f]{64})$') and (\"file_object_replicas\".\"status\" <> 'available' or (\"file_object_replicas\".\"checksum_sha256\" is not null and \"file_object_replicas\".\"object_key\" = 'attachments/v1/' || \"file_object_replicas\".\"practice_id\"::text || '/' || \"file_object_replicas\".\"file_id\"::text || '/' || \"file_object_replicas\".\"checksum_sha256\" and \"file_object_replicas\".\"object_version_id\" is not null)))"
+        },
+        "file_object_replicas_lease_coherence_check": {
+          "name": "file_object_replicas_lease_coherence_check",
+          "value": "(\"file_object_replicas\".\"lease_token\" is null and \"file_object_replicas\".\"lease_expires_at\" is null) or (\"file_object_replicas\".\"lease_token\" is not null and \"file_object_replicas\".\"lease_expires_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.file_storage_events": {
+      "name": "file_storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_target": {
+          "name": "storage_target",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_status": {
+          "name": "next_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_checksum_sha256": {
+          "name": "expected_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_checksum_sha256": {
+          "name": "observed_checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_file_size_bytes": {
+          "name": "expected_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_file_size_bytes": {
+          "name": "observed_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_etag": {
+          "name": "object_etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_version_id": {
+          "name": "object_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_run_id": {
+          "name": "worker_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_storage_events_event_key_uq": {
+          "name": "file_storage_events_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_events_file_created_idx": {
+          "name": "file_storage_events_file_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_events_operation_idx": {
+          "name": "file_storage_events_operation_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_storage_events_practice_id_practices_id_fk": {
+          "name": "file_storage_events_practice_id_practices_id_fk",
+          "tableFrom": "file_storage_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_events_file_tenant_fk": {
+          "name": "file_storage_events_file_tenant_fk",
+          "tableFrom": "file_storage_events",
+          "tableTo": "files",
+          "columnsFrom": [
+            "practice_id",
+            "file_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_storage_events_expected_checksum_format_check": {
+          "name": "file_storage_events_expected_checksum_format_check",
+          "value": "\"file_storage_events\".\"expected_checksum_sha256\" is null or \"file_storage_events\".\"expected_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "file_storage_events_observed_checksum_format_check": {
+          "name": "file_storage_events_observed_checksum_format_check",
+          "value": "\"file_storage_events\".\"observed_checksum_sha256\" is null or \"file_storage_events\".\"observed_checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "file_storage_events_expected_file_size_bytes_check": {
+          "name": "file_storage_events_expected_file_size_bytes_check",
+          "value": "\"file_storage_events\".\"expected_file_size_bytes\" is null or \"file_storage_events\".\"expected_file_size_bytes\" >= 0"
+        },
+        "file_storage_events_observed_file_size_bytes_check": {
+          "name": "file_storage_events_observed_file_size_bytes_check",
+          "value": "\"file_storage_events\".\"observed_file_size_bytes\" is null or \"file_storage_events\".\"observed_file_size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_etag": {
+          "name": "object_etag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_version_id": {
+          "name": "object_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_status": {
+          "name": "storage_status",
+          "type": "file_storage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "storage_verified_at": {
+          "name": "storage_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_date": {
+          "name": "document_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_practice_id_uq": {
+          "name": "files_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_practice_file_key_uq": {
+          "name": "files_practice_file_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_practice_idempotency_key_uq": {
+          "name": "files_practice_idempotency_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_patient_created_idx": {
+          "name": "files_patient_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_patient_tenant_fk": {
+          "name": "files_patient_tenant_fk",
+          "tableFrom": "files",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_patient_tenant_fk": {
+          "name": "files_appointment_patient_tenant_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploader_tenant_fk": {
+          "name": "files_uploader_tenant_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "files_checksum_sha256_format_check": {
+          "name": "files_checksum_sha256_format_check",
+          "value": "\"files\".\"checksum_sha256\" is null or \"files\".\"checksum_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "files_file_size_bytes_check": {
+          "name": "files_file_size_bytes_check",
+          "value": "\"files\".\"file_size_bytes\" is null or \"files\".\"file_size_bytes\" >= 0"
+        },
+        "files_available_evidence_check": {
+          "name": "files_available_evidence_check",
+          "value": "\"files\".\"storage_status\" <> 'available' or (\"files\".\"checksum_sha256\" is not null and \"files\".\"file_size_bytes\" is not null and \"files\".\"storage_verified_at\" is not null)"
+        },
+        "files_primary_namespace_check": {
+          "name": "files_primary_namespace_check",
+          "value": "\"files\".\"category\" in ('patient-photos', 'documents', 'lab-results', 'branding', 'consents') and \"files\".\"file_key\" ~ ('^' || \"files\".\"practice_id\"::text || '/' || \"files\".\"category\" || '/[^/]+$') and \"files\".\"file_url\" = '/api/files/' || \"files\".\"file_key\""
+        },
+        "files_category_required_check": {
+          "name": "files_category_required_check",
+          "value": "\"files\".\"category\" is not null"
+        },
+        "files_patient_entity_consistency_check": {
+          "name": "files_patient_entity_consistency_check",
+          "value": "\"files\".\"entity_type\" is distinct from 'patient' or (\"files\".\"patient_id\" is not null and \"files\".\"entity_id\" is not null and \"files\".\"entity_id\" = \"files\".\"patient_id\")"
+        },
+        "files_appointment_requires_patient_check": {
+          "name": "files_appointment_requires_patient_check",
+          "value": "\"files\".\"appointment_id\" is null or \"files\".\"patient_id\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_id_uq": {
+          "name": "consent_forms_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_png_bytes": {
+          "name": "signature_png_bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_sha256": {
+          "name": "signature_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_tenant_fk": {
+          "name": "consent_requests_patient_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_creator_tenant_fk": {
+          "name": "consent_requests_creator_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "created_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_patient_tenant_fk": {
+          "name": "consent_requests_appointment_patient_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_tenant_fk": {
+          "name": "consent_requests_form_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "practice_id",
+            "form_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_tenant_fk": {
+          "name": "consent_requests_file_tenant_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "practice_id",
+            "file_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "consent_requests_status_check": {
+          "name": "consent_requests_status_check",
+          "value": "\"consent_requests\".\"status\" in ('pending', 'signing', 'signed')"
+        },
+        "consent_requests_signing_evidence_check": {
+          "name": "consent_requests_signing_evidence_check",
+          "value": "(\"consent_requests\".\"status\" = 'pending' and \"consent_requests\".\"signer_name\" is null and \"consent_requests\".\"signed_at\" is null and \"consent_requests\".\"file_id\" is null and \"consent_requests\".\"signature_png_bytes\" is null and \"consent_requests\".\"signature_sha256\" is null) or (\"consent_requests\".\"status\" = 'signing' and \"consent_requests\".\"signer_name\" is not null and \"consent_requests\".\"signed_at\" is not null and \"consent_requests\".\"signature_png_bytes\" is not null and \"consent_requests\".\"signature_sha256\" is not null) or (\"consent_requests\".\"status\" = 'signed' and \"consent_requests\".\"signer_name\" is not null and \"consent_requests\".\"signed_at\" is not null and \"consent_requests\".\"file_id\" is not null)"
+        },
+        "consent_requests_signature_evidence_pair_check": {
+          "name": "consent_requests_signature_evidence_pair_check",
+          "value": "(\"consent_requests\".\"signature_png_bytes\" is null and \"consent_requests\".\"signature_sha256\" is null) or (\"consent_requests\".\"signature_png_bytes\" is not null and \"consent_requests\".\"signature_sha256\" is not null)"
+        },
+        "consent_requests_signature_evidence_size_check": {
+          "name": "consent_requests_signature_evidence_size_check",
+          "value": "\"consent_requests\".\"signature_png_bytes\" is null or octet_length(\"consent_requests\".\"signature_png_bytes\") between 1 and 500000"
+        },
+        "consent_requests_signature_evidence_hash_check": {
+          "name": "consent_requests_signature_evidence_hash_check",
+          "value": "\"consent_requests\".\"signature_sha256\" is null or (\"consent_requests\".\"signature_sha256\" ~ '^[0-9a-f]{64}$' and \"consent_requests\".\"signature_sha256\" = pg_catalog.encode(pg_catalog.sha256(\"consent_requests\".\"signature_png_bytes\"), 'hex'))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visit_treatment_plan_response_lines": {
+      "name": "visit_treatment_plan_response_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_line_id": {
+          "name": "revision_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "visit_treatment_plan_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_quantity": {
+          "name": "accepted_quantity",
+          "type": "numeric(12, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_treatment_plan_response_lines_response_line_uq": {
+          "name": "visit_treatment_plan_response_lines_response_line_uq",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_response_lines_response_idx": {
+          "name": "visit_treatment_plan_response_lines_response_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_treatment_plan_response_lines_response_tenant_fk": {
+          "name": "visit_treatment_plan_response_lines_response_tenant_fk",
+          "tableFrom": "visit_treatment_plan_response_lines",
+          "tableTo": "visit_treatment_plan_responses",
+          "columnsFrom": [
+            "practice_id",
+            "response_id",
+            "revision_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "revision_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plan_response_lines_revision_line_tenant_fk": {
+          "name": "visit_treatment_plan_response_lines_revision_line_tenant_fk",
+          "tableFrom": "visit_treatment_plan_response_lines",
+          "tableTo": "visit_treatment_plan_revision_lines",
+          "columnsFrom": [
+            "practice_id",
+            "revision_line_id",
+            "revision_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "revision_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_treatment_plan_response_lines_decision_quantity_check": {
+          "name": "visit_treatment_plan_response_lines_decision_quantity_check",
+          "value": "(\"visit_treatment_plan_response_lines\".\"decision\" = 'accepted' and \"visit_treatment_plan_response_lines\".\"accepted_quantity\" > 0) or (\"visit_treatment_plan_response_lines\".\"decision\" = 'declined' and \"visit_treatment_plan_response_lines\".\"accepted_quantity\" = 0)"
+        },
+        "visit_treatment_plan_response_lines_decline_reason_check": {
+          "name": "visit_treatment_plan_response_lines_decline_reason_check",
+          "value": "\"visit_treatment_plan_response_lines\".\"decline_reason\" is null or length(btrim(\"visit_treatment_plan_response_lines\".\"decline_reason\")) between 1 and 2000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_treatment_plan_responses": {
+      "name": "visit_treatment_plan_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_request_id": {
+          "name": "consent_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_file_id": {
+          "name": "signed_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_sha256": {
+          "name": "signature_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_document_sha256": {
+          "name": "signed_document_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_sha256": {
+          "name": "response_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "visit_treatment_plan_responses_practice_revision_id_uq": {
+          "name": "visit_treatment_plan_responses_practice_revision_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_responses_revision_uq": {
+          "name": "visit_treatment_plan_responses_revision_uq",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_responses_consent_uq": {
+          "name": "visit_treatment_plan_responses_consent_uq",
+          "columns": [
+            {
+              "expression": "consent_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_responses_practice_operation_uq": {
+          "name": "visit_treatment_plan_responses_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_responses_plan_history_idx": {
+          "name": "visit_treatment_plan_responses_plan_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_treatment_plan_responses_revision_tenant_fk": {
+          "name": "visit_treatment_plan_responses_revision_tenant_fk",
+          "tableFrom": "visit_treatment_plan_responses",
+          "tableTo": "visit_treatment_plan_revisions",
+          "columnsFrom": [
+            "practice_id",
+            "revision_id",
+            "plan_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "plan_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plan_responses_signed_file_tenant_fk": {
+          "name": "visit_treatment_plan_responses_signed_file_tenant_fk",
+          "tableFrom": "visit_treatment_plan_responses",
+          "tableTo": "files",
+          "columnsFrom": [
+            "practice_id",
+            "signed_file_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_treatment_plan_responses_signer_name_check": {
+          "name": "visit_treatment_plan_responses_signer_name_check",
+          "value": "length(btrim(\"visit_treatment_plan_responses\".\"signer_name\")) between 1 and 120"
+        },
+        "visit_treatment_plan_responses_operation_payload_hash_check": {
+          "name": "visit_treatment_plan_responses_operation_payload_hash_check",
+          "value": "\"visit_treatment_plan_responses\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "visit_treatment_plan_responses_response_hash_check": {
+          "name": "visit_treatment_plan_responses_response_hash_check",
+          "value": "\"visit_treatment_plan_responses\".\"response_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "visit_treatment_plan_responses_signature_hash_check": {
+          "name": "visit_treatment_plan_responses_signature_hash_check",
+          "value": "\"visit_treatment_plan_responses\".\"signature_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "visit_treatment_plan_responses_document_hash_check": {
+          "name": "visit_treatment_plan_responses_document_hash_check",
+          "value": "\"visit_treatment_plan_responses\".\"signed_document_sha256\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_treatment_plan_revision_lines": {
+      "name": "visit_treatment_plan_revision_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_quantity": {
+          "name": "offered_quantity",
+          "type": "numeric(12, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_subtotal": {
+          "name": "line_subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "visit_treatment_plan_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_treatment_plan_revision_lines_practice_revision_id_uq": {
+          "name": "visit_treatment_plan_revision_lines_practice_revision_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_revision_lines_revision_order_uq": {
+          "name": "visit_treatment_plan_revision_lines_revision_order_uq",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_revision_lines_revision_order_idx": {
+          "name": "visit_treatment_plan_revision_lines_revision_order_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_treatment_plan_revision_lines_revision_tenant_fk": {
+          "name": "visit_treatment_plan_revision_lines_revision_tenant_fk",
+          "tableFrom": "visit_treatment_plan_revision_lines",
+          "tableTo": "visit_treatment_plan_revisions",
+          "columnsFrom": [
+            "practice_id",
+            "revision_id",
+            "plan_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "plan_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plan_revision_lines_plan_tenant_fk": {
+          "name": "visit_treatment_plan_revision_lines_plan_tenant_fk",
+          "tableFrom": "visit_treatment_plan_revision_lines",
+          "tableTo": "visit_treatment_plans",
+          "columnsFrom": [
+            "practice_id",
+            "plan_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plan_revision_lines_service_tenant_fk": {
+          "name": "visit_treatment_plan_revision_lines_service_tenant_fk",
+          "tableFrom": "visit_treatment_plan_revision_lines",
+          "tableTo": "services",
+          "columnsFrom": [
+            "practice_id",
+            "service_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plan_revision_lines_product_tenant_fk": {
+          "name": "visit_treatment_plan_revision_lines_product_tenant_fk",
+          "tableFrom": "visit_treatment_plan_revision_lines",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_treatment_plan_revision_lines_sort_order_check": {
+          "name": "visit_treatment_plan_revision_lines_sort_order_check",
+          "value": "\"visit_treatment_plan_revision_lines\".\"sort_order\" >= 0"
+        },
+        "visit_treatment_plan_revision_lines_description_check": {
+          "name": "visit_treatment_plan_revision_lines_description_check",
+          "value": "length(btrim(\"visit_treatment_plan_revision_lines\".\"description\")) between 1 and 500"
+        },
+        "visit_treatment_plan_revision_lines_money_check": {
+          "name": "visit_treatment_plan_revision_lines_money_check",
+          "value": "\"visit_treatment_plan_revision_lines\".\"offered_quantity\" > 0 and \"visit_treatment_plan_revision_lines\".\"unit_price\" >= 0 and \"visit_treatment_plan_revision_lines\".\"line_subtotal\" = round(\"visit_treatment_plan_revision_lines\".\"offered_quantity\" * \"visit_treatment_plan_revision_lines\".\"unit_price\", 2) and \"visit_treatment_plan_revision_lines\".\"tax_amount\" >= 0 and \"visit_treatment_plan_revision_lines\".\"line_total\" = \"visit_treatment_plan_revision_lines\".\"line_subtotal\" + \"visit_treatment_plan_revision_lines\".\"tax_amount\""
+        },
+        "visit_treatment_plan_revision_lines_catalog_target_check": {
+          "name": "visit_treatment_plan_revision_lines_catalog_target_check",
+          "value": "(\"visit_treatment_plan_revision_lines\".\"item_type\" = 'service' and \"visit_treatment_plan_revision_lines\".\"service_id\" is not null and \"visit_treatment_plan_revision_lines\".\"product_id\" is null) or (\"visit_treatment_plan_revision_lines\".\"item_type\" = 'product' and \"visit_treatment_plan_revision_lines\".\"product_id\" is not null and \"visit_treatment_plan_revision_lines\".\"service_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_treatment_plan_revisions": {
+      "name": "visit_treatment_plan_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_number": {
+          "name": "revision_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_by": {
+          "name": "authored_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "visit_treatment_plan_revisions_practice_plan_id_uq": {
+          "name": "visit_treatment_plan_revisions_practice_plan_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_revisions_plan_revision_uq": {
+          "name": "visit_treatment_plan_revisions_plan_revision_uq",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_revisions_practice_operation_uq": {
+          "name": "visit_treatment_plan_revisions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plan_revisions_plan_history_idx": {
+          "name": "visit_treatment_plan_revisions_plan_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_treatment_plan_revisions_plan_tenant_fk": {
+          "name": "visit_treatment_plan_revisions_plan_tenant_fk",
+          "tableFrom": "visit_treatment_plan_revisions",
+          "tableTo": "visit_treatment_plans",
+          "columnsFrom": [
+            "practice_id",
+            "plan_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plan_revisions_author_tenant_fk": {
+          "name": "visit_treatment_plan_revisions_author_tenant_fk",
+          "tableFrom": "visit_treatment_plan_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "authored_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_treatment_plan_revisions_number_check": {
+          "name": "visit_treatment_plan_revisions_number_check",
+          "value": "\"visit_treatment_plan_revisions\".\"revision_number\" >= 1"
+        },
+        "visit_treatment_plan_revisions_currency_check": {
+          "name": "visit_treatment_plan_revisions_currency_check",
+          "value": "\"visit_treatment_plan_revisions\".\"currency\" ~ '^[A-Z]{3}$'"
+        },
+        "visit_treatment_plan_revisions_totals_check": {
+          "name": "visit_treatment_plan_revisions_totals_check",
+          "value": "\"visit_treatment_plan_revisions\".\"subtotal\" >= 0 and \"visit_treatment_plan_revisions\".\"tax\" >= 0 and \"visit_treatment_plan_revisions\".\"total\" = \"visit_treatment_plan_revisions\".\"subtotal\" + \"visit_treatment_plan_revisions\".\"tax\""
+        },
+        "visit_treatment_plan_revisions_operation_payload_hash_check": {
+          "name": "visit_treatment_plan_revisions_operation_payload_hash_check",
+          "value": "\"visit_treatment_plan_revisions\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "visit_treatment_plan_revisions_content_hash_check": {
+          "name": "visit_treatment_plan_revisions_content_hash_check",
+          "value": "\"visit_treatment_plan_revisions\".\"content_sha256\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_treatment_plans": {
+      "name": "visit_treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "visit_treatment_plans_practice_id_uq": {
+          "name": "visit_treatment_plans_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plans_practice_operation_uq": {
+          "name": "visit_treatment_plans_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plans_patient_history_idx": {
+          "name": "visit_treatment_plans_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_treatment_plans_appointment_idx": {
+          "name": "visit_treatment_plans_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_treatment_plans_practice_id_practices_id_fk": {
+          "name": "visit_treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "visit_treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plans_patient_client_tenant_fk": {
+          "name": "visit_treatment_plans_patient_client_tenant_fk",
+          "tableFrom": "visit_treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plans_appointment_tenant_fk": {
+          "name": "visit_treatment_plans_appointment_tenant_fk",
+          "tableFrom": "visit_treatment_plans",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id",
+            "client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_treatment_plans_creator_tenant_fk": {
+          "name": "visit_treatment_plans_creator_tenant_fk",
+          "tableFrom": "visit_treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "created_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_treatment_plans_title_check": {
+          "name": "visit_treatment_plans_title_check",
+          "value": "length(btrim(\"visit_treatment_plans\".\"title\")) between 1 and 255"
+        },
+        "visit_treatment_plans_operation_payload_hash_check": {
+          "name": "visit_treatment_plans_operation_payload_hash_check",
+          "value": "\"visit_treatment_plans\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": [
+            "original_webhook_id"
+          ],
+          "columnsTo": [
+            "webhook_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_practice_id_uq": {
+          "name": "messaging_registrations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registration_events": {
+      "name": "messaging_registration_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "messaging_registration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "messaging_registration_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "messaging_registration_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messaging_registration_events_registration_history_idx": {
+          "name": "messaging_registration_events_registration_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "registration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_practice_time_idx": {
+          "name": "messaging_registration_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registration_events_operation_event_uq": {
+          "name": "messaging_registration_events_operation_event_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registration_events_practice_id_practices_id_fk": {
+          "name": "messaging_registration_events_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_id_messaging_registrations_id_fk": {
+          "name": "messaging_registration_events_registration_id_messaging_registrations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "registration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_id_locations_id_fk": {
+          "name": "messaging_registration_events_location_id_locations_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_user_id_users_id_fk": {
+          "name": "messaging_registration_events_actor_user_id_users_id_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_registration_tenant_fk": {
+          "name": "messaging_registration_events_registration_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "messaging_registrations",
+          "columnsFrom": [
+            "practice_id",
+            "registration_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_location_tenant_fk": {
+          "name": "messaging_registration_events_location_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registration_events_actor_tenant_fk": {
+          "name": "messaging_registration_events_actor_tenant_fk",
+          "tableFrom": "messaging_registration_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registration_events_shape_check": {
+          "name": "messaging_registration_events_shape_check",
+          "value": "\"messaging_registration_events\".\"provider\" in ('telnyx', 'twilio')\n        and \"messaging_registration_events\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and \"messaging_registration_events\".\"actor_name\" = btrim(\"messaging_registration_events\".\"actor_name\")\n        and length(\"messaging_registration_events\".\"actor_name\") between 1 and 255\n        and (\n          (\"messaging_registration_events\".\"actor_type\" = 'clinic_user'\n            and \"messaging_registration_events\".\"actor_user_id\" is not null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n          or (\"messaging_registration_events\".\"actor_type\" = 'platform_operator'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and length(btrim(coalesce(\"messaging_registration_events\".\"actor_identity\", ''))) between 1 and 255)\n          or (\"messaging_registration_events\".\"actor_type\" = 'system'\n            and \"messaging_registration_events\".\"actor_user_id\" is null\n            and \"messaging_registration_events\".\"actor_identity\" is null)\n        )\n        and (\"messaging_registration_events\".\"provider_brand_id\" is null or (\n          \"messaging_registration_events\".\"provider_brand_id\" = btrim(\"messaging_registration_events\".\"provider_brand_id\")\n          and length(\"messaging_registration_events\".\"provider_brand_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_campaign_id\" is null or (\n          \"messaging_registration_events\".\"provider_campaign_id\" = btrim(\"messaging_registration_events\".\"provider_campaign_id\")\n          and length(\"messaging_registration_events\".\"provider_campaign_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"messaging_profile_id\" is null or (\n          \"messaging_registration_events\".\"messaging_profile_id\" = btrim(\"messaging_registration_events\".\"messaging_profile_id\")\n          and length(\"messaging_registration_events\".\"messaging_profile_id\") between 3 and 128))\n        and (\"messaging_registration_events\".\"provider_brand_status\" is null\n          or length(\"messaging_registration_events\".\"provider_brand_status\") between 1 and 64)\n        and (\"messaging_registration_events\".\"provider_campaign_status\" is null\n          or length(\"messaging_registration_events\".\"provider_campaign_status\") between 1 and 64)\n        and (\n          (\"messaging_registration_events\".\"event_type\" = 'details_saved'\n            and \"messaging_registration_events\".\"operation\" = 'registration_details')\n          or (\"messaging_registration_events\".\"event_type\" in (\n              'provider_operation_started',\n              'provider_operation_succeeded',\n              'provider_operation_failed'\n            ) and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'number_assignment'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_state_observed'\n            and \"messaging_registration_events\".\"operation\" in (\n              'brand_submission',\n              'campaign_submission',\n              'registration_reconciliation'\n            ))\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_ids_attached'\n            and \"messaging_registration_events\".\"operation\" = 'provider_id_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'stale_lock_cleared'\n            and \"messaging_registration_events\".\"operation\" = 'submission_lock_recovery')\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_enabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_activation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_disabled'\n            and \"messaging_registration_events\".\"operation\" = 'profile_deactivation'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n          or (\"messaging_registration_events\".\"event_type\" = 'provider_profile_verified'\n            and \"messaging_registration_events\".\"operation\" = 'profile_verification'\n            and \"messaging_registration_events\".\"location_id\" is not null\n            and \"messaging_registration_events\".\"messaging_profile_id\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": [
+            "delivery_event_id",
+            "reviewed_history_id"
+          ],
+          "columnsTo": [
+            "delivery_event_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_event_conflict_reviews": {
+      "name": "sms_provider_event_conflict_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "conflict_id": {
+          "name": "conflict_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "sms_provider_event_conflict_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_identity": {
+          "name": "reviewed_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_by_name": {
+          "name": "reviewed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_provider_event_conflict_reviews_conflict_uq": {
+          "name": "sms_provider_event_conflict_reviews_conflict_uq",
+          "columns": [
+            {
+              "expression": "conflict_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_conflict_reviews_operation_uq": {
+          "name": "sms_provider_event_conflict_reviews_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_conflict_reviews_history_idx": {
+          "name": "sms_provider_event_conflict_reviews_history_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_event_conflict_reviews_conflict_id_sms_provider_event_conflicts_id_fk": {
+          "name": "sms_provider_event_conflict_reviews_conflict_id_sms_provider_event_conflicts_id_fk",
+          "tableFrom": "sms_provider_event_conflict_reviews",
+          "tableTo": "sms_provider_event_conflicts",
+          "columnsFrom": [
+            "conflict_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_event_conflict_reviews_shape_check": {
+          "name": "sms_provider_event_conflict_reviews_shape_check",
+          "value": "(\n          (\"sms_provider_event_conflict_reviews\".\"resolution\" = 'semantic_duplicate_confirmed' and \"sms_provider_event_conflict_reviews\".\"reason_code\" in (\n            'provider_replay_verified', 'signature_evidence_verified'\n          ))\n          or (\"sms_provider_event_conflict_reviews\".\"resolution\" = 'provider_identity_rotated' and \"sms_provider_event_conflict_reviews\".\"reason_code\" in (\n            'sender_identity_rotated', 'provider_identity_reprovisioned'\n          ))\n          or (\"sms_provider_event_conflict_reviews\".\"resolution\" = 'incident_closed_no_projection' and \"sms_provider_event_conflict_reviews\".\"reason_code\" in (\n            'provider_support_incident_closed', 'security_review_closed'\n          ))\n        )\n        and \"sms_provider_event_conflict_reviews\".\"reviewed_by_identity\" = btrim(\"sms_provider_event_conflict_reviews\".\"reviewed_by_identity\")\n        and length(\"sms_provider_event_conflict_reviews\".\"reviewed_by_identity\") between 1 and 255\n        and \"sms_provider_event_conflict_reviews\".\"reviewed_by_name\" = btrim(\"sms_provider_event_conflict_reviews\".\"reviewed_by_name\")\n        and length(\"sms_provider_event_conflict_reviews\".\"reviewed_by_name\") between 1 and 255\n        and (\"sms_provider_event_conflict_reviews\".\"detail\" is null or length(btrim(\"sms_provider_event_conflict_reviews\".\"detail\")) between 1 and 2000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_event_conflicts": {
+      "name": "sms_provider_event_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "original_event_id": {
+          "name": "original_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint_sha256": {
+          "name": "incoming_raw_body_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_provider_event_type": {
+          "name": "incoming_provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_provider_event_id": {
+          "name": "incoming_provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_provider_event_conflicts_identity_uq": {
+          "name": "sms_provider_event_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_conflicts_recovery_idx": {
+          "name": "sms_provider_event_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_event_conflicts_original_event_id_sms_provider_events_id_fk": {
+          "name": "sms_provider_event_conflicts_original_event_id_sms_provider_events_id_fk",
+          "tableFrom": "sms_provider_event_conflicts",
+          "tableTo": "sms_provider_events",
+          "columnsFrom": [
+            "original_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_event_conflicts_shape_check": {
+          "name": "sms_provider_event_conflicts_shape_check",
+          "value": "\"sms_provider_event_conflicts\".\"incoming_raw_body_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'\n        and length(btrim(\"sms_provider_event_conflicts\".\"incoming_provider_event_type\")) between 1 and 80\n        and \"sms_provider_event_conflicts\".\"incoming_provider_event_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        and (\"sms_provider_event_conflicts\".\"incoming_provider_event_id\" is null or (\n          \"sms_provider_event_conflicts\".\"incoming_provider_event_id\" = btrim(\"sms_provider_event_conflicts\".\"incoming_provider_event_id\")\n          and length(\"sms_provider_event_conflicts\".\"incoming_provider_event_id\") between 1 and 255\n        ))\n        and (\"sms_provider_event_conflicts\".\"incoming_provider_message_id\" is null or (\n          \"sms_provider_event_conflicts\".\"incoming_provider_message_id\" = btrim(\"sms_provider_event_conflicts\".\"incoming_provider_message_id\")\n          and length(\"sms_provider_event_conflicts\".\"incoming_provider_message_id\") between 1 and 255\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_event_resolutions": {
+      "name": "sms_provider_event_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflict_id": {
+          "name": "conflict_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "sms_provider_event_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_communication_id": {
+          "name": "inbound_communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_event_id": {
+          "name": "sms_consent_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_delivery_event_id": {
+          "name": "sms_delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_registration_event_id": {
+          "name": "messaging_registration_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_evidence_reference": {
+          "name": "external_evidence_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_identity": {
+          "name": "resolved_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_provider_event_resolutions_base_event_uq": {
+          "name": "sms_provider_event_resolutions_base_event_uq",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_provider_event_resolutions\".\"conflict_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_event_idx": {
+          "name": "sms_provider_event_resolutions_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_conflict_uq": {
+          "name": "sms_provider_event_resolutions_conflict_uq",
+          "columns": [
+            {
+              "expression": "conflict_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_operation_uq": {
+          "name": "sms_provider_event_resolutions_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_practice_history_idx": {
+          "name": "sms_provider_event_resolutions_practice_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_communication_evidence_idx": {
+          "name": "sms_provider_event_resolutions_communication_evidence_idx",
+          "columns": [
+            {
+              "expression": "inbound_communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"inbound_communication_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_consent_evidence_idx": {
+          "name": "sms_provider_event_resolutions_consent_evidence_idx",
+          "columns": [
+            {
+              "expression": "sms_consent_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"sms_consent_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_delivery_evidence_idx": {
+          "name": "sms_provider_event_resolutions_delivery_evidence_idx",
+          "columns": [
+            {
+              "expression": "sms_delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_event_resolutions_registration_evidence_idx": {
+          "name": "sms_provider_event_resolutions_registration_evidence_idx",
+          "columns": [
+            {
+              "expression": "messaging_registration_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_event_resolutions_event_id_sms_provider_events_id_fk": {
+          "name": "sms_provider_event_resolutions_event_id_sms_provider_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_provider_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_conflict_id_sms_provider_event_conflicts_id_fk": {
+          "name": "sms_provider_event_resolutions_conflict_id_sms_provider_event_conflicts_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_provider_event_conflicts",
+          "columnsFrom": [
+            "conflict_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_practice_id_practices_id_fk": {
+          "name": "sms_provider_event_resolutions_practice_id_practices_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_inbound_communication_id_communications_id_fk": {
+          "name": "sms_provider_event_resolutions_inbound_communication_id_communications_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "inbound_communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_sms_consent_event_id_sms_consent_events_id_fk": {
+          "name": "sms_provider_event_resolutions_sms_consent_event_id_sms_consent_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_consent_events",
+          "columnsFrom": [
+            "sms_consent_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_sms_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_provider_event_resolutions_sms_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "sms_delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_event_resolutions_messaging_registration_event_id_messaging_registration_events_id_fk": {
+          "name": "sms_provider_event_resolutions_messaging_registration_event_id_messaging_registration_events_id_fk",
+          "tableFrom": "sms_provider_event_resolutions",
+          "tableTo": "messaging_registration_events",
+          "columnsFrom": [
+            "messaging_registration_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_event_resolutions_shape_check": {
+          "name": "sms_provider_event_resolutions_shape_check",
+          "value": "\"sms_provider_event_resolutions\".\"reason_code\" ~ '^[a-z0-9_]{3,64}$'\n        and (\"sms_provider_event_resolutions\".\"resolution\" = 'provider_attested_no_projection' or \"sms_provider_event_resolutions\".\"practice_id\" is not null)\n        and (\n          (\"sms_provider_event_resolutions\".\"resolution\" = 'authoritative_projection' and \"sms_provider_event_resolutions\".\"reason_code\" in (\n            'projection_repaired', 'delivery_reconciled'\n          ))\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'conservative_opt_out' and \"sms_provider_event_resolutions\".\"reason_code\" in (\n            'provider_identity_conflict_opt_out', 'sender_identity_drift_opt_out'\n          ))\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'carrier_state_reconciled'\n            and \"sms_provider_event_resolutions\".\"reason_code\" = 'carrier_state_readback_confirmed')\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'provider_attested_no_projection' and \"sms_provider_event_resolutions\".\"reason_code\" in (\n            'provider_support_invalid_callback', 'provider_support_duplicate_callback'\n          ))\n        )\n        and \"sms_provider_event_resolutions\".\"resolved_by_identity\" = btrim(\"sms_provider_event_resolutions\".\"resolved_by_identity\")\n        and length(\"sms_provider_event_resolutions\".\"resolved_by_identity\") between 1 and 255\n        and \"sms_provider_event_resolutions\".\"resolved_by_name\" = btrim(\"sms_provider_event_resolutions\".\"resolved_by_name\")\n        and length(\"sms_provider_event_resolutions\".\"resolved_by_name\") between 1 and 255\n        and (\"sms_provider_event_resolutions\".\"detail\" is null or length(btrim(\"sms_provider_event_resolutions\".\"detail\")) between 1 and 2000)\n        and (\"sms_provider_event_resolutions\".\"external_evidence_reference\" is null or (\n          \"sms_provider_event_resolutions\".\"external_evidence_reference\" = btrim(\"sms_provider_event_resolutions\".\"external_evidence_reference\")\n          and length(\"sms_provider_event_resolutions\".\"external_evidence_reference\") between 3 and 255\n          and \"sms_provider_event_resolutions\".\"external_evidence_reference\" ~ '^[A-Za-z0-9][A-Za-z0-9_.:/#-]{2,254}$'\n        ))\n        and (\n          (\"sms_provider_event_resolutions\".\"resolution\" = 'authoritative_projection'\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is null\n            and num_nonnulls(\n              \"sms_provider_event_resolutions\".\"inbound_communication_id\",\n              \"sms_provider_event_resolutions\".\"sms_consent_event_id\",\n              \"sms_provider_event_resolutions\".\"sms_delivery_event_id\",\n              \"sms_provider_event_resolutions\".\"messaging_registration_event_id\"\n            ) between 1 and 2)\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'conservative_opt_out'\n            and \"sms_provider_event_resolutions\".\"inbound_communication_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_consent_event_id\" is not null\n            and \"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is null)\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'carrier_state_reconciled'\n            and \"sms_provider_event_resolutions\".\"inbound_communication_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_consent_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is not null\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is null)\n          or (\"sms_provider_event_resolutions\".\"resolution\" = 'provider_attested_no_projection'\n            and \"sms_provider_event_resolutions\".\"inbound_communication_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_consent_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"sms_delivery_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"messaging_registration_event_id\" is null\n            and \"sms_provider_event_resolutions\".\"external_evidence_reference\" is not null)\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_provider_events": {
+      "name": "sms_provider_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_provider_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint_sha256": {
+          "name": "raw_body_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_e164": {
+          "name": "from_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_e164": {
+          "name": "to_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_body": {
+          "name": "message_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbound_classification": {
+          "name": "inbound_classification",
+          "type": "sms_provider_inbound_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_classification": {
+          "name": "delivery_classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_phone_e164": {
+          "name": "a2p_phone_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_status": {
+          "name": "a2p_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_type": {
+          "name": "a2p_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_event_type": {
+          "name": "a2p_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_observed_status": {
+          "name": "a2p_observed_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_detail": {
+          "name": "provider_detail",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_provider_event_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "clock_timestamp()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_detail": {
+          "name": "last_error_detail",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_provider_events_provider_event_key_uq": {
+          "name": "sms_provider_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_due_idx": {
+          "name": "sms_provider_events_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"state\" in ('pending', 'retry')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_practice_idx": {
+          "name": "sms_provider_events_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"practice_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_blocked_idx": {
+          "name": "sms_provider_events_blocked_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"state\" = 'blocked_recovery'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_provider_message_idx": {
+          "name": "sms_provider_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_consent_order_idx": {
+          "name": "sms_provider_events_consent_order_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"occurred_at\", \"received_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"kind\" = 'inbound'\n          and \"sms_provider_events\".\"inbound_classification\" in ('stop', 'start')\n          and \"sms_provider_events\".\"practice_id\" is not null\n          and \"sms_provider_events\".\"from_e164\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_provider_events_location_idx": {
+          "name": "sms_provider_events_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sms_provider_events\".\"location_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_provider_events_practice_id_practices_id_fk": {
+          "name": "sms_provider_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_provider_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_provider_events_location_tenant_fk": {
+          "name": "sms_provider_events_location_tenant_fk",
+          "tableFrom": "sms_provider_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_provider_events_provider_check": {
+          "name": "sms_provider_events_provider_check",
+          "value": "\"sms_provider_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_provider_events_identifiers_check": {
+          "name": "sms_provider_events_identifiers_check",
+          "value": "(\"sms_provider_events\".\"provider_event_id\" is null or (\n          \"sms_provider_events\".\"provider_event_id\" = btrim(\"sms_provider_events\".\"provider_event_id\")\n          and length(\"sms_provider_events\".\"provider_event_id\") between 1 and 255\n        ))\n        and (\"sms_provider_events\".\"provider_message_id\" is null or (\n          \"sms_provider_events\".\"provider_message_id\" = btrim(\"sms_provider_events\".\"provider_message_id\")\n          and length(\"sms_provider_events\".\"provider_message_id\") between 1 and 255\n        ))\n        and length(btrim(\"sms_provider_events\".\"provider_event_type\")) between 1 and 80\n        and \"sms_provider_events\".\"provider_event_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        and length(\"sms_provider_events\".\"event_key\") between 1 and 255\n        and \"sms_provider_events\".\"event_key\" ~ '^[A-Za-z0-9_.:-]+$'\n        and \"sms_provider_events\".\"raw_body_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_provider_events_e164_check": {
+          "name": "sms_provider_events_e164_check",
+          "value": "(\"sms_provider_events\".\"from_e164\" is null or \"sms_provider_events\".\"from_e164\" ~ '^\\+[1-9][0-9]{7,14}$')\n        and (\"sms_provider_events\".\"to_e164\" is null or \"sms_provider_events\".\"to_e164\" ~ '^\\+[1-9][0-9]{7,14}$')\n        and (\"sms_provider_events\".\"a2p_phone_e164\" is null or \"sms_provider_events\".\"a2p_phone_e164\" ~ '^\\+[1-9][0-9]{7,14}$')"
+        },
+        "sms_provider_events_bounded_facts_check": {
+          "name": "sms_provider_events_bounded_facts_check",
+          "value": "(\"sms_provider_events\".\"messaging_profile_id\" is null or (\n          \"sms_provider_events\".\"messaging_profile_id\" = btrim(\"sms_provider_events\".\"messaging_profile_id\")\n          and length(\"sms_provider_events\".\"messaging_profile_id\") between 1 and 128\n        ))\n        and (\"sms_provider_events\".\"provider_status\" is null or (\n          length(btrim(\"sms_provider_events\".\"provider_status\")) between 1 and 80\n          and \"sms_provider_events\".\"provider_status\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"provider_error_code\" is null or (\n          length(btrim(\"sms_provider_events\".\"provider_error_code\")) between 1 and 80\n          and \"sms_provider_events\".\"provider_error_code\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"a2p_brand_id\" is null or (\n          \"sms_provider_events\".\"a2p_brand_id\" = btrim(\"sms_provider_events\".\"a2p_brand_id\")\n          and length(\"sms_provider_events\".\"a2p_brand_id\") between 1 and 128\n        ))\n        and (\"sms_provider_events\".\"a2p_campaign_id\" is null or (\n          \"sms_provider_events\".\"a2p_campaign_id\" = btrim(\"sms_provider_events\".\"a2p_campaign_id\")\n          and length(\"sms_provider_events\".\"a2p_campaign_id\") between 1 and 128\n        ))\n        and (\"sms_provider_events\".\"a2p_status\" is null or (\n          length(btrim(\"sms_provider_events\".\"a2p_status\")) between 1 and 80\n          and \"sms_provider_events\".\"a2p_status\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"a2p_type\" is null or (\n          length(btrim(\"sms_provider_events\".\"a2p_type\")) between 1 and 80\n          and \"sms_provider_events\".\"a2p_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"a2p_event_type\" is null or (\n          length(btrim(\"sms_provider_events\".\"a2p_event_type\")) between 1 and 80\n          and \"sms_provider_events\".\"a2p_event_type\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"provider_detail\" is null or length(btrim(\"sms_provider_events\".\"provider_detail\")) between 1 and 1000)\n        and (\"sms_provider_events\".\"last_error_code\" is null or (\n          length(btrim(\"sms_provider_events\".\"last_error_code\")) between 1 and 64\n          and \"sms_provider_events\".\"last_error_code\" ~ '^[A-Za-z0-9_.:-]+$'\n        ))\n        and (\"sms_provider_events\".\"last_error_detail\" is null or length(btrim(\"sms_provider_events\".\"last_error_detail\")) between 1 and 2000)"
+        },
+        "sms_provider_events_attribution_check": {
+          "name": "sms_provider_events_attribution_check",
+          "value": "\"sms_provider_events\".\"location_id\" is null or \"sms_provider_events\".\"practice_id\" is not null"
+        },
+        "sms_provider_events_kind_shape_check": {
+          "name": "sms_provider_events_kind_shape_check",
+          "value": "(\n          \"sms_provider_events\".\"kind\" = 'inbound'\n          and \"sms_provider_events\".\"provider_event_type\" = 'message.received'\n          and \"sms_provider_events\".\"provider_message_id\" is not null\n          and \"sms_provider_events\".\"from_e164\" is not null\n          and (\"sms_provider_events\".\"to_e164\" is not null or \"sms_provider_events\".\"messaging_profile_id\" is not null)\n          and \"sms_provider_events\".\"message_body\" is not null\n          and length(btrim(\"sms_provider_events\".\"message_body\")) >= 1\n          and length(\"sms_provider_events\".\"message_body\") <= 1600\n          and \"sms_provider_events\".\"inbound_classification\" is not null\n          and \"sms_provider_events\".\"delivery_classification\" is null\n          and \"sms_provider_events\".\"provider_status\" is null\n          and \"sms_provider_events\".\"provider_error_code\" is null\n          and \"sms_provider_events\".\"a2p_brand_id\" is null\n          and \"sms_provider_events\".\"a2p_campaign_id\" is null\n          and \"sms_provider_events\".\"a2p_phone_e164\" is null\n          and \"sms_provider_events\".\"a2p_status\" is null\n          and \"sms_provider_events\".\"a2p_type\" is null\n          and \"sms_provider_events\".\"a2p_event_type\" is null\n          and \"sms_provider_events\".\"a2p_observed_status\" is null\n          and \"sms_provider_events\".\"provider_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"kind\" = 'delivery'\n          and \"sms_provider_events\".\"provider_event_type\" like 'message.%'\n          and \"sms_provider_events\".\"provider_event_type\" <> 'message.received'\n          and \"sms_provider_events\".\"provider_message_id\" is not null\n          and \"sms_provider_events\".\"from_e164\" is null\n          and \"sms_provider_events\".\"to_e164\" is null\n          and \"sms_provider_events\".\"messaging_profile_id\" is null\n          and \"sms_provider_events\".\"message_body\" is null\n          and \"sms_provider_events\".\"inbound_classification\" is null\n          and \"sms_provider_events\".\"delivery_classification\" is not null\n          and \"sms_provider_events\".\"a2p_brand_id\" is null\n          and \"sms_provider_events\".\"a2p_campaign_id\" is null\n          and \"sms_provider_events\".\"a2p_phone_e164\" is null\n          and \"sms_provider_events\".\"a2p_status\" is null\n          and \"sms_provider_events\".\"a2p_type\" is null\n          and \"sms_provider_events\".\"a2p_event_type\" is null\n          and \"sms_provider_events\".\"a2p_observed_status\" is null\n          and \"sms_provider_events\".\"provider_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"kind\" = 'a2p'\n          and \"sms_provider_events\".\"provider\" = 'telnyx'\n          and \"sms_provider_events\".\"provider_event_type\" in (\n            '10dlc.brand.update',\n            '10dlc.campaign.update',\n            '10dlc.phone_number.update'\n          )\n          and (\n            \"sms_provider_events\".\"a2p_brand_id\" is not null\n            or \"sms_provider_events\".\"a2p_campaign_id\" is not null\n            or \"sms_provider_events\".\"a2p_phone_e164\" is not null\n          )\n          and \"sms_provider_events\".\"a2p_observed_status\" is not null\n          and \"sms_provider_events\".\"a2p_observed_status\" in ('pending', 'action_required', 'failed', 'suspended')\n          and \"sms_provider_events\".\"provider_message_id\" is null\n          and \"sms_provider_events\".\"from_e164\" is null\n          and \"sms_provider_events\".\"to_e164\" is null\n          and \"sms_provider_events\".\"messaging_profile_id\" is null\n          and \"sms_provider_events\".\"message_body\" is null\n          and \"sms_provider_events\".\"inbound_classification\" is null\n          and \"sms_provider_events\".\"delivery_classification\" is null\n          and \"sms_provider_events\".\"provider_error_code\" is null\n        )"
+        },
+        "sms_provider_events_state_shape_check": {
+          "name": "sms_provider_events_state_shape_check",
+          "value": "\"sms_provider_events\".\"attempt_count\" >= 0 and (\n        (\n          \"sms_provider_events\".\"state\" = 'pending'\n          and \"sms_provider_events\".\"attempt_count\" = 0\n          and \"sms_provider_events\".\"next_attempt_at\" is not null\n          and \"sms_provider_events\".\"next_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"last_attempt_at\" is null\n          and \"sms_provider_events\".\"processed_at\" is null\n          and \"sms_provider_events\".\"last_error_code\" is null\n          and \"sms_provider_events\".\"last_error_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'retry'\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"next_attempt_at\" > \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"processed_at\" is null\n          and \"sms_provider_events\".\"last_error_code\" is not null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'blocked_recovery'\n          and \"sms_provider_events\".\"practice_id\" is not null\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'projected'\n          and (\"sms_provider_events\".\"practice_id\" is not null or \"sms_provider_events\".\"kind\" = 'delivery')\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is not null\n          and \"sms_provider_events\".\"processed_at\" >= \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"last_error_code\" is null\n          and \"sms_provider_events\".\"last_error_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'ignored'\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is not null\n          and \"sms_provider_events\".\"processed_at\" >= \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"last_error_code\" is null\n          and \"sms_provider_events\".\"last_error_detail\" is null\n        ) or (\n          \"sms_provider_events\".\"state\" = 'quarantined'\n          and \"sms_provider_events\".\"attempt_count\" >= 1\n          and \"sms_provider_events\".\"next_attempt_at\" is null\n          and \"sms_provider_events\".\"last_attempt_at\" is not null\n          and \"sms_provider_events\".\"last_attempt_at\" >= \"sms_provider_events\".\"received_at\"\n          and \"sms_provider_events\".\"processed_at\" is not null\n          and \"sms_provider_events\".\"processed_at\" >= \"sms_provider_events\".\"last_attempt_at\"\n          and \"sms_provider_events\".\"last_error_code\" is not null\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_email_identity": {
+      "name": "platform_email_identity",
+      "schema": "",
+      "columns": {
+        "key_slot": {
+          "name": "key_slot",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_identity_singleton_check": {
+          "name": "platform_email_identity_singleton_check",
+          "value": "\"platform_email_identity\".\"key_slot\" = 1"
+        },
+        "platform_email_identity_fingerprint_check": {
+          "name": "platform_email_identity_fingerprint_check",
+          "value": "\"platform_email_identity\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preference_events": {
+      "name": "platform_email_preference_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_marketing_enabled": {
+          "name": "requested_marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_key_hash": {
+          "name": "provider_event_key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preference_events_recipient_timeline_idx": {
+          "name": "platform_email_preference_events_recipient_timeline_idx",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preference_events_provider_event_key_uq": {
+          "name": "platform_email_preference_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider_event_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preference_events_email_hash_check": {
+          "name": "platform_email_preference_events_email_hash_check",
+          "value": "\"platform_email_preference_events\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_identity_fingerprint_check": {
+          "name": "platform_email_preference_events_identity_fingerprint_check",
+          "value": "\"platform_email_preference_events\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_provider_event_key_hash_check": {
+          "name": "platform_email_preference_events_provider_event_key_hash_check",
+          "value": "\"platform_email_preference_events\".\"provider_event_key_hash\" IS NULL OR \"platform_email_preference_events\".\"provider_event_key_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preference_events_source_check": {
+          "name": "platform_email_preference_events_source_check",
+          "value": "\"platform_email_preference_events\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preference_events_reason_check": {
+          "name": "platform_email_preference_events_reason_check",
+          "value": "\"platform_email_preference_events\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preference_events_request_state_check": {
+          "name": "platform_email_preference_events_request_state_check",
+          "value": "(\"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preference_events\".\"requested_marketing_enabled\" AND \"platform_email_preference_events\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.platform_email_preferences": {
+      "name": "platform_email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key_fingerprint": {
+          "name": "identity_key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketing_enabled": {
+          "name": "marketing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "platform_email_preferences_email_hash_uq": {
+          "name": "platform_email_preferences_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "platform_email_preferences_identity_fingerprint_idx": {
+          "name": "platform_email_preferences_identity_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "identity_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "platform_email_preferences_email_hash_check": {
+          "name": "platform_email_preferences_email_hash_check",
+          "value": "\"platform_email_preferences\".\"email_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_identity_fingerprint_check": {
+          "name": "platform_email_preferences_identity_fingerprint_check",
+          "value": "\"platform_email_preferences\".\"identity_key_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "platform_email_preferences_source_check": {
+          "name": "platform_email_preferences_source_check",
+          "value": "\"platform_email_preferences\".\"source\" in ('settings', 'unsubscribe_link', 'resend_webhook')"
+        },
+        "platform_email_preferences_reason_check": {
+          "name": "platform_email_preferences_reason_check",
+          "value": "\"platform_email_preferences\".\"reason\" in ('settings_enabled', 'settings_disabled', 'unsubscribe', 'complaint', 'bounce', 'provider_suppressed')"
+        },
+        "platform_email_preferences_state_check": {
+          "name": "platform_email_preferences_state_check",
+          "value": "(\"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" = 'settings_enabled') OR (NOT \"platform_email_preferences\".\"marketing_enabled\" AND \"platform_email_preferences\".\"reason\" <> 'settings_enabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilot_events": {
+      "name": "clinic_pilot_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clinic_pilot_id": {
+          "name": "clinic_pilot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "clinic_pilot_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "clinic_pilot_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_closeout_id": {
+          "name": "first_visit_validated_closeout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_hash": {
+          "name": "clinic_use_validated_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_version": {
+          "name": "projection_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_snapshot": {
+          "name": "evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilot_events_operation_uq": {
+          "name": "clinic_pilot_events_operation_uq",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilot_events_history_idx": {
+          "name": "clinic_pilot_events_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk": {
+          "name": "clinic_pilot_events_clinic_pilot_id_clinic_pilots_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": [
+            "clinic_pilot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_practice_id_practices_id_fk": {
+          "name": "clinic_pilot_events_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_first_visit_validated_closeout_id_visit_closeouts_id_fk": {
+          "name": "clinic_pilot_events_first_visit_validated_closeout_id_visit_closeouts_id_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "visit_closeouts",
+          "columnsFrom": [
+            "first_visit_validated_closeout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_pilot_practice_fk": {
+          "name": "clinic_pilot_events_pilot_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "clinic_pilots",
+          "columnsFrom": [
+            "clinic_pilot_id",
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id",
+            "practice_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilot_events_acceptance_user_practice_fk": {
+          "name": "clinic_pilot_events_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilot_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "clinic_acceptance_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilot_events_snapshot_check": {
+          "name": "clinic_pilot_events_snapshot_check",
+          "value": "\"clinic_pilot_events\".\"projection_version\" > 0\n        and \"clinic_pilot_events\".\"payload_hash\" ~ '^[a-f0-9]{64}$'\n        and \"clinic_pilot_events\".\"actor_identity\" = btrim(\"clinic_pilot_events\".\"actor_identity\")\n        and length(\"clinic_pilot_events\".\"actor_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"owner_identity\" = btrim(\"clinic_pilot_events\".\"owner_identity\")\n        and length(\"clinic_pilot_events\".\"owner_identity\") between 3 and 255\n        and \"clinic_pilot_events\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilot_events\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"readiness_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilot_events\".\"evidence_snapshot\") = 'object'\n        and (\"clinic_pilot_events\".\"last_contact_at\" is null) = (\"clinic_pilot_events\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilot_events\".\"clinic_acceptance_at\" is null) = (\"clinic_pilot_events\".\"clinic_acceptance_by_user_id\" is null)\n        and (\"clinic_pilot_events\".\"first_visit_validated_at\" is null) = (\"clinic_pilot_events\".\"first_visit_validated_closeout_id\" is null)\n        and (\"clinic_pilot_events\".\"clinic_use_validated_at\" is null) = (\"clinic_pilot_events\".\"clinic_use_validated_hash\" is null)\n        and (\"clinic_pilot_events\".\"clinic_use_validated_hash\" is null or \"clinic_pilot_events\".\"clinic_use_validated_hash\" ~ '^[a-f0-9]{64}$')\n        and \"clinic_pilot_events\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilot_events\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilot_events\".\"blocker_codes\", null) is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinic_pilots": {
+      "name": "clinic_pilots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_key": {
+          "name": "cohort_key",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "clinic_pilot_workflow",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "clinic_pilot_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "clinic_pilot_decision",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "qualification_checklist": {
+          "name": "qualification_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"supportedClinicType\":false,\"supportedJurisdictionConfirmed\":false,\"singleLocation\":false,\"connectedModeAccepted\":false,\"parallelRunAccepted\":false,\"championConfirmed\":false,\"supportedWorkflowConfirmed\":false,\"noUnsupportedMustHave\":false}'::jsonb"
+        },
+        "readiness_checklist": {
+          "name": "readiness_checklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"rolesAndDevicesValidated\":false,\"migrationPlanAccepted\":false,\"sampleValidationAccepted\":false,\"firstVisitScheduled\":false,\"exportAndRollbackConfirmed\":false,\"supportCadenceConfirmed\":false}'::jsonb"
+        },
+        "blocker_codes": {
+          "name": "blocker_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "clinic_pilot_next_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirm_fit'"
+        },
+        "support_cadence": {
+          "name": "support_cadence",
+          "type": "clinic_pilot_support_cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "owner_identity": {
+          "name": "owner_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "communication_mode": {
+          "name": "communication_mode",
+          "type": "clinic_pilot_communication_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email_only'"
+        },
+        "communication_tested_at": {
+          "name": "communication_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_at": {
+          "name": "first_visit_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_visit_validated_closeout_id": {
+          "name": "first_visit_validated_closeout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_at": {
+          "name": "clinic_use_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_use_validated_hash": {
+          "name": "clinic_use_validated_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_at": {
+          "name": "clinic_acceptance_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinic_acceptance_by_user_id": {
+          "name": "clinic_acceptance_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_contact_outcome": {
+          "name": "last_contact_outcome",
+          "type": "clinic_pilot_contact_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_start_on": {
+          "name": "target_start_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_at": {
+          "name": "next_review_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clinic_pilots_practice_uq": {
+          "name": "clinic_pilots_practice_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_id_practice_uq": {
+          "name": "clinic_pilots_id_practice_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinic_pilots_review_idx": {
+          "name": "clinic_pilots_review_idx",
+          "columns": [
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_review_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinic_pilots_practice_id_practices_id_fk": {
+          "name": "clinic_pilots_practice_id_practices_id_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilots_first_visit_validated_closeout_id_visit_closeouts_id_fk": {
+          "name": "clinic_pilots_first_visit_validated_closeout_id_visit_closeouts_id_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "visit_closeouts",
+          "columnsFrom": [
+            "first_visit_validated_closeout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinic_pilots_acceptance_user_practice_fk": {
+          "name": "clinic_pilots_acceptance_user_practice_fk",
+          "tableFrom": "clinic_pilots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "clinic_acceptance_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinic_pilots_version_check": {
+          "name": "clinic_pilots_version_check",
+          "value": "\"clinic_pilots\".\"version\" > 0"
+        },
+        "clinic_pilots_operating_shape_check": {
+          "name": "clinic_pilots_operating_shape_check",
+          "value": "\"clinic_pilots\".\"cohort_key\" ~ '^pilot-[0-9]{4}-[0-9]{2}$'\n        and jsonb_typeof(\"clinic_pilots\".\"qualification_checklist\") = 'object'\n        and jsonb_typeof(\"clinic_pilots\".\"readiness_checklist\") = 'object'\n        and \"clinic_pilots\".\"owner_identity\" = btrim(\"clinic_pilots\".\"owner_identity\")\n        and length(\"clinic_pilots\".\"owner_identity\") between 3 and 255\n        and (\"clinic_pilots\".\"last_contact_at\" is null) = (\"clinic_pilots\".\"last_contact_outcome\" is null)\n        and (\"clinic_pilots\".\"clinic_acceptance_at\" is null) = (\"clinic_pilots\".\"clinic_acceptance_by_user_id\" is null)\n        and (\"clinic_pilots\".\"first_visit_validated_at\" is null) = (\"clinic_pilots\".\"first_visit_validated_closeout_id\" is null)\n        and (\"clinic_pilots\".\"clinic_use_validated_at\" is null) = (\"clinic_pilots\".\"clinic_use_validated_hash\" is null)\n        and (\"clinic_pilots\".\"clinic_use_validated_hash\" is null or \"clinic_pilots\".\"clinic_use_validated_hash\" ~ '^[a-f0-9]{64}$')"
+        },
+        "clinic_pilots_blocker_codes_check": {
+          "name": "clinic_pilots_blocker_codes_check",
+          "value": "\"clinic_pilots\".\"blocker_codes\" <@ ARRAY[\n          'workflow_fit',\n          'data_import',\n          'staff_training',\n          'record_accuracy',\n          'billing',\n          'payments',\n          'email',\n          'sms',\n          'permissions',\n          'device_connectivity',\n          'backup_export',\n          'support_coverage'\n        ]::text[]\n        and cardinality(\"clinic_pilots\".\"blocker_codes\") <= 12\n        and array_position(\"clinic_pilots\".\"blocker_codes\", null) is null"
+        },
+        "clinic_pilots_lifecycle_check": {
+          "name": "clinic_pilots_lifecycle_check",
+          "value": "(\n          \"clinic_pilots\".\"stage\" = 'completed'\n          and \"clinic_pilots\".\"decision\" = 'graduated'\n          and cardinality(\"clinic_pilots\".\"blocker_codes\") = 0\n          and \"clinic_pilots\".\"next_action\" = 'support_retention'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" = 'closed'\n          and \"clinic_pilots\".\"decision\" = 'not_a_fit'\n          and \"clinic_pilots\".\"next_action\" = 'revisit_fit'\n          and \"clinic_pilots\".\"next_review_at\" is null\n        ) or (\n          \"clinic_pilots\".\"stage\" not in ('completed', 'closed')\n          and \"clinic_pilots\".\"decision\" not in ('graduated', 'not_a_fit')\n          and \"clinic_pilots\".\"next_review_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.care_reminders": {
+      "name": "care_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "care_reminder_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissal_reason": {
+          "name": "dismissal_reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "care_reminders_external_id_uq": {
+          "name": "care_reminders_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"care_reminders\".\"external_source\" is not null and \"care_reminders\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_reminders_import_fingerprint_uq": {
+          "name": "care_reminders_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"care_reminders\".\"import_fingerprint\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_reminders_open_due_idx": {
+          "name": "care_reminders_open_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"care_reminders\".\"status\" = 'open' and \"care_reminders\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_reminders_patient_timeline_idx": {
+          "name": "care_reminders_patient_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "care_reminders_practice_id_practices_id_fk": {
+          "name": "care_reminders_practice_id_practices_id_fk",
+          "tableFrom": "care_reminders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "care_reminders_patient_tenant_fk": {
+          "name": "care_reminders_patient_tenant_fk",
+          "tableFrom": "care_reminders",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "care_reminders_creator_tenant_fk": {
+          "name": "care_reminders_creator_tenant_fk",
+          "tableFrom": "care_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "created_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "care_reminders_completer_tenant_fk": {
+          "name": "care_reminders_completer_tenant_fk",
+          "tableFrom": "care_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "care_reminders_dismisser_tenant_fk": {
+          "name": "care_reminders_dismisser_tenant_fk",
+          "tableFrom": "care_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "dismissed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "care_reminders_notes_length_check": {
+          "name": "care_reminders_notes_length_check",
+          "value": "\"care_reminders\".\"notes\" is null or char_length(\"care_reminders\".\"notes\") <= 4000"
+        },
+        "care_reminders_state_check": {
+          "name": "care_reminders_state_check",
+          "value": "(\n          \"care_reminders\".\"status\" = 'open'\n          and \"care_reminders\".\"completed_at\" is null\n          and \"care_reminders\".\"completed_by\" is null\n          and \"care_reminders\".\"dismissed_at\" is null\n          and \"care_reminders\".\"dismissed_by\" is null\n          and \"care_reminders\".\"dismissal_reason\" is null\n        ) or (\n          \"care_reminders\".\"status\" = 'completed'\n          and \"care_reminders\".\"completed_at\" is not null\n          and \"care_reminders\".\"completed_by\" is not null\n          and \"care_reminders\".\"dismissed_at\" is null\n          and \"care_reminders\".\"dismissed_by\" is null\n          and \"care_reminders\".\"dismissal_reason\" is null\n        ) or (\n          \"care_reminders\".\"status\" = 'dismissed'\n          and \"care_reminders\".\"completed_at\" is null\n          and \"care_reminders\".\"completed_by\" is null\n          and \"care_reminders\".\"dismissed_at\" is not null\n          and \"care_reminders\".\"dismissed_by\" is not null\n          and char_length(btrim(\"care_reminders\".\"dismissal_reason\")) between 3 and 500\n        )"
+        },
+        "care_reminders_dismissal_reason_check": {
+          "name": "care_reminders_dismissal_reason_check",
+          "value": "\"care_reminders\".\"dismissal_reason\" is null or char_length(btrim(\"care_reminders\".\"dismissal_reason\")) between 3 and 500"
+        },
+        "care_reminders_external_identity_pair_check": {
+          "name": "care_reminders_external_identity_pair_check",
+          "value": "(\"care_reminders\".\"external_source\" is null) = (\"care_reminders\".\"external_id\" is null)"
+        },
+        "care_reminders_import_identity_check": {
+          "name": "care_reminders_import_identity_check",
+          "value": "(\n          \"care_reminders\".\"external_source\" is null\n          and \"care_reminders\".\"external_id\" is null\n          and \"care_reminders\".\"import_fingerprint\" is null\n          and \"care_reminders\".\"created_by\" is not null\n        ) or (\n          \"care_reminders\".\"external_source\" is not null\n          and \"care_reminders\".\"external_id\" is not null\n          and \"care_reminders\".\"import_fingerprint\" is not null\n        )"
+        },
+        "care_reminders_import_fingerprint_check": {
+          "name": "care_reminders_import_fingerprint_check",
+          "value": "\"care_reminders\".\"import_fingerprint\" is null or \"care_reminders\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "care_reminders_external_source_check": {
+          "name": "care_reminders_external_source_check",
+          "value": "\"care_reminders\".\"external_source\" is null or \"care_reminders\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.client_contacts": {
+      "name": "client_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_status": {
+          "name": "attribution_status",
+          "type": "migration_attribution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "client_contact_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'co_owner'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "client_contacts_practice_id_uq": {
+          "name": "client_contacts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_contacts_client_idx": {
+          "name": "client_contacts_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_contacts_external_id_uq": {
+          "name": "client_contacts_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"client_contacts\".\"external_source\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_contacts_import_fingerprint_uq": {
+          "name": "client_contacts_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"client_contacts\".\"import_fingerprint\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_contacts_practice_id_practices_id_fk": {
+          "name": "client_contacts_practice_id_practices_id_fk",
+          "tableFrom": "client_contacts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "client_contacts_client_tenant_fk": {
+          "name": "client_contacts_client_tenant_fk",
+          "tableFrom": "client_contacts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "client_contacts_name_check": {
+          "name": "client_contacts_name_check",
+          "value": "(\"client_contacts\".\"first_name\" is null or length(btrim(\"client_contacts\".\"first_name\")) > 0)\n        and (\"client_contacts\".\"last_name\" is null or length(btrim(\"client_contacts\".\"last_name\")) > 0)\n        and (\"client_contacts\".\"first_name\" is not null or \"client_contacts\".\"last_name\" is not null or \"client_contacts\".\"email\" is not null or \"client_contacts\".\"phone\" is not null)"
+        },
+        "client_contacts_attribution_check": {
+          "name": "client_contacts_attribution_check",
+          "value": "(\"client_contacts\".\"attribution_status\" = 'matched' and \"client_contacts\".\"client_id\" is not null)\n        or (\"client_contacts\".\"attribution_status\" = 'needs_review' and \"client_contacts\".\"client_id\" is null)"
+        },
+        "client_contacts_import_identity_check": {
+          "name": "client_contacts_import_identity_check",
+          "value": "(\"client_contacts\".\"external_source\" is null and \"client_contacts\".\"external_id\" is null and \"client_contacts\".\"import_fingerprint\" is null)\n        or (\"client_contacts\".\"external_source\" is not null and \"client_contacts\".\"external_id\" is not null and \"client_contacts\".\"import_fingerprint\" is not null)"
+        },
+        "client_contacts_import_source_check": {
+          "name": "client_contacts_import_source_check",
+          "value": "\"client_contacts\".\"external_source\" is null or \"client_contacts\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "client_contacts_import_fingerprint_check": {
+          "name": "client_contacts_import_fingerprint_check",
+          "value": "\"client_contacts\".\"import_fingerprint\" is null or \"client_contacts\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_lab_observations": {
+      "name": "external_lab_observations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range": {
+          "name": "reference_range",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag": {
+          "name": "flag",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "external_lab_observations_external_id_uq": {
+          "name": "external_lab_observations_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_lab_observations_import_fingerprint_uq": {
+          "name": "external_lab_observations_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_lab_observations_report_order_idx": {
+          "name": "external_lab_observations_report_order_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_lab_observations_practice_id_practices_id_fk": {
+          "name": "external_lab_observations_practice_id_practices_id_fk",
+          "tableFrom": "external_lab_observations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_lab_observations_report_tenant_fk": {
+          "name": "external_lab_observations_report_tenant_fk",
+          "tableFrom": "external_lab_observations",
+          "tableTo": "external_lab_reports",
+          "columnsFrom": [
+            "practice_id",
+            "report_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_lab_observations_value_check": {
+          "name": "external_lab_observations_value_check",
+          "value": "\"external_lab_observations\".\"sort_order\" >= 0 and length(btrim(\"external_lab_observations\".\"name\")) > 0 and (\"external_lab_observations\".\"value\" is null or char_length(\"external_lab_observations\".\"value\") <= 4000)"
+        },
+        "external_lab_observations_source_check": {
+          "name": "external_lab_observations_source_check",
+          "value": "\"external_lab_observations\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "external_lab_observations_fingerprint_check": {
+          "name": "external_lab_observations_fingerprint_check",
+          "value": "\"external_lab_observations\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_lab_reports": {
+      "name": "external_lab_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_status": {
+          "name": "attribution_status",
+          "type": "migration_attribution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "ordered_at": {
+          "name": "ordered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resulted_at": {
+          "name": "resulted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "external_lab_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "lab_name": {
+          "name": "lab_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_name": {
+          "name": "order_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accession_number": {
+          "name": "accession_number",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "imported_clinical_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreviewed'"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "external_lab_reports_practice_id_uq": {
+          "name": "external_lab_reports_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_lab_reports_external_id_uq": {
+          "name": "external_lab_reports_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_lab_reports_import_fingerprint_uq": {
+          "name": "external_lab_reports_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_lab_reports_patient_timeline_idx": {
+          "name": "external_lab_reports_patient_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resulted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_lab_reports_review_idx": {
+          "name": "external_lab_reports_review_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_lab_reports_practice_id_practices_id_fk": {
+          "name": "external_lab_reports_practice_id_practices_id_fk",
+          "tableFrom": "external_lab_reports",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_lab_reports_patient_tenant_fk": {
+          "name": "external_lab_reports_patient_tenant_fk",
+          "tableFrom": "external_lab_reports",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_lab_reports_reviewer_tenant_fk": {
+          "name": "external_lab_reports_reviewer_tenant_fk",
+          "tableFrom": "external_lab_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_lab_reports_review_shape_check": {
+          "name": "external_lab_reports_review_shape_check",
+          "value": "(\"external_lab_reports\".\"review_status\" = 'unreviewed' and \"external_lab_reports\".\"reviewed_at\" is null and \"external_lab_reports\".\"reviewed_by\" is null)\n        or (\"external_lab_reports\".\"review_status\" in ('confirmed', 'superseded') and \"external_lab_reports\".\"reviewed_at\" is not null and \"external_lab_reports\".\"reviewed_by\" is not null)"
+        },
+        "external_lab_reports_attribution_check": {
+          "name": "external_lab_reports_attribution_check",
+          "value": "(\"external_lab_reports\".\"attribution_status\" = 'matched' and \"external_lab_reports\".\"patient_id\" is not null)\n        or (\"external_lab_reports\".\"attribution_status\" = 'needs_review' and \"external_lab_reports\".\"patient_id\" is null)"
+        },
+        "external_lab_reports_date_check": {
+          "name": "external_lab_reports_date_check",
+          "value": "\"external_lab_reports\".\"resulted_at\" is null or \"external_lab_reports\".\"ordered_at\" is null or \"external_lab_reports\".\"resulted_at\" >= \"external_lab_reports\".\"ordered_at\""
+        },
+        "external_lab_reports_text_length_check": {
+          "name": "external_lab_reports_text_length_check",
+          "value": "(\"external_lab_reports\".\"summary\" is null or char_length(\"external_lab_reports\".\"summary\") <= 12000)\n        and (\"external_lab_reports\".\"interpretation\" is null or char_length(\"external_lab_reports\".\"interpretation\") <= 12000)"
+        },
+        "external_lab_reports_source_check": {
+          "name": "external_lab_reports_source_check",
+          "value": "\"external_lab_reports\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "external_lab_reports_fingerprint_check": {
+          "name": "external_lab_reports_fingerprint_check",
+          "value": "\"external_lab_reports\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_prescription_fills": {
+      "name": "external_prescription_fills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filled_at": {
+          "name": "filled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity_dispensed": {
+          "name": "quantity_dispensed",
+          "type": "numeric(14, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "directions": {
+          "name": "directions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_status": {
+          "name": "source_status",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescriber_display_name": {
+          "name": "prescriber_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "external_prescription_fills_external_id_uq": {
+          "name": "external_prescription_fills_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_prescription_fills_import_fingerprint_uq": {
+          "name": "external_prescription_fills_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_prescription_fills_history_idx": {
+          "name": "external_prescription_fills_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_prescription_fills_practice_id_practices_id_fk": {
+          "name": "external_prescription_fills_practice_id_practices_id_fk",
+          "tableFrom": "external_prescription_fills",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_prescription_fills_prescription_tenant_fk": {
+          "name": "external_prescription_fills_prescription_tenant_fk",
+          "tableFrom": "external_prescription_fills",
+          "tableTo": "external_prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_prescription_fills_value_check": {
+          "name": "external_prescription_fills_value_check",
+          "value": "(\"external_prescription_fills\".\"quantity_dispensed\" is null or \"external_prescription_fills\".\"quantity_dispensed\" >= 0)\n        and (\"external_prescription_fills\".\"directions\" is null or char_length(\"external_prescription_fills\".\"directions\") <= 12000)"
+        },
+        "external_prescription_fills_source_check": {
+          "name": "external_prescription_fills_source_check",
+          "value": "\"external_prescription_fills\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "external_prescription_fills_fingerprint_check": {
+          "name": "external_prescription_fills_fingerprint_check",
+          "value": "\"external_prescription_fills\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_prescriptions": {
+      "name": "external_prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directions": {
+          "name": "directions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(14, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_count": {
+          "name": "refill_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescribed_at": {
+          "name": "prescribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "external_prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "is_chronic": {
+          "name": "is_chronic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prescriber_display_name": {
+          "name": "prescriber_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "imported_clinical_review_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unreviewed'"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "external_prescriptions_practice_id_uq": {
+          "name": "external_prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_prescriptions_external_id_uq": {
+          "name": "external_prescriptions_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_prescriptions_import_fingerprint_uq": {
+          "name": "external_prescriptions_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_prescriptions_patient_status_idx": {
+          "name": "external_prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescribed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_prescriptions_review_idx": {
+          "name": "external_prescriptions_review_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "review_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_prescriptions_practice_id_practices_id_fk": {
+          "name": "external_prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "external_prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_prescriptions_patient_tenant_fk": {
+          "name": "external_prescriptions_patient_tenant_fk",
+          "tableFrom": "external_prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_prescriptions_reviewer_tenant_fk": {
+          "name": "external_prescriptions_reviewer_tenant_fk",
+          "tableFrom": "external_prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_prescriptions_review_shape_check": {
+          "name": "external_prescriptions_review_shape_check",
+          "value": "(\"external_prescriptions\".\"review_status\" = 'unreviewed' and \"external_prescriptions\".\"reviewed_at\" is null and \"external_prescriptions\".\"reviewed_by\" is null)\n        or (\"external_prescriptions\".\"review_status\" in ('confirmed', 'superseded') and \"external_prescriptions\".\"reviewed_at\" is not null and \"external_prescriptions\".\"reviewed_by\" is not null)"
+        },
+        "external_prescriptions_value_check": {
+          "name": "external_prescriptions_value_check",
+          "value": "length(btrim(\"external_prescriptions\".\"medication_name\")) > 0\n        and (\"external_prescriptions\".\"quantity\" is null or \"external_prescriptions\".\"quantity\" >= 0)\n        and (\"external_prescriptions\".\"refill_count\" is null or \"external_prescriptions\".\"refill_count\" >= 0)\n        and (\"external_prescriptions\".\"directions\" is null or char_length(\"external_prescriptions\".\"directions\") <= 12000)\n        and (\"external_prescriptions\".\"expires_at\" is null or \"external_prescriptions\".\"prescribed_at\" is null or \"external_prescriptions\".\"expires_at\" >= \"external_prescriptions\".\"prescribed_at\")"
+        },
+        "external_prescriptions_source_check": {
+          "name": "external_prescriptions_source_check",
+          "value": "\"external_prescriptions\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "external_prescriptions_fingerprint_check": {
+          "name": "external_prescriptions_fingerprint_check",
+          "value": "\"external_prescriptions\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.historical_appointments": {
+      "name": "historical_appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "historical_appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "appointment_type": {
+          "name": "appointment_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_display_name": {
+          "name": "provider_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "historical_appointments_practice_id_uq": {
+          "name": "historical_appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_appointments_external_id_uq": {
+          "name": "historical_appointments_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_appointments_import_fingerprint_uq": {
+          "name": "historical_appointments_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_appointments_patient_timeline_idx": {
+          "name": "historical_appointments_patient_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_appointments_client_timeline_idx": {
+          "name": "historical_appointments_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "historical_appointments_practice_id_practices_id_fk": {
+          "name": "historical_appointments_practice_id_practices_id_fk",
+          "tableFrom": "historical_appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_appointments_patient_tenant_fk": {
+          "name": "historical_appointments_patient_tenant_fk",
+          "tableFrom": "historical_appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_appointments_client_tenant_fk": {
+          "name": "historical_appointments_client_tenant_fk",
+          "tableFrom": "historical_appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "historical_appointments_time_check": {
+          "name": "historical_appointments_time_check",
+          "value": "\"historical_appointments\".\"started_at\" < \"historical_appointments\".\"ended_at\""
+        },
+        "historical_appointments_source_check": {
+          "name": "historical_appointments_source_check",
+          "value": "\"historical_appointments\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "historical_appointments_fingerprint_check": {
+          "name": "historical_appointments_fingerprint_check",
+          "value": "\"historical_appointments\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "historical_appointments_text_length_check": {
+          "name": "historical_appointments_text_length_check",
+          "value": "(\"historical_appointments\".\"reason\" is null or char_length(\"historical_appointments\".\"reason\") <= 4000)\n        and (\"historical_appointments\".\"notes\" is null or char_length(\"historical_appointments\".\"notes\") <= 12000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.historical_documents": {
+      "name": "historical_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "historical_document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "link_status": {
+          "name": "link_status",
+          "type": "historical_document_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_review'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_date": {
+          "name": "document_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_report_id": {
+          "name": "lab_report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "historical_appointment_id": {
+          "name": "historical_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "financial_document_id": {
+          "name": "financial_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "historical_documents_external_id_uq": {
+          "name": "historical_documents_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_documents_import_fingerprint_uq": {
+          "name": "historical_documents_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_documents_file_uq": {
+          "name": "historical_documents_file_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_documents_patient_timeline_idx": {
+          "name": "historical_documents_patient_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "historical_documents_review_idx": {
+          "name": "historical_documents_review_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "link_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "historical_documents_practice_id_practices_id_fk": {
+          "name": "historical_documents_practice_id_practices_id_fk",
+          "tableFrom": "historical_documents",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_documents_file_tenant_fk": {
+          "name": "historical_documents_file_tenant_fk",
+          "tableFrom": "historical_documents",
+          "tableTo": "files",
+          "columnsFrom": [
+            "practice_id",
+            "file_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_documents_patient_tenant_fk": {
+          "name": "historical_documents_patient_tenant_fk",
+          "tableFrom": "historical_documents",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_documents_lab_tenant_fk": {
+          "name": "historical_documents_lab_tenant_fk",
+          "tableFrom": "historical_documents",
+          "tableTo": "external_lab_reports",
+          "columnsFrom": [
+            "practice_id",
+            "lab_report_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_documents_prescription_tenant_fk": {
+          "name": "historical_documents_prescription_tenant_fk",
+          "tableFrom": "historical_documents",
+          "tableTo": "external_prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_documents_appointment_tenant_fk": {
+          "name": "historical_documents_appointment_tenant_fk",
+          "tableFrom": "historical_documents",
+          "tableTo": "historical_appointments",
+          "columnsFrom": [
+            "practice_id",
+            "historical_appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_documents_financial_tenant_fk": {
+          "name": "historical_documents_financial_tenant_fk",
+          "tableFrom": "historical_documents",
+          "tableTo": "legacy_financial_documents",
+          "columnsFrom": [
+            "practice_id",
+            "financial_document_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "historical_documents_link_shape_check": {
+          "name": "historical_documents_link_shape_check",
+          "value": "(\"historical_documents\".\"link_status\" = 'needs_review'\n          and \"historical_documents\".\"patient_id\" is null\n          and \"historical_documents\".\"lab_report_id\" is null\n          and \"historical_documents\".\"prescription_id\" is null\n          and \"historical_documents\".\"historical_appointment_id\" is null\n          and \"historical_documents\".\"financial_document_id\" is null)\n        or (\"historical_documents\".\"link_status\" = 'linked' and \"historical_documents\".\"patient_id\" is not null)"
+        },
+        "historical_documents_kind_shape_check": {
+          "name": "historical_documents_kind_shape_check",
+          "value": "(\"historical_documents\".\"kind\" <> 'lab_report' or \"historical_documents\".\"lab_report_id\" is not null)\n        and (\"historical_documents\".\"kind\" <> 'prescription' or \"historical_documents\".\"prescription_id\" is not null)\n        and (\"historical_documents\".\"kind\" <> 'appointment' or \"historical_documents\".\"historical_appointment_id\" is not null)\n        and (\"historical_documents\".\"kind\" <> 'financial' or \"historical_documents\".\"financial_document_id\" is not null)"
+        },
+        "historical_documents_source_check": {
+          "name": "historical_documents_source_check",
+          "value": "\"historical_documents\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "historical_documents_fingerprint_check": {
+          "name": "historical_documents_fingerprint_check",
+          "value": "\"historical_documents\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_financial_allocations": {
+      "name": "legacy_financial_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "legacy_financial_allocations_external_id_uq": {
+          "name": "legacy_financial_allocations_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_allocations_import_fingerprint_uq": {
+          "name": "legacy_financial_allocations_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_allocations_document_idx": {
+          "name": "legacy_financial_allocations_document_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allocated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_allocations_payment_idx": {
+          "name": "legacy_financial_allocations_payment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allocated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_financial_allocations_practice_id_practices_id_fk": {
+          "name": "legacy_financial_allocations_practice_id_practices_id_fk",
+          "tableFrom": "legacy_financial_allocations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_financial_allocations_document_tenant_fk": {
+          "name": "legacy_financial_allocations_document_tenant_fk",
+          "tableFrom": "legacy_financial_allocations",
+          "tableTo": "legacy_financial_documents",
+          "columnsFrom": [
+            "practice_id",
+            "document_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_financial_allocations_payment_tenant_fk": {
+          "name": "legacy_financial_allocations_payment_tenant_fk",
+          "tableFrom": "legacy_financial_allocations",
+          "tableTo": "legacy_financial_payments",
+          "columnsFrom": [
+            "practice_id",
+            "payment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "legacy_financial_allocations_amount_check": {
+          "name": "legacy_financial_allocations_amount_check",
+          "value": "\"legacy_financial_allocations\".\"amount\" >= 0"
+        },
+        "legacy_financial_allocations_source_check": {
+          "name": "legacy_financial_allocations_source_check",
+          "value": "\"legacy_financial_allocations\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "legacy_financial_allocations_fingerprint_check": {
+          "name": "legacy_financial_allocations_fingerprint_check",
+          "value": "\"legacy_financial_allocations\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_financial_documents": {
+      "name": "legacy_financial_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "legacy_financial_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invoice'"
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "legacy_financial_document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_status": {
+          "name": "source_status",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "legacy_financial_documents_practice_id_uq": {
+          "name": "legacy_financial_documents_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_documents_external_id_uq": {
+          "name": "legacy_financial_documents_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_documents_import_fingerprint_uq": {
+          "name": "legacy_financial_documents_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_documents_client_timeline_idx": {
+          "name": "legacy_financial_documents_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_documents_open_balance_idx": {
+          "name": "legacy_financial_documents_open_balance_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"legacy_financial_documents\".\"status\" in ('open', 'partial') and \"legacy_financial_documents\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_financial_documents_practice_id_practices_id_fk": {
+          "name": "legacy_financial_documents_practice_id_practices_id_fk",
+          "tableFrom": "legacy_financial_documents",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_financial_documents_client_tenant_fk": {
+          "name": "legacy_financial_documents_client_tenant_fk",
+          "tableFrom": "legacy_financial_documents",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_financial_documents_patient_tenant_fk": {
+          "name": "legacy_financial_documents_patient_tenant_fk",
+          "tableFrom": "legacy_financial_documents",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "legacy_financial_documents_amount_check": {
+          "name": "legacy_financial_documents_amount_check",
+          "value": "\"legacy_financial_documents\".\"subtotal\" >= 0 and \"legacy_financial_documents\".\"tax\" >= 0 and \"legacy_financial_documents\".\"discount\" >= 0\n        and \"legacy_financial_documents\".\"total\" >= 0 and \"legacy_financial_documents\".\"paid_amount\" >= 0 and \"legacy_financial_documents\".\"balance\" >= 0"
+        },
+        "legacy_financial_documents_currency_check": {
+          "name": "legacy_financial_documents_currency_check",
+          "value": "\"legacy_financial_documents\".\"currency\" ~ '^[A-Z]{3}$'"
+        },
+        "legacy_financial_documents_source_check": {
+          "name": "legacy_financial_documents_source_check",
+          "value": "\"legacy_financial_documents\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "legacy_financial_documents_fingerprint_check": {
+          "name": "legacy_financial_documents_fingerprint_check",
+          "value": "\"legacy_financial_documents\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "legacy_financial_documents_note_check": {
+          "name": "legacy_financial_documents_note_check",
+          "value": "\"legacy_financial_documents\".\"note\" is null or char_length(\"legacy_financial_documents\".\"note\") <= 12000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_financial_line_items": {
+      "name": "legacy_financial_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(14, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "legacy_financial_line_items_external_id_uq": {
+          "name": "legacy_financial_line_items_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_line_items_import_fingerprint_uq": {
+          "name": "legacy_financial_line_items_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_line_items_document_order_idx": {
+          "name": "legacy_financial_line_items_document_order_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_financial_line_items_practice_id_practices_id_fk": {
+          "name": "legacy_financial_line_items_practice_id_practices_id_fk",
+          "tableFrom": "legacy_financial_line_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_financial_line_items_document_tenant_fk": {
+          "name": "legacy_financial_line_items_document_tenant_fk",
+          "tableFrom": "legacy_financial_line_items",
+          "tableTo": "legacy_financial_documents",
+          "columnsFrom": [
+            "practice_id",
+            "document_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_financial_line_items_patient_tenant_fk": {
+          "name": "legacy_financial_line_items_patient_tenant_fk",
+          "tableFrom": "legacy_financial_line_items",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "legacy_financial_line_items_amount_check": {
+          "name": "legacy_financial_line_items_amount_check",
+          "value": "\"legacy_financial_line_items\".\"sort_order\" >= 0 and \"legacy_financial_line_items\".\"quantity\" >= 0 and \"legacy_financial_line_items\".\"unit_price\" >= 0\n        and \"legacy_financial_line_items\".\"subtotal\" >= 0 and \"legacy_financial_line_items\".\"tax\" >= 0 and \"legacy_financial_line_items\".\"discount\" >= 0 and \"legacy_financial_line_items\".\"total\" >= 0"
+        },
+        "legacy_financial_line_items_source_check": {
+          "name": "legacy_financial_line_items_source_check",
+          "value": "\"legacy_financial_line_items\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "legacy_financial_line_items_fingerprint_check": {
+          "name": "legacy_financial_line_items_fingerprint_check",
+          "value": "\"legacy_financial_line_items\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_financial_payments": {
+      "name": "legacy_financial_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_status": {
+          "name": "attribution_status",
+          "type": "migration_attribution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "legacy_financial_payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'payment'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_status": {
+          "name": "source_status",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "legacy_financial_payments_practice_id_uq": {
+          "name": "legacy_financial_payments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_payments_external_id_uq": {
+          "name": "legacy_financial_payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_payments_import_fingerprint_uq": {
+          "name": "legacy_financial_payments_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_financial_payments_client_timeline_idx": {
+          "name": "legacy_financial_payments_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_financial_payments_practice_id_practices_id_fk": {
+          "name": "legacy_financial_payments_practice_id_practices_id_fk",
+          "tableFrom": "legacy_financial_payments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "legacy_financial_payments_client_tenant_fk": {
+          "name": "legacy_financial_payments_client_tenant_fk",
+          "tableFrom": "legacy_financial_payments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "legacy_financial_payments_amount_check": {
+          "name": "legacy_financial_payments_amount_check",
+          "value": "\"legacy_financial_payments\".\"amount\" >= 0"
+        },
+        "legacy_financial_payments_attribution_check": {
+          "name": "legacy_financial_payments_attribution_check",
+          "value": "(\"legacy_financial_payments\".\"attribution_status\" = 'matched' and \"legacy_financial_payments\".\"client_id\" is not null)\n        or (\"legacy_financial_payments\".\"attribution_status\" = 'needs_review' and \"legacy_financial_payments\".\"client_id\" is null)"
+        },
+        "legacy_financial_payments_note_check": {
+          "name": "legacy_financial_payments_note_check",
+          "value": "\"legacy_financial_payments\".\"note\" is null or char_length(\"legacy_financial_payments\".\"note\") <= 4000"
+        },
+        "legacy_financial_payments_source_check": {
+          "name": "legacy_financial_payments_source_check",
+          "value": "\"legacy_financial_payments\".\"external_source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "legacy_financial_payments_fingerprint_check": {
+          "name": "legacy_financial_payments_fingerprint_check",
+          "value": "\"legacy_financial_payments\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": [
+        "not_required",
+        "open",
+        "completed"
+      ]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "normal",
+        "abnormal",
+        "critical"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "finalized"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.vaccination_dose_type": {
+      "name": "vaccination_dose_type",
+      "schema": "public",
+      "values": [
+        "initial",
+        "booster"
+      ]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result",
+        "patient_allergy"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.file_replica_status": {
+      "name": "file_replica_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "available",
+        "missing",
+        "corrupt",
+        "failed"
+      ]
+    },
+    "public.file_storage_status": {
+      "name": "file_storage_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "pending_upload",
+        "available",
+        "missing",
+        "corrupt",
+        "cleanup_pending"
+      ]
+    },
+    "public.visit_treatment_plan_decision": {
+      "name": "visit_treatment_plan_decision",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "declined"
+      ]
+    },
+    "public.visit_treatment_plan_item_type": {
+      "name": "visit_treatment_plan_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.visit_treatment_plan_status": {
+      "name": "visit_treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": [
+        "registration",
+        "authenticated_resend"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.messaging_registration_actor_type": {
+      "name": "messaging_registration_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator",
+        "system"
+      ]
+    },
+    "public.messaging_registration_event_type": {
+      "name": "messaging_registration_event_type",
+      "schema": "public",
+      "values": [
+        "details_saved",
+        "provider_operation_started",
+        "provider_operation_succeeded",
+        "provider_operation_failed",
+        "provider_state_observed",
+        "provider_ids_attached",
+        "stale_lock_cleared",
+        "provider_profile_enabled",
+        "provider_profile_disabled",
+        "provider_profile_verified"
+      ]
+    },
+    "public.messaging_registration_operation": {
+      "name": "messaging_registration_operation",
+      "schema": "public",
+      "values": [
+        "registration_details",
+        "brand_submission",
+        "campaign_submission",
+        "number_assignment",
+        "registration_reconciliation",
+        "provider_id_recovery",
+        "submission_lock_recovery",
+        "profile_activation",
+        "profile_deactivation",
+        "profile_verification"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "sent",
+        "failed",
+        "delivered"
+      ]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": [
+        "automatic",
+        "operator_reconciliation"
+      ]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.sms_provider_event_conflict_resolution": {
+      "name": "sms_provider_event_conflict_resolution",
+      "schema": "public",
+      "values": [
+        "semantic_duplicate_confirmed",
+        "provider_identity_rotated",
+        "incident_closed_no_projection"
+      ]
+    },
+    "public.sms_provider_event_kind": {
+      "name": "sms_provider_event_kind",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "delivery",
+        "a2p"
+      ]
+    },
+    "public.sms_provider_event_resolution": {
+      "name": "sms_provider_event_resolution",
+      "schema": "public",
+      "values": [
+        "authoritative_projection",
+        "conservative_opt_out",
+        "carrier_state_reconciled",
+        "provider_attested_no_projection"
+      ]
+    },
+    "public.sms_provider_event_state": {
+      "name": "sms_provider_event_state",
+      "schema": "public",
+      "values": [
+        "pending",
+        "retry",
+        "blocked_recovery",
+        "projected",
+        "ignored",
+        "quarantined"
+      ]
+    },
+    "public.sms_provider_inbound_classification": {
+      "name": "sms_provider_inbound_classification",
+      "schema": "public",
+      "values": [
+        "stop",
+        "start",
+        "help",
+        "other"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes",
+        "care_reminders",
+        "services",
+        "products",
+        "client_contacts",
+        "historical_appointments",
+        "external_prescriptions",
+        "external_prescription_fills",
+        "external_lab_reports",
+        "external_lab_observations",
+        "legacy_financial_documents",
+        "legacy_financial_line_items",
+        "legacy_financial_payments",
+        "legacy_financial_allocations",
+        "historical_documents"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    },
+    "public.clinic_pilot_communication_mode": {
+      "name": "clinic_pilot_communication_mode",
+      "schema": "public",
+      "values": [
+        "email_only",
+        "email_and_sms"
+      ]
+    },
+    "public.clinic_pilot_contact_outcome": {
+      "name": "clinic_pilot_contact_outcome",
+      "schema": "public",
+      "values": [
+        "replied",
+        "no_reply",
+        "scheduled",
+        "completed",
+        "declined"
+      ]
+    },
+    "public.clinic_pilot_decision": {
+      "name": "clinic_pilot_decision",
+      "schema": "public",
+      "values": [
+        "pending",
+        "eligible",
+        "approved",
+        "paused",
+        "not_a_fit",
+        "graduated"
+      ]
+    },
+    "public.clinic_pilot_event_type": {
+      "name": "clinic_pilot_event_type",
+      "schema": "public",
+      "values": [
+        "enrolled",
+        "updated"
+      ]
+    },
+    "public.clinic_pilot_next_action": {
+      "name": "clinic_pilot_next_action",
+      "schema": "public",
+      "values": [
+        "confirm_fit",
+        "schedule_setup",
+        "validate_import",
+        "complete_first_visit",
+        "review_communications",
+        "configure_payment",
+        "review_clinic_week",
+        "resolve_blockers",
+        "decide_graduation",
+        "support_retention",
+        "revisit_fit"
+      ]
+    },
+    "public.clinic_pilot_reason": {
+      "name": "clinic_pilot_reason",
+      "schema": "public",
+      "values": [
+        "initial_review",
+        "clinic_feedback",
+        "product_evidence",
+        "support_review",
+        "blocker_review",
+        "graduation_decision"
+      ]
+    },
+    "public.clinic_pilot_stage": {
+      "name": "clinic_pilot_stage",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "parallel_setup",
+        "visit_validation",
+        "pilot_week",
+        "graduation_review",
+        "completed",
+        "closed"
+      ]
+    },
+    "public.clinic_pilot_support_cadence": {
+      "name": "clinic_pilot_support_cadence",
+      "schema": "public",
+      "values": [
+        "daily",
+        "twice_weekly",
+        "weekly"
+      ]
+    },
+    "public.clinic_pilot_workflow": {
+      "name": "clinic_pilot_workflow",
+      "schema": "public",
+      "values": [
+        "general_practice",
+        "house_call"
+      ]
+    },
+    "public.care_reminder_status": {
+      "name": "care_reminder_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "completed",
+        "dismissed"
+      ]
+    },
+    "public.client_contact_kind": {
+      "name": "client_contact_kind",
+      "schema": "public",
+      "values": [
+        "co_owner",
+        "authorized_contact",
+        "billing_contact",
+        "emergency_contact",
+        "other"
+      ]
+    },
+    "public.external_lab_report_status": {
+      "name": "external_lab_report_status",
+      "schema": "public",
+      "values": [
+        "ordered",
+        "partial",
+        "final",
+        "corrected",
+        "cancelled",
+        "unknown"
+      ]
+    },
+    "public.external_prescription_status": {
+      "name": "external_prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired",
+        "unknown"
+      ]
+    },
+    "public.historical_appointment_status": {
+      "name": "historical_appointment_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "cancelled",
+        "no_show",
+        "unknown"
+      ]
+    },
+    "public.historical_document_kind": {
+      "name": "historical_document_kind",
+      "schema": "public",
+      "values": [
+        "patient_record",
+        "lab_report",
+        "prescription",
+        "appointment",
+        "financial",
+        "other"
+      ]
+    },
+    "public.historical_document_link_status": {
+      "name": "historical_document_link_status",
+      "schema": "public",
+      "values": [
+        "linked",
+        "needs_review"
+      ]
+    },
+    "public.imported_clinical_review_status": {
+      "name": "imported_clinical_review_status",
+      "schema": "public",
+      "values": [
+        "unreviewed",
+        "confirmed",
+        "superseded"
+      ]
+    },
+    "public.legacy_financial_document_status": {
+      "name": "legacy_financial_document_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "partial",
+        "paid",
+        "void",
+        "unknown"
+      ]
+    },
+    "public.legacy_financial_document_type": {
+      "name": "legacy_financial_document_type",
+      "schema": "public",
+      "values": [
+        "invoice",
+        "credit_note",
+        "estimate"
+      ]
+    },
+    "public.legacy_financial_payment_type": {
+      "name": "legacy_financial_payment_type",
+      "schema": "public",
+      "values": [
+        "payment",
+        "refund",
+        "adjustment"
+      ]
+    },
+    "public.migration_attribution_status": {
+      "name": "migration_attribution_status",
+      "schema": "public",
+      "values": [
+        "matched",
+        "needs_review"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -673,6 +673,13 @@
       "when": 1787530069579,
       "tag": "0095_thick_titania",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1787596645687,
+      "tag": "0096_vaccination_certificates_care_reminder_dismissal",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema-drift.ts
+++ b/packages/db/schema-drift.ts
@@ -537,7 +537,9 @@ export function criticalDatabaseContract(): DeclaredDatabaseObject[] {
       "care_reminders_patient_tenant_fk",
       "care_reminders_creator_tenant_fk",
       "care_reminders_completer_tenant_fk",
+      "care_reminders_dismisser_tenant_fk",
       "care_reminders_state_check",
+      "care_reminders_dismissal_reason_check",
       "care_reminders_import_identity_check",
     ].map((name) => ({
       kind: "constraint" as const,
@@ -558,6 +560,15 @@ export function criticalDatabaseContract(): DeclaredDatabaseObject[] {
       table: "care_reminders",
       name: "tenant_isolation",
     },
+    ...[
+      "vaccination_records_supervising_veterinarian_id_users_id_fk",
+      "vaccination_records_supervisor_practice_fk",
+      "vaccination_records_licensed_duration_check",
+    ].map((name) => ({
+      kind: "constraint" as const,
+      table: "vaccination_records",
+      name,
+    })),
     ...[
       "services_import_identity_check",
       "services_import_fingerprint_check",

--- a/packages/db/schema/care-reminders.ts
+++ b/packages/db/schema/care-reminders.ts
@@ -20,6 +20,7 @@ import { users } from "./users";
 export const careReminderStatusEnum = pgEnum("care_reminder_status", [
   "open",
   "completed",
+  "dismissed",
 ]);
 
 /**
@@ -45,6 +46,9 @@ export const careReminders = pgTable(
     createdBy: uuid("created_by"),
     completedAt: timestamp("completed_at", { withTimezone: true }),
     completedBy: uuid("completed_by"),
+    dismissedAt: timestamp("dismissed_at", { withTimezone: true }),
+    dismissedBy: uuid("dismissed_by"),
+    dismissalReason: varchar("dismissal_reason", { length: 500 }),
     externalSource: varchar("external_source", { length: 64 }),
     externalId: varchar("external_id", { length: 160 }),
     importFingerprint: varchar("import_fingerprint", { length: 64 }),
@@ -64,6 +68,11 @@ export const careReminders = pgTable(
       columns: [table.practiceId, table.completedBy],
       foreignColumns: [users.practiceId, users.id],
       name: "care_reminders_completer_tenant_fk",
+    }),
+    dismisserTenantFk: foreignKey({
+      columns: [table.practiceId, table.dismissedBy],
+      foreignColumns: [users.practiceId, users.id],
+      name: "care_reminders_dismisser_tenant_fk",
     }),
     externalIdUq: uniqueIndex("care_reminders_external_id_uq")
       .on(table.practiceId, table.externalSource, table.externalId)
@@ -92,11 +101,28 @@ export const careReminders = pgTable(
           ${table.status} = 'open'
           and ${table.completedAt} is null
           and ${table.completedBy} is null
+          and ${table.dismissedAt} is null
+          and ${table.dismissedBy} is null
+          and ${table.dismissalReason} is null
         ) or (
           ${table.status} = 'completed'
           and ${table.completedAt} is not null
           and ${table.completedBy} is not null
+          and ${table.dismissedAt} is null
+          and ${table.dismissedBy} is null
+          and ${table.dismissalReason} is null
+        ) or (
+          ${table.status} = 'dismissed'
+          and ${table.completedAt} is null
+          and ${table.completedBy} is null
+          and ${table.dismissedAt} is not null
+          and ${table.dismissedBy} is not null
+          and char_length(btrim(${table.dismissalReason})) between 3 and 500
         )`,
+    ),
+    dismissalReasonCheck: check(
+      "care_reminders_dismissal_reason_check",
+      sql`${table.dismissalReason} is null or char_length(btrim(${table.dismissalReason})) between 3 and 500`,
     ),
     externalIdentityPairCheck: check(
       "care_reminders_external_identity_pair_check",
@@ -144,5 +170,10 @@ export const careRemindersRelations = relations(careReminders, ({ one }) => ({
     fields: [careReminders.completedBy],
     references: [users.id],
     relationName: "careReminderCompleter",
+  }),
+  dismisser: one(users, {
+    fields: [careReminders.dismissedBy],
+    references: [users.id],
+    relationName: "careReminderDismisser",
   }),
 }));

--- a/packages/db/schema/clinical.ts
+++ b/packages/db/schema/clinical.ts
@@ -70,6 +70,11 @@ export const soapNoteStatusEnum = pgEnum("soap_note_status", [
   "finalized",
 ]);
 
+export const vaccinationDoseTypeEnum = pgEnum("vaccination_dose_type", [
+  "initial",
+  "booster",
+]);
+
 export const soapNotes = pgTable(
   "soap_notes",
   {
@@ -253,9 +258,17 @@ export const vaccinationRecords = pgTable(
     vaccineName: varchar("vaccine_name", { length: 255 }).notNull(),
     // Import-only dose identity. Normal administered doses keep this null.
     importFingerprint: varchar("import_fingerprint", { length: 64 }),
+    productName: varchar("product_name", { length: 255 }),
     lotNumber: varchar("lot_number", { length: 64 }),
     manufacturer: varchar("manufacturer", { length: 128 }),
+    productExpirationDate: date("product_expiration_date"),
+    doseType: vaccinationDoseTypeEnum("dose_type"),
+    licensedDurationMonths: integer("licensed_duration_months"),
+    rabiesTagNumber: varchar("rabies_tag_number", { length: 64 }),
     administeredBy: uuid("administered_by").references(() => users.id),
+    supervisingVeterinarianId: uuid("supervising_veterinarian_id").references(
+      () => users.id,
+    ),
     administeredAt: timestamp("administered_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -302,6 +315,15 @@ export const vaccinationRecords = pgTable(
       foreignColumns: [appointments.practiceId, appointments.id],
       name: "vaccination_records_practice_appointment_fk",
     }),
+    supervisorPracticeFk: foreignKey({
+      columns: [table.practiceId, table.supervisingVeterinarianId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "vaccination_records_supervisor_practice_fk",
+    }),
+    licensedDurationCheck: check(
+      "vaccination_records_licensed_duration_check",
+      sql`${table.licensedDurationMonths} is null or ${table.licensedDurationMonths} between 1 and 120`,
+    ),
   }),
 );
 
@@ -820,6 +842,12 @@ export const vaccinationRecordsRelations = relations(
     administeredByUser: one(users, {
       fields: [vaccinationRecords.administeredBy],
       references: [users.id],
+      relationName: "vaccinationAdministrator",
+    }),
+    supervisingVeterinarian: one(users, {
+      fields: [vaccinationRecords.supervisingVeterinarianId],
+      references: [users.id],
+      relationName: "vaccinationSupervisor",
     }),
   }),
 );


### PR DESCRIPTION
## What this adds
- Generate complete vaccination and rabies vaccination certificate PDFs from recorded vaccinations
- Send or resend certificate emails with explicit recipient confirmation and durable audit evidence
- Send due-care reminders individually or in a guarded batch
- Dismiss invalid care reminders with a required reason, and restore them safely
- Harden backup readback/version verification and SMS operations date queries found during production-readiness testing

## Safety and verification
- Full web suite: 4,154 passed, 13 infrastructure-gated tests identified
- All database gates enabled separately: 12/12 passed across 9 PostgreSQL integration suites
- Targeted certificate/reminder/backup/SMS tests: 116/116 passed
- Production Next.js build, lint, and type checking passed
- Migration 0096 dry-run/rollback passed, then applied to staging with 113 vaccination records and existing reminders preserved
- Staging database security advisor: no findings
- Preview branch has billing, live SMS, inbound messaging, provisioning, and file replication disabled

Production remains unchanged. This PR should not be merged until the protected preview UI/API/database/PDF walkthrough and recorded acceptance demos are complete.