### PR TITLE
fix(visits): close refill billing handoff gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,14 @@ jobs:
           PATIENT_MERGE_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run server/__tests__/patient-merge-transaction.integration.test.ts
 
+      # A refill can belong to an older prescription while its dispense charge
+      # belongs to the current visit. Prove the queue row remains visible in
+      # closeout history and blocks checkout/financial handoff under RLS.
+      - name: Execute visit-dispense closure contract
+        env:
+          VISIT_DISPENSE_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/visit-dispense-closure.integration.test.ts
+
       # Compile, bind, and execute the exact read-only SQL used by the shared
       # platform-admin and daily SMS operations queues. Unit tests cannot catch
       # postgres.js timestamp encoders or correlated identifier rendering.

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -1586,7 +1586,7 @@ describe("billing invoice integrity", () => {
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
-        "Resolve every performed vaccination, lab, procedure, and prescription before sending or collecting this visit invoice.",
+        "Resolve every performed vaccination, lab, procedure, prescription, and medication dispense before sending or collecting this visit invoice.",
     });
     expect(execute).toHaveBeenCalledTimes(8);
     expect(updateSet).not.toHaveBeenCalled();

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -216,6 +216,12 @@ describe("encounter prescription lifecycle semantics", () => {
     expect(routerSource).toContain(
       'medication.effectiveStatus === "active"',
     );
+    expect(routerSource).toContain(".from(dispenseChargeQueue)");
+    expect(routerSource).toContain(
+      "eq(dispenseChargeQueue.appointmentId, input.appointmentId)",
+    );
+    expect(routerSource).toContain("visitDispenseIdsAlreadyIncluded");
+    expect(routerSource).toContain("new Map<string");
 
     const pageSource = readFileSync(
       new URL(

--- a/apps/web/server/__tests__/records-prescription-lifecycle.test.ts
+++ b/apps/web/server/__tests__/records-prescription-lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -116,6 +117,30 @@ afterEach(() => {
 });
 
 describe("prescription lifecycle mutations", () => {
+  it("locks a visit-linked refill in appointment then prescription order", () => {
+    const source = readFileSync(
+      new URL("../routers/records.ts", import.meta.url),
+      "utf8",
+    );
+    const block = source.slice(
+      source.indexOf("recordPrescriptionRefill:"),
+      source.indexOf(
+        "cancelPrescription:",
+        source.indexOf("recordPrescriptionRefill:"),
+      ),
+    );
+    const routeRead = block.indexOf("const [prescriptionIdentity]");
+    const appointmentLock = block.indexOf("lockOpenAppointmentForClinicalWork");
+    const prescriptionLock = block.indexOf("lockPrescriptionForLifecycle");
+    const productWrite = block.indexOf("deductDispensedProductStock");
+
+    expect(routeRead).toBeGreaterThan(-1);
+    expect(appointmentLock).toBeGreaterThan(routeRead);
+    expect(prescriptionLock).toBeGreaterThan(appointmentLock);
+    expect(productWrite).toBeGreaterThan(prescriptionLock);
+    expect(block).toContain("prescription.patientId !== routedPatientId");
+  });
+
   it("deducts stock, decrements refills, and appends one attributed event", async () => {
     const updated = activePrescription({ refillsRemaining: 1 });
     const event = {

--- a/apps/web/server/__tests__/visit-dispense-closure.integration.test.ts
+++ b/apps/web/server/__tests__/visit-dispense-closure.integration.test.ts
@@ -1,0 +1,386 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it, vi } from "vitest";
+import * as schema from "../../../../packages/db/schema/index";
+import { withTenant } from "@/lib/tenant-db";
+import {
+  assertNoUnresolvedVisitWork,
+  assertVisitInvoiceReadyForFinancialAction,
+} from "../visit-billing-integrity";
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/webhook-dispatcher", () => ({
+  dispatchWebhookEvent: vi.fn(async () => undefined),
+}));
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithPostgres =
+  process.env.VISIT_DISPENSE_DB_INTEGRATION === "1"
+    ? describe.sequential
+    : describe.skip;
+
+function runPnpm(args: string[], databaseUrl: string): void {
+  const pnpmCliPath = process.env.PNPM_CLI_PATH?.trim();
+  execFileSync(
+    pnpmCliPath ? process.execPath : "pnpm",
+    pnpmCliPath ? [pnpmCliPath, ...args] : args,
+    {
+      cwd: repoRoot,
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      encoding: "utf8",
+    },
+  );
+}
+
+describeWithPostgres(
+  "visit-linked dispense closure PostgreSQL contract",
+  () => {
+    it("surfaces and blocks an older-prescription refill until it is resolved", async () => {
+      const adminUrl = process.env.DATABASE_URL?.trim();
+      if (!adminUrl) throw new Error("DATABASE_URL is required");
+      const hostname = new URL(adminUrl).hostname;
+      if (!["localhost", "127.0.0.1", "::1"].includes(hostname)) {
+        throw new Error(
+          "This drill is restricted to disposable local PostgreSQL",
+        );
+      }
+      if (!process.env.OPENPIMS_APP_DB_PASSWORD?.trim()) {
+        throw new Error("OPENPIMS_APP_DB_PASSWORD is required");
+      }
+
+      const databaseName = `openpims_visit_dispense_${randomUUID().replaceAll("-", "")}`;
+      if (!/^openpims_visit_dispense_[a-f0-9]+$/.test(databaseName)) {
+        throw new Error("unsafe disposable database name");
+      }
+      const databaseUrl = new URL(adminUrl);
+      databaseUrl.pathname = `/${databaseName}`;
+      databaseUrl.search = "";
+      databaseUrl.hash = "";
+
+      const adminSql = postgres(adminUrl, { max: 1 });
+      let ownerSql: ReturnType<typeof postgres> | undefined;
+      let databaseCreated = false;
+
+      try {
+        await adminSql.unsafe(`create database "${databaseName}"`);
+        databaseCreated = true;
+        runPnpm(
+          ["--filter", "@openpims/db", "db:migrate"],
+          databaseUrl.toString(),
+        );
+        runPnpm(["--filter", "@openpims/db", "db:rls"], databaseUrl.toString());
+
+        ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+        const ownerDb = drizzle(ownerSql, { schema });
+        const practiceId = randomUUID();
+        const userId = randomUUID();
+        const locationId = randomUUID();
+        const clientId = randomUUID();
+        const patientId = randomUUID();
+        const appointmentId = randomUUID();
+        const productId = randomUUID();
+        const invoiceId = randomUUID();
+        const prescriptionId = randomUUID();
+        const eventId = randomUUID();
+
+        await ownerDb.insert(schema.practices).values({
+          id: practiceId,
+          name: "Synthetic visit-dispense clinic",
+          timezone: "UTC",
+        });
+        await ownerDb.insert(schema.users).values({
+          id: userId,
+          practiceId,
+          email: `visit-dispense-${userId}@example.invalid`,
+          passwordHash: "synthetic-not-a-login",
+          name: "Synthetic veterinarian",
+          role: "admin",
+          isVeterinarian: true,
+        });
+        await ownerDb.insert(schema.locations).values({
+          id: locationId,
+          practiceId,
+          name: "Synthetic location",
+          isPrimary: true,
+        });
+        await ownerDb.insert(schema.clients).values({
+          id: clientId,
+          practiceId,
+          firstName: "Synthetic",
+          lastName: "Client",
+        });
+        await ownerDb.insert(schema.patients).values({
+          id: patientId,
+          practiceId,
+          clientId,
+          name: "Synthetic Patient",
+          species: "canine",
+        });
+        await ownerDb.insert(schema.appointments).values({
+          id: appointmentId,
+          practiceId,
+          locationId,
+          startTime: new Date("2026-08-25T14:00:00.000Z"),
+          endTime: new Date("2026-08-25T15:00:00.000Z"),
+          patientId,
+          clientId,
+          doctorId: userId,
+          status: "in_exam",
+        });
+        await ownerDb.insert(schema.products).values({
+          id: productId,
+          practiceId,
+          locationId,
+          name: "Synthetic tracked medication",
+          unitPrice: "15.00",
+          taxable: true,
+          inventoryTracked: true,
+          stockQuantity: 10,
+        });
+        await ownerDb.insert(schema.invoices).values({
+          id: invoiceId,
+          practiceId,
+          clientId,
+          patientId,
+          appointmentId,
+          status: "draft",
+          subtotal: "25.00",
+          tax: "0.00",
+          total: "25.00",
+          paidAmount: "0.00",
+          isEstimate: false,
+        });
+        await ownerDb.insert(schema.invoiceItems).values({
+          invoiceId,
+          description: "Synthetic visit charge",
+          quantity: 1,
+          unitPrice: "25.00",
+          total: "25.00",
+          taxable: false,
+          itemType: "product",
+          itemId: productId,
+        });
+        // This prescription predates the visit; only its refill dispense is
+        // linked to the current appointment.
+        await ownerDb.insert(schema.prescriptions).values({
+          id: prescriptionId,
+          practiceId,
+          patientId,
+          appointmentId: null,
+          medicationName: "Synthetic medication",
+          dosage: "25 mg",
+          frequency: "Once daily",
+          quantity: 2,
+          productId,
+          refillsRemaining: 1,
+          prescribedBy: userId,
+          startDate: "2026-08-01",
+          status: "active",
+        });
+        await ownerDb.insert(schema.prescriptionEvents).values({
+          id: eventId,
+          practiceId,
+          prescriptionId,
+          patientId,
+          productId,
+          eventType: "created",
+          quantity: 2,
+          statusBefore: null,
+          statusAfter: "active",
+          refillsBefore: null,
+          refillsAfter: 1,
+          reason: null,
+          actorId: userId,
+          actorName: "Synthetic veterinarian",
+        });
+
+        process.env.DATABASE_URL = databaseUrl.toString();
+        const [{ encountersRouter }, { billingRouter }, { recordsRouter }] =
+          await Promise.all([
+            import("../routers/encounters"),
+            import("../routers/billing"),
+            import("../routers/records"),
+          ]);
+        const callerContext = {
+          db: ownerDb,
+          session: {
+            user: {
+              id: userId,
+              email: `visit-dispense-${userId}@example.invalid`,
+              name: "Synthetic veterinarian",
+              role: "admin",
+              practiceId,
+            },
+          },
+        } as never;
+        const caller = encountersRouter.createCaller(callerContext);
+        const billingCaller = billingRouter.createCaller(callerContext);
+        const recordsCaller = recordsRouter.createCaller(callerContext);
+
+        await ownerSql`set role openpims_app`;
+        await expect(
+          recordsCaller.recordPrescriptionRefill({
+            id: prescriptionId,
+            operationId: randomUUID(),
+            appointmentId,
+            note: "Synthetic closure drill",
+          }),
+        ).resolves.toMatchObject({
+          replayed: false,
+          prescription: { refillsRemaining: 0 },
+          event: { eventType: "refill_dispensed" },
+        });
+        const [createdQueue] = await withTenant(ownerDb, practiceId, (tx) =>
+          tx
+            .select({
+              id: schema.dispenseChargeQueue.id,
+              status: schema.dispenseChargeQueue.status,
+            })
+            .from(schema.dispenseChargeQueue)
+            .where(eq(schema.dispenseChargeQueue.appointmentId, appointmentId)),
+        );
+        expect(createdQueue?.status).toBe("pending");
+        const queueId = createdQueue?.id;
+        if (!queueId)
+          throw new Error("refill did not create a dispense charge");
+        const [stockAfterRefill] = await withTenant(ownerDb, practiceId, (tx) =>
+          tx
+            .select({ stockQuantity: schema.products.stockQuantity })
+            .from(schema.products)
+            .where(eq(schema.products.id, productId)),
+        );
+        expect(stockAfterRefill?.stockQuantity).toBe(8);
+
+        await ownerSql`reset role`;
+        await ownerDb.insert(schema.visitCloseouts).values({
+          practiceId,
+          appointmentId,
+          status: "clinical_finalized",
+          prescriptionDisposition: "prescribed",
+          medicationSnapshot: [
+            {
+              prescriptionId,
+              medicationName: "Synthetic medication",
+              dosage: "25 mg",
+              frequency: "Once daily",
+              instructions: null,
+              quantity: 2,
+            },
+          ],
+          noInstructionsReason: "Synthetic drill has no owner instructions.",
+          followUpDisposition: "none",
+          documentationExceptionReason: "Synthetic closure drill.",
+          clinicalFinalizedAt: new Date(),
+          clinicalFinalizedBy: userId,
+          clinicalFinalizerName: "Synthetic veterinarian",
+          revision: 1,
+        });
+
+        await ownerSql`set role openpims_app`;
+        const [withoutTenantContext] = await ownerSql<
+          Array<{ count: number }>
+        >`select count(*)::int as count from dispense_charge_queue`;
+        expect(withoutTenantContext?.count).toBe(0);
+
+        const closeout = await caller.getCloseout({ appointmentId });
+        expect(closeout.medications).toEqual([
+          expect.objectContaining({
+            id: prescriptionId,
+            dispenseChargeId: queueId,
+            dispenseChargeStatus: "pending",
+            productId,
+            quantity: 2,
+          }),
+        ]);
+        expect(closeout.activeMedications).toEqual([
+          expect.objectContaining({
+            id: prescriptionId,
+            dispenseChargeId: queueId,
+          }),
+        ]);
+
+        await expect(
+          caller.completeVisit({
+            appointmentId,
+            expectedRevision: 1,
+            chargeDisposition: "no_charge",
+            noChargeReason: "Synthetic no-charge checkout",
+            handoffMethod: "print",
+          }),
+        ).rejects.toMatchObject({
+          code: "PRECONDITION_FAILED",
+          message: expect.stringContaining("medication dispense"),
+        });
+        await expect(
+          billingCaller.updateInvoiceStatus({ id: invoiceId, status: "sent" }),
+        ).rejects.toMatchObject({
+          code: "PRECONDITION_FAILED",
+          message: expect.stringContaining("medication dispense"),
+        });
+        await expect(
+          withTenant(ownerDb, practiceId, (tx) =>
+            assertVisitInvoiceReadyForFinancialAction(
+              { db: tx, practiceId },
+              appointmentId,
+            ),
+          ),
+        ).rejects.toMatchObject({
+          code: "PRECONDITION_FAILED",
+          message: expect.stringContaining("medication dispense"),
+        });
+        const stillOpen = await withTenant(ownerDb, practiceId, (tx) =>
+          tx
+            .select({ status: schema.appointments.status })
+            .from(schema.appointments)
+            .where(eq(schema.appointments.id, appointmentId)),
+        );
+        expect(stillOpen).toEqual([{ status: "in_exam" }]);
+
+        await ownerSql`reset role`;
+        await ownerDb
+          .update(schema.dispenseChargeQueue)
+          .set({
+            status: "waived",
+            resolvedBy: userId,
+            resolvedByName: "Synthetic veterinarian",
+            resolvedAt: new Date(),
+            resolutionReason: "Synthetic no-charge resolution",
+          })
+          .where(eq(schema.dispenseChargeQueue.id, queueId));
+        await ownerSql`set role openpims_app`;
+
+        await expect(
+          withTenant(ownerDb, practiceId, (tx) =>
+            assertNoUnresolvedVisitWork({ db: tx, practiceId }, appointmentId),
+          ),
+        ).resolves.toBeUndefined();
+        await expect(
+          withTenant(ownerDb, practiceId, (tx) =>
+            assertVisitInvoiceReadyForFinancialAction(
+              { db: tx, practiceId },
+              appointmentId,
+            ),
+          ),
+        ).resolves.toBeUndefined();
+      } finally {
+        process.env.DATABASE_URL = adminUrl;
+        if (ownerSql) await ownerSql.end();
+        try {
+          if (databaseCreated) {
+            await adminSql.unsafe(
+              `drop database if exists "${databaseName}" with (force)`,
+            );
+          }
+        } finally {
+          await adminSql.end();
+        }
+      }
+    }, 120_000);
+  },
+);

--- a/apps/web/server/__tests__/visit-work-reconciliation.test.ts
+++ b/apps/web/server/__tests__/visit-work-reconciliation.test.ts
@@ -143,6 +143,12 @@ describe("visit work reconciliation", () => {
     expect(integritySource).toMatch(
       /select \$\{labResults\.id\} as id[\s\S]*order by \$\{labResults\.id\}[\s\S]*\) as lab_source/,
     );
+    expect(integritySource).toContain(
+      "${dispenseChargeQueue.appointmentId} = ${appointmentId}",
+    );
+    expect(integritySource).toContain(
+      "${dispenseChargeQueue.status} = 'pending'",
+    );
   });
 
   it("does not create unresolved ledger work for a historical closed visit", async () => {

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -705,6 +705,7 @@ export const encountersRouter = createRouter({
         soapDraftRows,
         missingSoapReplacementRows,
         medications,
+        visitDispenses,
         followUpAppointments,
         followUpAssignees,
       ] = await Promise.all([
@@ -823,7 +824,50 @@ export const encountersRouter = createRouter({
             ),
           )
           .orderBy(desc(prescriptions.createdAt)),
-          appointment.patientId && appointment.clientId
+        ctx.db
+          .select({
+            id: prescriptions.id,
+            medicationName: prescriptions.medicationName,
+            dosage: prescriptions.dosage,
+            frequency: prescriptions.frequency,
+            instructions: prescriptions.instructions,
+            quantity: dispenseChargeQueue.quantity,
+            productId: dispenseChargeQueue.productId,
+            productName: products.name,
+            productTaxable: products.taxable,
+            productUnitPrice: dispenseChargeQueue.unitPriceSnapshot,
+            dispenseChargeId: dispenseChargeQueue.id,
+            dispenseChargeStatus: dispenseChargeQueue.status,
+            dispenseChargeDescription: dispenseChargeQueue.descriptionSnapshot,
+            status: prescriptions.status,
+            endDate: prescriptions.endDate,
+          })
+          .from(dispenseChargeQueue)
+          .innerJoin(
+            prescriptions,
+            and(
+              eq(dispenseChargeQueue.prescriptionId, prescriptions.id),
+              eq(prescriptions.practiceId, ctx.practiceId),
+            ),
+          )
+          .leftJoin(
+            products,
+            and(
+              eq(dispenseChargeQueue.productId, products.id),
+              eq(products.practiceId, ctx.practiceId),
+            ),
+          )
+          .where(
+            and(
+              eq(dispenseChargeQueue.practiceId, ctx.practiceId),
+              eq(dispenseChargeQueue.appointmentId, input.appointmentId),
+            ),
+          )
+          .orderBy(
+            desc(dispenseChargeQueue.createdAt),
+            desc(dispenseChargeQueue.id),
+          ),
+        appointment.patientId && appointment.clientId
             ? ctx.db
                 .select({
                   id: appointments.id,
@@ -885,7 +929,20 @@ export const encountersRouter = createRouter({
         new Date(),
         appointment.practiceTimezone,
       );
-      const medicationHistory = medications.map((medication) => ({
+      const visitDispenseIdsAlreadyIncluded = new Set(
+        medications
+          .map((medication) => medication.dispenseChargeId)
+          .filter((id): id is string => Boolean(id)),
+      );
+      const chargeCaptureMedications = [
+        ...medications,
+        ...visitDispenses.filter(
+          (medication) =>
+            !medication.dispenseChargeId ||
+            !visitDispenseIdsAlreadyIncluded.has(medication.dispenseChargeId),
+        ),
+      ];
+      const medicationHistory = chargeCaptureMedications.map((medication) => ({
         ...medication,
         effectiveStatus: effectivePrescriptionStatus({
           status: medication.status,
@@ -893,6 +950,17 @@ export const encountersRouter = createRouter({
           today: practiceToday,
         }),
       }));
+      const activeMedications = [
+        ...medicationHistory
+          .filter((medication) => medication.effectiveStatus === "active")
+          .reduce((byPrescription, medication) => {
+            if (!byPrescription.has(medication.id)) {
+              byPrescription.set(medication.id, medication);
+            }
+            return byPrescription;
+          }, new Map<string, (typeof medicationHistory)[number]>())
+          .values(),
+      ];
 
       return {
         closeout,
@@ -912,9 +980,7 @@ export const encountersRouter = createRouter({
             ? (missingSoapReplacementRows[0] ?? null)
             : null,
         medications: medicationHistory,
-        activeMedications: medicationHistory.filter(
-          (medication) => medication.effectiveStatus === "active",
-        ),
+        activeMedications,
         followUpAppointments,
         followUpAssignees,
         invoices: invoiceSummaries,

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -2944,22 +2944,51 @@ export const recordsRouter = createRouter({
         });
         if (replay) return replay;
 
-        const prescription = await lockPrescriptionForLifecycle(
-          txCtx,
-          input.id,
-        );
+        let routedPatientId: string | null = null;
         if (input.appointmentId) {
+          const [prescriptionIdentity] = await tx
+            .select({ patientId: prescriptions.patientId })
+            .from(prescriptions)
+            .where(
+              and(
+                eq(prescriptions.id, input.id),
+                eq(prescriptions.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(prescriptions.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!prescriptionIdentity) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Prescription not found",
+            });
+          }
+          routedPatientId = prescriptionIdentity.patientId;
           await assertAppointmentBelongsToPatient(
             txCtx,
             input.appointmentId,
-            prescription.patientId,
+            routedPatientId,
           );
           await lockOpenAppointmentForClinicalWork(
             txCtx,
             input.appointmentId,
-            prescription.patientId,
+            routedPatientId,
             "prescriptions",
           );
+        }
+        // Visit-linked work follows appointment -> prescription -> product.
+        // Keep refills in that canonical order to avoid a lock cycle with
+        // invoice and charge-capture paths.
+        const prescription = await lockPrescriptionForLifecycle(
+          txCtx,
+          input.id,
+        );
+        if (routedPatientId && prescription.patientId !== routedPatientId) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Prescription patient changed. Refresh and try again.",
+          });
         }
         const today = await practiceDateInput(txCtx);
         const effectiveStatus = effectivePrescriptionStatus({

--- a/apps/web/server/visit-billing-integrity.ts
+++ b/apps/web/server/visit-billing-integrity.ts
@@ -6,6 +6,7 @@ import {
   invoices,
   auditLog,
   clinicalRecordCorrections,
+  dispenseChargeQueue,
   labResults,
   prescriptions,
   procedures,
@@ -203,34 +204,43 @@ export async function syncVisitWorkItems(ctx: VisitBillingContext, appointmentId
 export async function assertNoUnresolvedVisitWork(
   ctx: VisitBillingContext,
   appointmentId: string,
-  message = "Resolve every performed vaccination, lab, procedure, and prescription as charged, no charge, or void/corrected before checkout."
+  message = "Resolve every performed vaccination, lab, procedure, prescription, and medication dispense as charged, no charge, waived, or void/corrected before checkout."
 ) {
   const rows = await ctx.db.execute(sql`
-    select ${visitWorkItems.id}
-    from ${visitWorkItems}
-    left join ${invoiceItems}
-      on ${invoiceItems.id} = ${visitWorkItems.invoiceItemId}
-    left join ${invoices}
-      on ${invoices.id} = ${visitWorkItems.invoiceId}
-      and ${invoices.practiceId} = ${ctx.practiceId}
-      and ${invoices.appointmentId} = ${appointmentId}
-    where ${visitWorkItems.practiceId} = ${ctx.practiceId}
-      and ${visitWorkItems.appointmentId} = ${appointmentId}
-      and (
-        ${visitWorkItems.status} = 'unresolved'
-        or (
-          ${visitWorkItems.status} = 'charged'
-          and (
-            ${invoiceItems.id} is null
-            or ${invoiceItems.deletedAt} is not null
-            or ${invoices.id} is null
-            or ${invoices.deletedAt} is not null
-            or ${invoices.status} = 'void'
+    select unresolved.id
+    from (
+      select ${visitWorkItems.id} as id, ${visitWorkItems.createdAt} as created_at
+      from ${visitWorkItems}
+      left join ${invoiceItems}
+        on ${invoiceItems.id} = ${visitWorkItems.invoiceItemId}
+      left join ${invoices}
+        on ${invoices.id} = ${visitWorkItems.invoiceId}
+        and ${invoices.practiceId} = ${ctx.practiceId}
+        and ${invoices.appointmentId} = ${appointmentId}
+      where ${visitWorkItems.practiceId} = ${ctx.practiceId}
+        and ${visitWorkItems.appointmentId} = ${appointmentId}
+        and (
+          ${visitWorkItems.status} = 'unresolved'
+          or (
+            ${visitWorkItems.status} = 'charged'
+            and (
+              ${invoiceItems.id} is null
+              or ${invoiceItems.deletedAt} is not null
+              or ${invoices.id} is null
+              or ${invoices.deletedAt} is not null
+              or ${invoices.status} = 'void'
+            )
           )
         )
-      )
-      and ${visitWorkItems.deletedAt} is null
-    order by ${visitWorkItems.createdAt}, ${visitWorkItems.id}
+        and ${visitWorkItems.deletedAt} is null
+      union all
+      select ${dispenseChargeQueue.id} as id, ${dispenseChargeQueue.createdAt} as created_at
+      from ${dispenseChargeQueue}
+      where ${dispenseChargeQueue.practiceId} = ${ctx.practiceId}
+        and ${dispenseChargeQueue.appointmentId} = ${appointmentId}
+        and ${dispenseChargeQueue.status} = 'pending'
+    ) unresolved
+    order by unresolved.created_at, unresolved.id
     limit 1
   `);
   if (rowsFromExecute<{ id: string }>(rows).length > 0) {
@@ -273,7 +283,7 @@ export async function assertVisitInvoiceReadyForFinancialAction(
   await assertNoUnresolvedVisitWork(
     ctx,
     appointmentId,
-    "Resolve every performed vaccination, lab, procedure, and prescription before sending or collecting this visit invoice."
+    "Resolve every performed vaccination, lab, procedure, prescription, and medication dispense before sending or collecting this visit invoice."
   );
 }
 


### PR DESCRIPTION
## Recovery scope

Current-base Slice A successor to #198. The old PR is conflicting and must not be merged or rebased wholesale.

This slice recovers only the visit-dispense closure boundary:

- pending visit-linked dispense charges block checkout and financial actions
- older-prescription refills appear in closeout medication history
- active medication history deduplicates by prescription
- refill mutation follows appointment → prescription → product lock order
- the real PostgreSQL/RLS contract invokes the actual refill route and proves tracked stock moves exactly once from 10 to 8

## Change boundary

- Server safety kernel, focused tests, and one dedicated CI database gate
- No UI or estimate-conversion changes
- No schema or migration changes
- No dependency changes
- Preserves later inventoryTracked/trackedStockOwnedItems semantics

## Exact local gate

Reviewed SHA: 521fffb5b60d79a36c78f0a0dbde0d0caafd0b9d
Tree: 0018bb9bd5d12b5340f35e3c76bd4e6ee3abef4f
Base: development@d8d12c4a4ef0d235015d0b8fa8db7aa087e6b588

- 56/56 focused unit tests passed
- disposable real PostgreSQL/RLS integration passed 1/1
- migration integrity passed 82 with 1 expected skip
- web TypeScript passed
- git diff --check passed
- clean worktree and no disposable database remained
- independent review: no P0/P1; GO for draft only

## Release boundary

Keep this PR draft until exact-head GitHub CI and final review pass. Preview deployment remains quarantined. This PR is not approved for staging or main promotion.