### PR TITLE
Defer unsupported lifecycle email job kinds safely

### DIFF
--- a/apps/web/lib/billing/lifecycle-email-outbox.test.ts
+++ b/apps/web/lib/billing/lifecycle-email-outbox.test.ts
@@ -30,6 +30,26 @@ beforeAll(async () => {
 afterAll(() => vi.unstubAllEnvs());
 
 describe("subscription lifecycle email outbox safety model", () => {
+  it("fails closed and defers job kinds introduced by a later migration", () => {
+    expect(helpers.isSupportedLifecycleEmailKind("subscription_confirmed")).toBe(
+      true,
+    );
+    expect(helpers.isSupportedLifecycleEmailKind("subscription_canceled")).toBe(
+      true,
+    );
+    expect(helpers.isSupportedLifecycleEmailKind("payment_receipt")).toBe(false);
+    expect(helpers.isSupportedLifecycleEmailKind("payment_failed")).toBe(false);
+
+    const guard = SOURCE.indexOf("isSupportedLifecycleEmailKind(loaded.kind)");
+    expect(guard).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(SOURCE.indexOf("prepareRequest(loaded)"));
+    expect(guard).toBeLessThan(SOURCE.indexOf("reserveAttempt("));
+    expect(SOURCE).toContain('lastErrorCode: "unsupported_job_kind"');
+    expect(SOURCE).toMatch(
+      /state: "pending",[\s\S]*leaseToken: null,[\s\S]*leaseExpiresAt: null/,
+    );
+  });
+
   it("binds recipient identity without persisting the address or rendered body", () => {
     const a = helpers.recipientHash(
       "00000000-0000-0000-0000-000000000001",

--- a/apps/web/lib/billing/lifecycle-email-outbox.ts
+++ b/apps/web/lib/billing/lifecycle-email-outbox.ts
@@ -55,7 +55,7 @@ type ClaimedJob = {
 type EligibleJob = {
   id: string;
   practiceId: string;
-  kind: SubscriptionLifecycleEmailKind;
+  kind: string;
   providerIdempotencyKey: string;
   recipientHashSha256: string;
   practiceName: string;
@@ -258,12 +258,50 @@ async function claimNextJob(now: Date): Promise<ClaimedJob | null> {
   });
 }
 
+export function isSupportedLifecycleEmailKind(
+  kind: string,
+): kind is SubscriptionLifecycleEmailKind {
+  return (
+    kind === "subscription_confirmed" || kind === "subscription_canceled"
+  );
+}
+
+async function deferUnsupportedJob(
+  claimed: ClaimedJob,
+  now: Date,
+): Promise<void> {
+  await withSystem(db, async (tx) => {
+    await tx
+      .update(lifecycleEmailJobs)
+      .set({
+        state: "pending",
+        nextAttemptAt: new Date(now.getTime() + RECOVERY_RECHECK_MS),
+        leaseToken: null,
+        leaseExpiresAt: null,
+        lastErrorCode: "unsupported_job_kind",
+        lastErrorDetail: null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(lifecycleEmailJobs.id, claimed.id),
+          eq(lifecycleEmailJobs.state, "delivering"),
+          eq(lifecycleEmailJobs.leaseToken, claimed.leaseToken),
+        ),
+      );
+  });
+}
+
 async function processClaimedJob(
   claimed: ClaimedJob,
   now: Date,
 ): Promise<LifecycleEmailProcessResult> {
   const loaded = await loadClaimedJob(claimed);
   if (!loaded) return "suppressed";
+  if (!isSupportedLifecycleEmailKind(loaded.kind)) {
+    await deferUnsupportedJob(claimed, now);
+    return "blocked";
+  }
 
   const prepared = await prepareRequest(loaded);
   const fingerprint = requestFingerprint(prepared);


### PR DESCRIPTION
## Scope

A migration-free rollback-compatibility prerequisite for future lifecycle-email job kinds. This PR does not add receipt/dunning kinds or behavior.

## Safety contract

- detect unknown runtime kinds immediately after loading the claimed row
- defer before request preparation, recipient work, attempt reservation, provider selection, or dispatch
- use delivering-state plus lease-token CAS to return the job to pending at a 15-minute recheck
- clear the lease and record only the sanitized `unsupported_job_kind` code
- leave attempt count, fingerprints, communications, and provider-attempt evidence unchanged
- preserve existing confirmed/canceled behavior
- no schema, enum, migration, RLS, hosted-resource, credential, or environment change

## Review and validation

- independent exact-head review: GO; no P0/P1
- patch-identical rebase onto current Development; stable patch ID `645b4e1ad987ea5c23d3b2193235669347e9f517`
- 11/11 focused tests passed
- web typecheck and diff check passed
- source head: `f95b77ae3ca5ed6eb208fd434b3fe0145340093a`
- source tree: `e12004dc3363a1503e96d76cac2321b11c45b907`

## Release sequencing

This compatibility change must be promoted through Staging and deployed Main before any migration introducing receipt/dunning job kinds is eligible to merge. The larger feature successor remains local, unpushed, and blocked on that deployed prerequisite.

## Non-blocking follow-up

When the later enum migration is reviewed, its real-PostgreSQL gate must seed an unknown-kind job and directly assert pending deferral, unchanged attempts, and zero provider calls.