### PR TITLE
Recover controlled SMS pilot activation preflight

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -79,6 +79,16 @@ const recoveryTrialStyles: Record<string, string> = {
   no_trial: "bg-gray-100 text-gray-600",
 };
 
+const smsPilotStageLabels: Record<string, string> = {
+  deferred: "Safely deferred",
+  blocked: "Blocked",
+  provisioning_prepared: "Provisioning prepared",
+  scope_prepared: "Scope prepared",
+  inbound_prepared: "Inbound prepared",
+  provider_ready: "Provider ready",
+  active: "Active",
+};
+
 function recoveryLabel(value: string) {
   return value.replaceAll("_", " ");
 }
@@ -118,6 +128,10 @@ export default function AdminPage() {
     trpc.admin.smsOperationsHealth.useQuery(undefined, { retry: false });
   const { data: smsConfiguration, error: smsConfigurationError } =
     trpc.admin.hostedSmsConfiguration.useQuery(undefined, { retry: false });
+  const { data: smsPilotPreflight, error: smsPilotPreflightError } =
+    trpc.admin.hostedSmsPilotActivationPreflight.useQuery(undefined, {
+      retry: false,
+    });
   const [extendTrialError, setExtendTrialError] = useState<string | null>(null);
   const [analyticsError, setAnalyticsError] = useState<string | null>(null);
   const [messagingError, setMessagingError] = useState<string | null>(null);
@@ -327,6 +341,103 @@ export default function AdminPage() {
             </span>
           ) : null}
         </div>
