### PR TITLE
chore: establish controlled development, staging, and production releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Default ownership. Add GitHub teams here as they are onboarded.
+* @evangauer
+
+# Production, security, identity, billing, and tenant-data boundaries.
+/.github/ @evangauer
+/apps/web/middleware.ts @evangauer
+/apps/web/lib/auth* @evangauer
+/apps/web/lib/billing/ @evangauer
+/apps/web/lib/stripe* @evangauer
+/apps/web/app/api/webhooks/ @evangauer
+/apps/web/server/routers/auth.ts @evangauer
+/apps/web/server/routers/billing.ts @evangauer
+/packages/db/ @evangauer
+/apps/web/scripts/vercel-build.sh @evangauer
+/apps/web/vercel.json @evangauer

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,12 +10,24 @@ Brief description of what this PR does and why.
 - [ ] Documentation
 - [ ] Other (describe):
 
+## Target and Risk
+
+- [ ] Feature/fix PR into `development`
+- [ ] Release promotion from `development` into `staging`
+- [ ] Production promotion from `staging` into `main`
+- [ ] Changes auth, billing, migrations, tenant isolation, deployment, or secrets
+
+Risk and blast radius:
+
+Rollback or recovery plan:
+
 ## Testing
 
 - [ ] `pnpm type-check` passes
 - [ ] `pnpm build` succeeds
 - [ ] Tested manually in a local dev environment
 - [ ] Added/updated E2E tests (if applicable)
+- [ ] Preview or staging smoke test completed (for promotions)
 
 ## Screenshots
 
@@ -26,4 +38,7 @@ If this affects the UI, include before/after screenshots.
 - [ ] Code follows the existing style (TypeScript, Tailwind, tRPC patterns)
 - [ ] No hardcoded secrets or credentials
 - [ ] Database changes include schema updates in `packages/db/schema/`
+- [ ] Database changes use backward-compatible expand/contract sequencing
+- [ ] Existing migration SQL and snapshots were not edited
 - [ ] New API endpoints include Zod validation and role-based access checks
+- [ ] Deployment, workflow, auth, billing, and migration changes have an explicit owner review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [development, staging, main]
   pull_request:
-    branches: [main]
+    branches: [development, staging, main]
 
 permissions:
   contents: read

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -8,17 +8,66 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      target:
+        description: Environment to migrate
+        required: true
+        type: choice
+        default: demo
+        options:
+          - demo
+          - production
+      production_confirmation:
+        description: Type MIGRATE_PRODUCTION for a production run
+        required: false
+        type: string
+      release_sha:
+        description: Exact 40-character main commit to migrate
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: apply-migrations
+  group: apply-migrations-${{ inputs.target || 'demo' }}
+  queue: max
   cancel-in-progress: false
 
 jobs:
