### PR TITLE
fix(billing): recover atomic estimate conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,14 @@ jobs:
           VISIT_DISPENSE_DB_INTEGRATION: "1"
         run: pnpm --filter @openpims/web exec vitest run server/__tests__/visit-dispense-closure.integration.test.ts
 
+      # Converting an estimate is one stock-owning state transition. Prove that
+      # concurrent visit billing converges, tracked stock changes once, and all
+      # stock/invoice/audit writes roll back together under least-privilege RLS.
+      - name: Execute estimate conversion database contract
+        env:
+          BILLING_CONVERSION_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run server/__tests__/billing-estimate-conversion.integration.test.ts
+
       # Compile, bind, and execute the exact read-only SQL used by the shared
       # platform-admin and daily SMS operations queues. Unit tests cannot catch
       # postgres.js timestamp encoders or correlated identifier rendering.

--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -219,7 +219,7 @@ export default function BillingPage() {
 
   const convertEstimate = trpc.billing.convertEstimateToInvoice.useMutation({
     onSuccess: () => {
-      toast.success("Estimate converted to invoice");
+      toast.success("Estimate converted to draft invoice");
     },
     onError: (err) => {
       toast.error(err.message);

--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -159,6 +159,11 @@ export default function BillingPage() {
   const [pendingInvoiceVoidId, setPendingInvoiceVoidId] = useState<
     string | null
   >(null);
+  const [pendingEstimateConversion, setPendingEstimateConversion] = useState<{
+    id: string;
+    updatedAt: Date;
+    appointmentId: string | null;
+  } | null>(null);
   const [invoiceVoidReason, setInvoiceVoidReason] = useState("");
   const limit = 25;
 
@@ -215,10 +220,31 @@ export default function BillingPage() {
   const convertEstimate = trpc.billing.convertEstimateToInvoice.useMutation({
     onSuccess: () => {
       toast.success("Estimate converted to invoice");
-      utils.billing.listInvoices.invalidate();
     },
     onError: (err) => {
       toast.error(err.message);
+    },
+    onSettled: async (_invoice, _error, variables) => {
+      const appointmentId = pendingEstimateConversion?.appointmentId ?? null;
+      try {
+        await Promise.all([
+          utils.billing.listInvoices.invalidate(),
+          utils.billing.getInvoice.invalidate({ id: variables.id }),
+          utils.billing.listProducts.invalidate(),
+          utils.inventory.list.invalidate(),
+          utils.billing.listDispenseChargeQueue.invalidate(),
+          ...(appointmentId
+            ? [
+                utils.encounters.getCloseout.invalidate({ appointmentId }),
+                utils.encounters.getVisitReconciliation.invalidate({
+                  appointmentId,
+                }),
+              ]
+            : []),
+        ]);
+      } finally {
+        setPendingEstimateConversion(null);
+      }
     },
   });
 
@@ -243,9 +269,33 @@ export default function BillingPage() {
     updateStatus.mutate({ id, status });
   };
 
-  const handleConvertEstimate = (e: React.MouseEvent, id: string) => {
+  const handleConvertEstimate = (
+    e: React.MouseEvent,
+    estimate: {
+      id: string;
+      updatedAt: Date | string;
+      appointmentId: string | null;
+    }
+  ) => {
     e.stopPropagation();
-    convertEstimate.mutate({ id });
+    setPendingEstimateConversion({
+      id: estimate.id,
+      updatedAt: new Date(estimate.updatedAt),
+      appointmentId: estimate.appointmentId,
+    });
+  };
+
+  const closeEstimateConversionDialog = () => {
+    if (convertEstimate.isPending) return;
+    setPendingEstimateConversion(null);
+  };
+
+  const confirmEstimateConversion = () => {
+    if (!pendingEstimateConversion || convertEstimate.isPending) return;
+    convertEstimate.mutate({
+      id: pendingEstimateConversion.id,
+      expectedUpdatedAt: pendingEstimateConversion.updatedAt,
+    });
   };
 
   const handleVoidInvoice = (e: React.MouseEvent, id: string) => {
@@ -493,6 +543,16 @@ export default function BillingPage() {
           }
         />
       )}
+
+      <ActionConfirmationDialog
+        open={pendingEstimateConversion !== null}
+        title="Convert estimate to invoice?"
+        description="This deducts tracked product stock and creates a draft invoice. It does not charge the client or automatically reconcile visit work."
+        confirmLabel="Convert to invoice"
+        isPending={convertEstimate.isPending}
+        onCancel={closeEstimateConversionDialog}
+        onConfirm={confirmEstimateConversion}
+      />
 
       <ActionConfirmationDialog
         open={pendingInvoiceVoidId !== null}
@@ -984,6 +1044,7 @@ function InvoiceRow({
     adjustedAmount?: string | null;
     dueDate: string | null;
     createdAt: Date | string | null;
+    updatedAt: Date | string;
     isEstimate: boolean;
     appointmentId: string | null;
     clientFirstName: string | null;
@@ -997,7 +1058,14 @@ function InvoiceRow({
     id: string,
     status: "sent"
   ) => void;
-  onConvertEstimate: (e: React.MouseEvent, id: string) => void;
+  onConvertEstimate: (
+    e: React.MouseEvent,
+    estimate: {
+      id: string;
+      updatedAt: Date | string;
+      appointmentId: string | null;
+    }
+  ) => void;
   onVoidInvoice: (e: React.MouseEvent, id: string) => void;
   practiceName: string;
   billingTimeZone?: string | null;
@@ -1067,7 +1135,7 @@ function InvoiceRow({
                 variant="ghost"
                 size="sm"
                 disabled={isMutating}
-                onClick={(e) => onConvertEstimate(e, invoice.id)}
+                onClick={(e) => onConvertEstimate(e, invoice)}
                 title="Convert to Invoice"
               >
                 <ArrowRightLeft className="h-3.5 w-3.5" />
@@ -1201,7 +1269,7 @@ function InvoiceRow({
                         <Button
                           size="sm"
                           disabled={isMutating}
-                          onClick={(e) => onConvertEstimate(e, invoice.id)}
+                          onClick={(e) => onConvertEstimate(e, invoice)}
                         >
                           <CheckCircle className="mr-1 h-3.5 w-3.5" />
                           Approve &amp; Convert

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -559,8 +559,12 @@ const sections: Section[] = [
       {
         name: "billing.convertEstimateToInvoice",
         method: "POST",
-        description: "Convert an approved estimate into a billable invoice.",
-        input: `{ id: string }`,
+        description:
+          "Convert the displayed estimate version into a draft invoice and deduct tracked product stock atomically. This does not charge the client or automatically reconcile visit work.",
+        input: `{
+  id: string,
+  expectedUpdatedAt: Date // updatedAt from the displayed estimate
+}`,
         response: `Invoice`,
       },
       {

--- a/apps/web/lib/__tests__/api-docs.test.ts
+++ b/apps/web/lib/__tests__/api-docs.test.ts
@@ -157,6 +157,13 @@ describe("API reference docs", () => {
       "Instruction text is trimmed and must be nonblank",
     );
     expect(source).toContain("/api/trpc/ + /api/v1/");
+    expect(source).toContain('name: "billing.convertEstimateToInvoice"');
+    expect(source).toContain(
+      "expectedUpdatedAt: Date // updatedAt from the displayed estimate",
+    );
+    expect(source).toContain("deduct tracked product stock atomically");
+    expect(source).toContain("does not charge the client");
+    expect(source).toContain("automatically reconcile visit work");
     expect(source).not.toContain("All endpoints are available via tRPC");
     expect(source).not.toContain("All endpoints use tRPC");
   });

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -187,6 +187,43 @@ describe("billing invoice form UX", () => {
 describe("billing invoice payment actions", () => {
   const source = readFileSync("app/(dashboard)/billing/page.tsx", "utf8");
 
+  it("requires explicit versioned confirmation before converting an estimate", () => {
+    expect(source).toContain('title="Convert estimate to invoice?"');
+    expect(source).toContain(
+      "This deducts tracked product stock and creates a draft invoice.",
+    );
+    expect(source).toContain("It does not charge the client");
+    expect(source).toContain("automatically reconcile visit work");
+    expect(source).toContain(
+      "expectedUpdatedAt: pendingEstimateConversion.updatedAt",
+    );
+    expect(source).toContain("isPending={convertEstimate.isPending}");
+    expect(source).toContain("if (convertEstimate.isPending) return");
+    expect(source).not.toContain("window.confirm");
+  });
+
+  it("refreshes every conversion-dependent surface after success or failure", () => {
+    const conversionBlock = source.slice(
+      source.indexOf(
+        "const convertEstimate = trpc.billing.convertEstimateToInvoice",
+      ),
+      source.indexOf("const voidInvoice ="),
+    );
+    expect(conversionBlock).toContain("onSettled:");
+    expect(conversionBlock).toContain("Promise.all([");
+    expect(conversionBlock).toContain("utils.billing.listInvoices.invalidate()");
+    expect(conversionBlock).toContain("utils.billing.getInvoice.invalidate");
+    expect(conversionBlock).toContain("utils.billing.listProducts.invalidate()");
+    expect(conversionBlock).toContain("utils.inventory.list.invalidate()");
+    expect(conversionBlock).toContain(
+      "utils.billing.listDispenseChargeQueue.invalidate()",
+    );
+    expect(conversionBlock).toContain("utils.encounters.getCloseout.invalidate");
+    expect(conversionBlock).toContain(
+      "utils.encounters.getVisitReconciliation.invalidate",
+    );
+  });
+
   it("only offers payment collection for sent or overdue invoice balances", () => {
     expect(source).toContain(
       'canManageBilling &&\n    (invoiceStatus === "sent" || invoiceStatus === "overdue") &&\n    remaining > 0',

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -197,6 +197,9 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain(
       "expectedUpdatedAt: pendingEstimateConversion.updatedAt",
     );
+    expect(source).toContain(
+      'toast.success("Estimate converted to draft invoice")',
+    );
     expect(source).toContain("isPending={convertEstimate.isPending}");
     expect(source).toContain("if (convertEstimate.isPending) return");
     expect(source).not.toContain("window.confirm");

--- a/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
+++ b/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
@@ -1,0 +1,531 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it, vi } from "vitest";
+import * as schema from "../../../../packages/db/schema/index";
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/webhook-dispatcher", () => ({
+  dispatchWebhookEvent: vi.fn(async () => undefined),
+}));
+
+const repoRoot = resolve(process.cwd(), "../..");
+const describeWithPostgres =
+  process.env.BILLING_CONVERSION_DB_INTEGRATION === "1"
+    ? describe.sequential
+    : describe.skip;
+
+function runPnpm(args: string[], databaseUrl: string): void {
+  const pnpmCliPath = process.env.PNPM_CLI_PATH?.trim();
+  execFileSync(
+    pnpmCliPath ? process.execPath : "pnpm",
+    pnpmCliPath ? [pnpmCliPath, ...args] : args,
+    {
+      cwd: repoRoot,
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      encoding: "utf8",
+    },
+  );
+}
+
+async function within<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} exceeded ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function rejectionDetails(reason: unknown): string {
+  const details: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = reason;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    if (current instanceof Error) details.push(current.message);
+    if (typeof current === "object") {
+      const record = current as Record<string, unknown>;
+      if (typeof record.code === "string") details.push(record.code);
+      current = record.cause;
+    } else {
+      details.push(String(current));
+      break;
+    }
+  }
+  return details.join(" | ");
+}
+
+function assertNoDeadlock(
+  results: readonly PromiseSettledResult<unknown>[],
+): void {
+  for (const result of results) {
+    if (result.status !== "rejected") continue;
+    const details = rejectionDetails(result.reason);
+    expect(details).not.toContain("40P01");
+    expect(details.toLowerCase()).not.toContain("deadlock detected");
+  }
+}
+
+function assertSingleDomainRejection(
+  results: readonly PromiseSettledResult<unknown>[],
+  code: string,
+): void {
+  const rejected = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  expect(rejected).toHaveLength(1);
+  expect(rejectionDetails(rejected[0]!.reason)).toContain(code);
+}
+
+describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
+  it("serializes competing invoices and rolls back conversion failures under RLS", async () => {
+    const adminUrl = process.env.DATABASE_URL?.trim();
+    if (!adminUrl) throw new Error("DATABASE_URL is required");
+    const hostname = new URL(adminUrl).hostname;
+    if (!["localhost", "127.0.0.1", "::1"].includes(hostname)) {
+      throw new Error(
+        "This drill is restricted to disposable local PostgreSQL",
+      );
+    }
+    const appPassword = process.env.OPENPIMS_APP_DB_PASSWORD?.trim();
+    if (!appPassword) throw new Error("OPENPIMS_APP_DB_PASSWORD is required");
+
+    const databaseName = `openpims_estimate_conversion_${randomUUID().replaceAll("-", "")}`;
+    if (!/^openpims_estimate_conversion_[a-f0-9]+$/.test(databaseName)) {
+      throw new Error("unsafe disposable database name");
+    }
+    const databaseUrl = new URL(adminUrl);
+    databaseUrl.pathname = `/${databaseName}`;
+    databaseUrl.search = "";
+    databaseUrl.hash = "";
+    const appUrl = new URL(databaseUrl);
+    appUrl.username = "openpims_app";
+    appUrl.password = appPassword;
+
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+    const adminSql = postgres(adminUrl, { max: 1 });
+    let ownerSql: ReturnType<typeof postgres> | undefined;
+    let appSql: ReturnType<typeof postgres> | undefined;
+    let databaseCreated = false;
+
+    try {
+      await adminSql.unsafe(`create database "${databaseName}"`);
+      databaseCreated = true;
+      runPnpm(
+        ["--filter", "@openpims/db", "db:migrate"],
+        databaseUrl.toString(),
+      );
+      runPnpm(["--filter", "@openpims/db", "db:rls"], databaseUrl.toString());
+
+      ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+      appSql = postgres(appUrl.toString(), { max: 8 });
+      const ownerDb = drizzle(ownerSql, { schema });
+      const appDb = drizzle(appSql, { schema });
+      process.env.DATABASE_URL = appUrl.toString();
+      const [{ billingRouter }, { recordsRouter }] = await Promise.all([
+        import("../routers/billing"),
+        import("../routers/records"),
+      ]);
+
+      type Fixture = {
+        practiceId: string;
+        userId: string;
+        locationId: string;
+        clientId: string;
+        patientId: string;
+        appointmentId: string;
+      };
+      const createFixture = async (): Promise<Fixture> => {
+        const fixture = {
+          practiceId: randomUUID(),
+          userId: randomUUID(),
+          locationId: randomUUID(),
+          clientId: randomUUID(),
+          patientId: randomUUID(),
+          appointmentId: randomUUID(),
+        };
+        await ownerDb.insert(schema.practices).values({
+          id: fixture.practiceId,
+          name: `Synthetic conversion clinic ${fixture.practiceId}`,
+        });
+        await ownerDb.insert(schema.users).values({
+          id: fixture.userId,
+          practiceId: fixture.practiceId,
+          email: `conversion-${fixture.userId}@example.invalid`,
+          passwordHash: "synthetic-not-a-login",
+          name: "Synthetic billing operator",
+          role: "admin",
+        });
+        await ownerDb.insert(schema.locations).values({
+          id: fixture.locationId,
+          practiceId: fixture.practiceId,
+          name: "Synthetic location",
+          isPrimary: true,
+        });
+        await ownerDb.insert(schema.clients).values({
+          id: fixture.clientId,
+          practiceId: fixture.practiceId,
+          firstName: "Synthetic",
+          lastName: "Client",
+        });
+        await ownerDb.insert(schema.patients).values({
+          id: fixture.patientId,
+          practiceId: fixture.practiceId,
+          clientId: fixture.clientId,
+          name: "Synthetic Patient",
+          species: "canine",
+        });
+        await ownerDb.insert(schema.appointments).values({
+          id: fixture.appointmentId,
+          practiceId: fixture.practiceId,
+          locationId: fixture.locationId,
+          startTime: new Date("2026-08-25T14:00:00.000Z"),
+          endTime: new Date("2026-08-25T15:00:00.000Z"),
+          patientId: fixture.patientId,
+          clientId: fixture.clientId,
+          status: "in_exam",
+        });
+        return fixture;
+      };
+      const createProduct = async (
+        fixture: Fixture,
+        stockQuantity: number,
+        inventoryTracked = true,
+      ) => {
+        const id = randomUUID();
+        await ownerDb.insert(schema.products).values({
+          id,
+          practiceId: fixture.practiceId,
+          locationId: fixture.locationId,
+          name: `Synthetic product ${id}`,
+          unitPrice: "15.00",
+          taxable: true,
+          inventoryTracked,
+          stockQuantity,
+          reorderPoint: inventoryTracked ? 10 : null,
+        });
+        return id;
+      };
+      type EstimateLine = {
+        productId: string;
+        quantity: number;
+      };
+      const createEstimate = async (
+        fixture: Fixture,
+        lines: EstimateLine[],
+      ) => {
+        const id = randomUUID();
+        const updatedAt = new Date();
+        const subtotal = lines.reduce(
+          (sum, line) => sum + line.quantity * 15,
+          0,
+        );
+        await ownerDb.insert(schema.invoices).values({
+          id,
+          practiceId: fixture.practiceId,
+          clientId: fixture.clientId,
+          patientId: fixture.patientId,
+          appointmentId: fixture.appointmentId,
+          status: "draft",
+          subtotal: subtotal.toFixed(2),
+          tax: "0.00",
+          total: subtotal.toFixed(2),
+          paidAmount: "0.00",
+          isEstimate: true,
+          updatedAt,
+        });
+        await ownerDb.insert(schema.invoiceItems).values(
+          lines.map((line) => ({
+            invoiceId: id,
+            description: `Synthetic product ${line.productId}`,
+            quantity: line.quantity,
+            unitPrice: "15.00",
+            total: (line.quantity * 15).toFixed(2),
+            taxable: true,
+            itemType: "product" as const,
+            itemId: line.productId,
+          })),
+        );
+        return { id, updatedAt };
+      };
+      const callerContext = (fixture: Fixture) =>
+        ({
+          db: appDb,
+          session: {
+            user: {
+              id: fixture.userId,
+              email: `conversion-${fixture.userId}@example.invalid`,
+              name: "Synthetic billing operator",
+              role: "admin",
+              practiceId: fixture.practiceId,
+            },
+          },
+        }) as never;
+      const caller = (fixture: Fixture) =>
+        billingRouter.createCaller(callerContext(fixture));
+      const recordsCaller = (fixture: Fixture) =>
+        recordsRouter.createCaller(callerContext(fixture));
+      const stock = async (productId: string) => {
+        const [row] = await ownerDb
+          .select({ stockQuantity: schema.products.stockQuantity })
+          .from(schema.products)
+          .where(eq(schema.products.id, productId));
+        return row?.stockQuantity;
+      };
+      const conversionAuditCount = async (practiceId: string) => {
+        const rows = await ownerDb
+          .select({ id: schema.auditLog.id })
+          .from(schema.auditLog)
+          .where(
+            and(
+              eq(schema.auditLog.practiceId, practiceId),
+              eq(schema.auditLog.action, "estimate_converted"),
+            ),
+          );
+        return rows.length;
+      };
+
+      const [appIdentity] = await appSql<
+        Array<{ currentUser: string }>
+      >`select current_user as "currentUser"`;
+      expect(appIdentity?.currentUser).toBe("openpims_app");
+      const [noContext] = await appSql<Array<{ count: number }>>`
+        select count(*)::int as count from invoices
+      `;
+      expect(noContext?.count).toBe(0);
+
+      // Two confirmations for one visit converge on one actual invoice. The
+      // untracked catalog product remains billable but never changes stock.
+      const raceFixture = await createFixture();
+      const otherTenantFixture = await createFixture();
+      const otherTenantProduct = await createProduct(otherTenantFixture, 9);
+      const otherTenantEstimate = await createEstimate(otherTenantFixture, [
+        { productId: otherTenantProduct, quantity: 2 },
+      ]);
+      await expect(
+        caller(raceFixture).convertEstimateToInvoice({
+          id: otherTenantEstimate.id,
+          expectedUpdatedAt: otherTenantEstimate.updatedAt,
+        }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(await stock(otherTenantProduct)).toBe(9);
+      const [otherTenantState] = await ownerDb
+        .select({ isEstimate: schema.invoices.isEstimate })
+        .from(schema.invoices)
+        .where(eq(schema.invoices.id, otherTenantEstimate.id));
+      expect(otherTenantState?.isEstimate).toBe(true);
+      expect(await conversionAuditCount(otherTenantFixture.practiceId)).toBe(0);
+
+      const trackedProduct = await createProduct(raceFixture, 10, true);
+      const untrackedProduct = await createProduct(raceFixture, 0, false);
+      const raceLines = [
+        { productId: trackedProduct, quantity: 2 },
+        { productId: untrackedProduct, quantity: 50 },
+      ];
+      const firstEstimate = await createEstimate(raceFixture, raceLines);
+      const secondEstimate = await createEstimate(raceFixture, raceLines);
+      const conversionRace = await within(
+        Promise.allSettled([
+          caller(raceFixture).convertEstimateToInvoice({
+            id: firstEstimate.id,
+            expectedUpdatedAt: firstEstimate.updatedAt,
+          }),
+          caller(raceFixture).convertEstimateToInvoice({
+            id: secondEstimate.id,
+            expectedUpdatedAt: secondEstimate.updatedAt,
+          }),
+        ]),
+        "competing estimate conversion",
+      );
+      assertNoDeadlock(conversionRace);
+      assertSingleDomainRejection(conversionRace, "CONFLICT");
+      expect(
+        conversionRace.filter((result) => result.status === "fulfilled"),
+      ).toHaveLength(1);
+      expect(
+        conversionRace.filter((result) => result.status === "rejected"),
+      ).toHaveLength(1);
+      expect(await stock(trackedProduct)).toBe(8);
+      expect(await stock(untrackedProduct)).toBe(0);
+      expect(await conversionAuditCount(raceFixture.practiceId)).toBe(1);
+
+      // Slice A and conversion now share appointment-first row locking after
+      // the invoice advisory lock. A same-visit refill must win without a
+      // deadlock, while the unsourced medication estimate fails closed.
+      const refillFixture = await createFixture();
+      const refillProduct = await createProduct(refillFixture, 10);
+      const prescriptionId = randomUUID();
+      await ownerDb.insert(schema.prescriptions).values({
+        id: prescriptionId,
+        practiceId: refillFixture.practiceId,
+        patientId: refillFixture.patientId,
+        appointmentId: refillFixture.appointmentId,
+        medicationName: "Synthetic medication",
+        dosage: "25 mg",
+        frequency: "Once daily",
+        quantity: 2,
+        productId: refillProduct,
+        refillsRemaining: 1,
+        prescribedBy: refillFixture.userId,
+        startDate: "2026-08-01",
+        status: "active",
+      });
+      await ownerDb.insert(schema.prescriptionEvents).values({
+        practiceId: refillFixture.practiceId,
+        prescriptionId,
+        patientId: refillFixture.patientId,
+        productId: refillProduct,
+        eventType: "created",
+        quantity: 2,
+        statusBefore: null,
+        statusAfter: "active",
+        refillsBefore: null,
+        refillsAfter: 1,
+        actorId: refillFixture.userId,
+        actorName: "Synthetic billing operator",
+      });
+      const refillEstimate = await createEstimate(refillFixture, [
+        { productId: refillProduct, quantity: 2 },
+      ]);
+      const refillRace = await within(
+        Promise.allSettled([
+          caller(refillFixture).convertEstimateToInvoice({
+            id: refillEstimate.id,
+            expectedUpdatedAt: refillEstimate.updatedAt,
+          }),
+          recordsCaller(refillFixture).recordPrescriptionRefill({
+            id: prescriptionId,
+            operationId: randomUUID(),
+            appointmentId: refillFixture.appointmentId,
+            note: "Synthetic conversion/refill drill",
+          }),
+        ]),
+        "conversion/refill serialization",
+      );
+      assertNoDeadlock(refillRace);
+      expect(refillRace[0]).toEqual(
+        expect.objectContaining({ status: "rejected" }),
+      );
+      expect(refillRace[1]).toEqual(
+        expect.objectContaining({ status: "fulfilled" }),
+      );
+      expect(await stock(refillProduct)).toBe(8);
+      const [refillState] = await ownerDb
+        .select({ refillsRemaining: schema.prescriptions.refillsRemaining })
+        .from(schema.prescriptions)
+        .where(eq(schema.prescriptions.id, prescriptionId));
+      expect(refillState?.refillsRemaining).toBe(0);
+      const refillQueue = await ownerDb
+        .select({ status: schema.dispenseChargeQueue.status })
+        .from(schema.dispenseChargeQueue)
+        .where(eq(schema.dispenseChargeQueue.prescriptionId, prescriptionId));
+      expect(refillQueue).toEqual([{ status: "pending" }]);
+
+      // A later insufficient row rolls back an earlier successful stock update,
+      // the estimate flip, and its audit as one transaction.
+      const rollbackFixture = await createFixture();
+      const sufficientProduct = await createProduct(rollbackFixture, 10);
+      const insufficientProduct = await createProduct(rollbackFixture, 1);
+      const rollbackEstimate = await createEstimate(rollbackFixture, [
+        { productId: sufficientProduct, quantity: 2 },
+        { productId: insufficientProduct, quantity: 2 },
+      ]);
+      await expect(
+        caller(rollbackFixture).convertEstimateToInvoice({
+          id: rollbackEstimate.id,
+          expectedUpdatedAt: rollbackEstimate.updatedAt,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(await stock(sufficientProduct)).toBe(10);
+      expect(await stock(insufficientProduct)).toBe(1);
+      const [rollbackState] = await ownerDb
+        .select({ isEstimate: schema.invoices.isEstimate })
+        .from(schema.invoices)
+        .where(eq(schema.invoices.id, rollbackEstimate.id));
+      expect(rollbackState?.isEstimate).toBe(true);
+      expect(await conversionAuditCount(rollbackFixture.practiceId)).toBe(0);
+
+      // Conversion and actual-invoice creation share the appointment lock, so
+      // exactly one wins and inventory is deducted exactly once.
+      const createRaceFixture = await createFixture();
+      const createRaceProduct = await createProduct(createRaceFixture, 10);
+      const createRaceEstimate = await createEstimate(createRaceFixture, [
+        { productId: createRaceProduct, quantity: 2 },
+      ]);
+      const createRace = await within(
+        Promise.allSettled([
+          caller(createRaceFixture).convertEstimateToInvoice({
+            id: createRaceEstimate.id,
+            expectedUpdatedAt: createRaceEstimate.updatedAt,
+          }),
+          caller(createRaceFixture).createInvoice({
+            clientId: createRaceFixture.clientId,
+            patientId: createRaceFixture.patientId,
+            appointmentId: createRaceFixture.appointmentId,
+            isEstimate: false,
+            items: [
+              {
+                description: "Synthetic product",
+                quantity: 2,
+                unitPrice: "15.00",
+                itemType: "product",
+                itemId: createRaceProduct,
+              },
+            ],
+          }),
+        ]),
+        "conversion/create serialization",
+      );
+      assertNoDeadlock(createRace);
+      assertSingleDomainRejection(createRace, "CONFLICT");
+      expect(
+        createRace.filter((result) => result.status === "fulfilled"),
+      ).toHaveLength(1);
+      expect(
+        createRace.filter((result) => result.status === "rejected"),
+      ).toHaveLength(1);
+      expect(await stock(createRaceProduct)).toBe(8);
+      const actualInvoices = await ownerDb
+        .select({ id: schema.invoices.id })
+        .from(schema.invoices)
+        .where(
+          and(
+            eq(schema.invoices.practiceId, createRaceFixture.practiceId),
+            eq(schema.invoices.isEstimate, false),
+          ),
+        );
+      expect(actualInvoices).toHaveLength(1);
+    } finally {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+      if (appSql) await appSql.end();
+      if (ownerSql) await ownerSql.end();
+      try {
+        if (databaseCreated) {
+          await adminSql.unsafe(
+            `drop database if exists "${databaseName}" with (force)`,
+          );
+        }
+      } finally {
+        await adminSql.end();
+      }
+    }
+  }, 120_000);
+});

--- a/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
+++ b/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/lib/webhook-dispatcher", () => ({
 }));
 
 const repoRoot = resolve(process.cwd(), "../..");
+type SqlClient = ReturnType<typeof postgres>;
 const describeWithPostgres =
   process.env.BILLING_CONVERSION_DB_INTEGRATION === "1"
     ? describe.sequential
@@ -140,10 +141,12 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
       const ownerDb = drizzle(ownerSql, { schema });
       const appDb = drizzle(appSql, { schema });
       process.env.DATABASE_URL = appUrl.toString();
-      const [{ billingRouter }, { recordsRouter }] = await Promise.all([
-        import("../routers/billing"),
-        import("../routers/records"),
-      ]);
+      const [{ billingRouter }, { recordsRouter }, { templatesRouter }] =
+        await Promise.all([
+          import("../routers/billing"),
+          import("../routers/records"),
+          import("../routers/templates"),
+        ]);
 
       type Fixture = {
         practiceId: string;
@@ -283,6 +286,8 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
         billingRouter.createCaller(callerContext(fixture));
       const recordsCaller = (fixture: Fixture) =>
         recordsRouter.createCaller(callerContext(fixture));
+      const templatesCaller = (fixture: Fixture) =>
+        templatesRouter.createCaller(callerContext(fixture));
       const stock = async (productId: string) => {
         const [row] = await ownerDb
           .select({ stockQuantity: schema.products.stockQuantity })
@@ -334,6 +339,60 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
       expect(otherTenantState?.isEstimate).toBe(true);
       expect(await conversionAuditCount(otherTenantFixture.practiceId)).toBe(0);
 
+      // Template application is a versioned invoice mutation. A confirmation
+      // captured before the template edit must not deduct stock or convert the
+      // now-stale estimate.
+      const staleTemplateFixture = await createFixture();
+      const staleTemplateProduct = await createProduct(
+        staleTemplateFixture,
+        7,
+      );
+      const staleTemplateEstimate = await createEstimate(
+        staleTemplateFixture,
+        [{ productId: staleTemplateProduct, quantity: 2 }],
+      );
+      const templateId = randomUUID();
+      await ownerDb.insert(schema.treatmentTemplates).values({
+        id: templateId,
+        practiceId: staleTemplateFixture.practiceId,
+        name: "Synthetic stale confirmation template",
+      });
+      await ownerDb.insert(schema.treatmentTemplateItems).values({
+        templateId,
+        itemType: "service",
+        description: "Synthetic template service",
+        defaultQuantity: 1,
+        defaultUnitPrice: "5.00",
+        sortOrder: 0,
+      });
+      const templateApplied = await templatesCaller(
+        staleTemplateFixture,
+      ).applyToInvoice({
+        templateId,
+        invoiceId: staleTemplateEstimate.id,
+      });
+      expect(templateApplied.updatedAt.getTime()).toBeGreaterThanOrEqual(
+        staleTemplateEstimate.updatedAt.getTime() + 1,
+      );
+      await expect(
+        caller(staleTemplateFixture).convertEstimateToInvoice({
+          id: staleTemplateEstimate.id,
+          expectedUpdatedAt: staleTemplateEstimate.updatedAt,
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        message: "Estimate changed. Refresh before converting it.",
+      });
+      expect(await stock(staleTemplateProduct)).toBe(7);
+      expect(await conversionAuditCount(staleTemplateFixture.practiceId)).toBe(
+        0,
+      );
+      const [staleTemplateState] = await ownerDb
+        .select({ isEstimate: schema.invoices.isEstimate })
+        .from(schema.invoices)
+        .where(eq(schema.invoices.id, staleTemplateEstimate.id));
+      expect(staleTemplateState?.isEstimate).toBe(true);
+
       const trackedProduct = await createProduct(raceFixture, 10, true);
       const untrackedProduct = await createProduct(raceFixture, 0, false);
       const raceLines = [
@@ -367,9 +426,45 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
       expect(await stock(untrackedProduct)).toBe(0);
       expect(await conversionAuditCount(raceFixture.practiceId)).toBe(1);
 
-      // Slice A and conversion now share appointment-first row locking after
-      // the invoice advisory lock. A same-visit refill must win without a
-      // deadlock, while the unsourced medication estimate fails closed.
+      // Exact duplicate confirmations serialize on the invoice key. One wins;
+      // the second observes the converted row and cannot repeat stock/audit.
+      const duplicateFixture = await createFixture();
+      const duplicateProduct = await createProduct(duplicateFixture, 10);
+      const duplicateEstimate = await createEstimate(duplicateFixture, [
+        { productId: duplicateProduct, quantity: 2 },
+      ]);
+      const duplicateRace = await within(
+        Promise.allSettled([
+          caller(duplicateFixture).convertEstimateToInvoice({
+            id: duplicateEstimate.id,
+            expectedUpdatedAt: duplicateEstimate.updatedAt,
+          }),
+          caller(duplicateFixture).convertEstimateToInvoice({
+            id: duplicateEstimate.id,
+            expectedUpdatedAt: duplicateEstimate.updatedAt,
+          }),
+        ]),
+        "duplicate estimate conversion",
+      );
+      assertNoDeadlock(duplicateRace);
+      expect(
+        duplicateRace.filter((result) => result.status === "fulfilled"),
+      ).toHaveLength(1);
+      assertSingleDomainRejection(duplicateRace, "CONFLICT");
+      const duplicateRejection = duplicateRace.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      expect(rejectionDetails(duplicateRejection?.reason)).toContain(
+        "Estimate changed. Refresh before converting it.",
+      );
+      expect(await stock(duplicateProduct)).toBe(8);
+      expect(await conversionAuditCount(duplicateFixture.practiceId)).toBe(1);
+
+      // Hold the estimate's serialization key so an older/unlinked
+      // prescription refill can commit its visit-linked queue work first.
+      // Conversion must then revalidate that work and fail without a second
+      // stock movement.
       const refillFixture = await createFixture();
       const refillProduct = await createProduct(refillFixture, 10);
       const prescriptionId = randomUUID();
@@ -377,7 +472,7 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
         id: prescriptionId,
         practiceId: refillFixture.practiceId,
         patientId: refillFixture.patientId,
-        appointmentId: refillFixture.appointmentId,
+        appointmentId: null,
         medicationName: "Synthetic medication",
         dosage: "25 mg",
         frequency: "Once daily",
@@ -405,28 +500,60 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
       const refillEstimate = await createEstimate(refillFixture, [
         { productId: refillProduct, quantity: 2 },
       ]);
-      const refillRace = await within(
-        Promise.allSettled([
-          caller(refillFixture).convertEstimateToInvoice({
-            id: refillEstimate.id,
-            expectedUpdatedAt: refillEstimate.updatedAt,
-          }),
+      let releaseInvoiceBarrier!: () => void;
+      const invoiceBarrierRelease = new Promise<void>((resolveRelease) => {
+        releaseInvoiceBarrier = resolveRelease;
+      });
+      let markInvoiceBarrierReady!: () => void;
+      const invoiceBarrierReady = new Promise<void>((resolveReady) => {
+        markInvoiceBarrierReady = resolveReady;
+      });
+      const invoiceBarrier = appSql.begin(async (barrierTx) => {
+        const barrierSql = barrierTx as unknown as SqlClient;
+        await barrierSql`
+          select pg_advisory_xact_lock(
+            hashtextextended(${refillEstimate.id}, 0)
+          )
+        `;
+        markInvoiceBarrierReady();
+        await invoiceBarrierRelease;
+      });
+      await within(invoiceBarrierReady, "invoice barrier acquisition");
+      let conversionSettled = false;
+      const blockedConversion = caller(refillFixture).convertEstimateToInvoice({
+        id: refillEstimate.id,
+        expectedUpdatedAt: refillEstimate.updatedAt,
+      });
+      void blockedConversion.then(
+        () => {
+          conversionSettled = true;
+        },
+        () => {
+          conversionSettled = true;
+        },
+      );
+      try {
+        await within(
           recordsCaller(refillFixture).recordPrescriptionRefill({
             id: prescriptionId,
             operationId: randomUUID(),
             appointmentId: refillFixture.appointmentId,
-            note: "Synthetic conversion/refill drill",
+            note: "Synthetic ordered conversion/refill drill",
           }),
-        ]),
-        "conversion/refill serialization",
-      );
-      assertNoDeadlock(refillRace);
-      expect(refillRace[0]).toEqual(
-        expect.objectContaining({ status: "rejected" }),
-      );
-      expect(refillRace[1]).toEqual(
-        expect.objectContaining({ status: "fulfilled" }),
-      );
+          "ordered refill commit",
+        );
+        expect(conversionSettled).toBe(false);
+      } finally {
+        releaseInvoiceBarrier();
+        await within(invoiceBarrier, "invoice barrier release");
+      }
+      await expect(
+        within(blockedConversion, "blocked conversion revalidation"),
+      ).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+        message:
+          "Charge this patient's already-dispensed medication from the medication billing queue so inventory is not deducted twice.",
+      });
       expect(await stock(refillProduct)).toBe(8);
       const [refillState] = await ownerDb
         .select({ refillsRemaining: schema.prescriptions.refillsRemaining })
@@ -438,6 +565,12 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
         .from(schema.dispenseChargeQueue)
         .where(eq(schema.dispenseChargeQueue.prescriptionId, prescriptionId));
       expect(refillQueue).toEqual([{ status: "pending" }]);
+      expect(await conversionAuditCount(refillFixture.practiceId)).toBe(0);
+      const [blockedEstimateState] = await ownerDb
+        .select({ isEstimate: schema.invoices.isEstimate })
+        .from(schema.invoices)
+        .where(eq(schema.invoices.id, refillEstimate.id));
+      expect(blockedEstimateState?.isEstimate).toBe(true);
 
       // A later insufficient row rolls back an earlier successful stock update,
       // the estimate flip, and its audit as one transaction.
@@ -513,6 +646,11 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
           ),
         );
       expect(actualInvoices).toHaveLength(1);
+
+      const [postRouteNoContext] = await appSql<Array<{ count: number }>>`
+        select count(*)::int as count from invoices
+      `;
+      expect(postRouteNoContext?.count).toBe(0);
     } finally {
       process.env.DATABASE_URL = originalDatabaseUrl;
       if (appSql) await appSql.end();

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -1527,10 +1527,20 @@ describe("billing invoice integrity", () => {
       ]),
     );
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
+        practiceId: PRACTICE_ID,
+        userId: USER_ID,
         action: "estimate_converted",
+        entityType: "invoice",
         entityId: INVOICE_ID,
-      }),
+        changes: {
+          priorStatus: "draft",
+          nextStatus: "draft",
+          visitLinked: false,
+          itemCount: 1,
+          productLineCount: 1,
+        },
+      },
     );
   });
 
@@ -1590,6 +1600,84 @@ describe("billing invoice integrity", () => {
 
     expect(updateSet).not.toHaveBeenCalled();
   });
+
+  it("rejects an empty estimate before inventory or audit writes", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [{ appointmentId: null }],
+        [
+          {
+            id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: null,
+            total: "0.00",
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
+          },
+        ],
+        [],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Add at least one line item before converting this estimate.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { sourcePrescriptionId: PRESCRIPTION_ID, sourceDispenseChargeId: null },
+    { sourcePrescriptionId: null, sourceDispenseChargeId: DISPENSE_CHARGE_ID },
+  ])(
+    "rejects a legacy sourced medication estimate before inventory or audit writes",
+    async (source) => {
+      const { db, updateSet, insertValues } = createDb({
+        selectResults: [
+          [{ appointmentId: null }],
+          [
+            {
+              id: INVOICE_ID,
+              clientId: CLIENT_ID,
+              patientId: PATIENT_ID,
+              appointmentId: null,
+              total: "30.00",
+              paidAmount: "0.00",
+              status: "draft",
+              isEstimate: true,
+              dueDate: null,
+              updatedAt: UPDATED_AT,
+            },
+          ],
+          [{ ...productLine, ...source }],
+        ],
+      });
+
+      await expect(
+        callerWithDb(db).convertEstimateToInvoice({
+          id: INVOICE_ID,
+          expectedUpdatedAt: UPDATED_AT,
+        }),
+      ).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+        message: expect.stringContaining("dispensed-medication line"),
+      });
+
+      expect(updateSet).not.toHaveBeenCalled();
+      expect(insertValues).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects conversion when product stock is insufficient", async () => {
     const { db, updateSet } = createDb({

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -101,12 +101,13 @@ function createDb(opts: {
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const updateReturns = [...(opts.updateReturns ?? [[]])];
-  const updateSet = vi.fn(() => {
+  const updateSet = vi.fn((values: unknown) => {
     writeCount += 1;
     return {
       where: vi.fn(() => ({
         returning: vi.fn(async () => updateReturns.shift() ?? []),
       })),
+      values,
     };
   });
   const update = vi.fn(() => ({ set: updateSet }));
@@ -144,13 +145,32 @@ afterEach(() => {
 });
 
 describe("billing invoice integrity", () => {
+  it("requires the displayed estimate version before conversion DB work", async () => {
+    const { db, select, updateSet, insertValues } = createDb({
+      selectResults: [],
+    });
+
+    await expect(
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+      } as never),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("keeps estimate conversion restricted to billing manager roles", async () => {
     const { db, select, updateSet, insertValues } = createDb({
       selectResults: [],
     });
 
     await expect(
-      callerWithDb(db, "viewer").convertEstimateToInvoice({ id: INVOICE_ID }),
+      callerWithDb(db, "viewer").convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(select).not.toHaveBeenCalled();
@@ -1442,36 +1462,82 @@ describe("billing invoice integrity", () => {
   });
 
   it("deducts product stock when converting an estimate to an invoice", async () => {
-    const { db, updateSet } = createDb({
+    const converted = {
+      id: INVOICE_ID,
+      isEstimate: false,
+      status: "draft",
+      updatedAt: new Date(UPDATED_AT.getTime() + 1),
+    };
+    const { db, updateSet, insertValues, lockCalls, execute } = createDb({
       selectResults: [
+        [{ appointmentId: null, updatedAt: UPDATED_AT }],
         [
           {
             id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: null,
             total: "30.00",
             paidAmount: "0.00",
             status: "draft",
             isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
           },
         ],
-        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
+        [
+          {
+            ...productLine,
+            sourcePrescriptionId: null,
+            sourceDispenseChargeId: null,
+          },
+        ],
+        [],
+        [{ id: PRODUCT_ID, deletedAt: null, taxable: true }],
+        [{ id: PRODUCT_ID }],
       ],
-      updateReturns: [
-        [{ id: INVOICE_ID, isEstimate: false }],
-        [{ id: PRODUCT_ID, stockQuantity: 8 }],
-      ],
+      updateReturns: [[{ id: PRODUCT_ID, stockQuantity: 8 }], [converted]],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID }),
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
     ).resolves.toMatchObject({ isEstimate: false });
 
-    expect(updateSet).toHaveBeenCalledWith({ isEstimate: false });
+    expect(execute).toHaveBeenCalledWith(expect.anything());
     expect(updateSet).toHaveBeenCalledTimes(2);
+    expect(updateSet.mock.calls[1]?.[0]).toMatchObject({
+      isEstimate: false,
+      status: "draft",
+    });
+    expect(lockCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          mode: "share",
+          inTransaction: true,
+          writesBeforeLock: 0,
+        }),
+        expect.objectContaining({
+          mode: "update",
+          inTransaction: true,
+          writesBeforeLock: 0,
+        }),
+      ]),
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "estimate_converted",
+        entityId: INVOICE_ID,
+      }),
+    );
   });
 
   it("rejects void estimate conversion before inventory changes", async () => {
     const { db, updateSet } = createDb({
       selectResults: [
+        [{ appointmentId: null, updatedAt: UPDATED_AT }],
         [
           {
             id: INVOICE_ID,
@@ -1479,13 +1545,17 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "void",
             isEstimate: true,
+            updatedAt: UPDATED_AT,
           },
         ],
       ],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID }),
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Cannot convert a void estimate.",
@@ -1497,6 +1567,7 @@ describe("billing invoice integrity", () => {
   it("rejects stale estimate conversion before inventory changes", async () => {
     const { db, updateSet } = createDb({
       selectResults: [
+        [{ appointmentId: null, updatedAt: UPDATED_AT }],
         [
           {
             id: INVOICE_ID,
@@ -1504,44 +1575,63 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "draft",
             isEstimate: true,
+            updatedAt: new Date(UPDATED_AT.getTime() + 1),
           },
         ],
-        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
       ],
-      updateReturns: [[]],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
 
-    expect(updateSet).toHaveBeenCalledTimes(1);
-    expect(updateSet).toHaveBeenCalledWith({ isEstimate: false });
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("rejects conversion when product stock is insufficient", async () => {
     const { db, updateSet } = createDb({
       selectResults: [
+        [{ appointmentId: null, updatedAt: UPDATED_AT }],
         [
           {
             id: INVOICE_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: null,
             total: "30.00",
             paidAmount: "0.00",
             status: "draft",
             isEstimate: true,
+            dueDate: null,
+            updatedAt: UPDATED_AT,
           },
         ],
-        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
+        [
+          {
+            ...productLine,
+            sourcePrescriptionId: null,
+            sourceDispenseChargeId: null,
+          },
+        ],
+        [],
+        [{ id: PRODUCT_ID, deletedAt: null, taxable: true }],
+        [{ id: PRODUCT_ID }],
       ],
-      updateReturns: [[{ id: INVOICE_ID, isEstimate: false }], []],
+      updateReturns: [[]],
     });
 
     await expect(
-      callerWithDb(db).convertEstimateToInvoice({ id: INVOICE_ID }),
+      callerWithDb(db).convertEstimateToInvoice({
+        id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
-    expect(updateSet).toHaveBeenCalledWith({ isEstimate: false });
-    expect(updateSet).toHaveBeenCalledTimes(2);
+    expect(updateSet).toHaveBeenCalledTimes(1);
+    expect(updateSet.mock.calls[0]?.[0]).toHaveProperty("stockQuantity");
   });
 
   it("rejects voiding through the generic status endpoint", async () => {

--- a/apps/web/server/__tests__/templates-safety.test.ts
+++ b/apps/web/server/__tests__/templates-safety.test.ts
@@ -642,6 +642,7 @@ describe("treatment template safety", () => {
       subtotal: "150.00",
       tax: "15.00",
       total: "165.00",
+      updatedAt: expect.anything(),
     });
     expect(lockFor).toHaveBeenCalledTimes(1);
     expect(lockFor).toHaveBeenCalledWith("share");
@@ -837,6 +838,7 @@ describe("treatment template safety", () => {
       subtotal: "36.00",
       tax: "0.00",
       total: "36.00",
+      updatedAt: expect.anything(),
     });
     expect(lockFor).toHaveBeenCalledWith("update");
   });
@@ -884,6 +886,7 @@ describe("treatment template safety", () => {
       subtotal: "36.00",
       tax: "0.00",
       total: "36.00",
+      updatedAt: expect.anything(),
     });
   });
 
@@ -1125,6 +1128,16 @@ describe("treatment template safety", () => {
     const applyBlock = source.slice(source.indexOf("applyToInvoice:"));
     expect(applyBlock).toContain("pg_advisory_xact_lock");
     expect(applyBlock).toContain("hashtextextended(${input.invoiceId}, 0)");
+    expect(applyBlock.indexOf("pg_advisory_xact_lock")).toBeLessThan(
+      applyBlock.indexOf("nextInvoiceUpdatedAtSql()"),
+    );
+    const versionSql = source.slice(
+      source.indexOf("function nextInvoiceUpdatedAtSql"),
+      source.indexOf("const templateItemBaseInput"),
+    );
+    expect(versionSql).toContain("date_trunc('milliseconds', clock_timestamp())");
+    expect(versionSql).toContain("${invoices.updatedAt}");
+    expect(versionSql.match(/interval '1 millisecond'/g)).toHaveLength(2);
   });
 
   it("rejects template reads and writes when the practice is missing or deleted", async () => {

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -4290,7 +4290,7 @@ export const billingRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // This lookup chooses the visit lock and captures a version only. Every
+      // This lookup chooses the visit serialization identity only. Every
       // mutable fact is re-read after the locks inside the transaction.
       const [identity] = await ctx.db
         .select({
@@ -4312,8 +4312,8 @@ export const billingRouter = createRouter({
 
       return ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
-        // Match invoice edit/void ordering: invoice advisory lock first. Visit
-        // creation then shares the appointment advisory/row lock below.
+        // Serialize this estimate first, then share the appointment
+        // advisory/row lock used by visit-linked invoice and refill paths.
         await tx.execute(
           sql`select pg_advisory_xact_lock(hashtextextended(${input.id}, 0))`
         );
@@ -4386,13 +4386,13 @@ export const billingRouter = createRouter({
         if (!existing) {
           throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
         }
-        assertCanConvertEstimate(existing);
         if (existing.updatedAt.getTime() !== expectedUpdatedAt.getTime()) {
           throw new TRPCError({
             code: "CONFLICT",
             message: "Estimate changed. Refresh before converting it.",
           });
         }
+        assertCanConvertEstimate(existing);
         if (existing.appointmentId !== identity.appointmentId) {
           throw new TRPCError({
             code: "CONFLICT",

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -642,6 +642,19 @@ function noActiveAdjustmentsForInvoice(): SQL {
   )`;
 }
 
+function invoiceUpdatedAtMatches(expectedUpdatedAt: Date): SQL {
+  // postgres.js decodes timestamptz into a JavaScript Date and therefore drops
+  // PostgreSQL's sub-millisecond precision. Compare at the precision callers
+  // can faithfully round-trip.
+  const start = expectedUpdatedAt.toISOString();
+  const end = new Date(expectedUpdatedAt.getTime() + 1).toISOString();
+  return sql`${invoices.updatedAt} >= ${start}::timestamptz and ${invoices.updatedAt} < ${end}::timestamptz`;
+}
+
+function nextInvoiceUpdatedAt(currentUpdatedAt: Date): Date {
+  return new Date(Math.max(Date.now(), currentUpdatedAt.getTime() + 1));
+}
+
 function invoiceAdjustmentTotalMatches(expectedCents: number): SQL {
   return sql`coalesce((
     select sum(${invoiceAdjustments.amount})
@@ -4268,17 +4281,222 @@ export const billingRouter = createRouter({
 
   convertEstimateToInvoice: protectedProcedure
     .use(requireRole("admin", "front_desk"))
-    .input(z.object({ id: z.string().uuid() }))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        // Conversion can deduct tracked inventory, so callers must confirm the
+        // exact estimate version they displayed to the user.
+        expectedUpdatedAt: z.date(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
-      const existing = await getInvoiceForPractice(ctx, input.id);
-      assertCanConvertEstimate(existing);
-
-      const items = await invoiceProductItemsForStock(ctx, input.id);
+      // This lookup chooses the visit lock and captures a version only. Every
+      // mutable fact is re-read after the locks inside the transaction.
+      const [identity] = await ctx.db
+        .select({
+          appointmentId: invoices.appointmentId,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.id, input.id),
+            eq(invoices.practiceId, ctx.practiceId),
+            isNull(invoices.deletedAt)
+          )
+        )
+        .limit(1);
+      if (!identity) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
+      }
+      const expectedUpdatedAt = input.expectedUpdatedAt;
 
       return ctx.db.transaction(async (tx) => {
+        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        // Match invoice edit/void ordering: invoice advisory lock first. Visit
+        // creation then shares the appointment advisory/row lock below.
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${input.id}, 0))`
+        );
+
+        let appointment:
+          | {
+              id: string;
+              clientId: string | null;
+              patientId: string | null;
+              status: (typeof appointments.$inferSelect)["status"];
+            }
+          | undefined;
+        if (identity.appointmentId) {
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${identity.appointmentId}, 0))`
+          );
+          [appointment] = await tx
+            .select({
+              id: appointments.id,
+              clientId: appointments.clientId,
+              patientId: appointments.patientId,
+              status: appointments.status,
+            })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, identity.appointmentId),
+                eq(appointments.practiceId, ctx.practiceId),
+                isNull(appointments.deletedAt)
+              )
+            )
+            .for("update");
+          if (!appointment) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "The linked appointment is no longer available.",
+            });
+          }
+          if (appointment.status !== "in_exam") {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                "Start the exam before converting this visit estimate to an invoice.",
+            });
+          }
+        }
+
+        const [existing] = await tx
+          .select({
+            id: invoices.id,
+            clientId: invoices.clientId,
+            patientId: invoices.patientId,
+            appointmentId: invoices.appointmentId,
+            total: invoices.total,
+            paidAmount: invoices.paidAmount,
+            status: invoices.status,
+            isEstimate: invoices.isEstimate,
+            dueDate: invoices.dueDate,
+            updatedAt: invoices.updatedAt,
+          })
+          .from(invoices)
+          .where(
+            and(
+              eq(invoices.id, input.id),
+              eq(invoices.practiceId, ctx.practiceId),
+              isNull(invoices.deletedAt)
+            )
+          )
+          .for("update");
+        if (!existing) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
+        }
+        assertCanConvertEstimate(existing);
+        if (existing.updatedAt.getTime() !== expectedUpdatedAt.getTime()) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Estimate changed. Refresh before converting it.",
+          });
+        }
+        if (existing.appointmentId !== identity.appointmentId) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Estimate visit changed. Refresh before converting it.",
+          });
+        }
+        if (
+          appointment &&
+          (appointment.clientId !== existing.clientId ||
+            appointment.patientId !== existing.patientId)
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "The estimate no longer matches the visit client and patient.",
+          });
+        }
+
+        if (existing.appointmentId) {
+          const [activeInvoice] = await tx
+            .select({ id: invoices.id })
+            .from(invoices)
+            .where(
+              and(
+                eq(invoices.practiceId, ctx.practiceId),
+                eq(invoices.appointmentId, existing.appointmentId),
+                ne(invoices.id, input.id),
+                eq(invoices.isEstimate, false),
+                ne(invoices.status, "void"),
+                isNull(invoices.deletedAt)
+              )
+            )
+            .limit(1);
+          if (activeInvoice) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "This visit already has an active invoice. Open it instead of converting another estimate.",
+            });
+          }
+        }
+
+        const items = await tx
+          .select({
+            description: invoiceItems.description,
+            quantity: invoiceItems.quantity,
+            unitPrice: invoiceItems.unitPrice,
+            itemType: invoiceItems.itemType,
+            itemId: invoiceItems.itemId,
+            sourcePrescriptionId: invoiceItems.sourcePrescriptionId,
+            sourceDispenseChargeId: invoiceItems.sourceDispenseChargeId,
+          })
+          .from(invoiceItems)
+          .where(
+            and(
+              eq(invoiceItems.invoiceId, input.id),
+              invoiceItemPracticeScope(txCtx),
+              isNull(invoiceItems.deletedAt)
+            )
+          )
+          .orderBy(invoiceItems.id)
+          .for("share");
+        if (items.length === 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Add at least one line item before converting this estimate.",
+          });
+        }
+        if (
+          items.some(
+            (item) => item.sourcePrescriptionId || item.sourceDispenseChargeId
+          )
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "This estimate contains a dispensed-medication line. Rebuild the medication charge from Charge capture or the medication billing queue before converting.",
+          });
+        }
+
+        await assertPrescriptionChargeSources(txCtx, items, {
+          appointmentId: existing.appointmentId,
+          patientId: existing.patientId,
+          currentInvoiceId: input.id,
+        });
+        await assertDispenseChargeSources(txCtx, items, {
+          clientId: existing.clientId,
+          patientId: existing.patientId,
+          appointmentId: existing.appointmentId,
+          currentInvoiceId: input.id,
+          isEstimate: false,
+        });
+        await assertLineItemReferences(txCtx, items, {
+          lockProductsForStock: true,
+        });
+        await deductProductStock(
+          txCtx,
+          await trackedStockOwnedItems(txCtx, items)
+        );
+
+        const convertedAt = nextInvoiceUpdatedAt(existing.updatedAt);
         const [invoice] = await tx
           .update(invoices)
-          .set({ isEstimate: false })
+          .set({ isEstimate: false, status: "draft", updatedAt: convertedAt })
           .where(
             and(
               eq(invoices.id, input.id),
@@ -4286,6 +4504,9 @@ export const billingRouter = createRouter({
               eq(invoices.isEstimate, true),
               eq(invoices.status, existing.status),
               eq(invoices.paidAmount, existing.paidAmount ?? "0"),
+              invoiceUpdatedAtMatches(expectedUpdatedAt),
+              noActivePaymentsForInvoice(),
+              noActiveAdjustmentsForInvoice(),
               isNull(invoices.deletedAt)
             )
           )
@@ -4293,15 +4514,29 @@ export const billingRouter = createRouter({
 
         if (!invoice) {
           throw new TRPCError({
-            code: "BAD_REQUEST",
+            code: "CONFLICT",
             message: "Estimate changed while converting. Refresh and try again.",
           });
         }
 
-        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
-        await deductProductStock(txCtx, items);
+        await tx.insert(auditLog).values({
+          practiceId: ctx.practiceId,
+          userId: ctx.user.id,
+          action: "estimate_converted",
+          entityType: "invoice",
+          entityId: input.id,
+          changes: {
+            priorStatus: existing.status,
+            nextStatus: "draft",
+            visitLinked: Boolean(existing.appointmentId),
+            itemCount: items.length,
+            productLineCount: items.filter(
+              (item) => item.itemType === "product"
+            ).length,
+          },
+        });
 
-        return invoice;
+        return invoice!;
       });
     }),
 });

--- a/apps/web/server/routers/templates.ts
+++ b/apps/web/server/routers/templates.ts
@@ -65,6 +65,13 @@ const moneyInput = z
 const PRODUCT_LINK_REQUIRED_MESSAGE =
   "Every product template item must be linked to an active inventory product.";
 
+function nextInvoiceUpdatedAtSql() {
+  return sql`greatest(
+    date_trunc('milliseconds', clock_timestamp()) + interval '1 millisecond',
+    date_trunc('milliseconds', ${invoices.updatedAt}) + interval '1 millisecond'
+  )`;
+}
+
 const templateItemBaseInput = z.object({
   itemType: z.enum(["service", "product"]),
   itemId: z.string().uuid().optional(),
@@ -954,6 +961,9 @@ export const templatesRouter = createRouter({
             subtotal: centsToMoney(totals.subtotalCents),
             tax: centsToMoney(totals.taxCents),
             total: centsToMoney(totals.totalCents),
+            // Keep the invoice version visible to millisecond-precision clients
+            // monotonic while holding the shared invoice serialization lock.
+            updatedAt: nextInvoiceUpdatedAtSql(),
           })
           .where(
             and(


### PR DESCRIPTION
## Purpose

Rebuild the valuable atomic estimate-to-invoice conversion slice from superseded PR #198 on the current protected `development` base. This does not rebase or cherry-pick the stale aggregate.

## Behavior

- serializes invoice and visit mutations in a single transaction
- revalidates tenant, visit, invoice version, items, catalog references, and sources under locks
- deducts only current `inventoryTracked` stock and rolls back atomically
- records one PHI-free conversion audit
- adds explicit Billing confirmation using the displayed `updatedAt` token
- advances template-applied invoice versions monotonically
- refreshes invoice, inventory, dispense, and linked-visit state after either outcome

## PostgreSQL/RLS proof

The disposable `openpims_app` gate covers tenant/no-context isolation, tracked/untracked inventory, rollback, two-estimate convergence, conversion-vs-actual creation, stale-template rejection, duplicate confirmation at-most-once behavior, and barrier-ordered conversion-vs-refill without deadlock.

## Local gates at exact head

- focused tests: 195/195
- disposable PostgreSQL/RLS: 1/1
- migration integrity: 82 passed, 1 skipped
- full web suite: 4,201 passed, 15 skipped
- web + DB typecheck: pass
- production web build: pass
- diff check: pass

## Explicit exclusions

No encounter-page shortcut, schema, migration, dependency, provider, hosted-resource, payment, send, repricing, or broad edit/void/template rewrite. `staging` and deployed `main` are unchanged.

## Merge gate

Keep draft until all checks on exact head `965539ecf2d2cf89ca2df89ea7e26378baeb921c` pass, including the PostgreSQL/RLS job and CodeQL.