### PR TITLE
Recover privacy-safe acquisition outcomes reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,14 @@ jobs:
       - name: Execute finance schema adoption contract
         run: pnpm --filter @openpims/db db:finance-adoption:test
 
+      # Platform acquisition outcomes aggregate across clinic tenants. Exercise
+      # the exact query as openpims_app and prove system-only access, no-context
+      # isolation, privacy filters, and cohort-versus-period semantics.
+      - name: Execute acquisition outcomes database contract
+        env:
+          JOURNEY_FUNNEL_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/web exec vitest run lib/__tests__/journey-funnel.integration.test.ts
+
       # Exercise the clinic-facing patient + owner search through the real
       # router and least-privilege RLS role. The fixture proves literal LIKE
       # escaping, deterministic bounds, context cleanup, and cross-tenant deny.

--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -134,6 +134,7 @@ export default function AdminPage() {
       utils.admin.overview.invalidate();
       utils.admin.activationFunnel.invalidate();
       utils.admin.activationRecovery.invalidate();
+      utils.admin.journeyFunnel.invalidate();
     },
     onError: (err) => setAnalyticsError(err.message),
   });
@@ -1246,6 +1247,122 @@ export default function AdminPage() {
                   ) : null}
                 </tbody>
               </table>
+            </div>
+
+            <div className="mt-6">
+              <h3 className="font-heading text-base font-semibold">
+                Acquisition outcomes · registrations in the past {journey.days}
+                days
+              </h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Restricted aggregate cohorts use fixed product-owned channel
+                buckets and canonical milestones. Rates use registered practices
+                as the denominator; missing values stay Unknown and unrecognized
+                values become Other without being displayed.
+              </p>
+              <div className="mt-3 overflow-x-auto rounded-md border border-border">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Source</th>
+                      <th className="px-3 py-2 font-medium">Medium</th>
+                      <th className="px-3 py-2 font-medium">Campaign</th>
+                      <th className="px-3 py-2 font-medium">Registered</th>
+                      <th className="px-3 py-2 font-medium">Activated</th>
+                      <th className="px-3 py-2 font-medium">Payment method</th>
+                      <th className="px-3 py-2 font-medium">
+                        Positive payment
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {journey.acquisitionOutcomes.map((outcome) => (
+                      <tr
+                        key={`${outcome.source}:${outcome.medium}:${outcome.campaign}`}
+                      >
+                        <td className="px-3 py-2 font-medium">
+                          {outcome.source}
+                        </td>
+                        <td className="px-3 py-2">{outcome.medium}</td>
+                        <td className="px-3 py-2">{outcome.campaign}</td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.registrations}
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.activated}{" "}
+                          <span className="text-xs text-muted-foreground">
+                            {formatPct(outcome.activationRate)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.paymentMethodCollected}{" "}
+                          <span className="text-xs text-muted-foreground">
+                            {formatPct(outcome.paymentMethodRate)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">
+                          {outcome.firstPositivePayment}{" "}
+                          <span className="text-xs text-muted-foreground">
+                            {formatPct(outcome.positivePaymentRate)}
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                    {journey.acquisitionOutcomes.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={7}
+                          className="px-3 py-6 text-center text-muted-foreground"
+                        >
+                          No registered acquisition cohorts in this window.
+                        </td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+              {journey.acquisitionOutcomesTruncated ? (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Showing the top {journey.acquisitionOutcomeRowLimit} bucket
+                  combinations in deterministic order; additional combinations
+                  are omitted.
+                </p>
+              ) : null}
+            </div>
+
+            <div className="mt-6">
+              <h3 className="font-heading text-base font-semibold">
+                Period activity · milestone events in the past {journey.days}
+                days
+              </h3>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                {[
+                  ["Registered", journey.periodActivity.registrations],
+                  ["Activated", journey.periodActivity.activated],
+                  [
+                    "Payment method",
+                    journey.periodActivity.paymentMethodCollected,
+                  ],
+                  [
+                    "Positive payment",
+                    journey.periodActivity.firstPositivePayment,
+                  ],
+                ].map(([label, value]) => (
+                  <div
+                    key={String(label)}
+                    className="rounded-md bg-muted/30 p-3"
+                  >
+                    <p className="text-xs text-muted-foreground">{label}</p>
+                    <p className="mt-1 font-heading text-xl font-bold tabular-nums">
+                      {value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                These counts use the exact milestone occurrence time and are not
+                a signup cohort conversion rate.
+              </p>
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
               Anonymous first touch is carried across openvpm.com, demo, and

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -128,6 +128,28 @@ function journey(days: number): JourneyFunnel {
   return {
     days,
     weeks: [],
+    acquisitionOutcomes: [
+      {
+        source: "demo<script>",
+        medium: "product",
+        campaign: "demo_dashboard",
+        registrations: 5,
+        activated: 2,
+        paymentMethodCollected: 1,
+        firstPositivePayment: 1,
+        activationRate: 0.4,
+        paymentMethodRate: 0.2,
+        positivePaymentRate: 0.2,
+      },
+    ],
+    acquisitionOutcomeRowLimit: 20,
+    acquisitionOutcomesTruncated: true,
+    periodActivity: {
+      registrations: 6,
+      activated: 3,
+      paymentMethodCollected: 2,
+      firstPositivePayment: 1,
+    },
     totals: {
       visitors: 20,
       demos: 8,
@@ -285,6 +307,20 @@ describe("activation digest cron", () => {
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
+        html: expect.stringContaining(
+          "Acquisition outcomes · registered in this window",
+        ),
+      }),
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining(
+          "Period activity · milestone events in this window:",
+        ),
+      }),
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
         html: expect.stringContaining("Supported clinic cohort"),
       }),
     );
@@ -294,6 +330,10 @@ describe("activation digest cron", () => {
       )[0]?.[0].html ?? "";
     expect(html).not.toContain("North &lt;Clinic&gt;");
     expect(html).not.toContain("North <Clinic>");
+    expect(html).toContain(">Other</td>");
+    expect(html).not.toContain("demo&lt;script&gt;");
+    expect(html).not.toContain("demo<script>");
+    expect(html).toContain("Showing the top 20 bucket combinations");
     expect(html).toContain("aggregate-only");
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({ to: "ops@openvpm.com" }),

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -14,6 +14,7 @@ import {
   type JourneyFunnel,
 } from "@/lib/admin/journey-funnel";
 import { loadClinicPilotQueue } from "@/lib/admin/clinic-pilots";
+import { safeAcquisitionReportingBucket } from "@/lib/acquisition";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -93,6 +94,17 @@ function pct(rate: number): string {
   return `${Math.round(rate * 100)}%`;
 }
 
+function escapeHtml(value: string): string {
+  const replacements: Record<string, string> = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  };
+  return value.replace(/[&<>"']/g, (character) => replacements[character]!);
+}
+
 function funnelSection(title: string, funnel: ActivationFunnel): string {
   const {
     signups,
@@ -157,6 +169,22 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
     paymentMethodRate,
     positivePaymentRate,
   } = funnel.totals;
+  const acquisitionRows = funnel.acquisitionOutcomes
+    .map(
+      (outcome) => `<tr style="font-size:13px;color:#111827;">
+    <td style="padding:5px 12px 5px 0;">${escapeHtml(safeAcquisitionReportingBucket("source", outcome.source))}</td>
+    <td style="padding:5px 12px 5px 0;">${escapeHtml(safeAcquisitionReportingBucket("medium", outcome.medium))}</td>
+    <td style="padding:5px 12px 5px 0;">${escapeHtml(safeAcquisitionReportingBucket("campaign", outcome.campaign))}</td>
+    <td style="padding:5px 12px 5px 0;">${outcome.registrations}</td>
+    <td style="padding:5px 12px 5px 0;">${outcome.activated} <span style="color:#6b7280;">${pct(outcome.activationRate)}</span></td>
+    <td style="padding:5px 12px 5px 0;">${outcome.paymentMethodCollected} <span style="color:#6b7280;">${pct(outcome.paymentMethodRate)}</span></td>
+    <td style="padding:5px 0;">${outcome.firstPositivePayment} <span style="color:#6b7280;">${pct(outcome.positivePaymentRate)}</span></td>
+  </tr>`,
+    )
+    .join("");
+  const acquisitionBody =
+    acquisitionRows ||
+    `<tr><td colspan="7" style="padding:8px 0;color:#6b7280;font-size:13px;">No registered acquisition cohorts in this window.</td></tr>`;
   return `<h2 style="margin:24px 0 8px;font-size:16px;color:#111827;">${title}</h2>
 <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
   <tr style="text-align:left;color:#6b7280;font-size:13px;">
@@ -178,7 +206,24 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
 </table>
 <p style="margin:8px 0 0;color:#374151;font-size:13px;line-height:1.5;"><strong>Signup path:</strong> ${signupProfileViewed} plan start(s) → ${signupProfileCompleted} plan(s) built → ${signupAccountViewed} account form(s) → ${signupSubmitted} submission(s) → ${registrations} registered.</p>
 <p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Left before trying: ${funnel.totals.leftBeforeTrying} · Demo without signup: ${funnel.totals.demoAbandoned} · Signup without activation: ${funnel.totals.registrationAbandoned} · Activated without payment method: ${funnel.totals.activationAbandoned} · Payment method without positive payment after trial: ${funnel.totals.paymentAbandoned} · Client errors: ${funnel.totals.clientErrors}</p>
-<p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>`;
+<p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>
+<h3 style="margin:16px 0 4px;font-size:14px;color:#111827;">Acquisition outcomes · registered in this window</h3>
+<p style="margin:0 0 6px;color:#6b7280;font-size:12px;line-height:1.5;">Restricted aggregate cohorts use fixed product-owned channel buckets and canonical milestones. Rates use registrations as the denominator; missing values stay Unknown and unrecognized values become Other without being displayed.</p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+  <tr style="text-align:left;color:#6b7280;font-size:12px;">
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Source</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Medium</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Campaign</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Registered</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Activated</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Payment method</th>
+    <th style="padding:4px 0;font-weight:500;">Positive payment</th>
+  </tr>
+  ${acquisitionBody}
+</table>
+${funnel.acquisitionOutcomesTruncated ? `<p style="margin:4px 0 0;color:#6b7280;font-size:12px;line-height:1.5;">Showing the top ${funnel.acquisitionOutcomeRowLimit} bucket combinations in deterministic order; additional combinations are omitted.</p>` : ""}
+<p style="margin:10px 0 0;color:#374151;font-size:13px;line-height:1.5;"><strong>Period activity · milestone events in this window:</strong> ${funnel.periodActivity.registrations} registered · ${funnel.periodActivity.activated} activated · ${funnel.periodActivity.paymentMethodCollected} payment method · ${funnel.periodActivity.firstPositivePayment} first positive payment.</p>
+<p style="margin:4px 0 0;color:#6b7280;font-size:12px;line-height:1.5;">Period activity uses exact milestone occurrence time and is not a signup cohort conversion rate.</p>`;
 }
 
 type ClinicPilotQueue = Awaited<ReturnType<typeof loadClinicPilotQueue>>;

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -104,6 +104,32 @@ describe("admin UI", () => {
     expect(compactSource).toContain("active trial with a collected");
   });
 
+  it("separates privacy-bucketed acquisition outcomes from period activity", () => {
+    expect(source).toContain(
+      "Acquisition outcomes · registrations in the past",
+    );
+    expect(source).toContain("journey.acquisitionOutcomes.map");
+    expect(source).toContain("outcome.source");
+    expect(source).toContain("outcome.medium");
+    expect(source).toContain("outcome.campaign");
+    expect(source).toContain("formatPct(outcome.activationRate)");
+    expect(source).toContain("formatPct(outcome.paymentMethodRate)");
+    expect(source).toContain("formatPct(outcome.positivePaymentRate)");
+    expect(source).toContain("fixed product-owned channel");
+    expect(compactSource).toContain(
+      "missing values stay Unknown and unrecognized values become Other",
+    );
+    expect(source).toContain("journey.acquisitionOutcomesTruncated");
+    expect(source).toContain("journey.acquisitionOutcomeRowLimit");
+    expect(source).toContain("Period activity · milestone events in the past");
+    expect(source).toContain("journey.periodActivity.registrations");
+    expect(source).toContain("journey.periodActivity.activated");
+    expect(source).toContain("journey.periodActivity.paymentMethodCollected");
+    expect(source).toContain("journey.periodActivity.firstPositivePayment");
+    expect(source).toContain("utils.admin.journeyFunnel.invalidate()");
+    expect(compactSource).toContain("not a signup cohort conversion rate");
+  });
+
   it("shows trial source and setup stage for diagnosing individual drop-off", () => {
     expect(source).toContain("{p.acquisitionSource}");
     expect(source).toContain("{p.onboardingIntent}");

--- a/apps/web/lib/__tests__/journey-funnel.integration.test.ts
+++ b/apps/web/lib/__tests__/journey-funnel.integration.test.ts
@@ -1,0 +1,274 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import * as schema from "../../../../packages/db/schema/index";
+import { computeJourneyFunnel } from "@/lib/admin/journey-funnel";
+
+const repoRoot = resolve(process.cwd(), "../..");
+type SqlClient = ReturnType<typeof postgres>;
+const describeWithPostgres =
+  process.env.JOURNEY_FUNNEL_DB_INTEGRATION === "1"
+    ? describe.sequential
+    : describe.skip;
+
+function runPnpm(args: string[], databaseUrl: string): void {
+  const pnpmCliPath = process.env.PNPM_CLI_PATH?.trim();
+  execFileSync(
+    pnpmCliPath ? process.execPath : "pnpm",
+    pnpmCliPath ? [pnpmCliPath, ...args] : args,
+    {
+      cwd: repoRoot,
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      encoding: "utf8",
+    },
+  );
+}
+
+describeWithPostgres("journey funnel PostgreSQL and RLS contract", () => {
+  it("uses canonical cross-tenant aggregates while keeping raw rows system-only", async () => {
+    const adminUrl = process.env.DATABASE_URL?.trim();
+    if (!adminUrl) throw new Error("DATABASE_URL is required");
+    const hostname = new URL(adminUrl).hostname;
+    if (!["localhost", "127.0.0.1", "::1"].includes(hostname)) {
+      throw new Error("This test is restricted to disposable local PostgreSQL");
+    }
+    const appPassword = process.env.OPENPIMS_APP_DB_PASSWORD?.trim();
+    if (!appPassword) throw new Error("OPENPIMS_APP_DB_PASSWORD is required");
+
+    const databaseName = `openpims_journey_funnel_${randomUUID().replaceAll("-", "")}`;
+    if (!/^openpims_journey_funnel_[a-f0-9]+$/.test(databaseName)) {
+      throw new Error("unsafe disposable database name");
+    }
+    const databaseUrl = new URL(adminUrl);
+    databaseUrl.pathname = `/${databaseName}`;
+    databaseUrl.search = "";
+    databaseUrl.hash = "";
+    const appUrl = new URL(databaseUrl);
+    appUrl.username = "openpims_app";
+    appUrl.password = appPassword;
+
+    const adminSql = postgres(adminUrl, { max: 1 });
+    let ownerSql: ReturnType<typeof postgres> | undefined;
+    let appSql: ReturnType<typeof postgres> | undefined;
+    let databaseCreated = false;
+
+    try {
+      await adminSql.unsafe(`create database "${databaseName}"`);
+      databaseCreated = true;
+      runPnpm(
+        ["--filter", "@openpims/db", "db:migrate"],
+        databaseUrl.toString(),
+      );
+      runPnpm(["--filter", "@openpims/db", "db:rls"], databaseUrl.toString());
+
+      ownerSql = postgres(databaseUrl.toString(), { max: 1 });
+      appSql = postgres(appUrl.toString(), { max: 2 });
+      const ownerDb = drizzle(ownerSql, { schema });
+      const appDb = drizzle(appSql, { schema });
+
+      const practice = (
+        name: string,
+        acquisition: Record<string, string>,
+        extra: Record<string, unknown> = {},
+      ) => ({
+        id: randomUUID(),
+        name,
+        settings: { acquisition, ...extra },
+      });
+      const homepageA = practice("Synthetic homepage A", {
+        source: "homepage_hero",
+        medium: "product",
+        campaign: "demo_dashboard",
+      });
+      const homepageB = practice("Synthetic homepage B", {
+        source: "homepage_pricing",
+        medium: "product",
+        campaign: "demo_dashboard",
+      });
+      const privateToken = practice("Synthetic private token", {
+        source: "clinic_private_name",
+        campaign: "partner_private_name",
+      });
+      const olderSignup = practice("Synthetic older signup", {
+        source: "direct",
+        medium: "direct",
+        campaign: "direct",
+      });
+      const deleted = {
+        ...practice("Synthetic deleted", {
+          source: "demo",
+          medium: "product",
+          campaign: "demo_login",
+        }),
+        deletedAt: new Date("2026-08-20T00:00:00.000Z"),
+      };
+      const excluded = practice(
+        "Synthetic analytics excluded",
+        { source: "demo", medium: "product", campaign: "demo_login" },
+        { analyticsExcluded: true },
+      );
+      const practices = [
+        homepageA,
+        homepageB,
+        privateToken,
+        olderSignup,
+        deleted,
+        excluded,
+      ];
+      await ownerDb.insert(schema.practices).values(practices);
+
+      type Milestone = typeof schema.practiceConversionMilestones.$inferInsert;
+      const registered = (
+        practiceId: string,
+        occurredAt: string,
+      ): Milestone => ({
+        practiceId,
+        milestone: "registered",
+        occurredAt: new Date(occurredAt),
+        evidenceSource: "practice_created",
+        evidenceKey: `practice:${practiceId}`,
+      });
+      const activated = (
+        practiceId: string,
+        occurredAt: string,
+      ): Milestone => ({
+        practiceId,
+        milestone: "activated",
+        occurredAt: new Date(occurredAt),
+        evidenceSource: "product_records",
+        evidenceKey: `client:${randomUUID()}|appointment:${randomUUID()}`,
+      });
+      const stripe = (
+        practiceId: string,
+        milestone: "payment_method_collected" | "first_positive_payment",
+        occurredAt: string,
+      ): Milestone => ({
+        practiceId,
+        milestone,
+        occurredAt: new Date(occurredAt),
+        evidenceSource: "stripe_webhook",
+        evidenceKey: `stripe:evt_${randomUUID()}`,
+        ...(milestone === "first_positive_payment"
+          ? { amountCents: 2500, currency: "usd" }
+          : {}),
+      });
+      await ownerDb
+        .insert(schema.practiceConversionMilestones)
+        .values([
+          registered(homepageA.id, "2026-08-01T12:00:00.000Z"),
+          activated(homepageA.id, "2026-08-02T12:00:00.000Z"),
+          stripe(
+            homepageA.id,
+            "payment_method_collected",
+            "2026-08-03T12:00:00.000Z",
+          ),
+          stripe(
+            homepageA.id,
+            "first_positive_payment",
+            "2026-08-04T12:00:00.000Z",
+          ),
+          registered(homepageB.id, "2026-08-05T12:00:00.000Z"),
+          registered(privateToken.id, "2026-08-06T12:00:00.000Z"),
+          activated(privateToken.id, "2026-08-07T12:00:00.000Z"),
+          registered(olderSignup.id, "2026-07-01T12:00:00.000Z"),
+          activated(olderSignup.id, "2026-08-10T12:00:00.000Z"),
+          registered(deleted.id, "2026-08-08T12:00:00.000Z"),
+          activated(deleted.id, "2026-08-09T12:00:00.000Z"),
+          registered(excluded.id, "2026-08-08T12:00:00.000Z"),
+          activated(excluded.id, "2026-08-09T12:00:00.000Z"),
+        ]);
+
+      const [identity] = await appSql<
+        Array<{ currentUser: string; bypass: string | null }>
+      >`
+        select
+          current_user as "currentUser",
+          nullif(current_setting('app.rls_bypass', true), '') as bypass
+      `;
+      expect(identity).toEqual({ currentUser: "openpims_app", bypass: null });
+      const [noContext] = await appSql<
+        Array<{ practices: number; milestones: number }>
+      >`
+        select
+          (select count(*)::int from practices) as practices,
+          (select count(*)::int from practice_conversion_milestones) as milestones
+      `;
+      expect(noContext).toEqual({ practices: 0, milestones: 0 });
+
+      const result = await computeJourneyFunnel(
+        appDb,
+        30,
+        new Date("2026-08-25T12:00:00.000Z"),
+      );
+
+      expect(result.acquisitionOutcomes).toEqual([
+        {
+          source: "homepage",
+          medium: "product",
+          campaign: "demo_dashboard",
+          registrations: 2,
+          activated: 1,
+          paymentMethodCollected: 1,
+          firstPositivePayment: 1,
+          activationRate: 0.5,
+          paymentMethodRate: 0.5,
+          positivePaymentRate: 0.5,
+        },
+        {
+          source: "Other",
+          medium: "Unknown",
+          campaign: "Other",
+          registrations: 1,
+          activated: 1,
+          paymentMethodCollected: 0,
+          firstPositivePayment: 0,
+          activationRate: 1,
+          paymentMethodRate: 0,
+          positivePaymentRate: 0,
+        },
+      ]);
+      expect(result.periodActivity).toEqual({
+        registrations: 3,
+        activated: 3,
+        paymentMethodCollected: 1,
+        firstPositivePayment: 1,
+      });
+
+      await appSql.begin(async (tenantSql) => {
+        const scopedSql = tenantSql as unknown as SqlClient;
+        await scopedSql`select set_config('app.current_practice_id', ${homepageA.id}, true)`;
+        const [tenantContext] = await scopedSql<
+          Array<{ practices: number; milestones: number }>
+        >`
+          select
+            (select count(*)::int from practices) as practices,
+            (select count(*)::int from practice_conversion_milestones) as milestones
+        `;
+        expect(tenantContext).toEqual({ practices: 1, milestones: 0 });
+      });
+      const [afterReport] = await appSql<
+        Array<{ practiceId: string | null; bypass: string | null }>
+      >`
+        select
+          nullif(current_setting('app.current_practice_id', true), '') as "practiceId",
+          nullif(current_setting('app.rls_bypass', true), '') as bypass
+      `;
+      expect(afterReport).toEqual({ practiceId: null, bypass: null });
+    } finally {
+      if (appSql) await appSql.end();
+      if (ownerSql) await ownerSql.end();
+      try {
+        if (databaseCreated) {
+          await adminSql.unsafe(
+            `drop database if exists "${databaseName}" with (force)`,
+          );
+        }
+      } finally {
+        await adminSql.end();
+      }
+    }
+  }, 120_000);
+});

--- a/apps/web/lib/__tests__/journey-funnel.test.ts
+++ b/apps/web/lib/__tests__/journey-funnel.test.ts
@@ -23,6 +23,9 @@ const mocks = vi.hoisted(() => {
 vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
 
 const { computeJourneyFunnel } = await import("@/lib/admin/journey-funnel");
+const { ACQUISITION_OUTCOME_ROW_LIMIT } =
+  await import("@/lib/admin/journey-funnel");
+const { safeAcquisitionReportingBucket } = await import("@/lib/acquisition");
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -54,6 +57,34 @@ describe("computeJourneyFunnel", () => {
       ],
       [{ historicalUnknown: "2", repairableGap: "1" }],
       [{ count: "4" }],
+      [
+        {
+          source: "demo",
+          medium: "product",
+          campaign: "demo_dashboard",
+          registrations: "4",
+          activated: "2",
+          paymentMethodCollected: "1",
+          firstPositivePayment: "1",
+        },
+        {
+          source: "Other",
+          medium: "Unknown",
+          campaign: "Other",
+          registrations: "1",
+          activated: "0",
+          paymentMethodCollected: "0",
+          firstPositivePayment: "0",
+        },
+      ],
+      [
+        {
+          registrations: "7",
+          activated: "3",
+          paymentMethodCollected: "2",
+          firstPositivePayment: "1",
+        },
+      ],
     );
 
     const result = await computeJourneyFunnel(mocks.db as never, 30);
@@ -73,6 +104,39 @@ describe("computeJourneyFunnel", () => {
         firstPositivePayment: 1,
       },
     ]);
+    expect(result.acquisitionOutcomes).toEqual([
+      {
+        source: "demo",
+        medium: "product",
+        campaign: "demo_dashboard",
+        registrations: 4,
+        activated: 2,
+        paymentMethodCollected: 1,
+        firstPositivePayment: 1,
+        activationRate: 0.5,
+        paymentMethodRate: 0.25,
+        positivePaymentRate: 0.25,
+      },
+      {
+        source: "Other",
+        medium: "Unknown",
+        campaign: "Other",
+        registrations: 1,
+        activated: 0,
+        paymentMethodCollected: 0,
+        firstPositivePayment: 0,
+        activationRate: 0,
+        paymentMethodRate: 0,
+        positivePaymentRate: 0,
+      },
+    ]);
+    expect(result.acquisitionOutcomesTruncated).toBe(false);
+    expect(result.periodActivity).toEqual({
+      registrations: 7,
+      activated: 3,
+      paymentMethodCollected: 2,
+      firstPositivePayment: 1,
+    });
     expect(result.totals).toMatchObject({
       visitors: 20,
       demos: 8,
@@ -104,7 +168,7 @@ describe("computeJourneyFunnel", () => {
       paymentMethodRate: 0.2,
       positivePaymentRate: 1,
     });
-    expect(mocks.execute).toHaveBeenCalledTimes(3);
+    expect(mocks.execute).toHaveBeenCalledTimes(5);
     const errorSql = new PgDialect().sqlToQuery(
       mocks.execute.mock.calls[2]![0] as SQL,
     ).sql;
@@ -115,8 +179,16 @@ describe("computeJourneyFunnel", () => {
   });
 
   it("returns safe zero rates when no journey has started", async () => {
-    mocks.executeResults.push([], [], []);
+    mocks.executeResults.push([], [], [], [], []);
     const result = await computeJourneyFunnel(mocks.db as never, 7);
+    expect(result.acquisitionOutcomes).toEqual([]);
+    expect(result.acquisitionOutcomesTruncated).toBe(false);
+    expect(result.periodActivity).toEqual({
+      registrations: 0,
+      activated: 0,
+      paymentMethodCollected: 0,
+      firstPositivePayment: 0,
+    });
     expect(result.totals).toMatchObject({
       visitors: 0,
       demos: 0,
@@ -188,5 +260,75 @@ describe("computeJourneyFunnel", () => {
     expect(errorQuery).toMatch(
       /select count\(\*\)::int as count\s+from funnel_events\s+where event_name = 'client_error'/,
     );
+  });
+
+  it("uses canonical milestones, privacy buckets, and a deterministic cap", async () => {
+    mocks.executeResults.push([], [], [], [], []);
+
+    await computeJourneyFunnel(mocks.db as never, 30);
+
+    const acquisitionSql = new PgDialect().sqlToQuery(
+      mocks.execute.mock.calls[3]![0] as SQL,
+    ).sql;
+    const periodSql = new PgDialect().sqlToQuery(
+      mocks.execute.mock.calls[4]![0] as SQL,
+    ).sql;
+
+    expect(acquisitionSql).toContain(
+      "from practice_conversion_milestones registered",
+    );
+    expect(acquisitionSql).toContain("registered.milestone = 'registered'");
+    expect(acquisitionSql).toContain("registered.occurred_at >= $1");
+    expect(acquisitionSql).toContain("p.deleted_at is null");
+    expect(acquisitionSql).toContain(
+      "p.settings ->> 'analyticsExcluded' is distinct from 'true'",
+    );
+    expect(acquisitionSql).toContain("then 'Unknown'");
+    expect(acquisitionSql).toContain("else 'Other'");
+    expect(acquisitionSql).toContain("activated.milestone = 'activated'");
+    expect(acquisitionSql).toContain(
+      "payment_method.milestone = 'payment_method_collected'",
+    );
+    expect(acquisitionSql).toContain(
+      "positive_payment.milestone = 'first_positive_payment'",
+    );
+    expect(acquisitionSql).toContain(
+      "order by registrations desc, source, medium, campaign",
+    );
+    expect(acquisitionSql).toContain("limit $2");
+    expect(periodSql).toContain("where pcm.occurred_at >= $1");
+    expect(periodSql).not.toMatch(
+      /amount_cents|currency|email|patient|client/i,
+    );
+  });
+
+  it("never returns raw acquisition tokens and limits rows to twenty", async () => {
+    expect(safeAcquisitionReportingBucket("source", "demo")).toBe("demo");
+    expect(
+      safeAcquisitionReportingBucket("source", "clinic_private_name"),
+    ).toBe("Other");
+    expect(safeAcquisitionReportingBucket("campaign", "")).toBe("Unknown");
+
+    const rows = Array.from(
+      { length: ACQUISITION_OUTCOME_ROW_LIMIT + 1 },
+      (_, index) => ({
+        source: index === 0 ? "demo" : `private_clinic_${index}`,
+        medium: "product",
+        campaign: "demo_dashboard",
+        registrations: "1",
+        activated: "0",
+        paymentMethodCollected: "0",
+        firstPositivePayment: "0",
+      }),
+    );
+    mocks.executeResults.push([], [], [], rows, []);
+
+    const result = await computeJourneyFunnel(mocks.db as never, 30);
+
+    expect(result.acquisitionOutcomes).toHaveLength(20);
+    expect(result.acquisitionOutcomesTruncated).toBe(true);
+    expect(
+      result.acquisitionOutcomes.some((row) => row.source.includes("clinic")),
+    ).toBe(false);
   });
 });

--- a/apps/web/lib/acquisition.ts
+++ b/apps/web/lib/acquisition.ts
@@ -1,5 +1,77 @@
 export const ACQUISITION_VALUE_MAX_LENGTH = 80;
 
+/**
+ * Privacy-bounded values exposed by aggregate acquisition reporting. Raw
+ * acquisition tokens are accepted only as input evidence and never returned
+ * to operators unless they resolve to one of these product-owned buckets.
+ */
+export const ACQUISITION_REPORTING_BUCKETS = {
+  source: [
+    "homepage",
+    "navigation",
+    "cloud",
+    "feature",
+    "solution",
+    "role",
+    "comparison",
+    "content",
+    "install",
+    "second_pims",
+    "why",
+    "demo",
+    "clinic_fit",
+    "marketing",
+    "direct",
+    "Other",
+    "Unknown",
+  ],
+  medium: [
+    "product",
+    "organic",
+    "cpc",
+    "paid_social",
+    "email",
+    "referral",
+    "direct",
+    "Other",
+    "Unknown",
+  ],
+  campaign: [
+    "demo_login",
+    "demo_dashboard",
+    "demo_ask_ai",
+    "demo_day_board",
+    "demo_whiteboard",
+    "demo_client_portal",
+    "demo_patients",
+    "demo_clients",
+    "demo_records",
+    "demo_billing",
+    "demo_inbox",
+    "demo_inventory",
+    "demo_reports",
+    "demo_settings",
+    "demo_other",
+    "demo_cta",
+    "launch",
+    "direct",
+    "Other",
+    "Unknown",
+  ],
+} as const;
+
+export type AcquisitionReportingDimension =
+  keyof typeof ACQUISITION_REPORTING_BUCKETS;
+
+export function safeAcquisitionReportingBucket(
+  dimension: AcquisitionReportingDimension,
+  value: unknown
+): string {
+  if (typeof value !== "string" || value.length === 0) return "Unknown";
+  const buckets = ACQUISITION_REPORTING_BUCKETS[dimension] as readonly string[];
+  return buckets.includes(value) ? value : "Other";
+}
+
 const FUNNEL_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 

--- a/apps/web/lib/admin/journey-funnel.ts
+++ b/apps/web/lib/admin/journey-funnel.ts
@@ -2,9 +2,11 @@ import { sql } from "drizzle-orm";
 import type { Database } from "@openpims/db/client";
 import { withSystem } from "@/lib/tenant-db";
 import { funnelRate } from "@/lib/admin/activation-funnel";
+import { safeAcquisitionReportingBucket } from "@/lib/acquisition";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 export const ABANDONMENT_GRACE_DAYS = 7;
+export const ACQUISITION_OUTCOME_ROW_LIMIT = 20;
 
 export interface JourneyFunnelWeek {
   weekStart: string;
@@ -52,9 +54,33 @@ export interface JourneyFunnelTotals {
   positivePaymentRate: number;
 }
 
+export interface AcquisitionOutcome {
+  source: string;
+  medium: string;
+  campaign: string;
+  registrations: number;
+  activated: number;
+  paymentMethodCollected: number;
+  firstPositivePayment: number;
+  activationRate: number;
+  paymentMethodRate: number;
+  positivePaymentRate: number;
+}
+
+export interface JourneyFunnelPeriodActivity {
+  registrations: number;
+  activated: number;
+  paymentMethodCollected: number;
+  firstPositivePayment: number;
+}
+
 export interface JourneyFunnel {
   days: number;
   weeks: JourneyFunnelWeek[];
+  acquisitionOutcomes: AcquisitionOutcome[];
+  acquisitionOutcomeRowLimit: number;
+  acquisitionOutcomesTruncated: boolean;
+  periodActivity: JourneyFunnelPeriodActivity;
   totals: JourneyFunnelTotals;
 }
 
@@ -77,6 +103,23 @@ interface JourneyRow {
   paymentAbandoned: number | string;
 }
 
+interface AcquisitionOutcomeRow {
+  source: string;
+  medium: string;
+  campaign: string;
+  registrations: number | string;
+  activated: number | string;
+  paymentMethodCollected: number | string;
+  firstPositivePayment: number | string;
+}
+
+interface PeriodActivityRow {
+  registrations: number | string;
+  activated: number | string;
+  paymentMethodCollected: number | string;
+  firstPositivePayment: number | string;
+}
+
 function rowsFromExecute<T>(result: unknown): T[] {
   if (Array.isArray(result)) return result as T[];
   const rows = (result as { rows?: unknown[] } | null)?.rows;
@@ -93,10 +136,14 @@ export async function computeJourneyFunnel(
     now.getTime() - ABANDONMENT_GRACE_DAYS * DAY_MS,
   ).toISOString();
 
-  const { weeklyResult, unattributedResult, errorsResult } = await withSystem(
-    db,
-    async (tx) => {
-      const weeklyResult = await tx.execute(sql`
+  const {
+    weeklyResult,
+    unattributedResult,
+    errorsResult,
+    acquisitionResult,
+    periodActivityResult,
+  } = await withSystem(db, async (tx) => {
+    const weeklyResult = await tx.execute(sql`
       with first_touch_all_time as (
         select
           fe.anonymous_id,
@@ -262,7 +309,7 @@ export async function computeJourneyFunnel(
       order by s.week_start
     `);
 
-      const unattributedResult = await tx.execute(sql`
+    const unattributedResult = await tx.execute(sql`
       select
         count(*) filter (
           where not (
@@ -291,16 +338,188 @@ export async function computeJourneyFunnel(
         and p.deleted_at is null
         and p.settings ->> 'analyticsExcluded' is distinct from 'true'
     `);
-      const errorsResult = await tx.execute(sql`
+    const errorsResult = await tx.execute(sql`
       select count(*)::int as count
       from funnel_events
       where event_name = 'client_error'
         and deleted_at is null
         and created_at >= ${windowStart}::timestamptz
     `);
-      return { weeklyResult, unattributedResult, errorsResult };
-    },
-  );
+
+    // These are signup cohorts: the registration timestamp selects the
+    // cohort, while all later canonical milestones become its outcomes.
+    // Bucketing occurs before grouping so neither raw tokens nor a long tail
+    // of one-off values can escape through the result cardinality.
+    const acquisitionResult = await tx.execute(sql`
+      with raw_signup_cohort as (
+        select
+          p.id as practice_id,
+          lower(btrim(coalesce(
+            p.settings -> 'acquisition' ->> 'source', ''
+          ))) as raw_source,
+          lower(btrim(coalesce(
+            p.settings -> 'acquisition' ->> 'medium', ''
+          ))) as raw_medium,
+          lower(btrim(coalesce(
+            p.settings -> 'acquisition' ->> 'campaign', ''
+          ))) as raw_campaign
+        from practice_conversion_milestones registered
+        join practices p on p.id = registered.practice_id
+        where registered.milestone = 'registered'
+          and registered.occurred_at >= ${windowStart}::timestamptz
+          and p.deleted_at is null
+          and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+      ), signup_cohort as (
+        select
+          practice_id,
+          case
+            when raw_source = ''
+              or raw_source !~ '^[a-z0-9._:/-]{1,80}$'
+              then 'Unknown'
+            when raw_source in (
+              'homepage_hero', 'homepage_start_small',
+              'homepage_pricing', 'homepage_closing', 'homepage_demo'
+            ) then 'homepage'
+            when raw_source in (
+              'nav', 'mobile_nav', 'resources_nav', 'footer'
+            ) then 'navigation'
+            when raw_source ~ '^cloud_(hero|founding_offer|closing)(_fit)?$'
+              then 'cloud'
+            when raw_source ~ '^feature_(schedule|records|billing|patients|communications|inventory|whiteboard|compliance|reports)_(hero|fit|hosting|hosting_fit|closing)$'
+              then 'feature'
+            when raw_source ~ '^solution_(general-practice|specialty-referral|emergency-critical-care|equine|mobile-house-call|multi-location|shelter-nonprofit|exotics-avian)_(hero|hosting|hosting_fit|closing)$'
+              or raw_source in (
+                'solutions_index_hosting', 'solutions_index_hosting_fit',
+                'solutions_index_closing'
+              )
+              then 'solution'
+            when raw_source ~ '^role_(practice-owners|practice-managers|veterinarians|veterinary-technicians|front-desk)_(hero|fit|hosting|hosting_fit|closing)$'
+              then 'role'
+            when raw_source ~ '^(compare|comparison)_openvpm-vs-(cornerstone|avimark|ezyvet|shepherd|provet-cloud|digitail|vetspire|idexx-neo|daysmart-vet|hippo-manager|navetor|impromed|openvpms)_(hero|fit|hosting|hosting_fit|closing)$'
+              or raw_source in (
+                'compare_index_hosting', 'compare_index_hosting_fit'
+              )
+              then 'comparison'
+            when raw_source = 'blog'
+              or raw_source ~ '^glossary_(pims|soap-notes|emr-vs-pims|controlled-substance-log|audit-trail|open-api|rest-api|webhook|vendor-lock-in|data-portability|open-source-veterinary-software|agplv3|self-hosting|managed-hosting|cloud-vs-on-premise|two-way-texting|appointment-reminder)_closing$'
+              then 'content'
+            when raw_source in ('install_demo', 'install_cloud')
+              then 'install'
+            when raw_source in (
+              'second_pims_hosting', 'second_pims_hosting_fit',
+              'second_pims_closing'
+            ) then 'second_pims'
+            when raw_source = 'why_closing' then 'why'
+            when raw_source = 'demo' then 'demo'
+            when raw_source = 'clinic_fit' then 'clinic_fit'
+            when raw_source = 'marketing' then 'marketing'
+            when raw_source = 'direct' then 'direct'
+            else 'Other'
+          end as source,
+          case
+            when raw_medium = ''
+              or raw_medium !~ '^[a-z0-9._:/-]{1,80}$'
+              then 'Unknown'
+            when raw_medium = 'product' then 'product'
+            when raw_medium = 'organic' then 'organic'
+            when raw_medium = 'cpc' then 'cpc'
+            when raw_medium in ('paid/social', 'paid_social')
+              then 'paid_social'
+            when raw_medium = 'email' then 'email'
+            when raw_medium = 'referral' then 'referral'
+            when raw_medium = 'direct' then 'direct'
+            else 'Other'
+          end as medium,
+          case
+            when raw_campaign = ''
+              or raw_campaign !~ '^[a-z0-9._:/-]{1,80}$'
+              then 'Unknown'
+            when raw_campaign in (
+              'demo_login', 'demo_dashboard', 'demo_ask_ai',
+              'demo_day_board', 'demo_whiteboard', 'demo_client_portal',
+              'demo_patients', 'demo_clients', 'demo_records',
+              'demo_billing', 'demo_inbox', 'demo_inventory',
+              'demo_reports', 'demo_settings', 'demo_other', 'demo_cta'
+            ) then raw_campaign
+            when raw_campaign in ('launch', 'clinic_launch-2026')
+              then 'launch'
+            when raw_campaign = 'direct' then 'direct'
+            else 'Other'
+          end as campaign
+        from raw_signup_cohort
+      ), outcomes as (
+        select
+          cohort.*,
+          exists (
+            select 1
+            from practice_conversion_milestones activated
+            where activated.practice_id = cohort.practice_id
+              and activated.milestone = 'activated'
+          ) as activated,
+          exists (
+            select 1
+            from practice_conversion_milestones payment_method
+            where payment_method.practice_id = cohort.practice_id
+              and payment_method.milestone = 'payment_method_collected'
+          ) as payment_method_collected,
+          exists (
+            select 1
+            from practice_conversion_milestones positive_payment
+            where positive_payment.practice_id = cohort.practice_id
+              and positive_payment.milestone = 'first_positive_payment'
+          ) as first_positive_payment
+        from signup_cohort cohort
+      )
+      select
+        source,
+        medium,
+        campaign,
+        count(*)::int as registrations,
+        count(*) filter (where activated)::int as activated,
+        count(*) filter (
+          where payment_method_collected
+        )::int as "paymentMethodCollected",
+        count(*) filter (
+          where first_positive_payment
+        )::int as "firstPositivePayment"
+      from outcomes
+      group by source, medium, campaign
+      order by registrations desc, source, medium, campaign
+      limit ${ACQUISITION_OUTCOME_ROW_LIMIT + 1}
+    `);
+
+    // This is intentionally not a registration cohort. It answers how many
+    // canonical events occurred in the period, including later outcomes for
+    // practices registered before it began.
+    const periodActivityResult = await tx.execute(sql`
+      select
+        count(*) filter (
+          where pcm.milestone = 'registered'
+        )::int as registrations,
+        count(*) filter (
+          where pcm.milestone = 'activated'
+        )::int as activated,
+        count(*) filter (
+          where pcm.milestone = 'payment_method_collected'
+        )::int as "paymentMethodCollected",
+        count(*) filter (
+          where pcm.milestone = 'first_positive_payment'
+        )::int as "firstPositivePayment"
+      from practice_conversion_milestones pcm
+      join practices p on p.id = pcm.practice_id
+      where pcm.occurred_at >= ${windowStart}::timestamptz
+        and p.deleted_at is null
+        and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+    `);
+
+    return {
+      weeklyResult,
+      unattributedResult,
+      errorsResult,
+      acquisitionResult,
+      periodActivityResult,
+    };
+  });
 
   const rawWeeks = rowsFromExecute<JourneyRow>(weeklyResult);
   const weeks = rawWeeks.map((row) => ({
@@ -338,10 +557,44 @@ export async function computeJourneyFunnel(
   const repairableAttributionGaps =
     Number(unattributedRows[0]?.repairableGap) || 0;
   const errorRows = rowsFromExecute<{ count: number | string }>(errorsResult);
+  const rawAcquisitionOutcomes =
+    rowsFromExecute<AcquisitionOutcomeRow>(acquisitionResult);
+  const acquisitionOutcomesTruncated =
+    rawAcquisitionOutcomes.length > ACQUISITION_OUTCOME_ROW_LIMIT;
+  const acquisitionOutcomes = rawAcquisitionOutcomes
+    .slice(0, ACQUISITION_OUTCOME_ROW_LIMIT)
+    .map((row) => {
+      const registrations = Number(row.registrations) || 0;
+      const activated = Number(row.activated) || 0;
+      const paymentMethodCollected = Number(row.paymentMethodCollected) || 0;
+      const firstPositivePayment = Number(row.firstPositivePayment) || 0;
+      return {
+        source: safeAcquisitionReportingBucket("source", row.source),
+        medium: safeAcquisitionReportingBucket("medium", row.medium),
+        campaign: safeAcquisitionReportingBucket("campaign", row.campaign),
+        registrations,
+        activated,
+        paymentMethodCollected,
+        firstPositivePayment,
+        activationRate: funnelRate(activated, registrations),
+        paymentMethodRate: funnelRate(paymentMethodCollected, registrations),
+        positivePaymentRate: funnelRate(firstPositivePayment, registrations),
+      };
+    });
+  const periodRow = rowsFromExecute<PeriodActivityRow>(periodActivityResult)[0];
 
   return {
     days,
     weeks,
+    acquisitionOutcomes,
+    acquisitionOutcomeRowLimit: ACQUISITION_OUTCOME_ROW_LIMIT,
+    acquisitionOutcomesTruncated,
+    periodActivity: {
+      registrations: Number(periodRow?.registrations) || 0,
+      activated: Number(periodRow?.activated) || 0,
+      paymentMethodCollected: Number(periodRow?.paymentMethodCollected) || 0,
+      firstPositivePayment: Number(periodRow?.firstPositivePayment) || 0,
+    },
     totals: {
       visitors,
       demos,

--- a/apps/web/server/__tests__/admin-extend-trial.test.ts
+++ b/apps/web/server/__tests__/admin-extend-trial.test.ts
@@ -169,3 +169,15 @@ describe("admin extendTrial", () => {
     expect(mocks.update).not.toHaveBeenCalled();
   });
 });
+
+describe("admin journey funnel", () => {
+  it("rejects callers outside the platform admin allowlist before querying", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(
+      caller("someone@clinic.example.com").journeyFunnel({ days: 30 })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.db.execute).not.toHaveBeenCalled();
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Rebuilds the valuable acquisition-outcomes reporting from stale PR #221 on current `development`. This is a current-base reconstruction, not a merge or cherry-pick.

- uses the canonical `registered` milestone for registration cohorts and canonical milestone existence for eventual activation/payment outcomes
- reports recent-period milestone activity separately from cohort conversion
- emits only fixed privacy-safe source/medium/campaign buckets, with deterministic top-20 truncation
- excludes deleted and analytics-excluded practices
- adds platform-admin UI and aggregate activation-digest reporting
- adds real PostgreSQL/RLS proof as `openpims_app`, wired into the required RLS CI job

## Provenance and scope

- source PR: #221 (`740c56d81bea8020a8168e22f9713ed866ac68f1`)
- base: `c7e163e0a45291dc5046ecfb369f512b0886a1db`
- reviewed head: `7505c1975834f8d453b1928b6a1e7dd342d9e6a8`
- reviewed tree: `7b8fb17db4bb9d04210be09d93a5a3fd8e177ead`
- no schema, migration, provider, dependency, hosted-environment, `main`, or `staging` changes

## Verification

- focused acquisition/admin/digest tests: 37 passed
- disposable PostgreSQL/RLS test: passed as `openpims_app`; cleanup verified
- full web suite: 4,229 passed, 16 skipped
- web type-check: passed
- migration integrity: 82 passed, 1 skipped
- workflow YAML parse and `git diff --check`: passed
- independent exact-head review: GO; no P0/P1

## Review notes

Two non-blocking P2 follow-ups were identified: document the cohort-versus-period distinction, and defensively cap period predicates at `now` with a future-dated regression fixture. Canonical writes make the latter low risk; neither is a stale-PR behavior regression.

Closes #221 only after successor merge and post-merge proof.