### PR TITLE
Allow admin veterinarians to finalize clinical handoffs

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -1311,7 +1311,7 @@ function VisitCloseout({
   const canDraftClinical =
     role === "admin" || role === "veterinarian" || role === "technician";
   const canFinalizeClinical =
-    role === "veterinarian" ||
+    data?.canFinalizeDoctorRequiredVisit === true ||
     (appointment.typeRequiresDoctor === 0 &&
       (role === "admin" || role === "technician"));
   const signedClinical =

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -241,6 +241,12 @@ describe("clinic encounter workspace", () => {
     expect(workspaceSource).toContain("Documented exception");
     expect(workspaceSource).toContain("linkedMedicationCount");
     expect(workspaceSource).toContain("disabled={!canFinalizeNow}");
+    expect(workspaceSource).toContain(
+      "data?.canFinalizeDoctorRequiredVisit === true",
+    );
+    expect(workspaceSource).not.toContain(
+      'role === "veterinarian" ||\n    (appointment.typeRequiresDoctor',
+    );
   });
 
   it("keeps the signed owner handoff reviewable and mobile billing reachable", () => {

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -233,6 +233,39 @@ describe("encounter prescription lifecycle semantics", () => {
   });
 });
 
+describe("encounter closeout clinical capability", () => {
+  it("reports that an admin veterinarian provider can finalize doctor-required visits", async () => {
+    const appointment = {
+      id: APPOINTMENT_ID,
+      patientId: null,
+      clientId: null,
+      practiceName: "Clinic",
+      practicePhone: null,
+      practiceTimezone: "America/Denver",
+    };
+    const { db } = createDb({
+      selectResults: [
+        [appointment],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [{ id: USER_ID }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db, "admin").getCloseout({
+        appointmentId: APPOINTMENT_ID,
+      }),
+    ).resolves.toMatchObject({
+      canFinalizeDoctorRequiredVisit: true,
+    });
+  });
+});
+
 describe("encounter closeout safety", () => {
   it("blocks checkout when performed visit work is unresolved", async () => {
     const { db, updateSet, execute } = createDb({

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -707,6 +707,7 @@ export const encountersRouter = createRouter({
         medications,
         followUpAppointments,
         followUpAssignees,
+        canFinalizeDoctorRequiredVisit,
       ] = await Promise.all([
         getCloseoutRow(ctx, input.appointmentId),
         ctx.db
@@ -867,6 +868,7 @@ export const encountersRouter = createRouter({
             )
             .orderBy(asc(users.name), asc(users.email))
             .limit(100),
+          isVeterinarianProvider(ctx, ctx.user.id, ctx.user.role),
         ]);
 
       const rawInvoices =
@@ -918,6 +920,7 @@ export const encountersRouter = createRouter({
         followUpAppointments,
         followUpAssignees,
         invoices: invoiceSummaries,
+        canFinalizeDoctorRequiredVisit,
       };
     }),
 


### PR DESCRIPTION
## Summary
- return the authoritative veterinarian-provider capability with encounter closeout data
- enable doctor-required finalization for Admin users who are active veterinarian providers
- retain the server-side authorization check on finalization

## Verification
- 53 focused workflow tests passed
- full web suite: 4,165 passed; 13 environment-gated skips
- TypeScript passed
- production Next.js build passed
- rendered simulated-clinic flow passed with durable attribution to the Admin account

## Risk and rollback
No database migration. Roll back by redeploying the prior production revision.