+  reject-non-main-dispatch:
+    name: reject non-main dispatch
+    if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::Migration dispatches must run from the main branch."
+          exit 1
+
+  validate-production-request:
+    name: validate production request
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.target == 'production'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require exact revision confirmation
+        env:
+          PRODUCTION_CONFIRMATION: ${{ inputs.production_confirmation }}
+          REQUESTED_RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          if [ "$PRODUCTION_CONFIRMATION" != "MIGRATE_PRODUCTION" ]; then
+            echo "::error::Production migration confirmation did not match MIGRATE_PRODUCTION."
+            exit 1
+          fi
+          if [[ ! "$REQUESTED_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || [ "$REQUESTED_RELEASE_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Production migration release SHA must match the exact dispatched main commit."
+            exit 1
+          fi
+
   production:
     name: production
+    needs: validate-production-request
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.target == 'production'
+    environment: Production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -29,17 +78,21 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
 
-      - name: Check environment is configured
+      - name: Require production database credentials
         id: configured
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+          APP_DB_PASSWORD: ${{ secrets.OPENPIMS_APP_DB_PASSWORD }}
         run: |
-          if [ -z "$DATABASE_URL" ]; then
-            echo "::notice::PRODUCTION_DATABASE_URL is not set — skipping production."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
+          if [[ -z "$DATABASE_URL" || "$DATABASE_URL" =~ ^[[:space:]]*$ ]]; then
+            echo "::error::PRODUCTION_DATABASE_URL is not configured."
+            exit 1
           fi
+          if [[ -z "$APP_DB_PASSWORD" || "$APP_DB_PASSWORD" =~ ^[[:space:]]*$ ]]; then
+            echo "::error::OPENPIMS_APP_DB_PASSWORD is not configured."
+            exit 1
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Schema state before
         if: steps.configured.outputs.ready == 'true'
@@ -75,6 +128,7 @@ jobs:
 
   demo:
     name: demo
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.target == 'demo')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/apps/web/lib/__tests__/deployment-order.test.ts
+++ b/apps/web/lib/__tests__/deployment-order.test.ts
@@ -1,8 +1,17 @@
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("hosted deployment ordering", () => {
-  it("gates production application promotion on schema readiness", () => {
+  it("gates production promotion on an exact approved commit and schema readiness", () => {
     const vercel = JSON.parse(readFileSync("vercel.json", "utf8")) as {
       buildCommand?: string;
     };
@@ -12,9 +21,71 @@ describe("hosted deployment ordering", () => {
     expect(buildScript).toContain(
       'if [ "${VERCEL_ENV:-}" = "production" ]',
     );
+    expect(buildScript).toContain('release_sha="${PRODUCTION_RELEASE_SHA:-}"');
+    expect(buildScript).toContain('commit_sha="${VERCEL_GIT_COMMIT_SHA:-}"');
+    expect(buildScript).toContain("^[0-9a-f]{40}$");
+    expect(buildScript).toContain('[ "$release_sha" != "$commit_sha" ]');
+    expect(buildScript).toContain(
+      "Production release approval is absent or does not match this exact commit",
+    );
     expect(buildScript).toContain("pnpm db:drift");
     expect(buildScript).toContain("schema_attempt_limit=30");
     expect(buildScript).toContain("refusing production promotion");
     expect(buildScript.trimEnd()).toMatch(/pnpm build$/);
+  });
+
+  it("fails before any build when the production approval does not match", () => {
+    const result = spawnSync("bash", ["scripts/vercel-build.sh"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        VERCEL_ENV: "production",
+        PRODUCTION_RELEASE_SHA: "0".repeat(40),
+        VERCEL_GIT_COMMIT_SHA: "1".repeat(40),
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      "Production release approval is absent or does not match this exact commit",
+    );
+    expect(result.stdout).not.toContain("Database migration is still in progress");
+  });
+
+  it("checks schema drift before building an exactly approved commit", () => {
+    const fixture = mkdtempSync(join(tmpdir(), "openvpm-deploy-order-"));
+    const fakePnpm = join(fixture, "pnpm");
+    const calls = join(fixture, "calls.txt");
+    const sha = "a".repeat(40);
+
+    try {
+      writeFileSync(
+        fakePnpm,
+        '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$PNPM_CALLS"\n',
+      );
+      chmodSync(fakePnpm, 0o700);
+
+      const result = spawnSync("bash", ["scripts/vercel-build.sh"], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture}:${process.env.PATH ?? ""}`,
+          PNPM_CALLS: calls,
+          VERCEL_ENV: "production",
+          PRODUCTION_RELEASE_SHA: sha,
+          VERCEL_GIT_COMMIT_SHA: sha,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(calls, "utf8").trim().split("\n")).toEqual([
+        "db:drift",
+        "build",
+      ]);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/web/lib/__tests__/repository-governance.test.ts
+++ b/apps/web/lib/__tests__/repository-governance.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const repoFile = (path: string) =>
+  readFileSync(new URL(`../../../../${path}`, import.meta.url), "utf8");
+
+describe("repository promotion controls", () => {
+  it("runs CI for each controlled branch", () => {
+    const workflow = repoFile(".github/workflows/ci.yml");
+
+    expect(workflow).toContain("branches: [development, staging, main]");
+    expect(workflow.match(/branches: \[development, staging, main\]/g)).toHaveLength(
+      2,
+    );
+  });
+
+  it("keeps production migrations manual, main-only, and exact-revision bound", () => {
+    const workflow = repoFile(".github/workflows/migrate.yml");
+    const [production, demo] = workflow.split("  demo:");
+
+    expect(demo).toBeDefined();
+    expect(production).toContain("github.event_name == 'workflow_dispatch'");
+    expect(production).toContain("github.ref == 'refs/heads/main'");
+    expect(production).toContain("inputs.target == 'production'");
+    expect(production).toContain("environment: Production");
+    expect(production).toContain("MIGRATE_PRODUCTION");
+    expect(production).toContain("^[0-9a-f]{40}$");
+    expect(production).toContain('[ "$REQUESTED_RELEASE_SHA" != "$GITHUB_SHA" ]');
+    expect(workflow).toContain("reject-non-main-dispatch:");
+    expect(workflow).toContain("validate-production-request:");
+    expect(workflow).toContain("needs: validate-production-request");
+    expect(workflow).toContain("group: apply-migrations-${{ inputs.target || 'demo' }}");
+    expect(workflow).toContain("queue: max");
+    expect(production).toContain("PRODUCTION_DATABASE_URL is not configured");
+    expect(production).toContain("OPENPIMS_APP_DB_PASSWORD is not configured");
+    expect(production).toContain("^[[:space:]]*$");
+    expect(production).not.toContain("skipping production");
+    expect(demo).toContain("github.event_name == 'push'");
+  });
+});

--- a/apps/web/lib/__tests__/repository-governance.test.ts
+++ b/apps/web/lib/__tests__/repository-governance.test.ts
@@ -37,4 +37,29 @@ describe("repository promotion controls", () => {
     expect(production).not.toContain("skipping production");
     expect(demo).toContain("github.event_name == 'push'");
   });
+
+  it("keeps backlog cleanup evidence-gated and migration collisions on hold", () => {
+    const policy = repoFile("docs/repository-governance.md");
+    const ledger = repoFile("docs/repository-recovery-ledger.md");
+
+    expect(policy).toContain("repository-recovery-ledger.md");
+    expect(ledger).toContain("Only `close-approved` permits closing");
+    expect(ledger).toContain("cc6fd16cc8d414f181d278546e2a1213300732a0");
+    expect(ledger).toContain("#205");
+    expect(ledger).toContain("#222");
+    expect(ledger).toContain("feat/lifecycle-emails");
+    expect(ledger).toContain("The local `0094` and `0095` names collide");
+    expect(ledger).toContain("No migration or snapshot from these worktrees");
+  });
+
+  it("requires non-production credential isolation before lifting preview quarantine", () => {
+    const policy = repoFile("docs/repository-governance.md");
+
+    expect(policy).toContain("Preview and non-production credential isolation");
+    expect(policy).toContain("must never receive a credential that can mutate Production");
+    expect(policy).toContain("rotate any");
+    expect(policy).toContain("Production credential that was previously available");
+    expect(policy).toContain("test ! -f .vercel-deploy-enabled");
+    expect(policy).toContain("Do not protect `development` or `staging`");
+  });
 });

--- a/apps/web/lib/__tests__/vercel-ignore-build.test.ts
+++ b/apps/web/lib/__tests__/vercel-ignore-build.test.ts
@@ -30,4 +30,12 @@ describe("Vercel ignored build policy", () => {
     // Vercel interprets exit 0 as "skip this deployment".
     expect(ignoredBuildStatus({})).toBe(0);
   });
+
+  it("also skips ordinary app-mode previews while credentials are quarantined", () => {
+    expect(ignoredBuildStatus({ NEXT_PUBLIC_DEMO_MODE: "false" })).toBe(0);
+  });
+
+  it("always lets production builds proceed to the release-SHA gate", () => {
+    expect(ignoredBuildStatus({ VERCEL_ENV: "production" })).toBe(1);
+  });
 });

--- a/apps/web/scripts/vercel-build.sh
+++ b/apps/web/scripts/vercel-build.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# Production deploys may begin at the same time as the main-branch migration
-# workflow. Do not build (and therefore do not promote) application code until
-# its target database has every table and column declared by that revision.
+# Production Git deployments are candidates, not approvals. Fail closed unless
+# an operator has pinned this exact commit, then wait for its target database to
+# contain every table and column declared by the same revision.
 
 set -euo pipefail
 
 if [ "${VERCEL_ENV:-}" = "production" ]; then
+  release_sha="${PRODUCTION_RELEASE_SHA:-}"
+  commit_sha="${VERCEL_GIT_COMMIT_SHA:-}"
+
+  if [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]] || [ "$release_sha" != "$commit_sha" ]; then
+    echo "::error::Production release approval is absent or does not match this exact commit; refusing production promotion."
+    exit 1
+  fi
+
   schema_attempt=1
   schema_attempt_limit=30
 

--- a/apps/web/scripts/vercel-ignore-build.sh
+++ b/apps/web/scripts/vercel-ignore-build.sh
@@ -3,12 +3,10 @@
 # Exit 0 skips the build; exit 1 lets it proceed.
 #
 # - Production deployments always build.
-# - An explicit operator-only override can force a protected preview rebuild.
-# - The public demo deployment (NEXT_PUBLIC_DEMO_MODE=true) tracks
-#   production only; its preview builds are skipped as duplicates.
-# - Preview builds are skipped when nothing that ships in the web app
-#   changed. turbo-ignore walks the workspace graph, so pushes that only
-#   touch docs, e2e specs, or infra stop producing throwaway builds.
+# - Preview builds are quarantined because the 2026-08-25 environment audit
+#   found production-capable provider credentials in Preview scope.
+# - An explicit operator-only override can force one protected canary after
+#   its environment has passed the credential-isolation checklist.
 
 set -u
 
@@ -20,15 +18,6 @@ if [ "${OPENVPM_FORCE_PREVIEW_BUILD:-}" = "true" ]; then
   exit 1
 fi
 
-if [ "${NEXT_PUBLIC_DEMO_MODE:-}" = "true" ]; then
-  exit 0
-fi
-case "${VERCEL_PROJECT_PRODUCTION_URL:-}" in
-  demo.*) exit 0 ;;
-esac
-
-# turbo-ignore exits 0 when @openpims/web and its workspace dependencies
-# are unchanged since the last deployment (falling back to the parent
-# commit). Any failure falls through to building, never to skipping.
-npx --yes turbo-ignore "@openpims/web" || exit 1
+# Do not infer preview safety from changed files, demo flags, branch names, or
+# package metadata. Lifting this quarantine is a reviewed environment action.
 exit 0

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -77,6 +77,9 @@ NEXTAUTH_URL=https://app.openvpm.com
 NEXT_PUBLIC_APP_URL=https://app.openvpm.com
 NEXTAUTH_SECRET=...
 DATABASE_URL=...
+# Transitional production release lock. Set only to the exact approved
+# 40-character commit, redeploy that revision, then clear or rotate it.
+PRODUCTION_RELEASE_SHA=
 
 STRIPE_SECRET_KEY=...
 STRIPE_WEBHOOK_SECRET=...
@@ -142,6 +145,32 @@ CRON_HEARTBEAT_URL=...
 CRON_HEARTBEAT_FILE_REPLICAS_URL=...
 PLATFORM_ADMIN_EMAILS=...
 ```
+
+### Transitional production release gate
+
+Until staging can promote one immutable artifact, every Vercel Production build
+fails closed unless `PRODUCTION_RELEASE_SHA` exactly matches
+`VERCEL_GIT_COMMIT_SHA`. A merge to `main` creates a candidate; it is not an
+approval.
+
+Keep **Automatically expose System Environment Variables** enabled on the app
+and demo Vercel projects so `VERCEL_GIT_COMMIT_SHA` is available. Changing or
+clearing a Vercel environment variable does not alter an existing deployment;
+the gate evaluates it only in a newly created or redeployed build.
+
+1. Dispatch **Apply migrations** from `main` for `production`, enter the exact
+   40-character `main` commit, and type `MIGRATE_PRODUCTION`.
+2. Wait for the RLS ownership preflight, migration, RLS reapplication, and final
+   drift check to pass.
+3. Set `PRODUCTION_RELEASE_SHA` to that same commit in the app and demo Vercel
+   projects, then redeploy the exact candidate in each project.
+4. Verify `/api/health` and the release smoke path before recording success.
+5. Clear or rotate the value so the approval cannot apply to a later commit.
+
+The GitHub `Production` environment must have an independent required reviewer
+before this is treated as two-person approval. See
+[`repository-governance.md`](repository-governance.md) for the target promotion
+model.
 
 `STRIPE_PRICE_CLOUD_USER` and `STRIPE_PRICE_CLOUD` are legacy-only. They must not be used for new checkout or required hosted readiness.
 

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -1,0 +1,317 @@
+# Repository governance and release policy
+
+This document defines the target operating model for repository changes and
+hosted releases. The goals are to keep production stable, preserve valuable
+work in progress, and make every release reviewable and recoverable.
+
+## Canonical branches and environments
+
+Changes move in one direction:
+
+```text
+feature or fix branch -> development -> staging -> main
+                            |             |          |
+                        Development    Staging   Production
+```
+
+| Branch | Purpose | Environment | Deployment rule |
+| --- | --- | --- | --- |
+| `development` | Integration branch for completed feature work | Development | Deploy automatically after required checks pass |
+| `staging` | Release-candidate branch; no unrelated feature work | Staging | Deploy an immutable release candidate for acceptance testing |
+| `main` | Audited production history and the deployed release line | Production | Deploy only an approved artifact already tested in staging |
+
+All three canonical branches must be protected. Direct pushes, force pushes,
+and branch deletion are disabled. Required checks and reviews apply to
+maintainers and administrators as well as other contributors. A bypass is an
+incident action, not a normal release mechanism, and must be recorded in the
+incident timeline.
+
+`main` is the source of truth for what is in production. A deployment is not
+considered a production release unless its source commit and immutable artifact
+identifier are recorded against `main`.
+
+## Normal change flow
+
+### Feature and fix pull requests
+
+1. Create a short-lived branch from current `development`. Before review,
+   rebase it on current `development` and resolve conflicts on the topic branch.
+2. Open a pull request into `development`. Do not open feature pull requests
+   directly into `staging` or `main`.
+3. Describe the user or operational outcome, risk, test evidence, rollout
+   controls, migration impact, and rollback limits. UI changes include visual
+   evidence; security- or data-sensitive changes identify their threat and
+   tenant-isolation considerations.
+4. Obtain the required independent and code-owner reviews, resolve all review
+   threads, and pass all required checks.
+5. Merge using the repository's configured merge strategy. Delete the topic
+   branch only after the merge is verified and no other pull request depends on
+   it.
+
+Keep pull requests small enough to review. If a feature must be integrated
+before it is ready for users, put it behind a default-off flag with an owner,
+activation criteria, and removal date.
+
+### Release pull requests
+
+1. Open a release pull request from `development` to `staging`. Its description
+   lists the included pull requests, migrations, configuration changes, feature
+   flags, operator actions, acceptance plan, and rollback constraints.
+2. Freeze the release candidate while it is tested. A release-blocking fix
+   branches from `staging`, returns to `staging` through a reviewed pull request,
+   and is immediately forward-ported to `development`.
+3. Build the release artifact once, deploy that immutable artifact to the
+   Staging environment, and record its digest and source commit.
+4. After staging acceptance, open a production release pull request from
+   `staging` to `main`. The pull request must identify the exact artifact tested
+   in staging and link the release evidence.
+5. After production approval, advance `main` and promote the same artifact to
+   Production. Do not rebuild the production artifact from a branch name.
+6. Verify production health, migrations, tenant isolation, and a minimal smoke
+   path. Record the result in the release.
+
+If `development` advances while a release candidate is in staging, those later
+changes wait for the next release. Do not merge `development` into a release in
+progress merely to make the branches appear synchronized.
+
+## Required reviews and checks
+
+Every pull request into a canonical branch requires:
+
+- at least one approval from a reviewer other than the author;
+- approval from an applicable code owner for owned paths;
+- all review conversations resolved and no outstanding change requests;
+- a current base branch with conflicts resolved before final approval;
+- successful `build`, `Migration history integrity`, and `RLS tenant
+  isolation` CI jobs; and
+- the testing, security, migration, and release evidence appropriate to the
+  change.
+
+Production release pull requests require a second approval from the designated
+release owner. Changes involving authentication, authorization, tenant
+boundaries, migrations, clinical records, billing, secrets, webhooks, provider
+integrations, recovery, CI, or deployment configuration require approval from
+the relevant security, data, or operations owner in addition to the normal
+reviewer. Authors cannot approve their own pull requests or deployments.
+
+Required checks must include the repository's existing public-release scan,
+production-dependency audit, type check, automated tests, build, append-only
+migration-history check, schema/migration consistency checks, and real-Postgres
+RLS isolation tests. A flaky or unavailable check blocks a release until it is
+fixed or an incident-scoped exception is documented and approved by both the
+release and relevant code owner.
+
+## CODEOWNERS policy
+
+The repository must maintain `.github/CODEOWNERS` using teams or durable roles,
+not a single individual's account. At minimum, it should assign ownership for:
+
+- default repository-wide review;
+- authentication, authorization, tenant scoping, and RLS;
+- database schema, migrations, and recovery tooling;
+- billing, messaging, email, webhooks, and external providers;
+- CI workflows, deployment configuration, and release runbooks; and
+- security policy and dependency controls.
+
+Code ownership is a review boundary, not merely a notification list. Owners are
+responsible for assessing failure modes, migration and rollback limits, data
+exposure, and operational readiness in their area. Ownership changes require a
+review from the existing owner or the repository maintainers and must not leave
+a sensitive path unowned.
+
+During the transition, the current maintainer account may bootstrap ownership
+so sensitive paths are not left unowned. Replace that temporary entry with
+durable teams before enabling independent code-owner approval as a required
+merge condition.
+
+## Database migration policy
+
+Production migrations follow an expand-and-contract sequence:
+
+1. **Expand:** add backward-compatible tables, columns, indexes, policies, or
+   dual-read/write support. Committed migration history is append-only; never
+   edit a migration that may have run in any shared environment.
+2. **Migrate:** backfill in bounded, observable batches. Make retries safe,
+   retain evidence of completion, and avoid long locks on live tables.
+3. **Switch:** deploy code that uses the new shape only after the expansion is
+   proven in Development and Staging. Keep rollback compatibility with the
+   prior artifact for the declared rollback window.
+4. **Contract:** remove old reads, writes, columns, tables, or policies in a
+   separate release after the old application version and all backfills are
+   confirmed inactive.
+
+A pull request must not combine an incompatible schema contraction with the
+code that first depends on the replacement. Production uses committed
+migrations and reapplies and verifies RLS; it must not use schema-push tooling.
+Before a high-risk migration, verify current backup and restore evidence,
+estimate lock and runtime behavior, define abort thresholds, and identify
+whether rollback means artifact rollback, a forward data repair, or restore.
+
+## Production release control
+
+The release pipeline must build an immutable artifact from the approved staging
+commit, store its digest, and deploy that same digest to Staging and Production.
+The production environment must require an explicit approval from a release
+owner who did not author the release. Environment credentials are scoped to the
+environment and unavailable to pull-request code.
+
+Each production release record contains:
+
+- the `main` commit, staging source commit, and immutable artifact digest;
+- included pull requests and user-visible release notes;
+- required-check results and staging acceptance evidence;
+- migrations, configuration changes, feature-flag state, and operator steps;
+- named approvers, approval time, and deployment time; and
+- the rollback artifact and any database rollback limitation.
+
+Production promotion is serialized: only one release or migration operation may
+modify Production at a time. Health checks and smoke tests must complete before
+the release is declared successful.
+
+## Rollback and incident path
+
+When a release causes harm or threatens data, tenant isolation, security, or
+availability:
+
+1. Stop further promotions and name an incident lead.
+2. Preserve logs and deployment evidence, identify the affected artifact and
+   migration state, and disable the smallest relevant feature or integration if
+   a safe kill switch exists.
+3. If the database remains compatible, promote the last known-good immutable
+   artifact. Do not rebuild an old branch.
+4. If a migration or data write makes artifact rollback unsafe, hold the
+   rollout and use a reviewed forward repair. Restore data only under the
+   backup/restore runbook with an explicit data-loss and tenant-impact review.
+5. For an urgent code repair, branch from `main`, use an expedited but reviewed
+   pull request with the required checks, and deploy through the production
+   approval gate. Immediately forward-port the repair to `staging` and
+   `development`.
+6. Record detection, decisions, approvals, customer impact, recovery, and
+   follow-up work. Rotate credentials promptly if exposure is possible and
+   complete a blameless post-incident review.
+
+The incident lead may shorten timing, but may not silently waive auditability,
+independent review, tenant-safety checks, or release recording.
+
+## Branch and pull-request cleanup
+
+Cleanup is an evidence-preservation exercise, not a bulk deletion event.
+
+### Phase 0: Stabilize
+
+- Pause nonessential production merges and all branch deletion.
+- Declare the deployed `main` commit as the baseline.
+- Back up repository metadata and record all open pull requests, remote
+  branches, tags, and deployment-linked commits.
+- Assign a cleanup owner and use a shared register for every branch and pull
+  request.
+
+### Phase 1: Inventory and classify
+
+For each item, record its owner, purpose, base and head commits, open pull
+request, last activity, unique commits, deployment history, dependencies,
+migrations, security or tenant impact, and test state. Classify it as:
+
+- merged or already equivalent to `main`;
+- active and owned;
+- valuable but needing recovery;
+- superseded, abandoned, or generated; or
+- unknown/high-risk and requiring specialist review.
+
+No unknown or high-risk item is deleted merely because it is old.
+
+### Phase 2: Recover valuable work
+
+Recreate valuable changes as small, current branches based on `development`.
+Prefer reviewed cherry-picks or a clean reimplementation over merging a stale
+branch wholesale. Re-run current checks and give migrations, authentication,
+tenant boundaries, billing, messaging, and provider changes specialist review.
+Link the replacement pull request to the original so authorship and decisions
+remain discoverable.
+
+### Phase 3: Close superseded work
+
+Close a pull request only after recording why it is obsolete, merged elsewhere,
+or replaced, with a link to the successor when one exists. Delete its remote
+branch only after confirming that all valuable unique commits are merged or
+preserved and no open work depends on it. Require two-maintainer approval for
+cleanup of a branch with migrations, deployment history, or uncertain ownership.
+
+### Phase 4: Prune and maintain
+
+After a published grace period, prune approved merged or superseded branches,
+verify that canonical and release references remain reachable, and publish a
+cleanup summary. Enable automatic deletion only for merged topic branches, not
+canonical or release references. Repeat the inventory on a regular cadence so
+the backlog does not regrow.
+
+## Retiring Orca as repository authority
+
+Orca worktrees and automation are not canonical repository state. Retire them
+in a controlled handoff:
+
+1. Freeze new work in Orca and inventory every Orca worktree, uncommitted
+   change, unique commit, open pull request, automation, and credential scope.
+2. Recover valuable work through reviewed branches and pull requests in the
+   canonical flow. Preserve provenance by linking the source worktree or pull
+   request in the cleanup register without publishing local paths or secrets.
+3. Prove that Development, Staging, and Production deploy successfully under
+   the new branch protections, environment approvals, and release recording.
+4. Disable Orca jobs and repository write access, then revoke its credentials
+   and webhooks. Verify that no required deployment, scheduled job, or recovery
+   process depended on them.
+5. Remove Orca worktrees only after all unique work is preserved and the grace
+   period has passed.
+
+Standard local clones and Git worktrees may still be used as working copies;
+the protected remote branches, reviewed pull requests, immutable artifacts, and
+release records remain authoritative.
+
+## Transition note — 2026-08-25
+
+This policy describes the target state, not controls that are already fully in
+place. At the start of this transition:
+
+- `main` is the deployed branch and automatically deploys today;
+- `staging` exists but is stale and materially behind `main`;
+- `development` does not exist;
+- pull-request CI is configured for `main`, not all three canonical branches;
+- the migration workflow runs from pushes to `main`;
+- `.github/CODEOWNERS` does not exist; and
+- protected-environment approval and exact-artifact promotion have not yet been
+  established by this document alone.
+
+Until the transition is complete, treat every merge to `main` as an immediate
+production change. Do not use `staging` for release decisions while it is stale,
+and do not delete branches or close pull requests before completing the
+inventory.
+
+The initial governance change adds a transitional fail-closed release lock.
+Automatic Vercel builds from `main` are only candidates: a Production build
+fails unless `PRODUCTION_RELEASE_SHA` equals that deployment's exact
+`VERCEL_GIT_COMMIT_SHA`. Production migrations must be dispatched from `main`
+with the same 40-character commit and the typed confirmation
+`MIGRATE_PRODUCTION`. After migrations and drift checks pass, set the exact SHA
+in each production-target Vercel project, redeploy that exact candidate, run
+health and smoke checks, and then clear or rotate the value. Until protected
+environment reviewers are configured, the SHA value is a kill switch and audit
+aid—not proof of independent approval. It is superseded by build-once artifact
+promotion when the target pipeline is ready.
+
+The initial control rollout is:
+
+1. Record the current deployed `main` commit and restrict `main` to approved,
+   checked production changes.
+2. Create `development` from that exact `main` commit.
+3. Preserve the current `staging` tip, then fast-forward `staging` to the same
+   baseline through a reviewed maintainer operation.
+4. Add branch protection, CODEOWNERS, and required CI coverage for
+   `development`, `staging`, and `main`.
+5. Configure distinct Development, Staging, and Production environments with
+   scoped credentials and production deployment approval.
+6. Implement build-once artifact recording and promotion, then rehearse a
+   normal release and rollback before resuming routine production delivery.
+7. Run the phased branch and pull-request inventory, recovery, and cleanup.
+
+Any step that would rewrite or delete a remote ref requires a preserved
+reference, a reviewed change record, and explicit maintainer approval.

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -186,6 +186,17 @@ rotated. The `openvpm` demo project already skipped non-production builds and
 now remains under the same quarantine boundary. This is an incident-prevention
 control, not the completed Development or Staging environment.
 
+The initial containment narrowed shared Resend and auth secrets to Production,
+removed only Preview credential entries proven byte-identical to retained
+Production copies, removed the stale branch-specific build override, and
+enabled Vercel Authentication for every app deployment except the customer
+custom domains. The remaining app Preview secrets are limited to a distinct
+database, auth secret, Blob token, and GCP service account; the demo Preview has
+a distinct database only. This scoping—not the repository-owned ignore
+script—is the security boundary, because pull-request code can modify its own
+`vercel.json`. The ignore script remains defense in depth. Historical exposure
+still makes the retained Production values rotation candidates.
+
 Before enabling either canonical non-production branch:
 
 1. provision environment-specific data stores and provider test accounts;

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -168,6 +168,42 @@ Production promotion is serialized: only one release or migration operation may
 modify Production at a time. Health checks and smoke tests must complete before
 the release is declared successful.
 
+## Preview and non-production credential isolation
+
+Pull-request code is untrusted until it has passed review. A preview deployment
+must never receive a credential that can mutate Production, even when the
+preview uses a separate database. Development and Staging require distinct
+databases, auth/session secrets, mail/provider credentials, webhook endpoints
+and signing secrets, object-storage credentials, billing test-mode keys, and
+least-privilege cloud identities. Default-off provider and fee-bearing flags
+remain off in both environments.
+
+The 2026-08-25 audit found that `openvpm-app` Preview used a different database
+but several Preview credentials had values identical to Production, including
+Stripe, Resend, webhook, MFA, cron, and replica credentials. New non-production
+builds are therefore quarantined in Vercel while credentials are separated and
+rotated. The `openvpm` demo project already skipped non-production builds and
+now remains under the same quarantine boundary. This is an incident-prevention
+control, not the completed Development or Staging environment.
+
+Before enabling either canonical non-production branch:
+
+1. provision environment-specific data stores and provider test accounts;
+2. create new non-production credentials rather than copying Production;
+3. remove every Production-capable credential from Preview and rotate any
+   Production credential that was previously available to preview code;
+4. configure explicit Development and Staging branch/environment mappings;
+5. prove a canary pull request receives only its intended environment and
+   cannot access Production data or providers; and
+6. record the Vercel project, deployment, source SHA, variable-scope audit, and
+   smoke-test evidence before lifting the quarantine.
+
+The placeholder `openvpm-docs` project is separately quarantined with an
+Ignored Build Step of `test ! -f .vercel-deploy-enabled`. Adding that sentinel
+is an explicit release decision requiring a focused docs pull request, build
+evidence, domains and environment review, and an owner. Package metadata alone
+must not infer that unfinished docs WIP is ready to deploy.
+
 ## Rollback and incident path
 
 When a release causes harm or threatens data, tenant isolation, security, or
@@ -196,6 +232,8 @@ independent review, tenant-safety checks, or release recording.
 ## Branch and pull-request cleanup
 
 Cleanup is an evidence-preservation exercise, not a bulk deletion event.
+The active item-by-item decisions are recorded in the
+[repository recovery and cleanup ledger](repository-recovery-ledger.md).
 
 ### Phase 0: Stabilize
 
@@ -312,6 +350,12 @@ The initial control rollout is:
 6. Implement build-once artifact recording and promotion, then rehearse a
    normal release and rollback before resuming routine production delivery.
 7. Run the phased branch and pull-request inventory, recovery, and cleanup.
+
+Do not protect `development` or `staging` while they still point at the old
+deployed baseline: that baseline's CI workflow emits canonical-branch checks
+only for `main`, which would deadlock required checks. First merge, deploy, and
+verify the governance commit on `main`; then create or fast-forward both
+branches to that exact deployed SHA and apply their no-bypass protections.
 
 Any step that would rewrite or delete a remote ref requires a preserved
 reference, a reviewed change record, and explicit maintainer approval.

--- a/docs/repository-recovery-ledger.md
+++ b/docs/repository-recovery-ledger.md
@@ -45,7 +45,7 @@ They are evidence for triage, not acceptance evidence for the underlying code.
 | [#222](https://github.com/evangauer/openvpm/pull/222) | P0 one-click billing integration | Draft, conflicting; 136 files | `evidence-only` | High-risk integration aggregate; decompose billing, auth, migration, and operational changes into independently testable recoveries |
 | [#224](https://github.com/evangauer/openvpm/pull/224) | Development dependency group | Behind; 7 files | `recreate` | Regenerate after baseline and review breaking toolchain changes separately |
 | [#230](https://github.com/evangauer/openvpm/pull/230) | Production dependency group | Behind; 4 files | `recreate` | Split security fixes from broad upgrades and prove runtime compatibility |
-| [#240](https://github.com/evangauer/openvpm/pull/240) | Repository governance | Draft; core checks pass | `governance` | Complete environment credentials, independent ownership, and release rehearsal before merge |
+| [#240](https://github.com/evangauer/openvpm/pull/240) | Repository governance | Draft; core checks pass | `governance` | Complete final review, merge through the gate, then execute the exact-SHA release rehearsal before canonical branch bootstrap |
 
 The stacked work represented by #198-#205 has one integration tip in #205.
 That containment is a preservation fact only; it does not make #205 a safe

--- a/docs/repository-recovery-ledger.md
+++ b/docs/repository-recovery-ledger.md
@@ -1,0 +1,132 @@
+# Repository recovery and cleanup ledger
+
+This ledger is the review record for the 2026-08-25 repository consolidation.
+It turns the branch and pull-request backlog into explicit recovery decisions.
+It is intentionally conservative: an item remains preserved until its successor
+has passed current checks and an owner approves the recorded disposition.
+
+The deployed baseline for this ledger is `main` at
+`cc6fd16cc8d414f181d278546e2a1213300732a0`. The cleanup owner holds a verified
+offline all-refs bundle plus separate snapshots of every dirty worktree. Those
+archives may contain secrets or private operational data and must not be pushed
+to GitHub or attached to a pull request.
+
+## Decision vocabulary
+
+| Decision | Meaning |
+| --- | --- |
+| `governance` | Required control-plane work; review before any routine cleanup |
+| `recover` | Valuable work; replay as a focused branch from `development` |
+| `evidence-only` | Preserve for history and test ideas; do not merge wholesale |
+| `recreate` | Close only after a current replacement pull request exists |
+| `hold` | Ownership, product value, or safety impact is still unresolved |
+| `close-approved` | All unique value is proven merged/preserved and closure is approved |
+
+Only `close-approved` permits closing a pull request or deleting its remote
+branch. Age, conflicts, or failing checks are never sufficient on their own.
+
+## Open pull-request register
+
+The counts and merge state below are the GitHub state observed on 2026-08-25.
+They are evidence for triage, not acceptance evidence for the underlying code.
+
+| PR | Topic | Observed state | Decision | Recovery boundary |
+| --- | --- | --- | --- | --- |
+| [#198](https://github.com/evangauer/openvpm/pull/198) | Encounter estimate conversion and medication charge handoff | Conflicting; 19 files | `recover` | Re-prove conversion, charge ownership, idempotency, and tenant boundaries separately |
+| [#199](https://github.com/evangauer/openvpm/pull/199) | Auditable medication charge workflow | Stacked on #198; 39 files | `recover` | Extract only after #198 concepts are mapped; do not merge the stack base-to-tip |
+| [#200](https://github.com/evangauer/openvpm/pull/200) | Onboarding conversion funnel | Conflicting; 16 files | `recover` | Reconcile with #221 and current analytics/privacy contracts |
+| [#202](https://github.com/evangauer/openvpm/pull/202) | Subscription conversion lifecycle | Draft, conflicting; 15 files | `recover` | Reconcile with current billing and webhook idempotency code |
+| [#203](https://github.com/evangauer/openvpm/pull/203) | First-clinic-win subscription conversion | Draft, stacked on #202; 58 files | `recover` | Separate product behavior from generated or fixture-heavy changes |
+| [#204](https://github.com/evangauer/openvpm/pull/204) | SMS pilot activation preflight | Draft, conflicting; 13 files | `recover` | Security/operations review; preserve all default-off and fee-bearing interlocks |
+| [#205](https://github.com/evangauer/openvpm/pull/205) | Clinic-launch integration stack | Draft, conflicting; 130 files | `evidence-only` | Umbrella branch contains the component stack; use it to trace provenance and tests, never as a wholesale merge |
+| [#219](https://github.com/evangauer/openvpm/pull/219) | Patient merge and migration safety | Draft, conflicting; 13 files | `recover` | Database/RLS specialist review and fresh real-Postgres evidence required |
+| [#220](https://github.com/evangauer/openvpm/pull/220) | pnpm/action-setup update | Behind; 2 files | `recreate` | Re-run Dependabot after governance baseline; retain pinning and supply-chain checks |
+| [#221](https://github.com/evangauer/openvpm/pull/221) | Privacy-safe acquisition reporting | Draft, behind; 7 files | `recover` | Reconcile overlap with #200 and re-review reporting privacy |
+| [#222](https://github.com/evangauer/openvpm/pull/222) | P0 one-click billing integration | Draft, conflicting; 136 files | `evidence-only` | High-risk integration aggregate; decompose billing, auth, migration, and operational changes into independently testable recoveries |
+| [#224](https://github.com/evangauer/openvpm/pull/224) | Development dependency group | Behind; 7 files | `recreate` | Regenerate after baseline and review breaking toolchain changes separately |
+| [#230](https://github.com/evangauer/openvpm/pull/230) | Production dependency group | Behind; 4 files | `recreate` | Split security fixes from broad upgrades and prove runtime compatibility |
+| [#240](https://github.com/evangauer/openvpm/pull/240) | Repository governance | Draft; core checks pass | `governance` | Complete environment credentials, independent ownership, and release rehearsal before merge |
+
+The stacked work represented by #198-#205 has one integration tip in #205.
+That containment is a preservation fact only; it does not make #205 a safe
+release candidate. #222 is a separate large aggregate with substantial overlap
+and must not be merged beside or on top of #205.
+
+## High-priority branch-only recovery
+
+These branches have valuable commits not represented by a current remote pull
+request or a safe current branch. Their commits are present in the offline
+bundle and dedicated safety refs.
+
+| Source | Preserved tip | Main divergence at inventory | Decision | First review |
+| --- | --- | --- | --- | --- |
+| `feat/lifecycle-emails` | `24a3347ced908f725f72260667d6f48c2f701ee9` | 4 unique commits; 219 behind | `recover` | Email event correctness, retries, privacy, and subscription-state semantics |
+| `feat/activation-funnel` | `09e4fadd41742103e6c8092a9497134138100759` | 3 unique commits; 219 behind | `recover` | Product fit, current onboarding behavior, and analytics privacy |
+| `codex/onboarding-first-day-density` | `68959b3a3ca088b00144ac846e91e4ab266f5af6` | 1 unique commit; 32 behind | `recover` | Separate the committed onboarding polish from the much larger dirty worktree |
+
+Twenty-two locally held worktree heads were absent from cached remote refs at
+inventory time. They are preserved in the verified bundle. Each remains
+`hold` until a domain owner maps it to current product behavior; no bulk push
+or deletion is authorized.
+
+## Dirty-worktree register
+
+Five worktrees contained uncommitted content at inventory time. Each has a
+tracked patch or WIP bundle and a separate untracked-file archive where
+applicable. The primary mixed worktree includes authentication/MFA, billing,
+email security, docs, database, migration, and operational work and is not a
+rebase candidate.
+
+| Work area | State | Decision | Constraint |
+| --- | --- | --- | --- |
+| Primary mixed checkout | 148 tracked changes plus 153 detailed untracked entries | `hold` | Extract by domain; exclude private `outputs/`; resolve migration numbering first |
+| GTM/CRO planning | Untracked planning documents | `hold` | Privacy and partnership-data review before publication |
+| Nutrition extension | Tracked WIP plus a conflicting migration number | `recover` | Regenerate migration from the current development ledger |
+| Resend incident hardening | Three unique commits plus lockfile WIP | `recover` | Separate security behavior from dependency churn |
+| Orca history-filter worktree | One-line migration journal WIP | `hold` | Compare against current append-only migration history before recovery |
+
+## Migration collision register
+
+The primary mixed checkout contains untracked migrations numbered `0090`
+through `0095`, while deployed `main` already contains `0090` through `0096`.
+The local `0094` and `0095` names collide with different migrations on main,
+and snapshot metadata diverges after `0090`. The nutrition worktree has another
+untracked `0091`.
+
+No migration or snapshot from these worktrees may be copied directly into a
+recovery branch. Recover the intended schema change against current
+`development`, generate new append-only numbers and snapshots, exercise the
+upgrade from a production-shaped database, and re-run migration integrity,
+drift, RLS, and rollback/forward-repair review.
+
+## Recovery order
+
+1. Land and rehearse repository governance without changing the production
+   application or database.
+2. Establish protected `development` and `staging` at the deployed baseline.
+3. Recover lifecycle email behavior as the first branch-only loss-risk item.
+4. Decompose #198-#205 into domain-sized recovery pull requests.
+5. Review #219 independently because patient identity and migration safety are
+   release-blocking boundaries.
+6. Treat #222 as an evidence source and extract only changes not already
+   recovered from the clinic-launch stack.
+7. Recreate dependency updates from the then-current lockfile.
+8. Publish a proposed closure list with successor links and a grace period.
+9. Close or delete only entries that reach `close-approved`.
+
+## Evidence required for a recovery pull request
+
+Every successor records its source branch/PR and the exact commits consulted.
+It must also provide:
+
+- a narrow user or operational outcome;
+- a current-base diff with no unrelated generated output;
+- current CI and domain-specific tests;
+- migration, tenant-isolation, auth, billing, provider, and privacy review when
+  those boundaries are touched;
+- rollout and rollback/forward-repair instructions; and
+- confirmation that the old source can remain evidence-only or advance to
+  `close-approved`.
+
+This ledger is updated in the same pull request as each disposition. A cleanup
+operation without a ledger update is out of policy.


### PR DESCRIPTION
## Goal

Establish the first reviewed control plane for moving from feature work through `development`, `staging`, and deployed `main` without risking current production or deleting in-flight work.

## What this change establishes

- documents the canonical `development -> staging -> main` promotion model;
- adds an evidence-gated recovery ledger for every open pull request and the highest-risk branch-only/dirty work;
- expands CI coverage to all three controlled branches;
- makes Production migrations manual, `main`-only, exact-SHA-bound, serialized, environment-approved, and fail-closed on missing credentials;
- preserves pre/post drift checks, RLS ownership preflight, migration, and RLS reapplication;
- adds a transitional Vercel exact-commit release lock before schema checks or builds;
- adds CODEOWNERS, review/risk prompts, and executable release-order tests;
- quarantines unfinished docs deployment behind an explicit reviewed sentinel; and
- defaults app previews to skipped while non-production isolation is completed.

## Live containment completed outside this diff

- all refs and every dirty worktree are preserved in verified offline bundles/archives;
- Preview copies of Production-identical Stripe, Resend, webhook, MFA, cron, email-signing, and replica credentials were removed only after confirming retained Production copies;
- shared Resend/auth secrets were narrowed to Production, and the stale branch-specific preview-build override was removed;
- remaining Preview capability keys are distinct from Production;
- Vercel Authentication now protects all app deployments except customer custom domains;
- `OPENPIMS_APP_DB_PASSWORD` retains the least-privilege Vercel runtime password, while `PRODUCTION_DATABASE_URL` now uses the rotated Supabase `postgres` owner session-pooler credential; the owner-only read-only RLS capability preflight passed, and both secrets are scoped to the GitHub `Production` environment; and
- `openvpm-docs` now returns a successful ignored deployment until `.vercel-deploy-enabled` is deliberately reviewed and added.

No secret value was displayed, written to disk, or committed. No Production deployment, Production migration, environment branch move, PR closure, worktree deletion, or branch deletion has occurred.

## Verification

- `bash -n` for both Vercel shell policies
- workflow YAML parsed for CI and migrations
- focused Vitest: 3 files / 11 tests passed
- TypeScript `--noEmit` passed
- `git diff --check` passed
- prior independent reviews drove two sequencing corrections and the Preview isolation remediation

## Merge and first-release gate

- [x] Verified deployed baseline `cc6fd16cc8d414f181d278546e2a1213300732a0`
- [x] Verified preservation bundles and dirty-worktree archives
- [x] Scoped Production migration credentials to the GitHub environment
- [x] Removed known Production-capable Preview credential reuse and protected preview URLs
- [x] Quarantined the incomplete docs project
- [x] Final CI/CodeQL checks pass at the current head
- [x] Final independent P0/P1 review passes at the current head
- [ ] Merge through protected `main` and capture the actual resulting SHA
- [ ] Prove automatic Production candidates fail closed while the old release stays live
- [ ] Run and approve the exact-SHA Production migration/RLS/drift rehearsal
- [ ] Set `PRODUCTION_RELEASE_SHA`, redeploy the exact candidates serially, and verify app/demo health
- [ ] Clear the release SHA and record the release
- [ ] Only then align and protect `development` and `staging` at that exact deployed SHA

## Transitional follow-up

A second human maintainer/team is not yet present. Before routine team delivery, replace individual CODEOWNERS entries, require independent approval and prevent self-review, rotate Production credentials that were historically available to Preview, and provision distinct Development/Staging data stores and provider test accounts. Until then, preview skipping remains defense in depth and canonical non-production deployments stay disabled.
