### PR TITLE
Fail closed on invalid promotional postal address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,8 @@ EMAIL_PREFERENCE_BASE_URL=
 # Hosted lifecycle email identity. Required for hosted production readiness so
 # Reply-To and footer contact details do not fall back to local/dev defaults.
 EMAIL_SUPPORT_ADDRESS=
+# Verified physical postal address for promotional email footers. Use a street,
+# registered PO box, or registered private mailbox; never an email address/URL.
 EMAIL_COMPANY_ADDRESS=
 # Optional override; defaults to OpenVPM <noreply@mail.openvpm.com>.
 EMAIL_FROM=

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -867,6 +867,27 @@ describe("health route", () => {
     expect(body).not.toContain("123 Cloud Lane");
   });
 
+  it("rejects a non-postal company address without exposing it", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    stubHostedRequiredEnvs();
+    vi.stubEnv("EMAIL_COMPANY_ADDRESS", "evan@openvpm.com");
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.hostedEmail).toEqual({
+      ok: false,
+      detail: "1 required hosted configuration value is invalid",
+    });
+    const body = JSON.stringify(json);
+    expect(body).not.toContain("evan@openvpm.com");
+    expect(body).not.toContain("EMAIL_COMPANY_ADDRESS");
+    expect(
+      mocks.platformEmailIdentityConfigurationReady,
+    ).not.toHaveBeenCalled();
+  });
+
   it("ignores blank AI_MODEL values before selecting the hosted Vertex provider", async () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
+import { isPlausiblePhysicalCompanyAddress } from "@openpims/email";
 import {
   describeDrift,
   driftIsClean,
@@ -187,10 +188,14 @@ async function hostedEmailCheck(): Promise<{ ok: boolean; detail: string }> {
   const invalidBaseUrl =
     configured("EMAIL_PREFERENCE_BASE_URL") &&
     preferenceBaseUrl !== CANONICAL_EMAIL_PREFERENCE_BASE_URL;
+  const invalidCompanyAddress =
+    configured("EMAIL_COMPANY_ADDRESS") &&
+    !isPlausiblePhysicalCompanyAddress(process.env.EMAIL_COMPANY_ADDRESS);
   const invalid =
     invalidSecrets.length +
     (invalidPreviousSecrets ? 1 : 0) +
-    (invalidBaseUrl ? 1 : 0);
+    (invalidBaseUrl ? 1 : 0) +
+    (invalidCompanyAddress ? 1 : 0);
   const issues = missing.length + invalid;
   const envResult = {
     ok: issues === 0,

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const resendSend = vi.fn();
@@ -28,6 +28,10 @@ async function loadEmailBrand() {
   vi.resetModules();
   return import("@openpims/email");
 }
+
+beforeEach(() => {
+  vi.stubEnv("EMAIL_COMPANY_ADDRESS", "123 Cloud Lane, Boston, MA 02108");
+});
 
 afterEach(() => {
   vi.useRealTimers();
@@ -512,9 +516,143 @@ describe("openvpmBrand", () => {
     expect(openvpmBrand().companyAddress).toBeUndefined();
     expect(openvpmBrand().logoUrl).toBeUndefined();
   });
+
+  it.each([
+    "123 Cloud Lane, Boston, MA 02108",
+    "Suite 400, 500 Market Street, Philadelphia, PA 19106",
+    "P.O. Box 123, Boston, MA 02108",
+    "RR 2 Box 152, Montpelier, VT 05602",
+    "PMB 42, 123 Main St, Austin, TX 78701",
+  ])("accepts a structurally plausible physical address: %s", async (value) => {
+    const { isPlausiblePhysicalCompanyAddress } = await loadEmailBrand();
+
+    expect(isPlausiblePhysicalCompanyAddress(value)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "support@openvpm.com",
+    "mailto:support@openvpm.com",
+    "https://openvpm.com/address/123",
+    "www.openvpm.com 123",
+    "123 Cloud Lane\nBoston, MA 02108",
+    "\t123 Cloud Lane, Boston, MA 02108",
+    "123 Cloud Building, Boston, MA 02108",
+  ])("rejects a non-postal address impostor: %s", async (value) => {
+    const { isPlausiblePhysicalCompanyAddress } = await loadEmailBrand();
+
+    expect(isPlausiblePhysicalCompanyAddress(value)).toBe(false);
+  });
 });
 
 describe("lifecycle email branding", () => {
+  it("fails promotional sends before provider initialization for an invalid address", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv("EMAIL_COMPANY_ADDRESS", "support@openvpm.com");
+    vi.stubEnv(
+      "EMAIL_PREFERENCE_IDENTITY_SECRET",
+      "stable-identity-secret-at-least-32-bytes",
+    );
+    vi.stubEnv(
+      "EMAIL_PREFERENCE_SIGNING_SECRET",
+      "stable-signing-secret-at-least-32-bytes",
+    );
+    vi.stubEnv("EMAIL_PREFERENCE_BASE_URL", "https://app.openvpm.com");
+    const {
+      sendFirstClinicWinEmail,
+      sendSetupRecoveryEmail,
+      sendTrialEndingEmail,
+      sendWelcomeEmail,
+    } = await loadEmail();
+    const failure = {
+      success: false,
+      error: "Promotional email requires a valid physical company address.",
+      outcome: "definite_failure",
+      failureCode: "invalid_company_address",
+    };
+
+    await expect(
+      sendWelcomeEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+      }),
+    ).resolves.toEqual(failure);
+    await expect(
+      sendSetupRecoveryEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        stepTitle: "clinic setup",
+        nextAction: "Resume setup.",
+        attemptNumber: 1,
+      }),
+    ).resolves.toEqual(failure);
+    await expect(
+      sendTrialEndingEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        daysLeft: 3,
+        trialEndDate: "August 28, 2026",
+      }),
+    ).resolves.toEqual(failure);
+    await expect(
+      sendFirstClinicWinEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        trialEndDate: "August 28, 2026",
+        idempotencyKey: "lc:first-clinic-win:v1:practice",
+      }),
+    ).resolves.toEqual(failure);
+    expect(mocks.Resend).not.toHaveBeenCalled();
+    expect(mocks.resendSend).not.toHaveBeenCalled();
+  });
+
+  it("does not apply the promotional address gate to auth or transactional email", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv("EMAIL_COMPANY_ADDRESS", "support@openvpm.com");
+    mocks.resendSend
+      .mockResolvedValueOnce({ data: { id: "email-reset" } })
+      .mockResolvedValueOnce({ data: { id: "email-receipt" } })
+      .mockResolvedValueOnce({ data: { id: "email-dunning" } })
+      .mockResolvedValueOnce({ data: { id: "email-confirmed" } });
+    const {
+      sendPasswordResetEmail,
+      sendPaymentFailedEmail,
+      sendPaymentReceiptEmail,
+      sendSubscriptionConfirmedEmail,
+    } = await loadEmail();
+
+    await expect(
+      sendPasswordResetEmail({
+        to: "owner@example.com",
+        name: "Taylor",
+        resetUrl: "https://app.openvpm.com/reset-password?token=test",
+      }),
+    ).resolves.toEqual({ success: true });
+    await expect(
+      sendPaymentReceiptEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        amount: "$79.00",
+        periodLabel: "August 2026",
+      }),
+    ).resolves.toEqual({ success: true, id: "email-receipt" });
+    await expect(
+      sendPaymentFailedEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        amount: "$79.00",
+      }),
+    ).resolves.toEqual({ success: true, id: "email-dunning" });
+    await expect(
+      sendSubscriptionConfirmedEmail({
+        to: "owner@example.com",
+        practiceName: "Neighborhood Veterinary",
+        idempotencyKey: "lc:confirmed:sub_123",
+      }),
+    ).resolves.toEqual({ success: true, id: "email-confirmed" });
+    expect(mocks.resendSend).toHaveBeenCalledTimes(4);
+  });
+
   it("renders setup recovery as a one-click, preference-aware resume", async () => {
     vi.stubEnv("RESEND_API_KEY", "re_test");
     vi.stubEnv(

--- a/apps/web/lib/__tests__/self-hosting-ops.test.ts
+++ b/apps/web/lib/__tests__/self-hosting-ops.test.ts
@@ -212,7 +212,10 @@ describe("self-hosting operations docs", () => {
     expect(emailSection).toContain("RESEND_WEBHOOK_SECRET");
     expect(emailSection).toContain("EMAIL_SUPPORT_ADDRESS");
     expect(emailSection).toContain("EMAIL_COMPANY_ADDRESS");
-    expect(emailSection).toContain("production emails do not fall back");
+    expect(emailSection).toContain("operator-verified physical postal");
+    expect(emailSection).toContain("never use an email address or URL");
+    expect(emailSection).toContain("promotional lifecycle sends");
+    expect(emailSection).toContain("transactional/service email");
     expect(envExample).toContain("RESEND_WEBHOOK_SECRET=");
     expect(envExample).toContain("EMAIL_SUPPORT_ADDRESS=");
     expect(envExample).toContain("EMAIL_COMPANY_ADDRESS=");

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -1,5 +1,6 @@
 import { Resend } from "resend";
 import {
+  isPlausiblePhysicalCompanyAddress,
   openvpmBrand,
   renderWelcomeEmail,
   renderSetupRecoveryEmail,
@@ -62,7 +63,27 @@ export interface EmailProviderEvidence {
     | "provider_outcome_ambiguous"
     | "send_timeout"
     | "provider_exception"
-    | "missing_provider_id";
+    | "missing_provider_id"
+    | "invalid_company_address";
+}
+
+type PromotionalEmailAddressFailure = {
+  success: false;
+  error: string;
+  outcome: "definite_failure";
+  failureCode: "invalid_company_address";
+};
+
+function promotionalEmailAddressFailure(
+  companyAddress: string | undefined,
+): PromotionalEmailAddressFailure | null {
+  if (isPlausiblePhysicalCompanyAddress(companyAddress)) return null;
+  return {
+    success: false,
+    error: "Promotional email requires a valid physical company address.",
+    outcome: "definite_failure",
+    failureCode: "invalid_company_address",
+  };
 }
 
 function emailSendTimeoutMessage(): string {
@@ -678,8 +699,15 @@ export async function sendWelcomeEmail(data: {
   to: string;
   practiceName: string;
   trialDays?: number;
-}): Promise<{ success: boolean; id?: string; error?: string }> {
+}): Promise<
+  | { success: boolean; id?: string; error?: string }
+  | PromotionalEmailAddressFailure
+> {
   const brand = openvpmBrand();
+  const addressFailure = promotionalEmailAddressFailure(
+    process.env.EMAIL_COMPANY_ADDRESS,
+  );
+  if (addressFailure) return addressFailure;
   const recipientHash = emailPreferenceRecipientHash(data.to);
   if (!recipientHash) {
     return {
@@ -723,8 +751,15 @@ export async function sendSetupRecoveryEmail(data: {
   nextAction: string;
   attemptNumber: 1 | 2;
   resumeUrl?: string;
-}): Promise<{ success: boolean; id?: string; error?: string }> {
+}): Promise<
+  | { success: boolean; id?: string; error?: string }
+  | PromotionalEmailAddressFailure
+> {
   const brand = openvpmBrand();
+  const addressFailure = promotionalEmailAddressFailure(
+    process.env.EMAIL_COMPANY_ADDRESS,
+  );
+  if (addressFailure) return addressFailure;
   const recipientHash = emailPreferenceRecipientHash(data.to);
   if (!recipientHash) {
     return {
@@ -773,8 +808,15 @@ export async function sendTrialEndingEmail(data: {
   billingUrl?: string;
   billingConnected?: boolean;
   idempotencyKey?: string;
-}): Promise<{ success: boolean; id?: string; error?: string }> {
+}): Promise<
+  | { success: boolean; id?: string; error?: string }
+  | PromotionalEmailAddressFailure
+> {
   const brand = openvpmBrand();
+  const addressFailure = promotionalEmailAddressFailure(
+    process.env.EMAIL_COMPANY_ADDRESS,
+  );
+  if (addressFailure) return addressFailure;
   const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
   const recipientHash = emailPreferenceRecipientHash(data.to);
   if (!recipientHash) {
@@ -823,8 +865,15 @@ export async function sendFirstClinicWinEmail(data: {
   trialEndDate: string;
   billingUrl?: string;
   idempotencyKey: string;
-}): Promise<{ success: boolean; id?: string; error?: string }> {
+}): Promise<
+  | { success: boolean; id?: string; error?: string }
+  | PromotionalEmailAddressFailure
+> {
   const brand = openvpmBrand();
+  const addressFailure = promotionalEmailAddressFailure(
+    process.env.EMAIL_COMPANY_ADDRESS,
+  );
+  if (addressFailure) return addressFailure;
   const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
   const recipientHash = emailPreferenceRecipientHash(data.to);
   if (!recipientHash) {

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -450,8 +450,14 @@ For local or staging signup tests without real email delivery, set `OPENVPM_EXPO
 Resend sends transactional email and posts delivery lifecycle callbacks back to OpenVPM so bounces, spam complaints, and provider suppressions can fail closed before future client email sends.
 
 `EMAIL_SUPPORT_ADDRESS` is used as lifecycle email Reply-To and footer contact
-address. `EMAIL_COMPANY_ADDRESS` is rendered in hosted email footers. Both gate
-hosted readiness so production emails do not fall back to local/dev defaults.
+address. `EMAIL_COMPANY_ADDRESS` must be an operator-verified physical postal
+address, such as a current street address, registered PO box, or registered
+private mailbox; never use an email address or URL. It is rendered in
+promotional email footers. Hosted readiness and promotional lifecycle sends
+fail closed when it is missing or structurally invalid. Structural validation
+does not prove that the address exists or is deliverable, so verify it before
+deployment or campaign activation. Authentication, receipt, and other
+transactional/service email does not use this promotional-address gate.
 `EMAIL_PREFERENCE_IDENTITY_SECRET` is the stable HMAC identity key for PII-free
 recipient hashes. Never rotate it without a coordinated migration of persisted
 preference identities. `EMAIL_PREFERENCE_SIGNING_SECRET` signs new durable

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -1,6 +1,6 @@
 // @openpims/email — branded transactional email templates (React Email).
 // Transport + send logic lives in the app; this package only renders HTML.
-export { openvpmBrand } from "./src/brand";
+export { isPlausiblePhysicalCompanyAddress, openvpmBrand } from "./src/brand";
 export type { Brand } from "./src/brand";
 export { theme } from "./src/theme";
 export * from "./src/render";

--- a/packages/email/src/brand.ts
+++ b/packages/email/src/brand.ts
@@ -23,6 +23,37 @@ export interface Brand {
   logoUrl?: string;
 }
 
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const URL_LIKE_PATTERN = /(?:[a-z][a-z0-9+.-]*:\/\/|mailto:|www\.)/iu;
+const PO_BOX_PATTERN =
+  /\b(?:p\.?\s*o\.?\s+box|post office box|pmb)\s*[a-z0-9-]+\b/iu;
+const RURAL_ROUTE_PATTERN =
+  /\b(?:rr|rural route)\s*\d+[a-z0-9-]*\s+box\s*[a-z0-9-]+\b/iu;
+const STREET_ADDRESS_PATTERN =
+  /\b\d+[a-z]?(?:-\d+[a-z]?)?\s+[a-z0-9.'-]+(?:\s+[a-z0-9.'-]+){0,5}\s+(?:avenue|ave|boulevard|blvd|circle|cir|court|ct|drive|dr|highway|hwy|lane|ln|loop|parkway|pkwy|place|pl|plaza|road|rd|route|rte|square|sq|street|st|terrace|ter|trail|trl|way)\b/iu;
+
+/**
+ * Conservative structural gate for the physical postal address required in
+ * promotional email footers. This does not prove that an address exists or is
+ * deliverable; a hosted operator must verify that separately.
+ */
+export function isPlausiblePhysicalCompanyAddress(
+  value: string | null | undefined,
+): boolean {
+  if (typeof value !== "string" || CONTROL_CHARACTER_PATTERN.test(value)) {
+    return false;
+  }
+  const address = value.trim();
+  if (!address || address.length < 10 || address.length > 300) return false;
+  if (address.includes("@") || URL_LIKE_PATTERN.test(address)) return false;
+
+  return (
+    PO_BOX_PATTERN.test(address) ||
+    RURAL_ROUTE_PATTERN.test(address) ||
+    STREET_ADDRESS_PATTERN.test(address)
+  );
+}
+
 function nonBlankEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
   return value ? value : undefined;


### PR DESCRIPTION
## Summary

Rebuilds the valuable promotional postal-address safety gate from stale PRs #202/#203 on current `development`. This is a narrow current-base reconstruction, not a merge or cherry-pick.

- validates a structurally plausible street, PO-box/PMB, or rural-route postal address
- rejects blank, email, URL, control-character, and malformed impostors
- blocks welcome, setup-recovery, trial-ending, and first-clinic-win sends before provider initialization
- returns fixed, non-sensitive failure evidence and makes hosted readiness fail generically
- leaves authentication, receipt, dunning, subscription-confirmed/canceled, and durable #242 outbox behavior ungated

## Provenance and scope

- source PRs: #202 (`bf2b16cc5f4e2a2c7d6e9941a27ed60879d2c3ea`) and stacked #203 (`8ccd86c63794c858f07e6d91b967fa65b209ae34`)
- base: `fdb1a2d94d5959d8a051af313fec87649a3d00fb`
- reviewed head: `6684e2f8c61ea46c1ef2d2ddc28f8f915b4c42fa`
- reviewed tree: `3c06bdbd3cb25c292ecf500f30994c408f6e7c0b`
- no schema, migration, workflow, outbox, provider, dependency, hosted-environment, `main`, or `staging` changes

## Verification

- focused/adjacent tests: 165 passed
- `@openpims/email` type-check: passed
- `@openpims/web` type-check: passed
- `git diff --check`: passed
- independent exact-head review: GO; no P0/P1
- stable patch identity across rebase: `cc169b31283db3c6a8f2bf8b012cc3c19c8ec1d1`

## Operational note

Structural validation cannot prove existence or deliverability; the runbook requires operator verification. Nonblocking hardening follow-ups are to deduplicate configuration-alert churn for retrying campaigns and reject Unicode bidi/format controls.

This preserves the remaining #202/#203 slices for separate current-base recovery; those stale PRs will not be merged wholesale.