### PR TITLE
fix(billing): prevent template medication double charging

### DIFF
--- a/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
+++ b/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
@@ -55,6 +55,29 @@ async function within<T>(
   }
 }
 
+async function waitForBlockedProductQueries(
+  sql: SqlClient,
+  databaseName: string,
+  minimum: number,
+): Promise<void> {
+  await within(
+    (async () => {
+      for (;;) {
+        const [row] = await sql<Array<{ count: number }>>`
+          select count(*)::int as count
+          from pg_stat_activity
+          where datname = ${databaseName}
+            and wait_event_type = 'Lock'
+            and query ilike '%products%'
+        `;
+        if ((row?.count ?? 0) >= minimum) return;
+        await new Promise((resolveWait) => setTimeout(resolveWait, 20));
+      }
+    })(),
+    `${minimum} blocked product queries`,
+  );
+}
+
 function rejectionDetails(reason: unknown): string {
   const details: string[] = [];
   const seen = new Set<unknown>();
@@ -269,6 +292,27 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
         );
         return { id, updatedAt };
       };
+      const createProductTemplate = async (
+        fixture: Fixture,
+        productId: string,
+      ) => {
+        const id = randomUUID();
+        await ownerDb.insert(schema.treatmentTemplates).values({
+          id,
+          practiceId: fixture.practiceId,
+          name: `Synthetic medication template ${id}`,
+        });
+        await ownerDb.insert(schema.treatmentTemplateItems).values({
+          templateId: id,
+          itemType: "product",
+          itemId: productId,
+          description: "Synthetic templated medication",
+          defaultQuantity: 2,
+          defaultUnitPrice: "15.00",
+          sortOrder: 0,
+        });
+        return id;
+      };
       const callerContext = (fixture: Fixture) =>
         ({
           db: appDb,
@@ -325,6 +369,16 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
       const otherTenantEstimate = await createEstimate(otherTenantFixture, [
         { productId: otherTenantProduct, quantity: 2 },
       ]);
+      const otherTenantTemplate = await createProductTemplate(
+        otherTenantFixture,
+        otherTenantProduct,
+      );
+      await expect(
+        templatesCaller(raceFixture).applyToInvoice({
+          templateId: otherTenantTemplate,
+          invoiceId: otherTenantEstimate.id,
+        }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
       await expect(
         caller(raceFixture).convertEstimateToInvoice({
           id: otherTenantEstimate.id,
@@ -343,14 +397,10 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
       // captured before the template edit must not deduct stock or convert the
       // now-stale estimate.
       const staleTemplateFixture = await createFixture();
-      const staleTemplateProduct = await createProduct(
-        staleTemplateFixture,
-        7,
-      );
-      const staleTemplateEstimate = await createEstimate(
-        staleTemplateFixture,
-        [{ productId: staleTemplateProduct, quantity: 2 }],
-      );
+      const staleTemplateProduct = await createProduct(staleTemplateFixture, 7);
+      const staleTemplateEstimate = await createEstimate(staleTemplateFixture, [
+        { productId: staleTemplateProduct, quantity: 2 },
+      ]);
       const templateId = randomUUID();
       await ownerDb.insert(schema.treatmentTemplates).values({
         id: templateId,
@@ -392,6 +442,179 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
         .from(schema.invoices)
         .where(eq(schema.invoices.id, staleTemplateEstimate.id));
       expect(staleTemplateState?.isEstimate).toBe(true);
+
+      // A standalone refill can hold the product lock before its queue row is
+      // visible. Force that order: the template's first evidence read sees no
+      // queue row, then waits behind the refill on the product. Its post-lock
+      // recheck must observe the committed queue work and roll back every
+      // template write without deducting the medication a second time.
+      const templateRefillFixture = await createFixture();
+      const templateRefillProduct = await createProduct(
+        templateRefillFixture,
+        10,
+      );
+      const templateRefillPrescription = randomUUID();
+      await ownerDb.insert(schema.prescriptions).values({
+        id: templateRefillPrescription,
+        practiceId: templateRefillFixture.practiceId,
+        patientId: templateRefillFixture.patientId,
+        appointmentId: null,
+        medicationName: "Synthetic standalone refill medication",
+        dosage: "25 mg",
+        frequency: "Once daily",
+        quantity: 2,
+        productId: templateRefillProduct,
+        refillsRemaining: 1,
+        prescribedBy: templateRefillFixture.userId,
+        startDate: "2026-08-01",
+        status: "active",
+      });
+      await ownerDb.insert(schema.prescriptionEvents).values({
+        practiceId: templateRefillFixture.practiceId,
+        prescriptionId: templateRefillPrescription,
+        patientId: templateRefillFixture.patientId,
+        productId: templateRefillProduct,
+        eventType: "created",
+        quantity: 2,
+        statusBefore: null,
+        statusAfter: "active",
+        refillsBefore: null,
+        refillsAfter: 1,
+        actorId: templateRefillFixture.userId,
+        actorName: "Synthetic billing operator",
+      });
+      const templateRefillInvoice = await caller(
+        templateRefillFixture,
+      ).createInvoice({
+        clientId: templateRefillFixture.clientId,
+        patientId: templateRefillFixture.patientId,
+        appointmentId: templateRefillFixture.appointmentId,
+        isEstimate: false,
+        items: [
+          {
+            description: "Synthetic exam service",
+            quantity: 1,
+            unitPrice: "5.00",
+            itemType: "service",
+          },
+        ],
+      });
+      const templateRefillTemplate = await createProductTemplate(
+        templateRefillFixture,
+        templateRefillProduct,
+      );
+      const templateRefillVersion = templateRefillInvoice.updatedAt;
+      let releaseProductBarrier!: () => void;
+      const productBarrierRelease = new Promise<void>((resolveRelease) => {
+        releaseProductBarrier = resolveRelease;
+      });
+      let markProductBarrierReady!: () => void;
+      const productBarrierReady = new Promise<void>((resolveReady) => {
+        markProductBarrierReady = resolveReady;
+      });
+      const productBarrier = ownerSql.begin(async (barrierTx) => {
+        const barrierSql = barrierTx as unknown as SqlClient;
+        await barrierSql`
+          select id
+          from products
+          where id = ${templateRefillProduct}
+          for update
+        `;
+        markProductBarrierReady();
+        await productBarrierRelease;
+      });
+      await within(productBarrierReady, "template/refill product barrier");
+      const refillAttempt = recordsCaller(
+        templateRefillFixture,
+      ).recordPrescriptionRefill({
+        id: templateRefillPrescription,
+        operationId: randomUUID(),
+        note: "Synthetic ordered template/refill drill",
+      });
+      await waitForBlockedProductQueries(adminSql, databaseName, 1);
+      const templateAttempt = templatesCaller(
+        templateRefillFixture,
+      ).applyToInvoice({
+        templateId: templateRefillTemplate,
+        invoiceId: templateRefillInvoice.id,
+      });
+      const templateRejection = expect(templateAttempt).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+        message: expect.stringContaining("medication billing queue"),
+      });
+      try {
+        await waitForBlockedProductQueries(adminSql, databaseName, 2);
+      } finally {
+        releaseProductBarrier();
+        await within(productBarrier, "template/refill product release");
+      }
+      await within(refillAttempt, "standalone refill completion");
+      await within(templateRejection, "blocked template recheck");
+      expect(await stock(templateRefillProduct)).toBe(8);
+      const templateRefillQueue = await ownerDb
+        .select({
+          id: schema.dispenseChargeQueue.id,
+          status: schema.dispenseChargeQueue.status,
+        })
+        .from(schema.dispenseChargeQueue)
+        .where(
+          eq(
+            schema.dispenseChargeQueue.prescriptionId,
+            templateRefillPrescription,
+          ),
+        );
+      expect(templateRefillQueue).toEqual([
+        { id: expect.any(String), status: "pending" },
+      ]);
+      const templateRefillItems = await ownerDb
+        .select({ id: schema.invoiceItems.id })
+        .from(schema.invoiceItems)
+        .where(eq(schema.invoiceItems.invoiceId, templateRefillInvoice.id));
+      expect(templateRefillItems).toHaveLength(1);
+      const [templateRefillInvoiceState] = await ownerDb
+        .select({ updatedAt: schema.invoices.updatedAt })
+        .from(schema.invoices)
+        .where(eq(schema.invoices.id, templateRefillInvoice.id));
+      expect(templateRefillInvoiceState?.updatedAt).toEqual(
+        templateRefillVersion,
+      );
+
+      // Once that dispense is sourced to its own invoice, it is historical
+      // evidence rather than unresolved work for the visit invoice. A deleted
+      // prescription from the visit is likewise not a live source. Neither may
+      // block a later explicitly applied product template.
+      await caller(templateRefillFixture).createDispenseChargeInvoice({
+        id: templateRefillQueue[0]!.id,
+        acknowledgeLegacyReview: false,
+      });
+      await ownerDb.insert(schema.prescriptions).values({
+        id: randomUUID(),
+        practiceId: templateRefillFixture.practiceId,
+        patientId: templateRefillFixture.patientId,
+        appointmentId: templateRefillFixture.appointmentId,
+        medicationName: "Deleted synthetic visit medication",
+        dosage: "25 mg",
+        frequency: "Once daily",
+        quantity: 2,
+        productId: templateRefillProduct,
+        refillsRemaining: 0,
+        prescribedBy: templateRefillFixture.userId,
+        startDate: "2026-08-01",
+        status: "active",
+        deletedAt: new Date(),
+      });
+      await expect(
+        templatesCaller(templateRefillFixture).applyToInvoice({
+          templateId: templateRefillTemplate,
+          invoiceId: templateRefillInvoice.id,
+        }),
+      ).resolves.toMatchObject({ id: templateRefillInvoice.id });
+      expect(await stock(templateRefillProduct)).toBe(6);
+      const templateRefillItemsAfterHistorical = await ownerDb
+        .select({ id: schema.invoiceItems.id })
+        .from(schema.invoiceItems)
+        .where(eq(schema.invoiceItems.invoiceId, templateRefillInvoice.id));
+      expect(templateRefillItemsAfterHistorical).toHaveLength(2);
 
       const trackedProduct = await createProduct(raceFixture, 10, true);
       const untrackedProduct = await createProduct(raceFixture, 0, false);

--- a/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
+++ b/apps/web/server/__tests__/billing-estimate-conversion.integration.test.ts
@@ -55,10 +55,11 @@ async function within<T>(
   }
 }
 
-async function waitForBlockedProductQueries(
+async function waitForBlockedQueries(
   sql: SqlClient,
   databaseName: string,
   minimum: number,
+  queryPattern = "%",
 ): Promise<void> {
   await within(
     (async () => {
@@ -68,7 +69,7 @@ async function waitForBlockedProductQueries(
           from pg_stat_activity
           where datname = ${databaseName}
             and wait_event_type = 'Lock'
-            and query ilike '%products%'
+            and query ilike ${queryPattern}
         `;
         if ((row?.count ?? 0) >= minimum) return;
         await new Promise((resolveWait) => setTimeout(resolveWait, 20));
@@ -76,6 +77,14 @@ async function waitForBlockedProductQueries(
     })(),
     `${minimum} blocked product queries`,
   );
+}
+
+function waitForBlockedProductQueries(
+  sql: SqlClient,
+  databaseName: string,
+  minimum: number,
+) {
+  return waitForBlockedQueries(sql, databaseName, minimum, "%products%");
 }
 
 function rejectionDetails(reason: unknown): string {
@@ -583,7 +592,9 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
       // evidence rather than unresolved work for the visit invoice. A deleted
       // prescription from the visit is likewise not a live source. Neither may
       // block a later explicitly applied product template.
-      await caller(templateRefillFixture).createDispenseChargeInvoice({
+      const historicalDispenseInvoice = await caller(
+        templateRefillFixture,
+      ).createDispenseChargeInvoice({
         id: templateRefillQueue[0]!.id,
         acknowledgeLegacyReview: false,
       });
@@ -615,6 +626,205 @@ describeWithPostgres("atomic estimate conversion PostgreSQL contract", () => {
         .from(schema.invoiceItems)
         .where(eq(schema.invoiceItems.invoiceId, templateRefillInvoice.id));
       expect(templateRefillItemsAfterHistorical).toHaveLength(2);
+
+      // updateInvoiceItems owns product -> sourced queue. Hold the product,
+      // queue the historical source edit first, then queue the template. The
+      // template must not pre-lock allowed invoiced-other evidence; both
+      // operations complete without a cycle and only the template moves stock.
+      await ownerDb
+        .update(schema.invoices)
+        .set({ updatedAt: new Date("2026-08-25T18:00:00.000Z") })
+        .where(eq(schema.invoices.id, historicalDispenseInvoice.invoiceId));
+      const [historicalInvoiceState] = await ownerDb
+        .select({ updatedAt: schema.invoices.updatedAt })
+        .from(schema.invoices)
+        .where(eq(schema.invoices.id, historicalDispenseInvoice.invoiceId));
+      const [historicalInvoiceLine] = await ownerDb
+        .select({
+          description: schema.invoiceItems.description,
+          quantity: schema.invoiceItems.quantity,
+          unitPrice: schema.invoiceItems.unitPrice,
+          itemType: schema.invoiceItems.itemType,
+          itemId: schema.invoiceItems.itemId,
+          sourceDispenseChargeId: schema.invoiceItems.sourceDispenseChargeId,
+        })
+        .from(schema.invoiceItems)
+        .where(
+          eq(
+            schema.invoiceItems.invoiceId,
+            historicalDispenseInvoice.invoiceId,
+          ),
+        );
+      expect(historicalInvoiceState).toBeDefined();
+      expect(historicalInvoiceLine?.sourceDispenseChargeId).toBe(
+        templateRefillQueue[0]!.id,
+      );
+      let releaseHistoricalProductBarrier!: () => void;
+      const historicalProductBarrierRelease = new Promise<void>(
+        (resolveRelease) => {
+          releaseHistoricalProductBarrier = resolveRelease;
+        },
+      );
+      let markHistoricalProductBarrierReady!: () => void;
+      const historicalProductBarrierReady = new Promise<void>(
+        (resolveReady) => {
+          markHistoricalProductBarrierReady = resolveReady;
+        },
+      );
+      const historicalProductBarrier = ownerSql.begin(async (barrierTx) => {
+        const barrierSql = barrierTx as unknown as SqlClient;
+        await barrierSql`
+          select id
+          from products
+          where id = ${templateRefillProduct}
+          for update
+        `;
+        markHistoricalProductBarrierReady();
+        await historicalProductBarrierRelease;
+      });
+      await within(
+        historicalProductBarrierReady,
+        "historical edit product barrier",
+      );
+      const historicalEditAttempt = caller(
+        templateRefillFixture,
+      ).updateInvoiceItems({
+        id: historicalDispenseInvoice.invoiceId,
+        expectedUpdatedAt: historicalInvoiceState!.updatedAt,
+        items: [
+          {
+            description: historicalInvoiceLine!.description,
+            quantity: historicalInvoiceLine!.quantity,
+            unitPrice: historicalInvoiceLine!.unitPrice,
+            itemType: historicalInvoiceLine!.itemType,
+            itemId: historicalInvoiceLine!.itemId ?? undefined,
+            sourceDispenseChargeId:
+              historicalInvoiceLine!.sourceDispenseChargeId ?? undefined,
+          },
+        ],
+      });
+      await waitForBlockedProductQueries(adminSql, databaseName, 1);
+      const historicalTemplateAttempt = templatesCaller(
+        templateRefillFixture,
+      ).applyToInvoice({
+        templateId: templateRefillTemplate,
+        invoiceId: templateRefillInvoice.id,
+      });
+      try {
+        await waitForBlockedProductQueries(adminSql, databaseName, 2);
+      } finally {
+        releaseHistoricalProductBarrier();
+        await within(
+          historicalProductBarrier,
+          "historical edit product release",
+        );
+      }
+      const historicalSchedule = await within(
+        Promise.allSettled([historicalEditAttempt, historicalTemplateAttempt]),
+        "historical edit/template schedule",
+      );
+      assertNoDeadlock(historicalSchedule);
+      expect(
+        historicalSchedule.map((result) =>
+          result.status === "fulfilled"
+            ? "fulfilled"
+            : rejectionDetails(result.reason),
+        ),
+      ).toEqual(["fulfilled", "fulfilled"]);
+      expect(await stock(templateRefillProduct)).toBe(4);
+
+      // createDispenseChargeInvoice owns appointment -> invoice. Create a
+      // visit-linked refill, hold the invoice row, and let the dispense path
+      // acquire the appointment boundary before the template starts. The
+      // template must wait on that same appointment order, then reject the now
+      // sourced medication without deadlocking or moving stock again.
+      await ownerDb
+        .update(schema.prescriptions)
+        .set({ refillsRemaining: 1 })
+        .where(eq(schema.prescriptions.id, templateRefillPrescription));
+      await recordsCaller(templateRefillFixture).recordPrescriptionRefill({
+        id: templateRefillPrescription,
+        operationId: randomUUID(),
+        appointmentId: templateRefillFixture.appointmentId,
+        note: "Synthetic visit-linked template/dispense drill",
+      });
+      const [visitDispense] = await ownerDb
+        .select({ id: schema.dispenseChargeQueue.id })
+        .from(schema.dispenseChargeQueue)
+        .where(
+          and(
+            eq(
+              schema.dispenseChargeQueue.prescriptionId,
+              templateRefillPrescription,
+            ),
+            eq(
+              schema.dispenseChargeQueue.appointmentId,
+              templateRefillFixture.appointmentId,
+            ),
+            eq(schema.dispenseChargeQueue.status, "pending"),
+          ),
+        );
+      expect(visitDispense).toBeDefined();
+      expect(await stock(templateRefillProduct)).toBe(2);
+      let releaseVisitInvoiceBarrier!: () => void;
+      const visitInvoiceBarrierRelease = new Promise<void>((resolveRelease) => {
+        releaseVisitInvoiceBarrier = resolveRelease;
+      });
+      let markVisitInvoiceBarrierReady!: () => void;
+      const visitInvoiceBarrierReady = new Promise<void>((resolveReady) => {
+        markVisitInvoiceBarrierReady = resolveReady;
+      });
+      const visitInvoiceBarrier = ownerSql.begin(async (barrierTx) => {
+        const barrierSql = barrierTx as unknown as SqlClient;
+        await barrierSql`
+          select id
+          from invoices
+          where id = ${templateRefillInvoice.id}
+          for update
+        `;
+        markVisitInvoiceBarrierReady();
+        await visitInvoiceBarrierRelease;
+      });
+      await within(visitInvoiceBarrierReady, "visit invoice barrier");
+      const createDispenseAttempt = caller(
+        templateRefillFixture,
+      ).createDispenseChargeInvoice({
+        id: visitDispense!.id,
+        acknowledgeLegacyReview: false,
+      });
+      await waitForBlockedQueries(adminSql, databaseName, 1, "%invoices%");
+      const orderedTemplateAttempt = templatesCaller(
+        templateRefillFixture,
+      ).applyToInvoice({
+        templateId: templateRefillTemplate,
+        invoiceId: templateRefillInvoice.id,
+      });
+      const orderedTemplateRejection = expect(
+        orderedTemplateAttempt,
+      ).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+        message: expect.stringContaining("medication billing queue"),
+      });
+      try {
+        await waitForBlockedQueries(adminSql, databaseName, 2);
+      } finally {
+        releaseVisitInvoiceBarrier();
+        await within(visitInvoiceBarrier, "visit invoice barrier release");
+      }
+      await within(createDispenseAttempt, "visit dispense creation");
+      await within(orderedTemplateRejection, "ordered template rejection");
+      expect(await stock(templateRefillProduct)).toBe(2);
+      const [visitDispenseState] = await ownerDb
+        .select({
+          status: schema.dispenseChargeQueue.status,
+          invoiceId: schema.dispenseChargeQueue.invoiceId,
+        })
+        .from(schema.dispenseChargeQueue)
+        .where(eq(schema.dispenseChargeQueue.id, visitDispense!.id));
+      expect(visitDispenseState).toEqual({
+        status: "invoiced",
+        invoiceId: templateRefillInvoice.id,
+      });
 
       const trackedProduct = await createProduct(raceFixture, 10, true);
       const untrackedProduct = await createProduct(raceFixture, 0, false);

--- a/apps/web/server/__tests__/templates-safety.test.ts
+++ b/apps/web/server/__tests__/templates-safety.test.ts
@@ -20,6 +20,9 @@ const SERVICE_ID = "00000000-0000-0000-0000-000000000005";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000006";
 const SECOND_SERVICE_ID = "00000000-0000-0000-0000-000000000007";
 const SECOND_PRODUCT_ID = "00000000-0000-0000-0000-000000000008";
+const CLIENT_ID = "00000000-0000-0000-0000-000000000009";
+const PATIENT_ID = "00000000-0000-0000-0000-00000000000a";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-00000000000b";
 
 function callerWithDb(db: Record<string, unknown>, role = "admin") {
   const session = {
@@ -585,7 +588,7 @@ describe("treatment template safety", () => {
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: expect.any(Date) });
   });
 
-  it("applies a template to a tenant invoice and recalculates active items", async () => {
+  it("applies a service-only template without imposing the visit product gate", async () => {
     const { db, insertValues, updateSet, lockFor, execute } = createDb({
       selectResults: [
         [{ id: PRACTICE_ID }],
@@ -596,6 +599,9 @@ describe("treatment template safety", () => {
             status: "draft",
             paidAmount: "0.00",
             isEstimate: false,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
           },
         ],
         [
@@ -644,8 +650,9 @@ describe("treatment template safety", () => {
       total: "165.00",
       updatedAt: expect.anything(),
     });
-    expect(lockFor).toHaveBeenCalledTimes(1);
-    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor).toHaveBeenCalledTimes(2);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "share");
     expect(execute).toHaveBeenCalled();
   });
 
@@ -773,11 +780,238 @@ describe("treatment template safety", () => {
         expect.objectContaining({ itemId: SECOND_PRODUCT_ID }),
       ]),
     );
-    expect(lockFor).toHaveBeenCalledTimes(2);
-    expect(lockFor).toHaveBeenNthCalledWith(1, "share");
+    expect(lockFor).toHaveBeenCalledTimes(3);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
     expect(lockFor).toHaveBeenNthCalledWith(2, "share");
+    expect(lockFor).toHaveBeenNthCalledWith(3, "share");
     // Four request setup/read queries + two catalog batches + totals + tax.
     expect(select).toHaveBeenCalledTimes(8);
+  });
+
+  it.each(["pending", "waived"] as const)(
+    "blocks a current-visit %s dispense before inventory or invoice writes",
+    async (status) => {
+      const { db, insertValues, updateSet, lockFor } = createDb({
+        selectResults: [
+          [{ id: PRACTICE_ID }],
+          [{ id: TEMPLATE_ID }],
+          [
+            {
+              id: INVOICE_ID,
+              status: "draft",
+              paidAmount: "0.00",
+              isEstimate: false,
+              clientId: CLIENT_ID,
+              patientId: PATIENT_ID,
+              appointmentId: APPOINTMENT_ID,
+            },
+          ],
+          [
+            {
+              description: "Dispensed medication",
+              defaultQuantity: 2,
+              defaultUnitPrice: "15.00",
+              itemType: "product",
+              itemId: PRODUCT_ID,
+            },
+          ],
+          [
+            {
+              id: APPOINTMENT_ID,
+              clientId: CLIENT_ID,
+              patientId: PATIENT_ID,
+              status: "in_exam",
+            },
+          ],
+          [],
+          [{ id: `${status}-dispense`, status, invoiceId: null }],
+        ],
+      });
+
+      await expect(
+        callerWithDb(db).applyToInvoice({
+          templateId: TEMPLATE_ID,
+          invoiceId: INVOICE_ID,
+        }),
+      ).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+        message: expect.stringContaining("medication billing queue"),
+      });
+
+      expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+      expect(lockFor).toHaveBeenNthCalledWith(2, "update");
+      expect(lockFor).toHaveBeenNthCalledWith(3, "share");
+      expect(lockFor).toHaveBeenNthCalledWith(4, "update");
+      expect(insertValues).not.toHaveBeenCalled();
+      expect(updateSet).not.toHaveBeenCalled();
+    },
+  );
+
+  it("blocks an active product prescription from the exact invoice visit", async () => {
+    const { db, insertValues, updateSet, lockFor } = createDb({
+      selectResults: [
+        [{ id: PRACTICE_ID }],
+        [{ id: TEMPLATE_ID }],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            paidAmount: "0.00",
+            isEstimate: false,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
+          },
+        ],
+        [
+          {
+            description: "Visit medication",
+            defaultQuantity: 1,
+            defaultUnitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+          },
+        ],
+        [
+          {
+            id: APPOINTMENT_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            status: "in_exam",
+          },
+        ],
+        [{ id: "current-visit-prescription" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).applyToInvoice({
+        templateId: TEMPLATE_ID,
+        invoiceId: INVOICE_ID,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(3, "share");
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("blocks a dispense already sourced to this invoice before writes", async () => {
+    const { db, insertValues, updateSet, lockFor } = createDb({
+      selectResults: [
+        [{ id: PRACTICE_ID }],
+        [{ id: TEMPLATE_ID }],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            paidAmount: "0.00",
+            isEstimate: false,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: null,
+          },
+        ],
+        [
+          {
+            description: "Dispensed medication",
+            defaultQuantity: 2,
+            defaultUnitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+          },
+        ],
+        [{ id: "sourced-dispense", status: "invoiced", invoiceId: INVOICE_ID }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).applyToInvoice({
+        templateId: TEMPLATE_ID,
+        invoiceId: INVOICE_ID,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(lockFor).toHaveBeenCalledTimes(2);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "update");
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("allows unrelated medication history and keeps untracked stock unchanged", async () => {
+    const { db, insertValues, updateSet, lockFor } = createDb({
+      selectResults: [
+        [{ id: PRACTICE_ID }],
+        [{ id: TEMPLATE_ID }],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            paidAmount: "0.00",
+            isEstimate: false,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
+          },
+        ],
+        [
+          {
+            description: "Untracked take-home product",
+            defaultQuantity: 2,
+            defaultUnitPrice: "15.00",
+            itemType: "product",
+            itemId: PRODUCT_ID,
+          },
+        ],
+        [
+          {
+            id: APPOINTMENT_ID,
+            clientId: CLIENT_ID,
+            patientId: PATIENT_ID,
+            status: "in_exam",
+          },
+        ],
+        [],
+        [],
+        [{ id: PRODUCT_ID, taxable: true }],
+        [],
+        [],
+        [{ quantity: 2, unitPrice: "15.00", taxable: true }],
+        [{ taxRatePercent: "0.00" }],
+      ],
+      updatedRows: [
+        {
+          id: INVOICE_ID,
+          subtotal: "30.00",
+          tax: "0.00",
+          total: "30.00",
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).applyToInvoice({
+        templateId: TEMPLATE_ID,
+        invoiceId: INVOICE_ID,
+      }),
+    ).resolves.toMatchObject({ id: INVOICE_ID, total: "30.00" });
+
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({ itemId: PRODUCT_ID, quantity: 2 }),
+    ]);
+    // Only the invoice totals/version update runs; no untracked stock update.
+    expect(updateSet).toHaveBeenCalledTimes(1);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ total: "30.00", updatedAt: expect.anything() }),
+    );
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(3, "share");
+    expect(lockFor).toHaveBeenNthCalledWith(4, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(5, "update");
   });
 
   it("deducts product stock when applying a template to a real invoice", async () => {
@@ -954,7 +1188,7 @@ describe("treatment template safety", () => {
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
-    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transaction).toHaveBeenCalledTimes(2);
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
   });
@@ -982,7 +1216,7 @@ describe("treatment template safety", () => {
       }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
-    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transaction).toHaveBeenCalledTimes(2);
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
   });
@@ -1062,8 +1296,9 @@ describe("treatment template safety", () => {
 
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
-    expect(lockFor).toHaveBeenCalledTimes(1);
-    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor).toHaveBeenCalledTimes(2);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "share");
   });
 
   it("rejects product references that are not active in the tenant", async () => {
@@ -1104,8 +1339,9 @@ describe("treatment template safety", () => {
 
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
-    expect(lockFor).toHaveBeenCalledTimes(1);
-    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor).toHaveBeenCalledTimes(2);
+    expect(lockFor).toHaveBeenNthCalledWith(1, "update");
+    expect(lockFor).toHaveBeenNthCalledWith(2, "share");
   });
 
   it("keeps batched catalog locks active, tenant-scoped, and deterministic", () => {
@@ -1135,9 +1371,38 @@ describe("treatment template safety", () => {
       source.indexOf("function nextInvoiceUpdatedAtSql"),
       source.indexOf("const templateItemBaseInput"),
     );
-    expect(versionSql).toContain("date_trunc('milliseconds', clock_timestamp())");
+    expect(versionSql).toContain(
+      "date_trunc('milliseconds', clock_timestamp())",
+    );
     expect(versionSql).toContain("${invoices.updatedAt}");
     expect(versionSql.match(/interval '1 millisecond'/g)).toHaveLength(2);
+    const medicationGuard = source.slice(
+      source.indexOf("function unsourcedTemplateProductIds"),
+      source.indexOf("export const templatesRouter"),
+    );
+    expect(medicationGuard).toContain(
+      "eq(dispenseChargeQueue.practiceId, ctx.practiceId)",
+    );
+    expect(medicationGuard).toContain(
+      "eq(dispenseChargeQueue.patientId, invoice.patientId)",
+    );
+    expect(medicationGuard).toContain('row.status === "pending"');
+    expect(medicationGuard).toContain('row.status === "waived"');
+    expect(medicationGuard).toContain(
+      "eq(prescriptions.appointmentId, invoice.appointmentId)",
+    );
+    expect(medicationGuard).toContain("isNull(prescriptions.deletedAt)");
+    expect(medicationGuard).toContain('row.status === "invoiced"');
+    expect(medicationGuard).toContain("row.invoiceId === invoiceId");
+    expect(applyBlock.indexOf("pg_advisory_xact_lock")).toBeLessThan(
+      applyBlock.indexOf("lockAndAssertNoUnsourcedMedicationTemplateConflict"),
+    );
+    expect(
+      applyBlock.indexOf("lockAndAssertNoUnsourcedMedicationTemplateConflict"),
+    ).toBeLessThan(applyBlock.indexOf("lockActiveTemplateCatalogItems"));
+    expect(applyBlock.indexOf("lockActiveTemplateCatalogItems")).toBeLessThan(
+      applyBlock.indexOf("recheckUnsourcedMedicationTemplateConflict"),
+    );
   });
 
   it("rejects template reads and writes when the practice is missing or deleted", async () => {

--- a/apps/web/server/__tests__/templates-safety.test.ts
+++ b/apps/web/server/__tests__/templates-safety.test.ts
@@ -44,6 +44,7 @@ function createDb(opts?: {
   updateResults?: unknown[][];
 }) {
   const selectResults = [...(opts?.selectResults ?? [])];
+  let routedInvoiceResult: unknown[] | undefined;
   const lockFor = vi.fn(() => afterWhereForCurrentSelect);
   let afterWhereForCurrentSelect: {
     limit: ReturnType<typeof vi.fn>;
@@ -54,8 +55,25 @@ function createDb(opts?: {
       reject?: (error: unknown) => unknown,
     ) => Promise<unknown>;
   };
-  const select = vi.fn(() => {
-    const result = selectResults.shift() ?? [];
+  const select = vi.fn((selection?: Record<string, unknown>) => {
+    const isInvoiceRouteRead =
+      selection &&
+      "isEstimate" in selection &&
+      "clientId" in selection &&
+      "appointmentId" in selection &&
+      !("status" in selection);
+    const isCurrentInvoiceRead =
+      selection &&
+      "isEstimate" in selection &&
+      "clientId" in selection &&
+      "appointmentId" in selection &&
+      "status" in selection &&
+      "paidAmount" in selection;
+    const result = isCurrentInvoiceRead
+      ? (routedInvoiceResult ?? [])
+      : (selectResults.shift() ?? []);
+    if (isInvoiceRouteRead) routedInvoiceResult = result;
+    if (isCurrentInvoiceRead) routedInvoiceResult = undefined;
     const afterWhere = {
       limit: vi.fn(async () => result),
       orderBy: vi.fn(() => afterWhere),
@@ -691,7 +709,7 @@ describe("treatment template safety", () => {
       message: expect.stringContaining("active inventory product"),
     });
 
-    expect(select).toHaveBeenCalledTimes(4);
+    expect(select).toHaveBeenCalledTimes(5);
     expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
   });
@@ -784,8 +802,8 @@ describe("treatment template safety", () => {
     expect(lockFor).toHaveBeenNthCalledWith(1, "update");
     expect(lockFor).toHaveBeenNthCalledWith(2, "share");
     expect(lockFor).toHaveBeenNthCalledWith(3, "share");
-    // Four request setup/read queries + two catalog batches + totals + tax.
-    expect(select).toHaveBeenCalledTimes(8);
+    // Routing/current invoice reads + template/catalog batches + totals + tax.
+    expect(select).toHaveBeenCalledTimes(9);
   });
 
   it.each(["pending", "waived"] as const)(
@@ -1367,6 +1385,20 @@ describe("treatment template safety", () => {
     expect(applyBlock.indexOf("pg_advisory_xact_lock")).toBeLessThan(
       applyBlock.indexOf("nextInvoiceUpdatedAtSql()"),
     );
+    const invoiceAdvisory = applyBlock.indexOf(
+      "hashtextextended(${input.invoiceId}, 0)",
+    );
+    const appointmentAdvisory = applyBlock.indexOf(
+      "hashtextextended(${routeIdentity.appointmentId}, 0)",
+    );
+    const appointmentRowLock = applyBlock.indexOf(".from(appointments)");
+    const currentInvoiceRowLock = applyBlock.indexOf(
+      "// Lock and re-read only after the visit boundary.",
+    );
+    expect(invoiceAdvisory).toBeGreaterThanOrEqual(0);
+    expect(appointmentAdvisory).toBeGreaterThan(invoiceAdvisory);
+    expect(appointmentRowLock).toBeGreaterThan(appointmentAdvisory);
+    expect(currentInvoiceRowLock).toBeGreaterThan(appointmentRowLock);
     const versionSql = source.slice(
       source.indexOf("function nextInvoiceUpdatedAtSql"),
       source.indexOf("const templateItemBaseInput"),
@@ -1386,14 +1418,22 @@ describe("treatment template safety", () => {
     expect(medicationGuard).toContain(
       "eq(dispenseChargeQueue.patientId, invoice.patientId)",
     );
-    expect(medicationGuard).toContain('row.status === "pending"');
-    expect(medicationGuard).toContain('row.status === "waived"');
+    expect(medicationGuard).toContain(
+      'inArray(dispenseChargeQueue.status, ["pending", "waived"])',
+    );
     expect(medicationGuard).toContain(
       "eq(prescriptions.appointmentId, invoice.appointmentId)",
     );
     expect(medicationGuard).toContain("isNull(prescriptions.deletedAt)");
-    expect(medicationGuard).toContain('row.status === "invoiced"');
-    expect(medicationGuard).toContain("row.invoiceId === invoiceId");
+    expect(medicationGuard).toContain(
+      'eq(dispenseChargeQueue.status, "invoiced")',
+    );
+    expect(medicationGuard).toContain(
+      "eq(dispenseChargeQueue.invoiceId, invoice.id)",
+    );
+    expect(medicationGuard).toContain(
+      "invoiced-other history is deliberately not locked ahead of products.",
+    );
     expect(applyBlock.indexOf("pg_advisory_xact_lock")).toBeLessThan(
       applyBlock.indexOf("lockAndAssertNoUnsourcedMedicationTemplateConflict"),
     );

--- a/apps/web/server/routers/templates.ts
+++ b/apps/web/server/routers/templates.ts
@@ -7,6 +7,9 @@ import {
   treatmentTemplateItems,
   invoices,
   invoiceItems,
+  appointments,
+  dispenseChargeQueue,
+  prescriptions,
   practices,
   products,
   services,
@@ -361,6 +364,165 @@ async function deductTemplateProductStock(
         message: "Insufficient stock for one or more product template items.",
       });
     }
+  }
+}
+
+function unsourcedTemplateProductIds(items: readonly TemplateInvoiceItem[]) {
+  return [
+    ...new Set(
+      items
+        .filter((item) => item.itemType === "product" && item.itemId)
+        .map((item) => item.itemId!),
+    ),
+  ].sort();
+}
+
+async function medicationDispenseEvidenceRows(
+  ctx: TemplatesContext,
+  invoice: {
+    id: string;
+    patientId: string | null;
+  },
+  productIds: string[],
+  lock: boolean,
+) {
+  if (!invoice.patientId || productIds.length === 0) return [];
+  const query = ctx.db
+    .select({
+      id: dispenseChargeQueue.id,
+      status: dispenseChargeQueue.status,
+      invoiceId: dispenseChargeQueue.invoiceId,
+    })
+    .from(dispenseChargeQueue)
+    .where(
+      and(
+        eq(dispenseChargeQueue.practiceId, ctx.practiceId),
+        eq(dispenseChargeQueue.patientId, invoice.patientId),
+        inArray(dispenseChargeQueue.productId, productIds),
+      ),
+    )
+    .orderBy(asc(dispenseChargeQueue.id));
+  return lock ? query.for("update") : query;
+}
+
+function hasUnsourcedMedicationTemplateConflict(
+  rows: Awaited<ReturnType<typeof medicationDispenseEvidenceRows>>,
+  invoiceId: string,
+) {
+  return rows.some(
+    (row) =>
+      row.status === "pending" ||
+      row.status === "waived" ||
+      (row.status === "invoiced" && row.invoiceId === invoiceId),
+  );
+}
+
+function medicationTemplateConflict(): TRPCError {
+  return new TRPCError({
+    code: "PRECONDITION_FAILED",
+    message:
+      "Review this patient's dispensed medication in the medication billing queue before applying an unsourced product template.",
+  });
+}
+
+async function lockAndAssertNoUnsourcedMedicationTemplateConflict(
+  ctx: TemplatesContext,
+  invoice: {
+    id: string;
+    clientId: string;
+    patientId: string | null;
+    appointmentId: string | null;
+    isEstimate: boolean;
+  },
+  items: readonly TemplateInvoiceItem[],
+) {
+  if (invoice.isEstimate || !invoice.patientId) return [];
+
+  const productIds = unsourcedTemplateProductIds(items);
+  if (productIds.length === 0) return [];
+
+  if (invoice.appointmentId) {
+    // Preserve the visit mutation order used by refill work: appointment,
+    // medication source, then catalog product. The invoice advisory lock is
+    // already held by the caller before this row lock is acquired.
+    const [appointment] = await ctx.db
+      .select({
+        id: appointments.id,
+        clientId: appointments.clientId,
+        patientId: appointments.patientId,
+        status: appointments.status,
+      })
+      .from(appointments)
+      .where(
+        and(
+          eq(appointments.id, invoice.appointmentId),
+          eq(appointments.practiceId, ctx.practiceId),
+          isNull(appointments.deletedAt),
+        ),
+      )
+      .for("update");
+    if (
+      !appointment ||
+      appointment.clientId !== invoice.clientId ||
+      appointment.patientId !== invoice.patientId ||
+      appointment.status !== "in_exam"
+    ) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message:
+          "The linked visit changed. Refresh before applying this treatment template.",
+      });
+    }
+
+    const visitPrescriptions = await ctx.db
+      .select({ id: prescriptions.id })
+      .from(prescriptions)
+      .where(
+        and(
+          eq(prescriptions.practiceId, ctx.practiceId),
+          eq(prescriptions.patientId, invoice.patientId),
+          eq(prescriptions.appointmentId, invoice.appointmentId),
+          inArray(prescriptions.productId, productIds),
+          isNull(prescriptions.deletedAt),
+        ),
+      )
+      .orderBy(asc(prescriptions.id))
+      .for("share");
+    if (visitPrescriptions.length > 0) throw medicationTemplateConflict();
+  }
+
+  // Lock all existing evidence for these patient/product pairs, including an
+  // allowed historical invoiced row. That row cannot be reopened to pending
+  // between the decision and the template write.
+  const evidence = await medicationDispenseEvidenceRows(
+    ctx,
+    invoice,
+    productIds,
+    true,
+  );
+  if (hasUnsourcedMedicationTemplateConflict(evidence, invoice.id)) {
+    throw medicationTemplateConflict();
+  }
+  return productIds;
+}
+
+async function recheckUnsourcedMedicationTemplateConflict(
+  ctx: TemplatesContext,
+  invoice: { id: string; patientId: string | null; isEstimate: boolean },
+  productIds: string[],
+) {
+  if (invoice.isEstimate) return;
+  // Standalone refill work locks and mutates the product before creating its
+  // queue row. Re-read after deterministic product locks so a refill that won
+  // that race cannot be charged again by an unsourced template.
+  const evidence = await medicationDispenseEvidenceRows(
+    ctx,
+    invoice,
+    productIds,
+    false,
+  );
+  if (hasUnsourcedMedicationTemplateConflict(evidence, invoice.id)) {
+    throw medicationTemplateConflict();
   }
 }
 
@@ -806,51 +968,55 @@ export const templatesRouter = createRouter({
         });
       }
 
-      // Verify invoice belongs to this practice
-      const [invoice] = await ctx.db
-        .select({
-          id: invoices.id,
-          status: invoices.status,
-          paidAmount: invoices.paidAmount,
-          isEstimate: invoices.isEstimate,
-        })
-        .from(invoices)
-        .where(
-          and(
-            eq(invoices.id, input.invoiceId),
-            eq(invoices.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(invoices.deletedAt),
-          ),
-        )
-        .limit(1);
-
-      if (!invoice) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Invoice not found",
-        });
-      }
-      if (invoice.status !== "draft") {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Apply treatment templates before sending the invoice.",
-        });
-      }
-      if (moneyToCents(invoice.paidAmount) > 0) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message:
-            "Cannot apply treatment templates to invoices with payments.",
-        });
-      }
-
       return ctx.db.transaction(async (tx) => {
         // Share the invoice serialization key used by direct charge edits so
         // concurrent template applications cannot calculate competing totals.
         await tx.execute(
           sql`select pg_advisory_xact_lock(hashtextextended(${input.invoiceId}, 0))`,
         );
+
+        // Re-read and lock the tenant invoice only after serialization. A
+        // confirmation that waited behind another mutation must use current
+        // patient, visit, payment, and estimate state.
+        const [invoice] = await tx
+          .select({
+            id: invoices.id,
+            status: invoices.status,
+            paidAmount: invoices.paidAmount,
+            isEstimate: invoices.isEstimate,
+            clientId: invoices.clientId,
+            patientId: invoices.patientId,
+            appointmentId: invoices.appointmentId,
+          })
+          .from(invoices)
+          .where(
+            and(
+              eq(invoices.id, input.invoiceId),
+              eq(invoices.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(invoices.deletedAt),
+            ),
+          )
+          .for("update");
+        if (!invoice) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Invoice not found",
+          });
+        }
+        if (invoice.status !== "draft") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Apply treatment templates before sending the invoice.",
+          });
+        }
+        if (moneyToCents(invoice.paidAmount) > 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Cannot apply treatment templates to invoices with payments.",
+          });
+        }
 
         // Fetch template items
         const items = await tx
@@ -871,6 +1037,17 @@ export const templatesRouter = createRouter({
           });
         }
 
+        const medicationProductIds =
+          await lockAndAssertNoUnsourcedMedicationTemplateConflict(
+            { db: tx, practiceId: ctx.practiceId },
+            invoice,
+            items.map((item) => ({
+              itemType: item.itemType,
+              itemId: item.itemId,
+              quantity: item.defaultQuantity,
+            })),
+          );
+
         // Templates snapshot descriptions and prices, but active catalog
         // references still need to be valid when the template is used. This
         // prevents archived services or products from silently being charged
@@ -882,6 +1059,11 @@ export const templatesRouter = createRouter({
             itemId: item.itemId ?? undefined,
           })),
           { lockProductsForStock: !invoice.isEstimate },
+        );
+        await recheckUnsourcedMedicationTemplateConflict(
+          { db: tx, practiceId: ctx.practiceId },
+          invoice,
+          medicationProductIds,
         );
 
         const invoiceItemRows = items.map((item) => {

--- a/apps/web/server/routers/templates.ts
+++ b/apps/web/server/routers/templates.ts
@@ -377,7 +377,7 @@ function unsourcedTemplateProductIds(items: readonly TemplateInvoiceItem[]) {
   ].sort();
 }
 
-async function medicationDispenseEvidenceRows(
+async function blockingDispenseChargeRows(
   ctx: TemplatesContext,
   invoice: {
     id: string;
@@ -388,33 +388,24 @@ async function medicationDispenseEvidenceRows(
 ) {
   if (!invoice.patientId || productIds.length === 0) return [];
   const query = ctx.db
-    .select({
-      id: dispenseChargeQueue.id,
-      status: dispenseChargeQueue.status,
-      invoiceId: dispenseChargeQueue.invoiceId,
-    })
+    .select({ id: dispenseChargeQueue.id })
     .from(dispenseChargeQueue)
     .where(
       and(
         eq(dispenseChargeQueue.practiceId, ctx.practiceId),
         eq(dispenseChargeQueue.patientId, invoice.patientId),
         inArray(dispenseChargeQueue.productId, productIds),
+        or(
+          inArray(dispenseChargeQueue.status, ["pending", "waived"]),
+          and(
+            eq(dispenseChargeQueue.status, "invoiced"),
+            eq(dispenseChargeQueue.invoiceId, invoice.id),
+          ),
+        ),
       ),
     )
     .orderBy(asc(dispenseChargeQueue.id));
   return lock ? query.for("update") : query;
-}
-
-function hasUnsourcedMedicationTemplateConflict(
-  rows: Awaited<ReturnType<typeof medicationDispenseEvidenceRows>>,
-  invoiceId: string,
-) {
-  return rows.some(
-    (row) =>
-      row.status === "pending" ||
-      row.status === "waived" ||
-      (row.status === "invoiced" && row.invoiceId === invoiceId),
-  );
 }
 
 function medicationTemplateConflict(): TRPCError {
@@ -429,7 +420,6 @@ async function lockAndAssertNoUnsourcedMedicationTemplateConflict(
   ctx: TemplatesContext,
   invoice: {
     id: string;
-    clientId: string;
     patientId: string | null;
     appointmentId: string | null;
     isEstimate: boolean;
@@ -442,38 +432,6 @@ async function lockAndAssertNoUnsourcedMedicationTemplateConflict(
   if (productIds.length === 0) return [];
 
   if (invoice.appointmentId) {
-    // Preserve the visit mutation order used by refill work: appointment,
-    // medication source, then catalog product. The invoice advisory lock is
-    // already held by the caller before this row lock is acquired.
-    const [appointment] = await ctx.db
-      .select({
-        id: appointments.id,
-        clientId: appointments.clientId,
-        patientId: appointments.patientId,
-        status: appointments.status,
-      })
-      .from(appointments)
-      .where(
-        and(
-          eq(appointments.id, invoice.appointmentId),
-          eq(appointments.practiceId, ctx.practiceId),
-          isNull(appointments.deletedAt),
-        ),
-      )
-      .for("update");
-    if (
-      !appointment ||
-      appointment.clientId !== invoice.clientId ||
-      appointment.patientId !== invoice.patientId ||
-      appointment.status !== "in_exam"
-    ) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message:
-          "The linked visit changed. Refresh before applying this treatment template.",
-      });
-    }
-
     const visitPrescriptions = await ctx.db
       .select({ id: prescriptions.id })
       .from(prescriptions)
@@ -491,18 +449,15 @@ async function lockAndAssertNoUnsourcedMedicationTemplateConflict(
     if (visitPrescriptions.length > 0) throw medicationTemplateConflict();
   }
 
-  // Lock all existing evidence for these patient/product pairs, including an
-  // allowed historical invoiced row. That row cannot be reopened to pending
-  // between the decision and the template write.
-  const evidence = await medicationDispenseEvidenceRows(
+  // A blocking row ends this transaction before product acquisition. Allowed
+  // invoiced-other history is deliberately not locked ahead of products.
+  const blockers = await blockingDispenseChargeRows(
     ctx,
     invoice,
     productIds,
     true,
   );
-  if (hasUnsourcedMedicationTemplateConflict(evidence, invoice.id)) {
-    throw medicationTemplateConflict();
-  }
+  if (blockers.length > 0) throw medicationTemplateConflict();
   return productIds;
 }
 
@@ -515,15 +470,13 @@ async function recheckUnsourcedMedicationTemplateConflict(
   // Standalone refill work locks and mutates the product before creating its
   // queue row. Re-read after deterministic product locks so a refill that won
   // that race cannot be charged again by an unsourced template.
-  const evidence = await medicationDispenseEvidenceRows(
+  const blockers = await blockingDispenseChargeRows(
     ctx,
     invoice,
     productIds,
     false,
   );
-  if (hasUnsourcedMedicationTemplateConflict(evidence, invoice.id)) {
-    throw medicationTemplateConflict();
-  }
+  if (blockers.length > 0) throw medicationTemplateConflict();
 }
 
 export const templatesRouter = createRouter({
@@ -968,6 +921,33 @@ export const templatesRouter = createRouter({
         });
       }
 
+      // This unlocked read chooses the routing boundary only. Every mutable
+      // invoice field is re-read under the canonical locks below.
+      const [routeIdentity] = await ctx.db
+        .select({
+          id: invoices.id,
+          isEstimate: invoices.isEstimate,
+          clientId: invoices.clientId,
+          patientId: invoices.patientId,
+          appointmentId: invoices.appointmentId,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.id, input.invoiceId),
+            eq(invoices.practiceId, ctx.practiceId),
+            activePracticePredicate(ctx.practiceId),
+            isNull(invoices.deletedAt),
+          ),
+        )
+        .limit(1);
+      if (!routeIdentity) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invoice not found",
+        });
+      }
+
       return ctx.db.transaction(async (tx) => {
         // Share the invoice serialization key used by direct charge edits so
         // concurrent template applications cannot calculate competing totals.
@@ -975,9 +955,73 @@ export const templatesRouter = createRouter({
           sql`select pg_advisory_xact_lock(hashtextextended(${input.invoiceId}, 0))`,
         );
 
-        // Re-read and lock the tenant invoice only after serialization. A
-        // confirmation that waited behind another mutation must use current
-        // patient, visit, payment, and estimate state.
+        // Fetch template items before choosing whether this actual invoice
+        // needs the visit medication lock path. Service-only templates do not
+        // inherit the in-exam requirement.
+        const items = await tx
+          .select()
+          .from(treatmentTemplateItems)
+          .where(
+            and(
+              eq(treatmentTemplateItems.templateId, input.templateId),
+              isNull(treatmentTemplateItems.deletedAt),
+            ),
+          )
+          .orderBy(asc(treatmentTemplateItems.sortOrder));
+        if (items.length === 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Template has no items",
+          });
+        }
+        const routeProductIds = routeIdentity.isEstimate
+          ? []
+          : unsourcedTemplateProductIds(
+              items.map((item) => ({
+                itemType: item.itemType,
+                itemId: item.itemId,
+                quantity: item.defaultQuantity,
+              })),
+            );
+
+        if (routeIdentity.appointmentId && routeProductIds.length > 0) {
+          // createDispenseChargeInvoice owns this same order: appointment
+          // advisory/row before the visit invoice row.
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${routeIdentity.appointmentId}, 0))`,
+          );
+          const [appointment] = await tx
+            .select({
+              id: appointments.id,
+              clientId: appointments.clientId,
+              patientId: appointments.patientId,
+              status: appointments.status,
+            })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, routeIdentity.appointmentId),
+                eq(appointments.practiceId, ctx.practiceId),
+                isNull(appointments.deletedAt),
+              ),
+            )
+            .for("update");
+          if (
+            !appointment ||
+            appointment.clientId !== routeIdentity.clientId ||
+            appointment.patientId !== routeIdentity.patientId ||
+            appointment.status !== "in_exam"
+          ) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                "The linked visit changed. Refresh before applying this treatment template.",
+            });
+          }
+        }
+
+        // Lock and re-read only after the visit boundary. A confirmation that
+        // waited behind another mutation must use current routing and state.
         const [invoice] = await tx
           .select({
             id: invoices.id,
@@ -1004,6 +1048,18 @@ export const templatesRouter = createRouter({
             message: "Invoice not found",
           });
         }
+        if (
+          invoice.clientId !== routeIdentity.clientId ||
+          invoice.patientId !== routeIdentity.patientId ||
+          invoice.appointmentId !== routeIdentity.appointmentId ||
+          invoice.isEstimate !== routeIdentity.isEstimate
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "Invoice routing changed. Refresh before applying this treatment template.",
+          });
+        }
         if (invoice.status !== "draft") {
           throw new TRPCError({
             code: "BAD_REQUEST",
@@ -1015,25 +1071,6 @@ export const templatesRouter = createRouter({
             code: "BAD_REQUEST",
             message:
               "Cannot apply treatment templates to invoices with payments.",
-          });
-        }
-
-        // Fetch template items
-        const items = await tx
-          .select()
-          .from(treatmentTemplateItems)
-          .where(
-            and(
-              eq(treatmentTemplateItems.templateId, input.templateId),
-              isNull(treatmentTemplateItems.deletedAt),
-            ),
-          )
-          .orderBy(asc(treatmentTemplateItems.sortOrder));
-
-        if (items.length === 0) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Template has no items",
           });
         }
 


### PR DESCRIPTION
## Purpose

Recover the first safe successor slice from closed PR #199 without adopting its stale schema or inventory stack.

## Safety behavior

- Blocks product-template invoicing when the visit prescription or medication queue already represents the same charge.
- Preserves estimates, service-only templates, deleted prescriptions, historical charges on another invoice, untracked inventory, tenant RLS, and atomic rollback/version behavior.
- Uses a consistent invoice-advisory, appointment, invoice, product, and blocker lock protocol.
- Retains the post-product refill-phantom recheck.

## Review and proof

- Independent exact-head review: GO; no P0/P1 findings.
- Focused template safety: 32/32.
- Disposable PostgreSQL contract as openpims_app: green, including forced template-vs-dispense-charge and historical-invoice-edit schedules, RLS, and stock invariants.
- Full web suite: 4,206 passed, 15 skipped.
- Web typecheck, migration integrity (82 passed, 1 skipped), production build, and diff check: green.

## Scope

Three files only. No schema, migration, UI, environment, provider, dependency, or deployment changes. Draft until exact-head GitHub CI and CodeQL are green.