### PR TITLE
fix(ops): enforce isolated staging boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,9 @@ FILE_REPLICA_S3_REGION=
 RESEND_API_KEY=
 # Resend webhook secret for delivery/bounce/complaint callbacks.
 RESEND_WEBHOOK_SECRET=
+# Required with Resend in Development/Staging: comma-separated SHA-256 hashes
+# of exact lowercased sandbox recipient addresses (maximum 20).
+NONPRODUCTION_EMAIL_RECIPIENT_HASHES=
 # Stable HMAC identity key for PII-free recipient hashes. Never rotate this key
 # without a coordinated preference-data migration; do not reuse another secret.
 EMAIL_PREFERENCE_IDENTITY_SECRET=

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -22,6 +22,10 @@ on:
         description: Type MIGRATE_PRODUCTION for a production run
         required: false
         type: string
+      staging_confirmation:
+        description: Type MIGRATE_STAGING for a staging run
+        required: false
+        type: string
       release_sha:
         description: Exact 40-character commit on the target canonical branch
         required: true
@@ -49,6 +53,7 @@ jobs:
         env:
           TARGET: ${{ inputs.target }}
           REQUESTED_RELEASE_SHA: ${{ inputs.release_sha }}
+          STAGING_CONFIRMATION: ${{ inputs.staging_confirmation }}
         run: |
           case "$TARGET" in
             development) expected_ref="refs/heads/development" ;;