+        {smsPilotPreflight ? (
+          <div className="mt-4 rounded-md border border-border bg-muted/20 p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-sm font-medium">
+                Hosted SMS pilot activation preflight
+              </p>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  smsPilotPreflight.stage === "blocked"
+                    ? "bg-red-100 text-red-800"
+                    : smsPilotPreflight.stage === "active"
+                      ? "bg-green-100 text-green-800"
+                      : smsPilotPreflight.stage === "deferred"
+                        ? "bg-gray-100 text-gray-700"
+                        : "bg-amber-100 text-amber-800"
+                }`}
+              >
+                {smsPilotStageLabels[smsPilotPreflight.stage] ??
+                  smsPilotPreflight.stage}
+              </span>
+            </div>
+            <p className="mt-2 text-sm">{smsPilotPreflight.detail}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Next: {smsPilotPreflight.nextAction}
+            </p>
+            {smsPilotPreflight.blockers.length > 0 ? (
+              <p className="mt-2 text-xs text-red-700">
+                Blocking checks: {smsPilotPreflight.blockers.join(", ")}
+              </p>
+            ) : null}
+            <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
+              {[
+                ["Launch flags", smsPilotPreflight.checks.launchFlagsValid],
+                [
+                  "Credential shapes",
+                  smsPilotPreflight.checks.credentialsValid,
+                ],
+                [
+                  "Provisioning scope",
+                  smsPilotPreflight.checks.provisioningScopeExact,
+                ],
+                ["Sending scope", smsPilotPreflight.checks.sendingScopeExact],
+                ["Scopes match", smsPilotPreflight.checks.scopesMatch],
+                ["Practice active", smsPilotPreflight.checks.practiceActive],
+                ["Recovery clear", smsPilotPreflight.checks.recoveryClear],
+                [
+                  "Carrier identity",
+                  smsPilotPreflight.checks.carrierIdentityReady,
+                ],
+                [
+                  "Provider profile",
+                  smsPilotPreflight.checks.providerProfileReady,
+                ],
+                [
+                  "Provider events",
+                  smsPilotPreflight.checks.providerEventsClear,
+                ],
+                [
+                  "Heartbeat delivery",
+                  smsPilotPreflight.checks.heartbeatDeliveryConfigured,
+                ],
+              ].map(([label, ready]) => (
+                <div
+                  key={String(label)}
+                  className="flex items-center justify-between rounded border border-border bg-background px-2 py-1.5"
+                >
+                  <span>{label}</span>
+                  <span
+                    className={
+                      ready === true
+                        ? "font-medium text-green-700"
+                        : ready === null
+                          ? "font-medium text-muted-foreground"
+                          : "font-medium text-red-700"
+                    }
+                  >
+                    {ready === true
+                      ? "Ready"
+                      : ready === null
+                        ? "Not staged"
+                        : "Blocked"}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              This check is read-only. It returns no secret, phone, clinic, or
+              provider identifier and never enables provisioning, inbound
+              projection, or sending. Configured heartbeat delivery does not
+              prove a fresh external receipt.
+            </p>
+          </div>
+        ) : smsPilotPreflightError ? (
+          <p className="mt-3 text-sm text-red-700">
+            Could not load the hosted SMS pilot activation preflight.
+          </p>
+        ) : null}
         {smsConfiguration ? (
           <div className="mt-4 rounded-md border border-border bg-muted/20 p-3">
             <div className="flex flex-wrap items-center justify-between gap-2">

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -1,7 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  dbExecute: vi.fn(async () => [{ ok: 1, scopeValid: true }]),
+  dbExecute: vi.fn(async () => [
+    {
+      ok: 1,
+      practiceActive: true,
+      recoveryClear: true,
+      carrierIdentityReady: true,
+      providerProfileReady: true,
+      providerProfileSyncedAt: new Date() as Date | string | null,
+      clinicSenderEnabled: true,
+    },
+  ]),
   withSystem: vi.fn(
     async (
       database: { execute: typeof mocks.dbExecute },
@@ -189,10 +199,27 @@ function stubHostedSmsInboundGate() {
   vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
 }
 
+function stubHostedSmsProvisioningScope() {
+  vi.stubEnv(
+    "MESSAGING_PROVISIONING_PRACTICE_IDS",
+    "00000000-0000-4000-8000-0000000000aa",
+  );
+}
+
 afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
-  mocks.dbExecute.mockResolvedValue([{ ok: 1, scopeValid: true }]);
+  mocks.dbExecute.mockResolvedValue([
+    {
+      ok: 1,
+      practiceActive: true,
+      recoveryClear: true,
+      carrierIdentityReady: true,
+      providerProfileReady: true,
+      providerProfileSyncedAt: new Date(),
+      clinicSenderEnabled: true,
+    },
+  ]);
   mocks.withSystem.mockImplementation(async (database, fn) => fn(database));
   mocks.billingEnforced.mockReturnValue(false);
   mocks.replicaStorageReadiness.mockReturnValue({
@@ -429,7 +456,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "3 required hosted SMS configuration issues detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
     expect(JSON.stringify(json)).not.toContain("TELNYX_API_KEY");
     expect(JSON.stringify(json)).not.toContain(
@@ -457,6 +484,7 @@ describe("health route", () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
+    stubHostedSmsProvisioningScope();
     stubHostedSmsInboundGate();
     vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
     vi.stubEnv(
@@ -470,7 +498,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -478,6 +506,7 @@ describe("health route", () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
+    stubHostedSmsProvisioningScope();
     stubHostedSmsInboundGate();
     vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
     vi.stubEnv(
@@ -497,7 +526,7 @@ describe("health route", () => {
       ok: true,
       detail: "Hosted SMS pilot configuration active",
     });
-    expect(mocks.withSystem).toHaveBeenCalledTimes(2);
+    expect(mocks.withSystem).toHaveBeenCalledTimes(1);
   });
 
   it("rejects different provisioning and sending clinic scopes", async () => {
@@ -524,7 +553,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -532,6 +561,7 @@ describe("health route", () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
+    stubHostedSmsProvisioningScope();
     stubHostedSmsInboundGate();
     vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
     vi.stubEnv(
@@ -543,8 +573,28 @@ describe("health route", () => {
       "00000000-0000-4000-8000-000000000002",
     );
     mocks.dbExecute
-      .mockResolvedValueOnce([{ ok: 1, scopeValid: true }])
-      .mockResolvedValueOnce([{ ok: 1, scopeValid: false }]);
+      .mockResolvedValueOnce([
+        {
+          ok: 1,
+          practiceActive: true,
+          recoveryClear: true,
+          carrierIdentityReady: true,
+          providerProfileReady: true,
+          providerProfileSyncedAt: new Date(),
+          clinicSenderEnabled: true,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          ok: 1,
+          practiceActive: true,
+          recoveryClear: true,
+          carrierIdentityReady: false,
+          providerProfileReady: false,
+          providerProfileSyncedAt: null,
+          clinicSenderEnabled: false,
+        },
+      ]);
 
     const response = await GET();
     const json = await response.json();
@@ -552,8 +602,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail:
-        "Hosted SMS pilot scope does not match an active, carrier-ready clinic location",
+      detail: "2 hosted SMS pilot readiness issues detected",
     });
   });
 
@@ -561,6 +610,7 @@ describe("health route", () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
+    stubHostedSmsProvisioningScope();
     stubHostedSmsInboundGate();
     vi.stubEnv("MESSAGING_PROVIDER", "twilio");
     vi.stubEnv(
@@ -578,7 +628,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -586,6 +636,7 @@ describe("health route", () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
+    stubHostedSmsProvisioningScope();
     stubHostedSmsInboundGate();
     vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", "not-a-practice-id");
     vi.stubEnv(
@@ -599,7 +650,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -607,6 +658,7 @@ describe("health route", () => {
     mocks.billingEnforced.mockReturnValue(true);
     stubHostedRequiredEnvs();
     stubValidTelnyxEnvs();
+    stubHostedSmsProvisioningScope();
     stubHostedSmsInboundGate();
     vi.stubEnv(
       "MESSAGING_SENDING_PRACTICE_IDS",
@@ -623,7 +675,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "1 required hosted SMS configuration issue detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
   });
 
@@ -646,7 +698,7 @@ describe("health route", () => {
     expect(response.status).toBe(503);
     expect(json.checks.hostedSms).toEqual({
       ok: false,
-      detail: "3 required hosted SMS configuration issues detected",
+      detail: "1 hosted SMS pilot readiness issue detected",
     });
     expect(JSON.stringify(json)).not.toContain("test-api-key");
     expect(JSON.stringify(json)).not.toContain("test-public-key");

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -19,7 +19,6 @@ import {
 } from "@/lib/rls-assertion";
 import { cronHeartbeatConfigured } from "@/lib/cron-heartbeat";
 import { envFlagEnabled } from "@/lib/env-bool";
-import { loadSmsProviderEventGateSummaryInTransaction } from "@/lib/messaging/sms-provider-event-operations";
 import {
   checkObjectStorageHealth,
   checkReplicaStorageHealth,
@@ -30,8 +29,6 @@ import {
 import { getFileReplicaCoverage } from "@/lib/file-replication";
 import { normalizeAppBaseUrl } from "@/lib/app-url";
 import { platformAdminEmails } from "@/lib/platform-admin";
-import { rowsFromExecute } from "@/lib/db/execute-rows";
-import { withSystem } from "@/lib/tenant-db";
 import {
   CANONICAL_EMAIL_PREFERENCE_BASE_URL,
   isValidEmailPreferencePreviousSecrets,
@@ -40,6 +37,10 @@ import {
 } from "@/lib/email-preferences";
 import { platformEmailIdentityConfigurationReady } from "@/lib/platform-email-preferences";
 import { hostedSmsCredentialIssueCount } from "@/lib/messaging/hosted-sms-readiness";
+import {
+  hostedSmsRolloutIntended,
+  loadHostedSmsPilotActivationPreflight,
+} from "@/lib/messaging/hosted-sms-pilot-preflight";
 import { inspectDeploymentEnvironment } from "@/lib/deployment-environment";
 
 export const dynamic = "force-dynamic";
@@ -104,10 +105,6 @@ const HOSTED_EMAIL_ENV_NAMES = [
   "EMAIL_SUPPORT_ADDRESS",
   "EMAIL_COMPANY_ADDRESS",
 ];
-const HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV =
-  "MESSAGING_PROVISIONING_PRACTICE_IDS";
-const HOSTED_SMS_SENDING_PRACTICE_IDS_ENV = "MESSAGING_SENDING_PRACTICE_IDS";
-const HOSTED_SMS_SENDING_LOCATION_IDS_ENV = "MESSAGING_SENDING_LOCATION_IDS";
 const HOSTED_VERTEX_AI_ENV_NAMES = [
   "GOOGLE_VERTEX_PROJECT",
   "GOOGLE_VERTEX_LOCATION",
@@ -281,23 +278,6 @@ function hostedSubscriptionTaxCheck(): { ok: boolean; detail: string } {
   };
 }
 
-function commaSeparatedValues(name: string): string[] {
-  return (process.env[name] ?? "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-}
-
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-    value,
-  );
-}
-
-function isExactPilotScope(values: string[]): boolean {
-  return values.length === 1 && isUuid(values[0]!);
-}
-
 function hostedTelnyxCredentialCheck(): { ok: boolean; detail: string } {
   const issueCount = hostedSmsCredentialIssueCount();
   return issueCount > 0
@@ -311,164 +291,6 @@ function hostedTelnyxCredentialCheck(): { ok: boolean; detail: string } {
         ok: true,
         detail: "Hosted Telnyx credentials are structurally valid",
       };
-}
-
-function hostedSmsRolloutIntended(): boolean {
-  return (
-    envFlagEnabled("MESSAGING_PROVISIONING_ENABLED") ||
-    envFlagEnabled("MESSAGING_SENDING_ENABLED") ||
-    envFlagEnabled("MESSAGING_INBOUND_ENABLED") ||
-    commaSeparatedValues(HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV).length > 0 ||
-    commaSeparatedValues(HOSTED_SMS_SENDING_PRACTICE_IDS_ENV).length > 0 ||
-    commaSeparatedValues(HOSTED_SMS_SENDING_LOCATION_IDS_ENV).length > 0
-  );
-}
-
-async function hostedSmsRolloutCheck(): Promise<{
-  ok: boolean;
-  detail: string;
-}> {
-  const credentialIssues = hostedSmsCredentialIssueCount();
-  const provisioningEnabled = envFlagEnabled("MESSAGING_PROVISIONING_ENABLED");
-  const sendingEnabled = envFlagEnabled("MESSAGING_SENDING_ENABLED");
-  const inboundEnabled = envFlagEnabled("MESSAGING_INBOUND_ENABLED");
-  const provisioningPracticeIds = commaSeparatedValues(
-    HOSTED_SMS_PROVISIONING_PRACTICE_IDS_ENV,
-  );
-  const sendingPracticeIds = commaSeparatedValues(
-    HOSTED_SMS_SENDING_PRACTICE_IDS_ENV,
-  );
-  const sendingLocationIds = commaSeparatedValues(
-    HOSTED_SMS_SENDING_LOCATION_IDS_ENV,
-  );
-  const provisioningScopePrepared = provisioningPracticeIds.length > 0;
-  const sendingScopePrepared =
-    sendingPracticeIds.length > 0 || sendingLocationIds.length > 0;
-
-  let configurationIssues = 0;
-  if (envValue("MESSAGING_PROVIDER")?.toLowerCase() !== "telnyx") {
-    configurationIssues += 1;
-  }
-  if (
-    (provisioningEnabled || provisioningScopePrepared) &&
-    !isExactPilotScope(provisioningPracticeIds)
-  ) {
-    configurationIssues += 1;
-  }
-  if (
-    (sendingEnabled || sendingScopePrepared) &&
-    (!isExactPilotScope(sendingPracticeIds) ||
-      !isExactPilotScope(sendingLocationIds))
-  ) {
-    configurationIssues += 1;
-  }
-  if (
-    (sendingEnabled || sendingScopePrepared || inboundEnabled) &&
-    !inboundEnabled
-  ) {
-    configurationIssues += 1;
-  }
-  if (inboundEnabled && !sendingScopePrepared) {
-    configurationIssues += 1;
-  }
-  if (
-    provisioningScopePrepared &&
-    sendingScopePrepared &&
-    provisioningPracticeIds[0] !== sendingPracticeIds[0]
-  ) {
-    configurationIssues += 1;
-  }
-
-  const issueCount = credentialIssues + configurationIssues;
-  if (issueCount > 0) {
-    return {
-      ok: false,
-      detail: `${issueCount} required hosted SMS configuration ${
-        issueCount === 1 ? "issue" : "issues"
-      } detected`,
-    };
-  }
-
-  const pilotPracticeId = sendingPracticeIds[0] ?? provisioningPracticeIds[0]!;
-  const sendingLocationId = sendingLocationIds[0] ?? null;
-  try {
-    // Health has no tenant identity. Verify the explicitly configured rollout
-    // scope in system context so hosted RLS does not hide a valid pilot clinic.
-    const result = await withSystem(db, (tx) =>
-      tx.execute(sql`
-        select (
-          exists (
-            select 1
-            from practices as practice
-            where practice.id = ${pilotPracticeId}::uuid
-              and practice.deleted_at is null
-          )
-          and ${
-            sendingLocationId
-              ? sql`exists (
-                  select 1
-                  from locations as location
-                  join location_messaging as sender
-                    on sender.practice_id = location.practice_id
-                    and sender.location_id = location.id
-                    and sender.deleted_at is null
-                  join messaging_registrations as registration
-                    on registration.practice_id = location.practice_id
-                    and registration.deleted_at is null
-                  where location.id = ${sendingLocationId}::uuid
-                    and location.practice_id = ${pilotPracticeId}::uuid
-                    and location.deleted_at is null
-                    and sender.provider = 'telnyx'
-                    and sender.registration_status = 'active'
-                    and nullif(btrim(sender.sender_e164), '') is not null
-                    and nullif(btrim(sender.messaging_profile_id), '') is not null
-                    and sender.provider_profile_ready = true
-                    and sender.provider_profile_synced_at is not null
-                    and registration.provider = 'telnyx'
-                    and registration.status = 'active'
-                    and sender.a2p_brand_id = registration.provider_brand_id
-                    and sender.a2p_campaign_id = registration.provider_campaign_id
-                )`
-              : sql`true`
-          }
-        ) as "scopeValid"
-      `),
-    );
-    const scopeValid =
-      rowsFromExecute<{ scopeValid: boolean }>(result)[0]?.scopeValid === true;
-    if (!scopeValid) {
-      return {
-        ok: false,
-        detail:
-          "Hosted SMS pilot scope does not match an active, carrier-ready clinic location",
-      };
-    }
-    const providerEventGate = await withSystem(db, (tx) =>
-      loadSmsProviderEventGateSummaryInTransaction(tx, {
-        practiceId: pilotPracticeId,
-        locationId: sendingLocationId ?? undefined,
-      }),
-    );
-    if (providerEventGate.total > 0) {
-      return {
-        ok: false,
-        detail:
-          "Hosted SMS pilot has unresolved provider-event projection evidence",
-      };
-    }
-  } catch {
-    return {
-      ok: false,
-      detail: "Hosted SMS pilot scope verification failed",
-    };
-  }
-
-  return {
-    ok: true,
-    detail: sendingEnabled
-      ? "Hosted SMS pilot configuration active"
-      : "Hosted SMS pilot configuration prepared and sending gated off",
-  };
 }
 
 export async function GET() {
@@ -609,12 +431,18 @@ export async function GET() {
     // while provisioning or sending is nominally enabled without credentials,
     // webhook verification, encrypted registration storage, or exact pilot
     // scope. Missing/partial launch state still fails closed at every send.
-    checks.hostedSms = hostedSmsRolloutIntended()
-      ? await hostedSmsRolloutCheck()
-      : {
-          ...hostedTelnyxCredentialCheck(),
-          advisory: true,
-        };
+    if (hostedSmsRolloutIntended()) {
+      const smsPreflight = await loadHostedSmsPilotActivationPreflight(db);
+      checks.hostedSms = {
+        ok: smsPreflight.ok,
+        detail: smsPreflight.detail,
+      };
+    } else {
+      checks.hostedSms = {
+        ...hostedTelnyxCredentialCheck(),
+        advisory: true,
+      };
+    }
     checks.hostedOpsAlerting = {
       ...hostedEnvCheck(
         HOSTED_OPS_ALERTING_ENV_NAMES,

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -173,6 +173,27 @@ describe("admin UI", () => {
     expect(source).toContain('"Needs attention"');
   });
 
+  it("shows the sequenced read-only hosted SMS pilot activation preflight", () => {
+    expect(source).toContain(
+      "trpc.admin.hostedSmsPilotActivationPreflight.useQuery",
+    );
+    expect(source).toContain("Hosted SMS pilot activation preflight");
+    expect(source).toContain('scope_prepared: "Scope prepared"');
+    expect(source).toContain('inbound_prepared: "Inbound prepared"');
+    expect(source).toContain('provider_ready: "Provider ready"');
+    expect(source).toContain("smsPilotPreflight.checks.launchFlagsValid");
+    expect(source).toContain("smsPilotPreflight.checks.providerEventsClear");
+    expect(source).toContain(
+      "smsPilotPreflight.checks.heartbeatDeliveryConfigured",
+    );
+    expect(compactSource).toContain(
+      "This check is read-only. It returns no secret, phone, clinic, or provider identifier",
+    );
+    expect(compactSource).toContain(
+      "Configured heartbeat delivery does not prove a fresh external receipt",
+    );
+  });
+
   it("shows bounded read-only redacted carrier lifecycle history", () => {
     expect(source).toContain(
       "trpc.admin.messagingRegistrationHistory.useQuery",

--- a/apps/web/lib/messaging/__tests__/hosted-sms-pilot-preflight.test.ts
+++ b/apps/web/lib/messaging/__tests__/hosted-sms-pilot-preflight.test.ts
@@ -1,0 +1,431 @@
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const execute = vi.fn();
+  const database = { execute };
+  return {
+    execute,
+    database,
+    withSystem: vi.fn(
+      async (
+        db: typeof database,
+        action: (tx: typeof database) => Promise<unknown>,
+      ) => action(db),
+    ),
+    heartbeatConfigured: vi.fn(() => ({
+      ok: true,
+      detail: "Job-specific cron heartbeat URLs configured",
+    })),
+    loadGate: vi.fn(async () => ({ total: 0 })),
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({ db: mocks.database }));
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
+vi.mock("@/lib/cron-heartbeat", () => ({
+  cronHeartbeatConfigured: mocks.heartbeatConfigured,
+}));
+vi.mock("../sms-provider-event-operations", () => ({
+  loadSmsProviderEventGateSummaryInTransaction: mocks.loadGate,
+}));
+
+const { hostedSmsRolloutIntended, loadHostedSmsPilotActivationPreflight } =
+  await import("../hosted-sms-pilot-preflight");
+
+const PRACTICE_ID = "00000000-0000-4000-8000-0000000000aa";
+const OTHER_PRACTICE_ID = "00000000-0000-4000-8000-0000000000bb";
+const LOCATION_ID = "00000000-0000-4000-8000-000000000002";
+const SECRET = "KEY_sensitive-not-for-output";
+const SOURCE = readFileSync(
+  "lib/messaging/hosted-sms-pilot-preflight.ts",
+  "utf8",
+);
+
+function stubValidCredentials() {
+  vi.stubEnv("MESSAGING_PROVIDER", "telnyx");
+  vi.stubEnv("TELNYX_API_KEY", `${SECRET}abcdefghijk`);
+  vi.stubEnv("TELNYX_PUBLIC_KEY", Buffer.alloc(32, 1).toString("base64"));
+  vi.stubEnv(
+    "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
+    Buffer.alloc(32, 2).toString("base64"),
+  );
+}
+
+function stubExactPilotScope() {
+  vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", PRACTICE_ID);
+  vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
+  vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", LOCATION_ID);
+}
+
+function scopeRow(
+  overrides: Partial<{
+    practiceActive: boolean;
+    recoveryClear: boolean;
+    carrierIdentityReady: boolean;
+    providerProfileReady: boolean;
+    providerProfileSyncedAt: Date | string | number | null;
+    clinicSenderEnabled: boolean;
+  }> = {},
+) {
+  return {
+    practiceActive: true,
+    recoveryClear: true,
+    carrierIdentityReady: true,
+    providerProfileReady: false,
+    providerProfileSyncedAt: new Date(),
+    clinicSenderEnabled: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.execute.mockResolvedValue([scopeRow()]);
+  mocks.heartbeatConfigured.mockReturnValue({
+    ok: true,
+    detail: "Job-specific cron heartbeat URLs configured",
+  });
+  mocks.loadGate.mockResolvedValue({ total: 0 });
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("hosted SMS pilot activation preflight", () => {
+  it("keeps an unstaged rollout advisory and performs no database or provider work", async () => {
+    stubValidCredentials();
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+      new Date("2026-08-25T12:00:00.000Z"),
+    );
+
+    expect(result).toMatchObject({
+      stage: "deferred",
+      ok: true,
+      readyForInboundEnable: false,
+      providerEventBlocking: null,
+    });
+    expect(hostedSmsRolloutIntended()).toBe(false);
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.execute).not.toHaveBeenCalled();
+    expect(SOURCE).not.toContain("telnyx-provisioning");
+    expect(SOURCE).not.toContain("updateMessagingProfileEnabled");
+    expect(SOURCE).not.toContain("sendSms");
+    expect(SOURCE).not.toContain("fetch(");
+  });
+
+  it("fails closed on a malformed launch flag instead of treating rollout as deferred", async () => {
+    stubValidCredentials();
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "yes");
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(hostedSmsRolloutIntended()).toBe(true);
+    expect(result).toMatchObject({ stage: "blocked", ok: false });
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        "launch_flag_invalid",
+        "provisioning_scope_invalid",
+      ]),
+    );
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing location", PRACTICE_ID, ""],
+    ["malformed practice", "not-a-uuid", LOCATION_ID],
+    ["multiple practices", `${PRACTICE_ID},${OTHER_PRACTICE_ID}`, LOCATION_ID],
+  ])(
+    "fails closed on %s in a staged sending scope",
+    async (_, practice, location) => {
+      stubValidCredentials();
+      vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", PRACTICE_ID);
+      vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", practice);
+      vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", location);
+
+      const result = await loadHostedSmsPilotActivationPreflight(
+        mocks.database as never,
+      );
+
+      expect(result).toMatchObject({ stage: "blocked", ok: false });
+      expect(result.blockers).toContain("sending_scope_invalid");
+      expect(mocks.withSystem).not.toHaveBeenCalled();
+    },
+  );
+
+  it("requires the exact same provisioning and sending practice", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", OTHER_PRACTICE_ID);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({ stage: "blocked", ok: false });
+    expect(result.blockers).toContain("scope_mismatch");
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+  });
+
+  it("requires both SMS heartbeat destinations for every rollout signal", async () => {
+    stubValidCredentials();
+    vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", PRACTICE_ID);
+    mocks.heartbeatConfigured.mockReturnValue({
+      ok: false,
+      detail: "sensitive monitor configuration detail",
+    });
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(mocks.heartbeatConfigured).toHaveBeenCalledWith([
+      "sms-provider-events",
+      "sms-operations",
+    ]);
+    expect(result.blockers).toContain("heartbeat_not_configured");
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("sensitive monitor");
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+  });
+
+  it("accepts an exact carrier-ready scope while inbound and sending remain off", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "scope_prepared",
+      ok: true,
+      blockers: [],
+      readyForInboundEnable: true,
+      readyForProviderActivation: false,
+      readyForSendingEnable: false,
+      checks: {
+        carrierIdentityReady: true,
+        providerProfileReady: false,
+        providerEventsClear: true,
+      },
+    });
+    expect(mocks.withSystem).toHaveBeenCalledTimes(1);
+    expect(mocks.loadGate).toHaveBeenCalledWith(mocks.database, {
+      practiceId: PRACTICE_ID,
+      locationId: LOCATION_ID,
+    });
+  });
+
+  it("fails closed when the database readiness query fails or returns no active practice", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    mocks.execute.mockRejectedValueOnce(new Error("postgres://secret-host/db"));
+
+    const failed = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+    expect(failed.blockers).toEqual(["readiness_check_failed"]);
+    expect(JSON.stringify(failed)).not.toContain("secret-host");
+
+    mocks.execute.mockResolvedValueOnce([]);
+    const unavailable = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+    expect(unavailable.blockers).toEqual(["pilot_practice_unavailable"]);
+    expect(unavailable.ok).toBe(false);
+  });
+
+  it("blocks unresolved or malformed provider-event evidence without returning identifiers", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    mocks.loadGate.mockResolvedValueOnce({ total: 2 });
+
+    const backlog = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+    expect(backlog).toMatchObject({
+      stage: "blocked",
+      ok: false,
+      providerEventBlocking: 2,
+      checks: { providerEventsClear: false },
+    });
+    expect(backlog.blockers).toContain("provider_event_backlog");
+
+    mocks.loadGate.mockResolvedValueOnce({ total: Number.NaN });
+    const malformed = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+    expect(malformed.blockers).toEqual(["readiness_check_failed"]);
+
+    const serialized = JSON.stringify([backlog, malformed]);
+    expect(serialized).not.toContain(PRACTICE_ID);
+    expect(serialized).not.toContain(LOCATION_ID);
+    expect(serialized).not.toContain(SECRET);
+  });
+
+  it("blocks held, carrier-incomplete, and sending-before-profile-ready states", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    mocks.execute.mockResolvedValue([
+      scopeRow({
+        recoveryClear: false,
+        carrierIdentityReady: false,
+        providerProfileReady: false,
+      }),
+    ]);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result.blockers).toEqual([
+      "practice_recovery_hold",
+      "carrier_identity_not_ready",
+      "provider_profile_not_ready",
+    ]);
+    expect(result.ok).toBe(false);
+  });
+
+  it.each([
+    [false, false, "scope_prepared"],
+    [true, false, "inbound_prepared"],
+    [true, true, "provider_ready"],
+  ])(
+    "reports the safe sequence for inbound=%s profile=%s",
+    async (inboundEnabled, providerProfileReady, stage) => {
+      stubValidCredentials();
+      stubExactPilotScope();
+      vi.stubEnv("MESSAGING_INBOUND_ENABLED", String(inboundEnabled));
+      mocks.execute.mockResolvedValue([scopeRow({ providerProfileReady })]);
+
+      const result = await loadHostedSmsPilotActivationPreflight(
+        mocks.database as never,
+      );
+
+      expect(result).toMatchObject({ stage, ok: true });
+      if (stage === "inbound_prepared") {
+        expect(result.readyForProviderActivation).toBe(false);
+        expect(result.nextAction).toContain("provider-mutation kill-switch");
+      }
+    },
+  );
+
+  it("advertises provider activation only while the mutation switch is explicitly enabled", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    mocks.execute.mockResolvedValue([scopeRow()]);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "inbound_prepared",
+      ok: true,
+      readyForProviderActivation: true,
+    });
+  });
+
+  it.each([
+    ["stale", "2026-08-25T11:44:59.999Z"],
+    ["future", "2026-08-25T12:00:00.001Z"],
+    ["malformed", "not-a-timestamp"],
+  ])("blocks sending on a %s provider-profile attestation", async (_, observedAt) => {
+    const now = new Date("2026-08-25T12:00:00.000Z");
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    mocks.execute.mockResolvedValue([
+      scopeRow({
+        providerProfileReady: true,
+        providerProfileSyncedAt: observedAt,
+      }),
+    ]);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+      now,
+    );
+
+    expect(result).toMatchObject({
+      stage: "blocked",
+      ok: false,
+      checks: { providerProfileReady: false },
+    });
+    expect(result.blockers).toContain("provider_profile_not_ready");
+  });
+
+  it("accepts a provider-profile attestation at the exact freshness boundary", async () => {
+    const now = new Date("2026-08-25T12:00:00.000Z");
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    mocks.execute.mockResolvedValue([
+      scopeRow({
+        providerProfileReady: true,
+        providerProfileSyncedAt: "2026-08-25T11:45:00.000Z",
+      }),
+    ]);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+      now,
+    );
+
+    expect(result).toMatchObject({
+      stage: "provider_ready",
+      ok: true,
+      checks: { providerProfileReady: true },
+    });
+  });
+
+  it("reports active only after inbound and provider profile readiness", async () => {
+    stubValidCredentials();
+    stubExactPilotScope();
+    vi.stubEnv("MESSAGING_INBOUND_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    mocks.execute.mockResolvedValue([
+      scopeRow({ providerProfileReady: true, clinicSenderEnabled: true }),
+    ]);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "active",
+      ok: true,
+      detail: "Hosted SMS pilot configuration active",
+    });
+  });
+
+  it("supports provisioning-only preparation without inventing location readiness", async () => {
+    stubValidCredentials();
+    vi.stubEnv("MESSAGING_PROVISIONING_PRACTICE_IDS", PRACTICE_ID);
+
+    const result = await loadHostedSmsPilotActivationPreflight(
+      mocks.database as never,
+    );
+
+    expect(result).toMatchObject({
+      stage: "provisioning_prepared",
+      ok: true,
+      checks: {
+        provisioningScopeExact: true,
+        sendingScopeExact: null,
+        carrierIdentityReady: null,
+        providerProfileReady: null,
+        providerEventsClear: true,
+      },
+    });
+  });
+});

--- a/apps/web/lib/messaging/hosted-sms-pilot-preflight.ts
+++ b/apps/web/lib/messaging/hosted-sms-pilot-preflight.ts
@@ -1,0 +1,495 @@
+import { sql } from "drizzle-orm";
+import { db } from "@openpims/db/client";
+import type { Database } from "@openpims/db/client";
+import { cronHeartbeatConfigured } from "@/lib/cron-heartbeat";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import { withSystem } from "@/lib/tenant-db";
+import { loadSmsProviderEventGateSummaryInTransaction } from "./sms-provider-event-operations";
+import { hostedSmsConfigurationDiagnostics } from "./hosted-sms-readiness";
+import { providerProfileAttestationIsCurrent } from "./provider-profile-attestation";
+
+const PROVISIONING_PRACTICE_IDS_ENV = "MESSAGING_PROVISIONING_PRACTICE_IDS";
+const SENDING_PRACTICE_IDS_ENV = "MESSAGING_SENDING_PRACTICE_IDS";
+const SENDING_LOCATION_IDS_ENV = "MESSAGING_SENDING_LOCATION_IDS";
+const ROLLOUT_FLAG_ENVS = [
+  "MESSAGING_PROVISIONING_ENABLED",
+  "MESSAGING_INBOUND_ENABLED",
+  "MESSAGING_SENDING_ENABLED",
+] as const;
+const PILOT_HEARTBEAT_JOBS = ["sms-provider-events", "sms-operations"] as const;
+
+export type HostedSmsPilotStage =
+  | "deferred"
+  | "blocked"
+  | "provisioning_prepared"
+  | "scope_prepared"
+  | "inbound_prepared"
+  | "provider_ready"
+  | "active";
+
+export type HostedSmsPilotBlocker =
+  | "launch_flag_invalid"
+  | "provider_not_telnyx"
+  | "credential_shape_invalid"
+  | "provisioning_scope_invalid"
+  | "sending_scope_invalid"
+  | "scope_mismatch"
+  | "inbound_disabled_while_sending"
+  | "pilot_practice_unavailable"
+  | "practice_recovery_hold"
+  | "carrier_identity_not_ready"
+  | "provider_event_backlog"
+  | "heartbeat_not_configured"
+  | "provider_profile_not_ready"
+  | "readiness_check_failed";
+
+export interface HostedSmsPilotActivationPreflight {
+  generatedAt: string;
+  stage: HostedSmsPilotStage;
+  ok: boolean;
+  detail: string;
+  nextAction: string;
+  blockers: HostedSmsPilotBlocker[];
+  configuration: ReturnType<typeof hostedSmsConfigurationDiagnostics>;
+  checks: {
+    launchFlagsValid: boolean;
+    credentialsValid: boolean;
+    provisioningScopeExact: boolean | null;
+    sendingScopeExact: boolean | null;
+    scopesMatch: boolean | null;
+    practiceActive: boolean | null;
+    recoveryClear: boolean | null;
+    carrierIdentityReady: boolean | null;
+    providerProfileReady: boolean | null;
+    providerEventsClear: boolean | null;
+    heartbeatDeliveryConfigured: boolean;
+  };
+  providerEventBlocking: number | null;
+  readyForInboundEnable: boolean;
+  readyForProviderActivation: boolean;
+  readyForSendingEnable: boolean;
+}
+
+interface PilotScopeRow {
+  practiceActive: boolean;
+  recoveryClear: boolean;
+  carrierIdentityReady: boolean;
+  providerProfileReady: boolean;
+  providerProfileSyncedAt: unknown;
+  clinicSenderEnabled: boolean;
+}
+
+function commaSeparatedValues(name: string): string[] {
+  return (process.env[name] ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+function exactUuidScope(values: string[]): boolean {
+  return values.length === 1 && isUuid(values[0]!);
+}
+
+function flagValueIsValid(name: string): boolean {
+  const value = process.env[name]?.trim();
+  return (
+    value === undefined || value === "" || value === "true" || value === "false"
+  );
+}
+
+function malformedFlagSignalsRollout(): boolean {
+  return ROLLOUT_FLAG_ENVS.some((name) => {
+    const value = process.env[name]?.trim();
+    return Boolean(value) && !flagValueIsValid(name);
+  });
+}
+
+function uniqueBlockers(
+  values: readonly HostedSmsPilotBlocker[],
+): HostedSmsPilotBlocker[] {
+  return [...new Set(values)];
+}
+
+function nextActionForBlocker(blocker: HostedSmsPilotBlocker): string {
+  switch (blocker) {
+    case "launch_flag_invalid":
+      return "Set every hosted SMS launch flag explicitly to true or false.";
+    case "provider_not_telnyx":
+      return "Select Telnyx as the hosted messaging provider.";
+    case "credential_shape_invalid":
+      return "Fix the secret-safe Telnyx credential checks before staging a clinic.";
+    case "provisioning_scope_invalid":
+      return "Stage exactly one approved provisioning practice UUID.";
+    case "sending_scope_invalid":
+      return "Stage exactly one sending practice and its exact location while sending remains off.";
+    case "scope_mismatch":
+      return "Make the provisioning and sending practice scopes name the same clinic.";
+    case "inbound_disabled_while_sending":
+      return "Turn sending off until the inbound gate and provider profile are ready.";
+    case "pilot_practice_unavailable":
+      return "Select one active, non-deleted pilot practice.";
+    case "practice_recovery_hold":
+      return "Finish or safely release the clinic recovery hold before SMS activation.";
+    case "carrier_identity_not_ready":
+      return "Reconcile the exact Telnyx registration, campaign assignment, sender number, and messaging profile.";
+    case "provider_event_backlog":
+      return "Project or reconcile every blocking provider event before activation.";
+    case "heartbeat_not_configured":
+      return "Configure both SMS heartbeat destinations, then verify fresh receipts in the external monitor.";
+    case "provider_profile_not_ready":
+      return "Keep sending off and enable/read back the exact provider profile first.";
+    case "readiness_check_failed":
+      return "Retry the read-only preflight and investigate database readiness if it fails again.";
+  }
+}
+
+function blockedPreflight(
+  base: Omit<
+    HostedSmsPilotActivationPreflight,
+    | "stage"
+    | "ok"
+    | "detail"
+    | "nextAction"
+    | "readyForInboundEnable"
+    | "readyForProviderActivation"
+    | "readyForSendingEnable"
+  >,
+): HostedSmsPilotActivationPreflight {
+  const blockers = uniqueBlockers(base.blockers);
+  const first = blockers[0] ?? "readiness_check_failed";
+  return {
+    ...base,
+    blockers,
+    stage: "blocked",
+    ok: false,
+    detail: `${blockers.length} hosted SMS pilot readiness ${
+      blockers.length === 1 ? "issue" : "issues"
+    } detected`,
+    nextAction: nextActionForBlocker(first),
+    readyForInboundEnable: false,
+    readyForProviderActivation: false,
+    readyForSendingEnable: false,
+  };
+}
+
+export function hostedSmsRolloutIntended(): boolean {
+  return (
+    hostedSmsConfigurationDiagnostics().rolloutIntended ||
+    malformedFlagSignalsRollout()
+  );
+}
+
+/**
+ * Secret- and PHI-free hosted SMS activation preflight. It performs no
+ * provider I/O and no mutation. Configured UUIDs are bounded internal lookup
+ * keys and are never returned to the caller.
+ */
+export async function loadHostedSmsPilotActivationPreflight(
+  database: Database = db,
+  now: Date = new Date(),
+): Promise<HostedSmsPilotActivationPreflight> {
+  const configuration = hostedSmsConfigurationDiagnostics();
+  const launchFlagsValid = ROLLOUT_FLAG_ENVS.every(flagValueIsValid);
+  const rolloutIntended =
+    configuration.rolloutIntended || malformedFlagSignalsRollout();
+  const provisioningPracticeIds = commaSeparatedValues(
+    PROVISIONING_PRACTICE_IDS_ENV,
+  );
+  const sendingPracticeIds = commaSeparatedValues(SENDING_PRACTICE_IDS_ENV);
+  const sendingLocationIds = commaSeparatedValues(SENDING_LOCATION_IDS_ENV);
+  const sendingSignal =
+    configuration.sendingEnabled ||
+    configuration.inboundEnabled ||
+    sendingPracticeIds.length > 0 ||
+    sendingLocationIds.length > 0;
+  const provisioningSignal =
+    configuration.provisioningEnabled ||
+    provisioningPracticeIds.length > 0 ||
+    sendingSignal;
+  const credentialsValid =
+    configuration.apiKeyShapeValid &&
+    configuration.webhookPublicKeyShapeValid &&
+    configuration.registrationEncryptionKeyShapeValid;
+  const provisioningScopeExact = provisioningSignal
+    ? exactUuidScope(provisioningPracticeIds)
+    : null;
+  const sendingScopeExact = sendingSignal
+    ? exactUuidScope(sendingPracticeIds) && exactUuidScope(sendingLocationIds)
+    : null;
+  const scopesMatch =
+    provisioningScopeExact === true && sendingScopeExact === true
+      ? provisioningPracticeIds[0] === sendingPracticeIds[0]
+      : null;
+  const heartbeat = cronHeartbeatConfigured(PILOT_HEARTBEAT_JOBS);
+  const checks: HostedSmsPilotActivationPreflight["checks"] = {
+    launchFlagsValid,
+    credentialsValid,
+    provisioningScopeExact,
+    sendingScopeExact,
+    scopesMatch,
+    practiceActive: null,
+    recoveryClear: null,
+    carrierIdentityReady: null,
+    providerProfileReady: null,
+    providerEventsClear: null,
+    heartbeatDeliveryConfigured: heartbeat.ok,
+  };
+  const base: Parameters<typeof blockedPreflight>[0] = {
+    generatedAt: now.toISOString(),
+    configuration,
+    checks,
+    providerEventBlocking: null,
+    blockers: [],
+  };
+
+  if (!rolloutIntended) {
+    return {
+      ...base,
+      stage: "deferred",
+      ok: true,
+      detail: "Hosted SMS pilot is safely deferred",
+      nextAction:
+        "Fix any credential-shape issue, then stage one approved provisioning practice with all launch flags off.",
+      readyForInboundEnable: false,
+      readyForProviderActivation: false,
+      readyForSendingEnable: false,
+    };
+  }
+
+  if (!launchFlagsValid) base.blockers.push("launch_flag_invalid");
+  if (!configuration.providerIsTelnyx) {
+    base.blockers.push("provider_not_telnyx");
+  }
+  if (!credentialsValid) base.blockers.push("credential_shape_invalid");
+  if (provisioningScopeExact !== true) {
+    base.blockers.push("provisioning_scope_invalid");
+  }
+  if (sendingSignal && sendingScopeExact !== true) {
+    base.blockers.push("sending_scope_invalid");
+  }
+  if (scopesMatch === false) base.blockers.push("scope_mismatch");
+  if (configuration.sendingEnabled && !configuration.inboundEnabled) {
+    base.blockers.push("inbound_disabled_while_sending");
+  }
+  if (!checks.heartbeatDeliveryConfigured) {
+    base.blockers.push("heartbeat_not_configured");
+  }
+  if (base.blockers.length > 0) return blockedPreflight(base);
+
+  const practiceId = provisioningPracticeIds[0]!;
+  const locationId = sendingSignal ? sendingLocationIds[0]! : null;
+
+  try {
+    const result = await withSystem(database, async (tx) => {
+      const scopeResult = await tx.execute(sql`
+        select
+          exists (
+            select 1
+            from practices practice
+            where practice.id = ${practiceId}::uuid
+              and practice.deleted_at is null
+          ) as "practiceActive",
+          exists (
+            select 1
+            from practices practice
+            where practice.id = ${practiceId}::uuid
+              and practice.deleted_at is null
+              and practice.recovery_hold = false
+          ) as "recoveryClear",
+          ${
+            locationId
+              ? sql`exists (
+                  select 1
+                  from locations location
+                  join location_messaging sender
+                    on sender.practice_id = location.practice_id
+                    and sender.location_id = location.id
+                    and sender.deleted_at is null
+                  join messaging_registrations registration
+                    on registration.practice_id = location.practice_id
+                    and registration.deleted_at is null
+                  where location.id = ${locationId}::uuid
+                    and location.practice_id = ${practiceId}::uuid
+                    and location.deleted_at is null
+                    and sender.provider = 'telnyx'
+                    and sender.registration_status = 'active'
+                    and nullif(btrim(sender.sender_e164), '') is not null
+                    and nullif(btrim(sender.messaging_profile_id), '') is not null
+                    and registration.provider = 'telnyx'
+                    and registration.status = 'active'
+                    and sender.a2p_brand_id = registration.provider_brand_id
+                    and sender.a2p_campaign_id = registration.provider_campaign_id
+                )`
+              : sql`false`
+          } as "carrierIdentityReady",
+          ${
+            locationId
+              ? sql`exists (
+                  select 1
+                  from location_messaging sender
+                  where sender.practice_id = ${practiceId}::uuid
+                    and sender.location_id = ${locationId}::uuid
+                    and sender.deleted_at is null
+                    and sender.provider = 'telnyx'
+                    and sender.provider_profile_ready = true
+                    and sender.provider_profile_synced_at is not null
+                )`
+              : sql`false`
+          } as "providerProfileReady",
+          ${
+            locationId
+              ? sql`(
+                  select sender.provider_profile_synced_at
+                  from location_messaging sender
+                  where sender.practice_id = ${practiceId}::uuid
+                    and sender.location_id = ${locationId}::uuid
+                    and sender.deleted_at is null
+                    and sender.provider = 'telnyx'
+                  limit 1
+                )`
+              : sql`null::timestamptz`
+          } as "providerProfileSyncedAt",
+          ${
+            locationId
+              ? sql`exists (
+                  select 1
+                  from location_messaging sender
+                  where sender.practice_id = ${practiceId}::uuid
+                    and sender.location_id = ${locationId}::uuid
+                    and sender.deleted_at is null
+                    and sender.enabled = true
+                )`
+              : sql`false`
+          } as "clinicSenderEnabled"
+      `);
+      const scope = rowsFromExecute<PilotScopeRow>(scopeResult)[0];
+      if (!scope?.practiceActive) {
+        return { scope: null, providerEventBlocking: null };
+      }
+      const gate = await loadSmsProviderEventGateSummaryInTransaction(tx, {
+        practiceId,
+        ...(locationId ? { locationId } : {}),
+      });
+      if (!Number.isSafeInteger(gate.total) || gate.total < 0) {
+        throw new Error("Invalid provider-event gate summary");
+      }
+      return { scope, providerEventBlocking: gate.total };
+    });
+
+    checks.practiceActive = result.scope?.practiceActive ?? false;
+    checks.recoveryClear = result.scope?.recoveryClear ?? false;
+    checks.carrierIdentityReady = locationId
+      ? (result.scope?.carrierIdentityReady ?? false)
+      : null;
+    checks.providerProfileReady = locationId
+      ? result.scope?.providerProfileReady === true &&
+        providerProfileAttestationIsCurrent(
+          result.scope.providerProfileSyncedAt,
+          now,
+        )
+      : null;
+    checks.providerEventsClear =
+      result.providerEventBlocking === null
+        ? null
+        : result.providerEventBlocking === 0;
+    base.providerEventBlocking = result.providerEventBlocking;
+
+    if (!checks.practiceActive) {
+      base.blockers.push("pilot_practice_unavailable");
+    }
+    if (checks.practiceActive && !checks.recoveryClear) {
+      base.blockers.push("practice_recovery_hold");
+    }
+    if (locationId && checks.practiceActive && !checks.carrierIdentityReady) {
+      base.blockers.push("carrier_identity_not_ready");
+    }
+    if (checks.providerEventsClear === false) {
+      base.blockers.push("provider_event_backlog");
+    }
+    if (configuration.sendingEnabled && checks.providerProfileReady !== true) {
+      base.blockers.push("provider_profile_not_ready");
+    }
+    if (base.blockers.length > 0) return blockedPreflight(base);
+
+    if (!locationId) {
+      return {
+        ...base,
+        stage: "provisioning_prepared",
+        ok: true,
+        detail: "Hosted SMS provisioning scope prepared; sending remains off",
+        nextAction:
+          "Complete carrier registration, then stage the exact sending practice and location with sending off.",
+        readyForInboundEnable: false,
+        readyForProviderActivation: false,
+        readyForSendingEnable: false,
+      };
+    }
+
+    if (configuration.sendingEnabled) {
+      return {
+        ...base,
+        stage: "active",
+        ok: true,
+        detail: "Hosted SMS pilot configuration active",
+        nextAction: result.scope?.clinicSenderEnabled
+          ? "Run and record the consented live SMS validation drill."
+          : "Have the clinic admin enable the exact approved sender, then run the live validation drill.",
+        readyForInboundEnable: false,
+        readyForProviderActivation: false,
+        readyForSendingEnable: false,
+      };
+    }
+
+    if (!configuration.inboundEnabled) {
+      return {
+        ...base,
+        stage: "scope_prepared",
+        ok: true,
+        detail:
+          "Hosted SMS pilot scope prepared; inbound and sending remain off",
+        nextAction:
+          "Verify fresh provider-event and SMS-operations heartbeat receipts, then enable inbound projection while sending stays off.",
+        readyForInboundEnable: true,
+        readyForProviderActivation: false,
+        readyForSendingEnable: false,
+      };
+    }
+
+    if (checks.providerProfileReady !== true) {
+      return {
+        ...base,
+        stage: "inbound_prepared",
+        ok: true,
+        detail: "Hosted SMS inbound projection prepared; sending remains off",
+        nextAction:
+          configuration.provisioningEnabled
+            ? "Enable and read back the exact provider profile in the platform-admin queue."
+            : "Enable the provider-mutation kill-switch, then enable and read back the exact provider profile in the platform-admin queue.",
+        readyForInboundEnable: false,
+        readyForProviderActivation: configuration.provisioningEnabled,
+        readyForSendingEnable: false,
+      };
+    }
+
+    return {
+      ...base,
+      stage: "provider_ready",
+      ok: true,
+      detail: "Hosted SMS provider profile ready; sending remains off",
+      nextAction:
+        "Enable the exact sending allowlist flag, redeploy, and confirm health before clinic enablement.",
+      readyForInboundEnable: false,
+      readyForProviderActivation: false,
+      readyForSendingEnable: true,
+    };
+  } catch {
+    base.blockers.push("readiness_check_failed");
+    return blockedPreflight(base);
+  }
+}

--- a/apps/web/lib/messaging/provider-profile-attestation.ts
+++ b/apps/web/lib/messaging/provider-profile-attestation.ts
@@ -1,0 +1,26 @@
+export const MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS =
+  15 * 60 * 1000;
+
+/**
+ * Provider-profile readiness is deliberately short-lived. A future timestamp
+ * is not evidence, and malformed values fail closed.
+ */
+export function providerProfileAttestationIsCurrent(
+  value: unknown,
+  now: Date = new Date(),
+): boolean {
+  const observedAt =
+    value instanceof Date
+      ? value
+      : typeof value === "string" || typeof value === "number"
+        ? new Date(value)
+        : null;
+  const observedMs = observedAt?.getTime() ?? Number.NaN;
+  const nowMs = now.getTime();
+  return (
+    Number.isFinite(observedMs) &&
+    Number.isFinite(nowMs) &&
+    observedMs <= nowMs &&
+    observedMs >= nowMs - MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS
+  );
+}

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -82,6 +82,13 @@ const mocks = vi.hoisted(() => {
       duplicate: false,
     })),
     loadSmsProviderEventResolutionHistory: vi.fn(),
+    loadHostedSmsPilotActivationPreflight: vi.fn(async () => ({
+      stage: "scope_prepared",
+      ok: true,
+      detail: "Hosted SMS pilot scope prepared; inbound and sending remain off",
+      nextAction: "Verify fresh heartbeats, then enable inbound projection.",
+      blockers: [],
+    })),
     MockTelnyxError,
     withTenant: vi.fn(
       async (
@@ -114,6 +121,10 @@ vi.mock("@/lib/messaging/sms-provider-event-remediation", () => ({
   resolveSmsProviderEventInTransaction: mocks.resolveSmsProviderEvent,
   loadSmsProviderEventResolutionHistory:
     mocks.loadSmsProviderEventResolutionHistory,
+}));
+vi.mock("@/lib/messaging/hosted-sms-pilot-preflight", () => ({
+  loadHostedSmsPilotActivationPreflight:
+    mocks.loadHostedSmsPilotActivationPreflight,
 }));
 vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   createA2pBrand: mocks.createA2pBrand,
@@ -223,6 +234,13 @@ afterEach(() => {
     events: [],
     truncated: false,
   });
+  mocks.loadHostedSmsPilotActivationPreflight.mockResolvedValue({
+    stage: "scope_prepared",
+    ok: true,
+    detail: "Hosted SMS pilot scope prepared; inbound and sending remain off",
+    nextAction: "Verify fresh heartbeats, then enable inbound projection.",
+    blockers: [],
+  });
 });
 
 describe("platform messaging operations", () => {
@@ -307,6 +325,24 @@ describe("platform messaging operations", () => {
     });
     expect(JSON.stringify(result)).not.toContain("legacy-sensitive-value");
     expect(mocks.noStore).toHaveBeenCalled();
+  });
+
+  it("returns the read-only pilot preflight only to platform admins", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(caller().hostedSmsPilotActivationPreflight()).resolves.toEqual(
+      expect.objectContaining({ stage: "scope_prepared", ok: true }),
+    );
+    expect(mocks.loadHostedSmsPilotActivationPreflight).toHaveBeenCalledWith(
+      mocks.db,
+    );
+    expect(mocks.noStore).toHaveBeenCalled();
+
+    mocks.loadHostedSmsPilotActivationPreflight.mockClear();
+    await expect(
+      caller("clinic@example.com").hostedSmsPilotActivationPreflight(),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.loadHostedSmsPilotActivationPreflight).not.toHaveBeenCalled();
   });
 
   it("returns bounded newest-first PHI-free registration history", async () => {
@@ -571,6 +607,24 @@ describe("platform messaging operations", () => {
     expect(mocks.withSystem).not.toHaveBeenCalled();
     expect(mocks.createA2pBrand).not.toHaveBeenCalled();
   });
+
+  it.each(["1", "TRUE", "yes"])(
+    "blocks malformed provider-mutation flag %s before DB or provider work",
+    async (flag) => {
+      vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+      vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", flag);
+
+      await expect(
+        caller().submitMessagingBrand({
+          practiceId: PRACTICE_ID,
+          confirmProviderCharges: true,
+          retryAfterProviderReview: false,
+        }),
+      ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+      expect(mocks.withSystem).not.toHaveBeenCalled();
+      expect(mocks.createA2pBrand).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not submit fee-bearing provider work while the clinic is held", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -113,6 +113,8 @@ import {
   RECOVERY_HOLD_BLOCK_MESSAGE,
 } from "@/lib/recovery-hold";
 import { hostedSmsConfigurationDiagnostics } from "@/lib/messaging/hosted-sms-readiness";
+import { loadHostedSmsPilotActivationPreflight } from "@/lib/messaging/hosted-sms-pilot-preflight";
+import { providerProfileAttestationIsCurrent } from "@/lib/messaging/provider-profile-attestation";
 import { envFlagEnabled } from "@/lib/env-bool";
 
 /**
@@ -174,7 +176,6 @@ async function withMessagingProviderEffectsAllowed<T>(
 }
 
 const MESSAGING_SUBMISSION_LOCK_STALE_MS = 15 * 60 * 1000;
-const MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
 const WITHHELD_PHONE_LIKE_OPERATIONAL_ID = "[withheld: phone-like identifier]";
 
 const smsProviderEventResolutionBaseInput = z
@@ -274,8 +275,7 @@ function safeOperationalProviderId(value: string | null): string | null {
 }
 
 function assertMessagingProviderMutationsEnabled() {
-  const flag = process.env.MESSAGING_PROVISIONING_ENABLED?.trim().toLowerCase();
-  if (flag !== "true" && flag !== "1") {
+  if (!envFlagEnabled("MESSAGING_PROVISIONING_ENABLED")) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message:
@@ -1520,6 +1520,12 @@ export const adminRouter = createRouter({
     return hostedSmsConfigurationDiagnostics();
   }),
 
+  /** Read-only, secret- and PHI-free readiness for the exact staged pilot. */
+  hostedSmsPilotActivationPreflight: platformAdminProcedure.query(() => {
+    noStore();
+    return loadHostedSmsPilotActivationPreflight(db);
+  }),
+
   /** Newest-first, PHI-free carrier lifecycle evidence for one exact clinic. */
   messagingRegistrationHistory: platformAdminProcedure
     .input(
@@ -1659,9 +1665,9 @@ export const adminRouter = createRouter({
             ...sender,
             providerProfileReady:
               sender.providerProfileReady &&
-              sender.providerProfileSyncedAt !== null &&
-              sender.providerProfileSyncedAt.getTime() >=
-                Date.now() - MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS,
+              providerProfileAttestationIsCurrent(
+                sender.providerProfileSyncedAt,
+              ),
           })),
       }));
     }),


### PR DESCRIPTION
## Scope

Rebuilds the valuable hosted SMS pilot preflight from stale PR #204 on current Development. This successor is intentionally limited to read-only preflight, platform-admin visibility, exact single-clinic projection/send gates, and fail-closed provider activation readiness.

## Safety

- no provider calls, sends, hosted mutations, schema changes, or environment changes
- secrets, phone numbers, clinic identifiers, provider identifiers, and PHI are not returned
- provider attestation must be current within an inclusive 15-minute window
- fee-bearing mutations require the shared exact trimmed `true` policy
- activation readiness remains false while provisioning is disabled

## Review and validation

- independent exact-head review: GO, no P0/P1
- 118 focused tests passed
- full web suite: 419 files / 4,271 tests passed; 12 files / 16 guarded integration tests skipped
- web typecheck and diff check passed
- source head: `9517ab2373b72c93ef34e5043dee42865cb2127e`
- source tree: `75806b3f2a0ba55276757c84305b78aa35fe2f31`

## Provenance

Successor to #204. The original PR and branch remain preserved until exact-tree merge and post-merge verification complete.

## Non-blocking follow-up

Add an isolated ready-plus-null-attestation assertion and disposable-Postgres coverage for the core read-only query.