### PR TITLE
ci: normalize pnpm action pin on current development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -95,7 +95,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
@@ -171,7 +171,7 @@ jobs:
           persist-credentials: false
       - name: Verify checked-out revision
         run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
@@ -254,7 +254,7 @@ jobs:
           persist-credentials: false
       - name: Verify checked-out revision
         run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
@@ -337,7 +337,7 @@ jobs:
           persist-credentials: false
       - name: Verify checked-out revision
         run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-      - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24


### PR DESCRIPTION
## Summary

- replace all seven `pnpm/action-setup` uses with immutable commit `0977fd99725f1db4007ccb2928dbb4e90d06cc86`
- preserve the current Development, Staging, Demo, and Production workflow structure
- supersede stale PR #220 without replaying its old main-based workflow files

## Supply-chain evidence

The prior value `f520eceda224fe1a4aed5a2a27a194379a409996` is the verified signed annotated `v6` tag object. Its target is exactly commit `0977fd99725f1db4007ccb2928dbb4e90d06cc86`; `action.yml` and `dist/index.js` resolve to identical blob SHAs through both refs. This normalizes the immutable pin and does not change action code or runtime behavior.

## Verification

- independent exact-commit review: GO, no P0/P1/P2
- exactly 7 new pins and 0 old pins
- both workflow YAML files parse
- repository-governance tests: 7/7
- `git diff --check`

No migration dispatch, hosted environment, credential, provider, staging, or production change is included.