@@ -65,6 +70,10 @@ jobs:
           fi
           if [[ ! "$REQUESTED_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || [ "$REQUESTED_RELEASE_SHA" != "$GITHUB_SHA" ]; then
             echo "::error::Migration release SHA must match the exact dispatched commit."
+            exit 1
+          fi
+          if [ "$TARGET" = "staging" ] && [ "$STAGING_CONFIRMATION" != "MIGRATE_STAGING" ]; then
+            echo "::error::Staging migration confirmation did not match MIGRATE_STAGING."
             exit 1
           fi
 
@@ -264,12 +273,13 @@ jobs:
         run: pnpm --filter @openpims/db db:migrations:check
       - name: Require environment-scoped database controls
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           APP_DB_PASSWORD: ${{ secrets.OPENPIMS_APP_DB_PASSWORD }}
+          STAGING_PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
           TARGET_FINGERPRINT: ${{ vars.DATABASE_TARGET_FINGERPRINT }}
           FORBIDDEN_FINGERPRINTS: ${{ vars.FORBIDDEN_DATABASE_TARGET_FINGERPRINTS }}
         run: |
-          for value in "$DATABASE_URL" "$APP_DB_PASSWORD" "$TARGET_FINGERPRINT" "$FORBIDDEN_FINGERPRINTS"; do
+          for value in "$DATABASE_URL" "$APP_DB_PASSWORD" "$STAGING_PROJECT_REF" "$TARGET_FINGERPRINT" "$FORBIDDEN_FINGERPRINTS"; do
             if [[ -z "$value" || "$value" =~ ^[[:space:]]*$ ]]; then
               echo "::error::Staging database controls are not configured."
               exit 1
@@ -280,43 +290,48 @@ jobs:
           OPENVPM_ENVIRONMENT: staging
           HOSTED_BILLING_ENABLED: "true"
         run: pnpm --filter @openpims/web environment:validate
+      - name: Reject protected or mismatched staging project
+        env:
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
+        run: pnpm --filter @openpims/web staging:verify-database-target
       - name: Verify database target identity
         env:
           OPENVPM_ENVIRONMENT: staging
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           DATABASE_TARGET_FINGERPRINT: ${{ vars.DATABASE_TARGET_FINGERPRINT }}
           FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: ${{ vars.FORBIDDEN_DATABASE_TARGET_FINGERPRINTS }}
         run: pnpm db:target:check
       - name: Verify applied history is a committed prefix
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           MIGRATION_CONFORMANCE_MODE: prefix
         run: pnpm db:migrations:conformance
       - name: Schema state before
         continue-on-error: true
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
         run: pnpm db:drift
       - name: Verify RLS deployment ownership
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
         run: pnpm db:rls:preflight
       - name: Apply migrations
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
         run: pnpm db:migrate
       - name: Re-apply row-level security
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           OPENPIMS_APP_DB_PASSWORD: ${{ secrets.OPENPIMS_APP_DB_PASSWORD }}
         run: pnpm db:rls
       - name: Verify schema matches the code
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
         run: pnpm db:drift
       - name: Verify exact applied migration history
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           MIGRATION_CONFORMANCE_MODE: exact
         run: pnpm db:migrations:conformance
 

--- a/apps/web/lib/__tests__/deployment-environment.test.ts
+++ b/apps/web/lib/__tests__/deployment-environment.test.ts
@@ -42,7 +42,8 @@ describe("deployment environment contract", () => {
 
   it("rejects unknown or case-drifted environment names", () => {
     expect(
-      inspectDeploymentEnvironment({ OPENVPM_ENVIRONMENT: "Production" }).issues,
+      inspectDeploymentEnvironment({ OPENVPM_ENVIRONMENT: "Production" })
+        .issues,
     ).toEqual(["OPENVPM_ENVIRONMENT is invalid"]);
   });
 
@@ -102,6 +103,36 @@ describe("deployment environment contract", () => {
         managed("development", {
           STRIPE_CONNECT_APPLICATION_FEE_BPS: "0",
           STRIPE_SECRET_KEY: "rk_test_redacted",
+        }),
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("requires an exact hashed recipient allowlist for nonproduction Resend", () => {
+    expect(
+      inspectDeploymentEnvironment(
+        managed("staging", { RESEND_API_KEY: "re_sandbox" }),
+      ).issues,
+    ).toContain(
+      "Nonproduction Resend requires NONPRODUCTION_EMAIL_RECIPIENT_HASHES",
+    );
+
+    expect(
+      inspectDeploymentEnvironment(
+        managed("staging", {
+          RESEND_API_KEY: "re_sandbox",
+          NONPRODUCTION_EMAIL_RECIPIENT_HASHES: "not-a-hash",
+        }),
+      ).issues,
+    ).toContain(
+      "NONPRODUCTION_EMAIL_RECIPIENT_HASHES must contain 1-20 unique SHA-256 values",
+    );
+
+    expect(
+      inspectDeploymentEnvironment(
+        managed("staging", {
+          RESEND_API_KEY: "re_sandbox",
+          NONPRODUCTION_EMAIL_RECIPIENT_HASHES: "a".repeat(64),
         }),
       ).ok,
     ).toBe(true);

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -167,6 +167,52 @@ describe("sendEmail", () => {
     expect(EMAIL_SEND_TIMEOUT_MS).toBe(10_000);
   });
 
+  it("blocks non-allowlisted staging recipients before calling Resend", async () => {
+    vi.stubEnv("OPENVPM_ENVIRONMENT", "staging");
+    vi.stubEnv("RESEND_API_KEY", "re_sandbox");
+    vi.stubEnv("NONPRODUCTION_EMAIL_RECIPIENT_HASHES", "a".repeat(64));
+    mocks.billingEnforced.mockReturnValue(true);
+    const { dispatchPreparedEmailWithProviderEvidence } = await loadEmail();
+
+    await expect(
+      dispatchPreparedEmailWithProviderEvidence({
+        to: "client@example.com",
+        subject: "Reminder",
+        html: "<p>Hello</p>",
+      }),
+    ).resolves.toEqual({
+      success: false,
+      provider: "resend",
+      error: "Recipient is not approved for nonproduction email delivery.",
+      outcome: "definite_failure",
+      failureCode: "nonproduction_recipient_blocked",
+    });
+
+    expect(mocks.resendSend).not.toHaveBeenCalled();
+  });
+
+  it("allows only the exact normalized staging recipient hash", async () => {
+    vi.stubEnv("OPENVPM_ENVIRONMENT", "staging");
+    vi.stubEnv("RESEND_API_KEY", "re_sandbox");
+    vi.stubEnv(
+      "NONPRODUCTION_EMAIL_RECIPIENT_HASHES",
+      "bcfc20648a6c9cfde57c8355191f48af699658f7729aea11b81b09ed21a71936",
+    );
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.resendSend.mockResolvedValue({ data: { id: "email-staging-1" } });
+    const { sendEmail } = await loadEmail();
+
+    await expect(
+      sendEmail({
+        to: " Sandbox@Example.com ",
+        subject: "Reminder",
+        html: "<p>Hello</p>",
+      }),
+    ).resolves.toEqual({ success: true, id: "email-staging-1" });
+
+    expect(mocks.resendSend).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back from blank from/reply-to values before sending", async () => {
     vi.stubEnv("RESEND_API_KEY", "re_test");
     vi.stubEnv("EMAIL_FROM", "   ");
@@ -417,7 +463,11 @@ describe("sendEmail", () => {
         .mockImplementation(() => undefined);
       mocks.resendSend.mockResolvedValue({
         data: null,
-        error: { message: "Provider outcome is not provable", name, statusCode },
+        error: {
+          message: "Provider outcome is not provable",
+          name,
+          statusCode,
+        },
       });
       const { dispatchPreparedEmailWithProviderEvidence } = await loadEmail();
 
@@ -879,10 +929,8 @@ describe("lifecycle email branding", () => {
     mocks.resendSend
       .mockResolvedValueOnce({ data: { id: "email-confirmed" } })
       .mockResolvedValueOnce({ data: { id: "email-canceled" } });
-    const {
-      sendSubscriptionConfirmedEmail,
-      sendSubscriptionCanceledEmail,
-    } = await loadEmail();
+    const { sendSubscriptionConfirmedEmail, sendSubscriptionCanceledEmail } =
+      await loadEmail();
 
     await expect(
       sendSubscriptionConfirmedEmail({

--- a/apps/web/lib/__tests__/repository-governance.test.ts
+++ b/apps/web/lib/__tests__/repository-governance.test.ts
@@ -95,7 +95,8 @@ describe("repository promotion controls", () => {
     expect(workflow.match(/environment: Development/g)).toHaveLength(1);
     expect(workflow.match(/environment: Staging/g)).toHaveLength(1);
     expect(workflow.match(/environment: Demo/g)).toHaveLength(1);
-    expect(workflow.match(/secrets\.DATABASE_URL/g)).toHaveLength(27);
+    expect(workflow.match(/secrets\.DATABASE_URL/g)).toHaveLength(18);
+    expect(workflow.match(/secrets\.STAGING_DATABASE_URL/g)).toHaveLength(10);
     expect(
       workflow.match(/group: apply-migrations-(development|staging|demo)/g),
     ).toHaveLength(3);
@@ -119,8 +120,16 @@ describe("repository promotion controls", () => {
     expect(staging).toContain("needs: validate-nonproduction-request");
     expect(staging).toContain("if: inputs.target == 'staging'");
     expect(staging).toContain("environment: Staging");
+    expect(workflow).toContain("staging_confirmation:");
+    expect(workflow).toContain("MIGRATE_STAGING");
+    expect(staging).toContain("secrets.STAGING_DATABASE_URL");
+    expect(staging).not.toContain("secrets.DATABASE_URL");
+    expect(staging).toContain("vars.STAGING_PROJECT_REF");
     expect(staging).toContain("DATABASE_TARGET_FINGERPRINT");
     expect(staging).toContain("FORBIDDEN_DATABASE_TARGET_FINGERPRINTS");
+    expect(staging).toContain(
+      "run: pnpm --filter @openpims/web staging:verify-database-target",
+    );
     expect(staging).toContain("run: pnpm db:target:check");
     expect(staging).toContain("run: pnpm db:rls:preflight");
     expect(staging).toContain("run: pnpm db:migrate");
@@ -131,6 +140,9 @@ describe("repository promotion controls", () => {
     expect(
       staging.indexOf("MIGRATION_CONFORMANCE_MODE: exact"),
     ).toBeGreaterThan(staging.indexOf("run: pnpm db:migrate"));
+    expect(staging.indexOf("staging:verify-database-target")).toBeLessThan(
+      staging.indexOf("run: pnpm db:migrate"),
+    );
   });
 
   it("keeps backlog cleanup evidence-gated and migration collisions on hold", () => {

--- a/apps/web/lib/deployment-environment.ts
+++ b/apps/web/lib/deployment-environment.ts
@@ -1,3 +1,5 @@
+import { nonproductionEmailPolicyIssues } from "@/lib/email-env";
+
 export const OPENVPM_ENVIRONMENTS = [
   "development",
   "staging",
@@ -74,7 +76,9 @@ function parseEnvironment(
     : undefined;
 }
 
-function usesTestStripeCredential(env: DeploymentEnvironmentVariables): boolean {
+function usesTestStripeCredential(
+  env: DeploymentEnvironmentVariables,
+): boolean {
   const key = nonBlank(env.STRIPE_SECRET_KEY);
   return !key || key.startsWith("sk_test_") || key.startsWith("rk_test_");
 }
@@ -159,6 +163,7 @@ export function inspectDeploymentEnvironment(
     if (!usesTestStripeCredential(env)) {
       issues.push("Nonproduction Stripe credentials must use test mode");
     }
+    issues.push(...nonproductionEmailPolicyIssues(env));
   }
 
   return {

--- a/apps/web/lib/email-env.ts
+++ b/apps/web/lib/email-env.ts
@@ -1,7 +1,12 @@
+import { createHash } from "node:crypto";
+
 const DEFAULT_EMAIL_FROM = "OpenVPM <noreply@mail.openvpm.com>";
+const NONPRODUCTION_EMAIL_ENVIRONMENTS = new Set(["development", "staging"]);
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const MAX_NONPRODUCTION_EMAIL_RECIPIENTS = 20;
 
 export function nonBlankEmailValue(
-  value: string | null | undefined
+  value: string | null | undefined,
 ): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
@@ -13,12 +18,74 @@ export function emailEnv(name: string): string | undefined {
 
 export function defaultEmailFrom(override?: string | null): string {
   return (
-    nonBlankEmailValue(override) ??
-    emailEnv("EMAIL_FROM") ??
-    DEFAULT_EMAIL_FROM
+    nonBlankEmailValue(override) ?? emailEnv("EMAIL_FROM") ?? DEFAULT_EMAIL_FROM
   );
 }
 
 export function emailDemoMode(): boolean {
   return emailEnv("NEXT_PUBLIC_DEMO_MODE") === "true";
+}
+
+function configuredRecipientHashes(
+  env: Readonly<Record<string, string | undefined>>,
+): string[] | null {
+  const raw = nonBlankEmailValue(env.NONPRODUCTION_EMAIL_RECIPIENT_HASHES);
+  if (!raw) return null;
+  const hashes = raw
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  if (
+    hashes.length === 0 ||
+    hashes.length > MAX_NONPRODUCTION_EMAIL_RECIPIENTS ||
+    hashes.some((hash) => !SHA256_PATTERN.test(hash)) ||
+    new Set(hashes).size !== hashes.length
+  ) {
+    return null;
+  }
+  return hashes;
+}
+
+export function nonproductionEmailPolicyIssues(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): string[] {
+  const environment = nonBlankEmailValue(env.OPENVPM_ENVIRONMENT);
+  if (
+    !NONPRODUCTION_EMAIL_ENVIRONMENTS.has(environment ?? "") ||
+    !nonBlankEmailValue(env.RESEND_API_KEY)
+  ) {
+    return [];
+  }
+  if (!nonBlankEmailValue(env.NONPRODUCTION_EMAIL_RECIPIENT_HASHES)) {
+    return [
+      "Nonproduction Resend requires NONPRODUCTION_EMAIL_RECIPIENT_HASHES",
+    ];
+  }
+  if (!configuredRecipientHashes(env)) {
+    return [
+      "NONPRODUCTION_EMAIL_RECIPIENT_HASHES must contain 1-20 unique SHA-256 values",
+    ];
+  }
+  return [];
+}
+
+/**
+ * Fail closed before crossing the provider boundary. The configured hashes are
+ * exact, normalized recipient identities so staging cannot broaden delivery to
+ * a domain or disclose sandbox addresses through ordinary environment output.
+ */
+export function nonproductionEmailRecipientAllowed(
+  recipient: string,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  const environment = nonBlankEmailValue(env.OPENVPM_ENVIRONMENT);
+  if (!NONPRODUCTION_EMAIL_ENVIRONMENTS.has(environment ?? "")) return true;
+  if (!nonBlankEmailValue(env.RESEND_API_KEY)) return true;
+  const hashes = configuredRecipientHashes(env);
+  if (!hashes) return false;
+  const normalizedRecipient = recipient.trim().toLowerCase();
+  const recipientHash = createHash("sha256")
+    .update(normalizedRecipient)
+    .digest("hex");
+  return hashes.includes(recipientHash);
 }

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -20,6 +20,7 @@ import {
   defaultEmailFrom,
   emailDemoMode,
   emailEnv,
+  nonproductionEmailRecipientAllowed,
   nonBlankEmailValue,
 } from "@/lib/email-env";
 
@@ -64,6 +65,7 @@ export interface EmailProviderEvidence {
     | "send_timeout"
     | "provider_exception"
     | "missing_provider_id"
+    | "nonproduction_recipient_blocked"
     | "invalid_company_address";
 }
 
@@ -217,6 +219,16 @@ async function dispatchEmail(
         ? `dev-console:${options.idempotencyKey}`.slice(0, 128)
         : "dev-console",
       outcome: "accepted",
+    };
+  }
+
+  if (!nonproductionEmailRecipientAllowed(options.to)) {
+    return {
+      success: false,
+      provider,
+      error: "Recipient is not approved for nonproduction email delivery.",
+      outcome: "definite_failure",
+      failureCode: "nonproduction_recipient_blocked",
     };
   }
 
@@ -1014,8 +1026,7 @@ export async function prepareSubscriptionCanceledEmail(data: {
   const { subject, html } = await renderSubscriptionCanceledEmail({
     brand,
     practiceName: data.practiceName,
-    reactivateUrl:
-      data.reactivateUrl ?? `${brand.appUrl}/settings?tab=billing`,
+    reactivateUrl: data.reactivateUrl ?? `${brand.appUrl}/settings?tab=billing`,
   });
   return {
     to: data.to,

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -294,6 +294,14 @@ check. Run `pnpm db:seed` only with the documented synthetic seed and route all
 email/SMS/payment destinations to non-delivering or allowlisted sandbox
 providers.
 
+If Resend is configured in Development or Staging, set
+`NONPRODUCTION_EMAIL_RECIPIENT_HASHES` to 1-20 comma-separated SHA-256 hashes of
+the exact lowercased sandbox recipient addresses. Deployment validation fails
+without a valid list, and the runtime rejects every non-matching recipient
+before calling Resend. Do not use domain wildcards or real clinic/client
+addresses. An environment with no Resend key remains non-delivering and hosted
+email operations fail closed.
+
 Set the GitHub `Staging` environment variable `STAGING_PROJECT_REF` to the new
 project's exact 20-character Supabase ref. Before any database command, the
 workflow proves that `STAGING_DATABASE_URL` resolves to that same project and


### PR DESCRIPTION
## Outcome

Closes the drift between the documented isolated-staging boundary and the actual migration/provider controls. Staging now fails closed before any database command unless the dispatch, credential, Supabase project identity, and independent fingerprint controls all agree. Development and Staging also cannot use Resend to contact an address outside an exact sandbox-recipient allowlist.

## Changes

### Database and dispatch boundary

- require the typed `MIGRATE_STAGING` confirmation;
- use the dedicated `STAGING_DATABASE_URL` secret and require `STAGING_PROJECT_REF`;
- invoke the existing project-ref verifier before any database inspection/mutation;
- reject both known data-bearing Supabase project identities even if renamed;
- retain the independent expected/forbidden target-fingerprint checks;
- regression-test secret isolation, identity checks, and verifier-before-migrate ordering.

### Outbound email boundary

- when Resend is configured in Development or Staging, require 1–20 exact normalized sandbox recipient SHA-256 identities;
- reject a missing, malformed, duplicate, or overbroad allowlist during deployment validation;
- reject every nonmatching address at runtime before calling Resend;
- record a blocked attempt as a definite provider-boundary failure;
- document the protected configuration and prohibit domain wildcards/real clinic addresses.

## Verification at `d0836c433a999199ce6f87e9c0377a10808423dc`

- `pnpm test`: 4,599 passed, 31 intentional integration skips
- focused staging, environment, email, and governance controls: 70/70 passed
- archive-preflight serial rerun after a parallel resource-contention timeout: 49/49 passed; it also passed in the final full suite
- `pnpm lint`: passed
- `pnpm type-check`: passed
- `pnpm build`: passed, 56 static pages generated
- Prettier and `git diff --check`: passed

## Release boundary

Draft and stacked on #301. **NO MERGE / NO STAGING MIGRATION / NO PRODUCTION DEPLOYMENT.** This PR does not provision staging, contact a database or provider, change GitHub/Vercel environment secrets, or incur spend. #278 remains open until a separate synthetic-only Supabase project and sandbox provider stack are approved, provisioned, exercised, restored, and independently reviewed.
