### PR TITLE
fix(billing): harden flexible Stripe subscription creation

### DIFF
--- a/apps/web/lib/__tests__/stripe.test.ts
+++ b/apps/web/lib/__tests__/stripe.test.ts
@@ -148,6 +148,7 @@ describe("buildSubscriptionCheckoutSessionParams", () => {
 
     expect(params.payment_method_collection).toBe("always");
     expect(params.subscription_data).toEqual({
+      billing_mode: { type: "flexible" },
       description: "OpenVPM Cloud — monthly",
       metadata: {
         practiceId: "practice_123",
@@ -190,9 +191,28 @@ describe("buildSubscriptionCheckoutSessionParams", () => {
       source: "settings",
     });
     expect(params.subscription_data).toMatchObject({
+      billing_mode: { type: "flexible" },
       description: "OpenVPM Cloud — annual",
       metadata: { billingCadence: "year" },
     });
+  });
+
+  it("rejects mixed annual and metered items in Checkout", () => {
+    expect(() =>
+      buildSubscriptionCheckoutSessionParams({
+        practiceId: "practice_123",
+        customerId: "cus_123",
+        billingCadence: "year",
+        lineItems: [
+          { priceId: "price_annual", quantity: 1 },
+          { priceId: "price_monthly_metered", metered: true },
+        ],
+        successUrl: "https://app.example.com/success",
+        cancelUrl: "https://app.example.com/cancel",
+      }),
+    ).toThrow(
+      "Annual Checkout must contain only licensed items; attach monthly metered companions after Stripe creates the flexible subscription.",
+    );
   });
 
   it("enables Stripe Tax for hosted subscriptions when configured", () => {

--- a/apps/web/lib/billing/__tests__/stripe-billing-inventory.test.ts
+++ b/apps/web/lib/billing/__tests__/stripe-billing-inventory.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import type Stripe from "stripe";
+import {
+  assertStripeInventoryCredential,
+  summarizeStripeBillingSubscriptions,
+  validateStripeBillingPrices,
+  type StripeBillingPriceSpec,
+} from "../stripe-billing-inventory";
+
+function price(
+  id: string,
+  interval: "month" | "year",
+  usageType: "licensed" | "metered",
+): Stripe.Price {
+  return {
+    id,
+    object: "price",
+    active: true,
+    billing_scheme: "per_unit",
+    created: 1,
+    currency: "usd",
+    custom_unit_amount: null,
+    livemode: false,
+    lookup_key: null,
+    metadata: {},
+    nickname: null,
+    product: "prod_openvpm",
+    recurring: {
+      interval,
+      interval_count: 1,
+      meter: usageType === "metered" ? "mtr_1" : null,
+      trial_period_days: null,
+      usage_type: usageType,
+    },
+    tax_behavior: "unspecified",
+    tiers_mode: null,
+    transform_quantity: null,
+    type: "recurring",
+    unit_amount: 7900,
+    unit_amount_decimal: "7900",
+  } as unknown as Stripe.Price;
+}
+
+function subscription(input: {
+  id: string;
+  billingMode: "classic" | "flexible";
+  prices: string[];
+  schedule?: string | null;
+}): Stripe.Subscription {
+  return {
+    id: input.id,
+    billing_mode: { type: input.billingMode },
+    schedule: input.schedule ?? null,
+    items: {
+      data: input.prices.map((priceId, index) => ({
+        id: `si_${index}`,
+        price: { id: priceId },
+      })),
+    },
+  } as Stripe.Subscription;
+}
+
+describe("Stripe billing inventory", () => {
+  it("accepts the intended licensed and metered price intervals", () => {
+    const specs: StripeBillingPriceSpec[] = [
+      {
+        role: "location_monthly",
+        priceId: "price_monthly",
+        interval: "month",
+        usageType: "licensed",
+      },
+      {
+        role: "location_annual",
+        priceId: "price_annual",
+        interval: "year",
+        usageType: "licensed",
+      },
+      {
+        role: "ai_metered_monthly",
+        priceId: "price_ai",
+        interval: "month",
+        usageType: "metered",
+      },
+    ];
+    expect(
+      validateStripeBillingPrices(
+        specs.map((spec) => ({
+          spec,
+          price: price(spec.priceId, spec.interval, spec.usageType),
+        })),
+      ),
+    ).toEqual([]);
+  });
+
+  it("reports interval, usage, active-state, and currency mismatches", () => {
+    const annual = price("price_annual", "month", "metered");
+    annual.active = false;
+    annual.currency = "cad";
+    const findings = validateStripeBillingPrices([
+      {
+        spec: {
+          role: "location_monthly",
+          priceId: "price_monthly",
+          interval: "month",
+          usageType: "licensed",
+        },
+        price: price("price_monthly", "month", "licensed"),
+      },
+      {
+        spec: {
+          role: "location_annual",
+          priceId: "price_annual",
+          interval: "year",
+          usageType: "licensed",
+        },
+        price: annual,
+      },
+    ]);
+    expect(findings.map((finding) => finding.code)).toEqual([
+      "price_inactive",
+      "price_interval_mismatch",
+      "price_usage_type_mismatch",
+      "price_currency_mismatch",
+    ]);
+  });
+
+  it("rejects one Stripe price being configured for multiple billing roles", () => {
+    const shared = price("price_shared", "month", "licensed");
+    const findings = validateStripeBillingPrices([
+      {
+        spec: {
+          role: "location_monthly",
+          priceId: shared.id,
+          interval: "month",
+          usageType: "licensed",
+        },
+        price: shared,
+      },
+      {
+        spec: {
+          role: "location_annual",
+          priceId: shared.id,
+          interval: "month",
+          usageType: "licensed",
+        },
+        price: shared,
+      },
+    ]);
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "error",
+        code: "price_role_collision",
+        resourceId: "price_shared",
+      }),
+    );
+  });
+
+  it("summarizes safe flexible subscriptions without exposing customer data", () => {
+    const summary = summarizeStripeBillingSubscriptions({
+      monthlyLocationPriceId: "price_monthly",
+      annualLocationPriceId: "price_annual",
+      companionPriceIds: ["price_ai", "price_sms"],
+      subscriptions: [
+        subscription({
+          id: "sub_monthly",
+          billingMode: "flexible",
+          prices: ["price_monthly", "price_ai", "price_sms"],
+        }),
+        subscription({
+          id: "sub_annual",
+          billingMode: "flexible",
+          prices: ["price_annual", "price_ai", "price_sms"],
+          schedule: "sub_sched_1",
+        }),
+      ],
+    });
+    expect(summary).toMatchObject({
+      total: 2,
+      billingModes: { flexible: 2 },
+      cadences: { monthly: 1, annual: 1 },
+      attachedSchedules: 1,
+      findings: [],
+    });
+    expect(JSON.stringify(summary)).not.toContain("customer");
+  });
+
+  it("flags classic cadence and missing companion states with bounded IDs", () => {
+    const summary = summarizeStripeBillingSubscriptions({
+      monthlyLocationPriceId: "price_monthly",
+      annualLocationPriceId: "price_annual",
+      companionPriceIds: ["price_ai"],
+      subscriptions: [
+        subscription({
+          id: "sub_classic_monthly",
+          billingMode: "classic",
+          prices: ["price_monthly", "price_ai"],
+        }),
+        subscription({
+          id: "sub_classic_annual",
+          billingMode: "classic",
+          prices: ["price_annual"],
+        }),
+      ],
+    });
+    expect(summary.findings.map((finding) => finding.code)).toEqual([
+      "monthly_subscription_not_flexible",
+      "annual_subscription_not_flexible",
+      "subscription_companion_missing",
+    ]);
+    expect(summary.findings[1]?.resourceId).toBe("sub_classic_annual");
+  });
+
+  it("requires deliberate confirmation before live read-only access", () => {
+    expect(
+      assertStripeInventoryCredential({
+        key: "sk_test_redacted",
+        allowLiveReadOnly: false,
+      }),
+    ).toBe("test");
+    expect(() =>
+      assertStripeInventoryCredential({
+        key: "rk_live_redacted",
+        allowLiveReadOnly: true,
+      }),
+    ).toThrow("Live Stripe inventory requires");
+    expect(
+      assertStripeInventoryCredential({
+        key: "rk_live_redacted",
+        allowLiveReadOnly: true,
+        liveConfirmation: "OPENVPM_STRIPE_LIVE_READ_ONLY",
+      }),
+    ).toBe("live");
+  });
+});

--- a/apps/web/lib/billing/__tests__/subscription-sync.test.ts
+++ b/apps/web/lib/billing/__tests__/subscription-sync.test.ts
@@ -144,13 +144,14 @@ describe("billing sync practice scoping", () => {
     expect(syncState).toContain("stripe.subscriptionItems.create(");
   });
 
-  it("syncs annual quantity without attaching monthly metered items", async () => {
+  it("syncs annual quantity and attaches monthly metered items in flexible mode", async () => {
     vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
     vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION", "price_monthly");
     vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION_ANNUAL", "price_annual");
     vi.stubEnv("STRIPE_PRICE_AI_OVERAGE", "price_ai");
     vi.stubEnv("STRIPE_PRICE_SMS_OVERAGE", "price_sms");
     mocks.retrieve.mockResolvedValue({
+      billing_mode: { type: "flexible" },
       items: {
         data: [{ id: "si_annual", price: { id: "price_annual" } }],
       },
@@ -204,6 +205,74 @@ describe("billing sync practice scoping", () => {
       { quantity: 1 },
       expect.objectContaining({ idempotencyKey: expect.any(String) }),
     );
+    expect(mocks.create).toHaveBeenCalledTimes(2);
+    expect(mocks.create).toHaveBeenCalledWith(
+      { subscription: "sub_annual", price: "price_ai" },
+      expect.objectContaining({ idempotencyKey: expect.any(String) }),
+    );
+    expect(mocks.create).toHaveBeenCalledWith(
+      { subscription: "sub_annual", price: "price_sms" },
+      expect.objectContaining({ idempotencyKey: expect.any(String) }),
+    );
+    expect(writeWhere).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed before mutating a classic annual subscription with metered prices", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION", "price_monthly");
+    vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION_ANNUAL", "price_annual");
+    vi.stubEnv("STRIPE_PRICE_AI_OVERAGE", "price_ai");
+    mocks.retrieve.mockResolvedValue({
+      billing_mode: { type: "classic" },
+      items: {
+        data: [{ id: "si_annual", price: { id: "price_annual" } }],
+      },
+    });
+
+    const rows = [
+      {
+        stripeSubscriptionId: "sub_annual",
+        recoveryHold: false,
+        leaseToken: "lease-test",
+        leaseExpiresAt,
+      },
+      { c: 1 },
+      { c: 1 },
+    ];
+    const select = vi.fn(() => {
+      const result = [rows.shift()!];
+      const builder: Record<string, unknown> = {};
+      builder.from = () => builder;
+      builder.where = () => builder;
+      builder.limit = () => builder;
+      builder.for = async () => result;
+      builder.then = (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (reason: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject);
+      return builder;
+    });
+    const writeWhere = vi.fn(async () => []);
+    const dbUpdate = vi.fn(() => ({
+      set: () => ({ where: writeWhere }),
+    }));
+
+    await expect(
+      syncPracticeSubscriptionQuantities({
+        db: { select, update: dbUpdate } as never,
+        practiceId: "practice-annual",
+        ...durableOptions,
+        subscriptionId: "sub_annual",
+        alertOnError: false,
+      }),
+    ).resolves.toMatchObject({
+      status: "error",
+      billingCadence: "year",
+      message:
+        "Annual Stripe subscriptions must use flexible billing mode before monthly metered overage items can be synchronized.",
+    });
+
+    expect(mocks.update).not.toHaveBeenCalled();
     expect(mocks.create).not.toHaveBeenCalled();
     expect(writeWhere).toHaveBeenCalledOnce();
   });

--- a/apps/web/lib/billing/stripe-billing-inventory.ts
+++ b/apps/web/lib/billing/stripe-billing-inventory.ts
@@ -1,0 +1,208 @@
+import type Stripe from "stripe";
+
+export type StripeBillingPriceRole =
+  | "location_monthly"
+  | "location_annual"
+  | "ai_metered_monthly"
+  | "sms_metered_monthly";
+
+export type StripeBillingPriceSpec = {
+  role: StripeBillingPriceRole;
+  priceId: string;
+  interval: "month" | "year";
+  usageType: "licensed" | "metered";
+};
+
+export type StripeBillingInventoryFinding = {
+  severity: "error" | "warning";
+  code: string;
+  resourceId: string;
+  detail: string;
+};
+
+function resourceId(
+  resource: string | { id: string } | Stripe.DeletedCustomer | null,
+): string | null {
+  if (!resource) return null;
+  return typeof resource === "string" ? resource : resource.id;
+}
+
+export function validateStripeBillingPrices(
+  entries: Array<{ spec: StripeBillingPriceSpec; price: Stripe.Price }>,
+): StripeBillingInventoryFinding[] {
+  const findings: StripeBillingInventoryFinding[] = [];
+  const currencies = new Set<string>();
+  const rolesByPriceId = new Map<string, StripeBillingPriceRole[]>();
+
+  for (const { spec, price } of entries) {
+    const roles = rolesByPriceId.get(price.id) ?? [];
+    roles.push(spec.role);
+    rolesByPriceId.set(price.id, roles);
+    const recurring = price.recurring;
+    currencies.add(price.currency);
+    if (!price.active) {
+      findings.push({
+        severity: "error",
+        code: "price_inactive",
+        resourceId: price.id,
+        detail: `${spec.role} is inactive.`,
+      });
+    }
+    if (!recurring) {
+      findings.push({
+        severity: "error",
+        code: "price_not_recurring",
+        resourceId: price.id,
+        detail: `${spec.role} is not recurring.`,
+      });
+      continue;
+    }
+    if (
+      recurring.interval !== spec.interval ||
+      recurring.interval_count !== 1
+    ) {
+      findings.push({
+        severity: "error",
+        code: "price_interval_mismatch",
+        resourceId: price.id,
+        detail: `${spec.role} must recur every 1 ${spec.interval}.`,
+      });
+    }
+    if (recurring.usage_type !== spec.usageType) {
+      findings.push({
+        severity: "error",
+        code: "price_usage_type_mismatch",
+        resourceId: price.id,
+        detail: `${spec.role} must use ${spec.usageType} usage.`,
+      });
+    }
+  }
+
+  for (const [priceId, roles] of rolesByPriceId) {
+    if (roles.length > 1) {
+      findings.push({
+        severity: "error",
+        code: "price_role_collision",
+        resourceId: priceId,
+        detail: `One Stripe price is configured for multiple roles: ${roles.join(", ")}.`,
+      });
+    }
+  }
+
+  if (currencies.size > 1) {
+    findings.push({
+      severity: "error",
+      code: "price_currency_mismatch",
+      resourceId: "configured_prices",
+      detail: "Configured hosted prices do not share one currency.",
+    });
+  }
+  return findings;
+}
+
+export type StripeBillingSubscriptionSummary = {
+  total: number;
+  billingModes: Record<string, number>;
+  cadences: Record<string, number>;
+  attachedSchedules: number;
+  findings: StripeBillingInventoryFinding[];
+};
+
+export function summarizeStripeBillingSubscriptions(input: {
+  subscriptions: Stripe.Subscription[];
+  monthlyLocationPriceId: string;
+  annualLocationPriceId: string;
+  companionPriceIds: string[];
+}): StripeBillingSubscriptionSummary {
+  const billingModes: Record<string, number> = {};
+  const cadences: Record<string, number> = {};
+  const findings: StripeBillingInventoryFinding[] = [];
+  let attachedSchedules = 0;
+
+  for (const subscription of input.subscriptions) {
+    const itemPriceIds = subscription.items.data
+      .map((item) => resourceId(item.price))
+      .filter((value): value is string => Boolean(value));
+    const hasMonthly = itemPriceIds.includes(input.monthlyLocationPriceId);
+    const hasAnnual = itemPriceIds.includes(input.annualLocationPriceId);
+    const cadence = hasMonthly && hasAnnual
+      ? "ambiguous"
+      : hasAnnual
+        ? "annual"
+        : hasMonthly
+          ? "monthly"
+          : "unrecognized";
+    const billingMode = subscription.billing_mode?.type ?? "unknown";
+    billingModes[billingMode] = (billingModes[billingMode] ?? 0) + 1;
+    cadences[cadence] = (cadences[cadence] ?? 0) + 1;
+    if (resourceId(subscription.schedule)) attachedSchedules += 1;
+
+    if (cadence === "ambiguous" || cadence === "unrecognized") {
+      findings.push({
+        severity: "error",
+        code: `subscription_${cadence}_location_price`,
+        resourceId: subscription.id,
+        detail:
+          cadence === "ambiguous"
+            ? "Subscription contains both monthly and annual location prices."
+            : "Subscription contains neither configured location price.",
+      });
+      continue;
+    }
+    if (cadence === "annual" && billingMode !== "flexible") {
+      findings.push({
+        severity: "error",
+        code: "annual_subscription_not_flexible",
+        resourceId: subscription.id,
+        detail:
+          "Annual subscription is not eligible for monthly metered companions.",
+      });
+    }
+    if (cadence === "monthly" && billingMode !== "flexible") {
+      findings.push({
+        severity: "warning",
+        code: "monthly_subscription_not_flexible",
+        resourceId: subscription.id,
+        detail:
+          "Monthly subscription requires an explicit operator decision before annual cadence automation.",
+      });
+    }
+    for (const companionPriceId of input.companionPriceIds) {
+      if (!itemPriceIds.includes(companionPriceId)) {
+        findings.push({
+          severity: "error",
+          code: "subscription_companion_missing",
+          resourceId: subscription.id,
+          detail: `Subscription is missing configured companion ${companionPriceId}.`,
+        });
+      }
+    }
+  }
+
+  return {
+    total: input.subscriptions.length,
+    billingModes,
+    cadences,
+    attachedSchedules,
+    findings,
+  };
+}
+
+export function assertStripeInventoryCredential(input: {
+  key: string;
+  allowLiveReadOnly: boolean;
+  liveConfirmation?: string;
+}): "test" | "live" {
+  const mode = input.key.includes("_live_") ? "live" : "test";
+  if (mode === "live") {
+    if (
+      !input.allowLiveReadOnly ||
+      input.liveConfirmation !== "OPENVPM_STRIPE_LIVE_READ_ONLY"
+    ) {
+      throw new Error(
+        "Live Stripe inventory requires --allow-live-read-only and STRIPE_LIVE_READ_ONLY_CONFIRMATION=OPENVPM_STRIPE_LIVE_READ_ONLY.",
+      );
+    }
+  }
+  return mode;
+}

--- a/apps/web/lib/billing/subscription-sync.ts
+++ b/apps/web/lib/billing/subscription-sync.ts
@@ -274,6 +274,31 @@ export async function syncPracticeSubscriptionQuantities(opts: {
       return state;
     }
 
+    const { aiOveragePriceId, smsOveragePriceId } = cloudMeteredPriceIds();
+    const meteredPriceIds = [aiOveragePriceId, smsOveragePriceId].filter(
+      (priceId): priceId is string => Boolean(priceId),
+    );
+    if (
+      billingCadence === "year" &&
+      meteredPriceIds.length > 0 &&
+      subscription.billing_mode?.type !== "flexible"
+    ) {
+      const state = buildState(
+        "error",
+        "Annual Stripe subscriptions must use flexible billing mode before monthly metered overage items can be synchronized.",
+        counts,
+        billingCadence,
+      );
+      await writeBillingSyncState(db, practiceId, state);
+      if (opts.alertOnError !== false) {
+        await alertOps(
+          "Annual subscription metering blocked",
+          `${state.message} practice=${practiceId} subscription=${subscriptionId}`,
+        );
+      }
+      return state;
+    }
+
     const updates: Promise<unknown>[] = [
       stripe.subscriptionItems.update(
         locationItem.id,
@@ -311,10 +336,7 @@ export async function syncPracticeSubscriptionQuantities(opts: {
     // clinic); the metered overage items (AI + SMS) are attached here after
     // the subscription exists. Idempotent: only add what is missing, so this
     // also self-heals subscriptions created before overage prices existed.
-    const { aiOveragePriceId, smsOveragePriceId } = cloudMeteredPriceIds();
-    for (const meteredPriceId of billingCadence === "year"
-      ? []
-      : [aiOveragePriceId, smsOveragePriceId]) {
+    for (const meteredPriceId of meteredPriceIds) {
       if (
         meteredPriceId &&
         !items.some((item) => item.price?.id === meteredPriceId)

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -609,6 +609,14 @@ export function buildSubscriptionCheckoutSessionParams(data: {
     : undefined;
   const hasTrial = !!trialEnd || !!data.trialPeriodDays;
   const billingCadence = data.billingCadence ?? "month";
+  if (
+    billingCadence === "year" &&
+    data.lineItems.some((item) => item.metered)
+  ) {
+    throw new Error(
+      "Annual Checkout must contain only licensed items; attach monthly metered companions after Stripe creates the flexible subscription.",
+    );
+  }
   const metadata = {
     practiceId: data.practiceId,
     billingCadence,
@@ -642,6 +650,11 @@ export function buildSubscriptionCheckoutSessionParams(data: {
     metadata,
     ...subscriptionTaxCheckoutParams(data.customerId),
     subscription_data: {
+      // Make the provider contract explicit. Flexible mode is required before
+      // an annual licensed subscription can safely receive monthly metered
+      // companion items after Checkout, and before cadence schedules can be
+      // managed without a one-way migration of an existing subscription.
+      billing_mode: { type: "flexible" },
       description: `OpenVPM Cloud — ${
         billingCadence === "year" ? "annual" : "monthly"
       }`,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,8 @@
     "staging:verify-database-target": "tsx scripts/verify-staging-database-target.ts",
     "files:recover-legacy": "tsx scripts/recover-legacy-file.ts",
     "incident:verify-evidence": "tsx scripts/verify-incident-response-evidence.ts",
-    "billing:recover-cadence": "tsx scripts/recover-subscription-cadence.ts"
+    "billing:recover-cadence": "tsx scripts/recover-subscription-cadence.ts",
+    "billing:audit-stripe": "tsx scripts/audit-stripe-billing.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.86",

--- a/apps/web/scripts/audit-stripe-billing.ts
+++ b/apps/web/scripts/audit-stripe-billing.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import Stripe from "stripe";
+import { STRIPE_API_VERSION } from "../lib/stripe";
+import { stripeSecretKey } from "../lib/stripe-config";
+import {
+  STRIPE_PRICE_AI_OVERAGE_ENV,
+  STRIPE_PRICE_CLOUD_LOCATION_ANNUAL_ENV,
+  STRIPE_PRICE_CLOUD_LOCATION_ENV,
+  STRIPE_PRICE_SMS_OVERAGE_ENV,
+  stripePriceIdFromEnv,
+} from "../lib/billing/plans";
+import {
+  assertStripeInventoryCredential,
+  summarizeStripeBillingSubscriptions,
+  validateStripeBillingPrices,
+  type StripeBillingInventoryFinding,
+  type StripeBillingPriceSpec,
+} from "../lib/billing/stripe-billing-inventory";
+
+function requiredPrice(envName: string): string {
+  const value = stripePriceIdFromEnv(envName);
+  if (!value) throw new Error(`${envName} is required.`);
+  return value;
+}
+
+async function collectSubscriptions(
+  stripe: Stripe,
+  priceIds: string[],
+): Promise<Stripe.Subscription[]> {
+  const subscriptions = new Map<string, Stripe.Subscription>();
+  for (const price of priceIds) {
+    for await (const subscription of stripe.subscriptions.list({
+      price,
+      limit: 100,
+      expand: ["data.items.data.price"],
+    })) {
+      subscriptions.set(subscription.id, subscription);
+    }
+  }
+  return [...subscriptions.values()];
+}
+
+export async function runStripeBillingInventory(args: string[]) {
+  const key = stripeSecretKey();
+  if (!key) throw new Error("STRIPE_SECRET_KEY is required.");
+  const mode = assertStripeInventoryCredential({
+    key,
+    allowLiveReadOnly: args.includes("--allow-live-read-only"),
+    liveConfirmation: process.env.STRIPE_LIVE_READ_ONLY_CONFIRMATION,
+  });
+  const monthlyLocationPriceId = requiredPrice(
+    STRIPE_PRICE_CLOUD_LOCATION_ENV,
+  );
+  const annualLocationPriceId = requiredPrice(
+    STRIPE_PRICE_CLOUD_LOCATION_ANNUAL_ENV,
+  );
+  const aiPriceId = stripePriceIdFromEnv(STRIPE_PRICE_AI_OVERAGE_ENV);
+  const smsPriceId = stripePriceIdFromEnv(STRIPE_PRICE_SMS_OVERAGE_ENV);
+  const companionPriceIds = [aiPriceId, smsPriceId].filter(
+    (priceId): priceId is string => Boolean(priceId),
+  );
+  const configurationFindings: StripeBillingInventoryFinding[] = [];
+  if (!aiPriceId) {
+    configurationFindings.push({
+      severity: "warning",
+      code: "optional_price_not_configured",
+      resourceId: STRIPE_PRICE_AI_OVERAGE_ENV,
+      detail: "AI metered overage is not configured.",
+    });
+  }
+  if (!smsPriceId) {
+    configurationFindings.push({
+      severity: "warning",
+      code: "optional_price_not_configured",
+      resourceId: STRIPE_PRICE_SMS_OVERAGE_ENV,
+      detail: "SMS metered overage is not configured.",
+    });
+  }
+  const specs: StripeBillingPriceSpec[] = [
+    {
+      role: "location_monthly",
+      priceId: monthlyLocationPriceId,
+      interval: "month",
+      usageType: "licensed",
+    },
+    {
+      role: "location_annual",
+      priceId: annualLocationPriceId,
+      interval: "year",
+      usageType: "licensed",
+    },
+    ...(aiPriceId
+      ? [
+          {
+            role: "ai_metered_monthly" as const,
+            priceId: aiPriceId,
+            interval: "month" as const,
+            usageType: "metered" as const,
+          },
+        ]
+      : []),
+    ...(smsPriceId
+      ? [
+          {
+            role: "sms_metered_monthly" as const,
+            priceId: smsPriceId,
+            interval: "month" as const,
+            usageType: "metered" as const,
+          },
+        ]
+      : []),
+  ];
+
+  const stripe = new Stripe(key, { apiVersion: STRIPE_API_VERSION });
+  const prices = await Promise.all(
+    specs.map(async (spec) => ({
+      spec,
+      price: await stripe.prices.retrieve(spec.priceId),
+    })),
+  );
+  const subscriptions = await collectSubscriptions(stripe, [
+    monthlyLocationPriceId,
+    annualLocationPriceId,
+  ]);
+  const priceFindings = validateStripeBillingPrices(prices);
+  const subscriptionSummary = summarizeStripeBillingSubscriptions({
+    subscriptions,
+    monthlyLocationPriceId,
+    annualLocationPriceId,
+    companionPriceIds,
+  });
+  const findings: StripeBillingInventoryFinding[] = [
+    ...configurationFindings,
+    ...priceFindings,
+    ...subscriptionSummary.findings,
+  ];
+  return {
+    generatedAt: new Date().toISOString(),
+    mode,
+    apiVersion: STRIPE_API_VERSION,
+    configuredPrices: specs.map(({ role, priceId }) => ({ role, priceId })),
+    subscriptions: subscriptionSummary,
+    findings,
+    counts: {
+      errors: findings.filter((finding) => finding.severity === "error").length,
+      warnings: findings.filter((finding) => finding.severity === "warning")
+        .length,
+    },
+  };
+}
+
+if (process.argv[1]?.endsWith("audit-stripe-billing.ts")) {
+  runStripeBillingInventory(process.argv.slice(2))
+    .then((report) => {
+      console.log(JSON.stringify(report, null, 2));
+      if (report.counts.errors > 0) process.exitCode = 1;
+    })
+    .catch((error) => {
+      console.error(
+        "Stripe billing inventory failed:",
+        error instanceof Error ? error.message : "unknown error",
+      );
+      process.exitCode = 1;
+    });
+}

--- a/docs/subscription-cadence-recovery-runbook.md
+++ b/docs/subscription-cadence-recovery-runbook.md
@@ -36,6 +36,27 @@ the feature behind the normal release, staging, and hosted-billing gates.
   into tickets or chat. The operation id, revision, Stripe subscription id, and
   schedule id are sufficient for operator correlation.
 
+## Read-only provider inventory
+
+Before a provider drill or rollout, run the bounded inventory with a Stripe
+test-mode key and the configured monthly, annual, AI, and SMS price ids:
+
+```bash
+pnpm --filter @openpims/web billing:audit-stripe
+```
+
+The command performs only price retrieval and subscription listing. Its JSON
+contains price/subscription ids, aggregate billing-mode and cadence counts, and
+actionable findings; it never emits customer objects, email addresses, payment
+methods, or the API key. It verifies price activity, interval, usage type, and
+currency, then identifies classic-mode subscriptions and missing metered
+companions.
+
+Live inventory requires both `--allow-live-read-only` and the separate
+`STRIPE_LIVE_READ_ONLY_CONFIRMATION=OPENVPM_STRIPE_LIVE_READ_ONLY` environment
+confirmation. Prefer a restricted read-only key. This guard authorizes reads
+only; the command contains no mutation path and does not authorize remediation.
+
 ## Normal automatic recovery
 
 The authenticated `/api/cron/billing-lifecycle` job runs a bounded cadence

--- a/docs/subscription-cadence-recovery-runbook.md
+++ b/docs/subscription-cadence-recovery-runbook.md
@@ -15,6 +15,15 @@ the feature behind the normal release, staging, and hosted-billing gates.
 - The monthly subscription must already use Stripe flexible billing mode.
   OpenVPM stops in `manual_review` for classic mode instead of performing the
   irreversible provider migration implicitly.
+- New OpenVPM Checkout subscriptions explicitly request flexible billing mode.
+  Stripe Checkout still receives only the licensed location item: it does not
+  support creating the mixed annual-location/monthly-usage subscription in one
+  Checkout request. The durable post-Checkout quantity sync attaches the
+  allowlisted metered AI/SMS items after Stripe creates the subscription.
+- If a direct annual subscription is not flexible while metered prices are
+  configured, quantity sync records an error and alerts operations before it
+  updates the location item or adds any companion. Never work around that stop
+  by deleting the metered prices or migrating the subscription implicitly.
 - The annual phase must preserve every explicitly allowlisted metered AI/SMS
   companion item. Missing, duplicated, or changed companion billing evidence
   is a provider mismatch; do not repair it by deleting the usage price.


### PR DESCRIPTION
## Why

This is the provider-readiness hardening layer stacked on #287. The cadence audit found that direct annual Checkout created only the annual licensed item while post-Checkout sync deliberately skipped the monthly AI/SMS metered companions. It also found that Checkout did not explicitly request the flexible billing mode required by the cadence scheduler and by mixed annual/monthly subscriptions.

## Safety behavior

- explicitly requests Stripe flexible billing mode for every new hosted subscription Checkout
- keeps Checkout single-interval: annual Checkout rejects metered line items instead of attempting an unsupported mixed-interval Checkout Session
- attaches allowlisted AI/SMS metered companions only after Stripe creates the subscription
- permits annual companion attachment only when Stripe confirms flexible billing mode
- fails before any location update or companion creation for classic annual subscriptions with configured metered prices
- preserves the existing durable lease and stable per-price idempotency keys for retry/concurrency safety
- does not migrate any existing classic subscription and does not touch production/provider state
- adds a read-only Stripe inventory command that validates price activity/interval/usage/currency, price-role collisions, billing-mode counts, schedule counts, and missing companion items
- bounds inventory output to price/subscription ids, aggregates, and findings; it excludes customer objects, email addresses, payment methods, and credentials
- requires a dual confirmation before the inventory command can read live-mode Stripe data
- documents the two-stage Checkout/sync and inventory invariants in the recovery runbook

## Local evidence at exact SHA `1c82344cc487260650e77000b125cf8940047edf`

- focused Checkout/sync/inventory suite: 48/48 passed
- full application suite: 4,576 passed; 31 explicit integration skips
- lint: passed
- type-check: passed
- production build passed at parent SHA `f76d59f623b1f927d9e51a71ae4f8b7aec5391fc`; hosted CI below is authoritative for the current SHA
- inventory CLI without a key: fails closed with a bounded configuration error
- diff check: passed

## Release posture

Draft only. Do not merge or deploy.

Required stack: #285 → #286 → #287 → this PR. #288 remains the release gate. The read-only inventory command is ready, but no Stripe credentials are available in this worktree; controlled test-mode drills must still prove actual Checkout billing mode, annual companion attachment, invoices, usage metering, retry behavior, and webhook reconciliation. No production Stripe mutation is authorized.
