### PR TITLE
fix(ops): make staging resets fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,3 +432,10 @@ jobs:
         run: pnpm --filter @openpims/db db:rls:test
 
       - run: pnpm --filter @openpims/db db:migration-runs:test
+
+      # This is intentionally last: it destroys every application row in the
+      # disposable CI database, then proves migration history remains intact.
+      - name: Execute safe reset database contract
+        env:
+          RESET_DB_INTEGRATION: "1"
+        run: pnpm --filter @openpims/db db:reset:test

--- a/.github/workflows/reset-staging.yml
+++ b/.github/workflows/reset-staging.yml
@@ -1,0 +1,149 @@
+name: Reset isolated staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      reset_confirmation:
+        description: Type RESET_STAGING_DATA to destroy and reseed isolated staging
+        required: true
+        type: string
+      release_sha:
+        description: Exact 40-character commit at the head of staging
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-staging-reset-request:
+    name: validate staging reset request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require exact staging revision and destructive confirmation
+        env:
+          REQUESTED_RELEASE_SHA: ${{ inputs.release_sha }}
+          RESET_CONFIRMATION: ${{ inputs.reset_confirmation }}
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/staging" ]; then
+            echo "::error::Staging reset must be dispatched from the staging branch."
+            exit 1
+          fi
+          if [[ ! "$REQUESTED_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || [ "$REQUESTED_RELEASE_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Staging reset release SHA must match the exact dispatched commit."
+            exit 1
+          fi
+          if [ "$RESET_CONFIRMATION" != "RESET_STAGING_DATA" ]; then
+            echo "::error::Staging reset confirmation did not match RESET_STAGING_DATA."
+            exit 1
+          fi
+
+  reset-staging:
+    name: reset isolated staging
+    needs: validate-staging-reset-request
+    environment: Staging
+    concurrency:
+      group: apply-migrations-staging
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.release_sha }}
+          persist-credentials: false
+      - name: Verify checked-out revision
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+
+      - name: Require environment-scoped staging controls
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          APP_DB_PASSWORD: ${{ secrets.OPENPIMS_APP_DB_PASSWORD }}
+          STAGING_PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
+          TARGET_FINGERPRINT: ${{ vars.DATABASE_TARGET_FINGERPRINT }}
+          FORBIDDEN_FINGERPRINTS: ${{ vars.FORBIDDEN_DATABASE_TARGET_FINGERPRINTS }}
+        run: |
+          for value in "$DATABASE_URL" "$APP_DB_PASSWORD" "$STAGING_PROJECT_REF" "$TARGET_FINGERPRINT" "$FORBIDDEN_FINGERPRINTS"; do
+            if [[ -z "$value" || "$value" =~ ^[[:space:]]*$ ]]; then
+              echo "::error::Staging reset controls are not configured."
+              exit 1
+            fi
+          done
+
+      - name: Verify non-delivering staging code contract
+        env:
+          OPENVPM_ENVIRONMENT: staging
+          HOSTED_BILLING_ENABLED: "true"
+        run: pnpm --filter @openpims/web environment:validate
+
+      - name: Reject protected or mismatched staging project
+        env:
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
+        run: pnpm --filter @openpims/web staging:verify-database-target
+
+      - name: Verify database target identity
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          DATABASE_TARGET_FINGERPRINT: ${{ vars.DATABASE_TARGET_FINGERPRINT }}
+          FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: ${{ vars.FORBIDDEN_DATABASE_TARGET_FINGERPRINTS }}
+        run: pnpm db:target:check
+
+      - name: Apply migrations before reset
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: pnpm db:migrate
+
+      - name: Re-apply row-level security before reset
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          OPENPIMS_APP_DB_PASSWORD: ${{ secrets.OPENPIMS_APP_DB_PASSWORD }}
+        run: pnpm db:rls
+
+      - name: Reset every staging application table
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
+          DATABASE_TARGET_FINGERPRINT: ${{ vars.DATABASE_TARGET_FINGERPRINT }}
+          FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: ${{ vars.FORBIDDEN_DATABASE_TARGET_FINGERPRINTS }}
+          OPENVPM_ENVIRONMENT: staging
+          STAGING_RESET_CONFIRMATION: ${{ inputs.reset_confirmation }}
+        run: pnpm --filter @openpims/db db:reset:staging
+
+      - name: Seed repository-owned synthetic clinic
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: pnpm db:seed
+
+      - name: Re-apply row-level security after seed
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          OPENPIMS_APP_DB_PASSWORD: ${{ secrets.OPENPIMS_APP_DB_PASSWORD }}
+        run: pnpm db:rls
+
+      - name: Verify exact schema and migration history
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          MIGRATION_CONFORMANCE_MODE: exact
+        run: |
+          pnpm db:drift
+          pnpm db:migrations:conformance
+
+      - name: Prove synthetic-only staging data and contact boundaries
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_PROJECT_REF: ${{ vars.STAGING_PROJECT_REF }}
+          DATABASE_TARGET_FINGERPRINT: ${{ vars.DATABASE_TARGET_FINGERPRINT }}
+          FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: ${{ vars.FORBIDDEN_DATABASE_TARGET_FINGERPRINTS }}
+          OPENVPM_ENVIRONMENT: staging
+          STAGING_RESET_CONFIRMATION: ${{ inputs.reset_confirmation }}
+          STAGING_RELEASE_SHA: ${{ inputs.release_sha }}
+        run: pnpm --filter @openpims/db db:staging:synthetic:audit

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ pnpm db:seed
 pnpm dev
 ```
 
+`pnpm db:reset` is intentionally destructive and local-only. It refuses CI,
+Vercel, non-loopback hosts, unrelated database names, and calls without
+`RESET_DATABASE_CONFIRMATION=RESET_LOCAL_OPENVPM`. Hosted staging has a
+separate protected workflow; this developer command cannot reset it.
+
 Open [http://localhost:3000](http://localhost:3000) and sign in with the demo credentials:
 
 | Role         | Email                                     | Password    |

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -360,9 +360,14 @@ describe("health route schema drift", () => {
 
     expect(response.status).toBe(200);
     expect(json.releaseSha).toBe("a".repeat(40));
+    expect(json.databaseTargetFingerprint).toMatch(/^[0-9a-f]{64}$/);
     expect(json.checks.hostedRelease).toEqual({
       ok: true,
       detail: "Hosted deployment release SHA is available",
+    });
+    expect(json.checks.hostedDatabaseIdentity).toEqual({
+      ok: true,
+      detail: "Hosted database identity is available",
     });
   });
 

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
+import { databaseConnectionIdentityFingerprint } from "@openpims/db/deployment-target";
 import { isPlausiblePhysicalCompanyAddress } from "@openpims/email";
 import {
   describeDrift,
@@ -312,6 +313,17 @@ export async function GET() {
   const startedAt = Date.now();
   const releaseSha = deploymentReleaseSha();
   const hostedMode = billingEnforced();
+  let databaseTargetFingerprint: string | null = null;
+  try {
+    const databaseUrl = envValue("DATABASE_URL");
+    if (databaseUrl) {
+      databaseTargetFingerprint =
+        databaseConnectionIdentityFingerprint(databaseUrl);
+    }
+  } catch {
+    // The public response exposes only a credential-free fingerprint. Invalid
+    // connection identity remains null and fails the hosted readiness check.
+  }
   const checks: Record<
     string,
     { ok: boolean; detail?: string; advisory?: boolean }
@@ -363,6 +375,12 @@ export async function GET() {
       detail: releaseSha
         ? "Hosted deployment release SHA is available"
         : "Hosted deployment release SHA is missing or invalid",
+    };
+    checks.hostedDatabaseIdentity = {
+      ok: databaseTargetFingerprint !== null,
+      detail: databaseTargetFingerprint
+        ? "Hosted database identity is available"
+        : "Hosted database identity is missing or invalid",
     };
     if (shouldAssertHostedRlsRole()) {
       try {
@@ -520,6 +538,7 @@ export async function GET() {
       service: "openvpm-web",
       mode: hostedMode ? "hosted" : "self-host",
       releaseSha,
+      databaseTargetFingerprint,
       checks,
       latencyMs: Date.now() - startedAt,
     },

--- a/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
@@ -8,6 +8,7 @@ import { CLINICAL_DATA_AUDIT_SCHEMAS } from "../clinical-data-integrity-evidence
 
 const sha = "a".repeat(40);
 const clinicalDatabaseFingerprint = "d".repeat(64);
+const stagingDatabaseFingerprint = "e".repeat(64);
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
@@ -267,6 +268,7 @@ function authoritativeResponses(options: { missingBuildStep?: string } = {}) {
   const checks = Object.fromEntries(
     [
       "hostedRelease",
+      "hostedDatabaseIdentity",
       "database",
       "schema",
       "hostedRlsRole",
@@ -331,6 +333,31 @@ function authoritativeResponses(options: { missingBuildStep?: string } = {}) {
         "Apply migrations",
         "Re-apply row-level security",
         "Verify schema matches the code",
+      ]),
+    ],
+  };
+  const stagingResetRun = {
+    name: "Reset isolated staging",
+    event: "workflow_dispatch",
+    status: "completed",
+    conclusion: "success",
+    head_sha: sha,
+    head_branch: "staging",
+    html_url: "https://github.example/staging-reset",
+  };
+  const stagingResetJobs = {
+    total_count: 2,
+    jobs: [
+      successfulJob("validate staging reset request", [
+        "Require exact staging revision and destructive confirmation",
+      ]),
+      successfulJob("reset isolated staging", [
+        "Reject protected or mismatched staging project",
+        "Verify database target identity",
+        "Reset every staging application table",
+        "Seed repository-owned synthetic clinic",
+        "Verify exact schema and migration history",
+        "Prove synthetic-only staging data and contact boundaries",
       ]),
     ],
   };
@@ -436,6 +463,10 @@ function authoritativeResponses(options: { missingBuildStep?: string } = {}) {
     if (url.endsWith("/actions/runs/151/jobs?per_page=100")) {
       return response(stagingMigrationJobs);
     }
+    if (url.endsWith("/actions/runs/171")) return response(stagingResetRun);
+    if (url.endsWith("/actions/runs/171/jobs?per_page=100")) {
+      return response(stagingResetJobs);
+    }
     if (url.endsWith("/actions/runs/202")) return response(migrationRun);
     if (url.endsWith("/actions/runs/202/jobs?per_page=100")) {
       return response(migrationJobs);
@@ -458,9 +489,17 @@ function authoritativeResponses(options: { missingBuildStep?: string } = {}) {
     if (url.endsWith("/branches/staging/protection")) {
       return response(stagingProtection);
     }
-    if (url === "https://staging.example/api/health") return response(health);
+    if (url === "https://staging.example/api/health") {
+      return response({
+        ...health,
+        databaseTargetFingerprint: stagingDatabaseFingerprint,
+      });
+    }
     if (url === "https://production.example/api/health")
-      return response(health);
+      return response({
+        ...health,
+        databaseTargetFingerprint: clinicalDatabaseFingerprint,
+      });
     return response({ error: "unexpected URL" }, 404);
   }) as unknown as typeof fetch;
 }
@@ -471,6 +510,8 @@ function options(fetchFn: typeof fetch) {
     repository: "openvpm/openvpm",
     ciRunId: 101,
     stagingMigrationRunId: 151,
+    stagingResetRunId: 171,
+    stagingDatabaseFingerprint,
     migrationRunId: 202,
     stagingHealthUrl: "https://staging.example/api/health",
     hostedHealthUrl: "https://production.example/api/health",
@@ -491,7 +532,7 @@ describe("clinic readiness evidence collector", () => {
     );
 
     expect(evidence).toMatchObject({
-      evidenceFormatVersion: 6,
+      evidenceFormatVersion: 7,
       releaseSha: sha,
       ci: {
         releaseSha: sha,
@@ -529,7 +570,10 @@ describe("clinic readiness evidence collector", () => {
       },
       staging: {
         releaseSha: sha,
+        databaseTargetFingerprint: stagingDatabaseFingerprint,
         migrationRunId: 151,
+        resetRunId: 171,
+        syntheticDataAudit: "passed",
         hostedHealth: { releaseSha: sha, statusCode: 200 },
       },
       hostedHealth: { releaseSha: sha, statusCode: 200 },
@@ -670,6 +714,26 @@ describe("clinic readiness evidence collector", () => {
       collectClinicReadinessEvidence(options(wrapped)),
     ).rejects.toThrow(
       "Staging migration must be a successful exact-SHA Apply migrations run from staging.",
+    );
+  });
+
+  it("rejects a staging reset that is not exact-SHA staging evidence", async () => {
+    const fetchFn = authoritativeResponses();
+    const wrapped = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const result = await fetchFn(input, init);
+        if (String(input).endsWith("/actions/runs/171")) {
+          const body = await result.json();
+          return response({ ...body, head_sha: "d".repeat(40) });
+        }
+        return result;
+      },
+    ) as unknown as typeof fetch;
+
+    await expect(
+      collectClinicReadinessEvidence(options(wrapped)),
+    ).rejects.toThrow(
+      "Staging reset must be a successful exact-SHA Reset isolated staging run from staging.",
     );
   });
 

--- a/apps/web/lib/__tests__/clinic-readiness-release.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-release.test.ts
@@ -5,6 +5,7 @@ import { CLINICAL_DATA_AUDIT_SCHEMAS } from "../clinical-data-integrity-evidence
 const now = Date.parse("2026-08-29T21:00:00.000Z");
 const sha = "a".repeat(40);
 const clinicalDatabaseFingerprint = "d".repeat(64);
+const stagingDatabaseFingerprint = "e".repeat(64);
 
 function healthyClinicalDataIntegrityEvidence() {
   type AuditDomain = keyof typeof CLINICAL_DATA_AUDIT_SCHEMAS;
@@ -165,6 +166,7 @@ function healthyEvidence() {
     Object.fromEntries(
       [
         "hostedRelease",
+        "hostedDatabaseIdentity",
         "database",
         "schema",
         "hostedRlsRole",
@@ -180,7 +182,7 @@ function healthyEvidence() {
       ].map((name) => [name, { ok: true }]),
     );
   return {
-    evidenceFormatVersion: 6,
+    evidenceFormatVersion: 7,
     releaseSha: sha,
     clinicalDataIntegrity: healthyClinicalDataIntegrityEvidence(),
     ci: {
@@ -256,7 +258,10 @@ function healthyEvidence() {
     },
     staging: {
       releaseSha: sha,
+      databaseTargetFingerprint: stagingDatabaseFingerprint,
       migrationRunId: 151,
+      resetRunId: 171,
+      syntheticDataAudit: "passed",
       hostedHealth: {
         releaseSha: sha,
         checkedAt: "2026-08-29T20:55:00.000Z",
@@ -265,6 +270,7 @@ function healthyEvidence() {
           ok: true,
           mode: "hosted",
           releaseSha: sha,
+          databaseTargetFingerprint: stagingDatabaseFingerprint,
           checks: structuredClone(checks),
         },
       },
@@ -273,7 +279,13 @@ function healthyEvidence() {
       releaseSha: sha,
       checkedAt: "2026-08-29T20:55:00.000Z",
       statusCode: 200,
-      body: { ok: true, mode: "hosted", releaseSha: sha, checks },
+      body: {
+        ok: true,
+        mode: "hosted",
+        releaseSha: sha,
+        databaseTargetFingerprint: clinicalDatabaseFingerprint,
+        checks,
+      },
     },
     restoreDrill: {
       releaseSha: sha,
@@ -349,7 +361,7 @@ describe("clinic readiness release decision", () => {
     const evidence = healthyEvidence();
     evidence.evidenceFormatVersion = 5;
     expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
-      "Clinic readiness evidence format version must be 6.",
+      "Clinic readiness evidence format version must be 7.",
     );
   });
 
@@ -419,6 +431,36 @@ describe("clinic readiness release decision", () => {
         "Staging hosted health evidence is stale.",
         "Staging hosted health body does not identify the release SHA.",
       ]),
+    );
+  });
+
+  it("requires a successful isolated staging reset and synthetic-data audit", () => {
+    const evidence = healthyEvidence();
+    evidence.staging.resetRunId = 0;
+    evidence.staging.syntheticDataAudit = "failed";
+    expect(evaluateClinicReadinessRelease(evidence, now).reasons).toEqual(
+      expect.arrayContaining([
+        "Isolated staging reset run ID is missing or invalid.",
+        "Isolated staging synthetic-data and contact audit has not passed.",
+      ]),
+    );
+  });
+
+  it("binds staging and production health to distinct expected databases", () => {
+    const evidence = healthyEvidence();
+    evidence.staging.hostedHealth.body.databaseTargetFingerprint =
+      clinicalDatabaseFingerprint;
+    evidence.staging.databaseTargetFingerprint = clinicalDatabaseFingerprint;
+    const reasons = evaluateClinicReadinessRelease(evidence, now).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Isolated staging and clinical production use the same database target.",
+      ]),
+    );
+
+    evidence.staging.databaseTargetFingerprint = stagingDatabaseFingerprint;
+    expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
+      "Staging hosted health does not match the expected database target.",
     );
   });
 

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -14,6 +14,14 @@ function readRepoFile(path: string): string {
   return readFileSync(resolve(repoRoot, path), "utf8");
 }
 
+function expectSchemaDrivenApplicationReset(reset: string): void {
+  expect(reset).toContain("declaredSchema().keys()");
+  expect(reset).toContain('quoteIdentifier("public")');
+  expect(reset).toContain(
+    "TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE",
+  );
+}
+
 describe("committed Drizzle migrations", () => {
   it("exercises committed migrations in the CI RLS isolation job", () => {
     const ci = readRepoFile(".github/workflows/ci.yml");
@@ -239,12 +247,7 @@ describe("committed Drizzle migrations", () => {
     );
 
     const reset = readRepoFile("packages/db/reset.ts");
-    expect(reset.indexOf('"sms_provider_event_conflict_reviews"')).toBeLessThan(
-      reset.indexOf('"sms_provider_event_conflicts"'),
-    );
-    expect(reset.indexOf('"sms_provider_event_conflicts"')).toBeLessThan(
-      reset.indexOf('"sms_provider_events"'),
-    );
+    expectSchemaDrivenApplicationReset(reset);
   });
 
   it("revokes legacy portal credentials before enforcing one-time session state", () => {
@@ -1813,16 +1816,7 @@ describe("committed Drizzle migrations", () => {
     );
 
     const reset = readRepoFile("packages/db/reset.ts");
-    expect(reset).toContain('"auth_email_delivery_events"');
-    expect(reset).toContain('"auth_email_webhook_conflicts"');
-    expect(reset).toContain('"auth_email_provider_identity_conflicts"');
-    expect(reset).toContain('"auth_email_attempts"');
-    expect(reset.indexOf('"auth_email_webhook_conflicts"')).toBeLessThan(
-      reset.indexOf('"auth_email_delivery_events"'),
-    );
-    expect(reset.indexOf('"auth_email_delivery_events"')).toBeLessThan(
-      reset.indexOf('"auth_email_attempts"'),
-    );
+    expectSchemaDrivenApplicationReset(reset);
 
     const rls = readRepoFile("packages/db/rls/enable-rls.sql");
     expect(rls).toContain("CREATE POLICY system_only ON auth_email_attempts");
@@ -2051,10 +2045,7 @@ describe("committed Drizzle migrations", () => {
     );
 
     const reset = readRepoFile("packages/db/reset.ts");
-    expect(reset).toContain('"soap_note_replacements"');
-    expect(reset.indexOf('"soap_note_replacements"')).toBeLessThan(
-      reset.indexOf('"clinical_record_corrections"'),
-    );
+    expectSchemaDrivenApplicationReset(reset);
 
     const rls = readRepoFile("packages/db/rls/enable-rls.sql");
     expect(rls).toContain("'soap_note_replacements'");
@@ -2120,7 +2111,7 @@ describe("committed Drizzle migrations", () => {
     );
 
     const reset = readRepoFile("packages/db/reset.ts");
-    expect(reset).toContain('"messaging_registration_events"');
+    expectSchemaDrivenApplicationReset(reset);
 
     const rls = readRepoFile("packages/db/rls/enable-rls.sql");
     expect(rls).toContain("'messaging_registration_events'");
@@ -2204,7 +2195,7 @@ describe("committed Drizzle migrations", () => {
       "GRANT SELECT, INSERT, UPDATE ON subscription_checkout_attempts TO openpims_app",
     );
     const reset = readRepoFile("packages/db/reset.ts");
-    expect(reset).toContain('"subscription_checkout_attempts"');
+    expectSchemaDrivenApplicationReset(reset);
   });
 
   it("adopts tenant-bound prescription integrity without rewriting clinical history", () => {

--- a/apps/web/lib/__tests__/lab-result-safety.test.ts
+++ b/apps/web/lib/__tests__/lab-result-safety.test.ts
@@ -17,18 +17,34 @@ describe("lab result clinical safety contract", () => {
     const migration = read("../../packages/db/drizzle/0059_daffy_darkstar.sql");
     const router = read("server/routers/records.ts");
 
-    expect(schema).toContain('resultValue: varchar("result_value", { length: 128 })');
+    expect(schema).toContain(
+      'resultValue: varchar("result_value", { length: 128 })',
+    );
     expect(schema).toContain('unit: varchar("unit", { length: 32 })');
-    expect(schema).toContain('referenceRangeLow: numeric("reference_range_low"');
-    expect(schema).toContain("${table.statusAfter} in ('completed', 'reviewed')");
-    expect(schema).toContain("length(btrim(coalesce(${table.resultValue}, ''))) between 1 and 128");
+    expect(schema).toContain(
+      'referenceRangeLow: numeric("reference_range_low"',
+    );
+    expect(schema).toContain(
+      "${table.statusAfter} in ('completed', 'reviewed')",
+    );
+    expect(schema).toContain(
+      "length(btrim(coalesce(${table.resultValue}, ''))) between 1 and 128",
+    );
     expect(migration).toContain('"result_value" varchar(128)');
-    expect(migration).toContain("source.appointment_id IS NOT DISTINCT FROM NEW.appointment_id");
+    expect(migration).toContain(
+      "source.appointment_id IS NOT DISTINCT FROM NEW.appointment_id",
+    );
     expect(migration).not.toContain("source.status = NEW.status_after");
-    expect(migration).not.toContain("source.result_value IS NOT DISTINCT FROM NEW.result_value");
+    expect(migration).not.toContain(
+      "source.result_value IS NOT DISTINCT FROM NEW.result_value",
+    );
     expect(migration).toContain("app.ledger_maintenance");
-    expect(migration).toContain("Lab result events are append-only and cannot be updated or deleted.");
-    expect(router.match(/resultValue: updated\.resultValue/g)?.length ?? 0).toBeGreaterThanOrEqual(4);
+    expect(migration).toContain(
+      "Lab result events are append-only and cannot be updated or deleted.",
+    );
+    expect(
+      router.match(/resultValue: updated\.resultValue/g)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(4);
     expect(router).toContain("resultValue: created.resultValue");
   });
 
@@ -36,15 +52,25 @@ describe("lab result clinical safety contract", () => {
     const migration = read("../../packages/db/drizzle/0059_daffy_darkstar.sql");
     const schema = read("../../packages/db/schema/clinical.ts");
 
-    expect(migration).toContain("Rows without a result cannot truthfully remain completed or reviewed");
-    expect(migration).toContain("A legacy reviewed row without an attributable reviewer is awaiting review");
+    expect(migration).toContain(
+      "Rows without a result cannot truthfully remain completed or reviewed",
+    );
+    expect(migration).toContain(
+      "A legacy reviewed row without an attributable reviewer is awaiting review",
+    );
     expect(migration).toContain('SET "result_value" = null');
     expect(schema).toContain("table.status} = 'reviewed'");
     expect(schema).toContain("${table.reviewedBy} is not null");
     expect(schema).toContain("${table.completedAt} is not null");
-    expect(migration).toContain('"lab_result_events"."status_after" <> \'pending\' or "lab_result_events"."follow_up_status" = \'not_required\'');
-    expect(migration).toContain('"lab_result_events"."follow_up_status" in (\'open\', \'completed\')');
-    expect(migration).toContain('"lab_results"."follow_up_status" in (\'open\', \'completed\')');
+    expect(migration).toContain(
+      '"lab_result_events"."status_after" <> \'pending\' or "lab_result_events"."follow_up_status" = \'not_required\'',
+    );
+    expect(migration).toContain(
+      "\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')",
+    );
+    expect(migration).toContain(
+      "\"lab_results\".\"follow_up_status\" in ('open', 'completed')",
+    );
   });
 
   it("keeps lab mutations idempotent and the clinic queue bounded", () => {
@@ -54,9 +80,13 @@ describe("lab result clinical safety contract", () => {
     expect(router).toContain("pg_advisory_xact_lock");
     expect(router).toContain("operationPayloadHash !== expected.payloadHash");
     expect(router).toContain(".limit(input.resultId ? 2 : input.limit + 1)");
-    expect(router).toContain("truncated: !input.resultId && visibleRows.length > input.limit");
+    expect(router).toContain(
+      "truncated: !input.resultId && visibleRows.length > input.limit",
+    );
     expect(router).toContain("when 'critical' then 0 else 1 end");
-    expect(router).toContain("coalesce(${labResults.followUpDueAt}, 'infinity'::timestamptz)");
+    expect(router).toContain(
+      "coalesce(${labResults.followUpDueAt}, 'infinity'::timestamptz)",
+    );
     expect(inbox).toContain("reviewOperationIds.current.get(resultId)");
     expect(inbox).toContain("operationId: actionPanel.operationId");
     expect(inbox).toContain("More than 100 results match this view");
@@ -80,31 +110,49 @@ describe("lab result clinical safety contract", () => {
     expect(router).toContain("eq(labResultEvents.practiceId, ctx.practiceId)");
     expect(inbox).toContain("Show evidence history");
     expect(inbox).toContain("Snapshot:");
-    expect(router).toContain('const frontDeskMode = ctx.user.role === "front_desk"');
-    expect(router).toContain('eq(labResults.followUpAssignedTo, ctx.user.id)');
+    expect(router).toContain(
+      'const frontDeskMode = ctx.user.role === "front_desk"',
+    );
+    expect(router).toContain("eq(labResults.followUpAssignedTo, ctx.user.id)");
     expect(router).toContain('resultFlag: "unknown" as const');
-    expect(inbox).toContain("Clinical values are restricted; follow the instructions below.");
-    expect(inbox).toMatch(/!isFrontDesk \? <div>\s*<dt[^>]*>Clinical review<\/dt>/);
-    expect(inbox).toContain("Your 100 highest-priority assigned items are shown.");
+    expect(inbox).toContain(
+      "Clinical values are restricted; follow the instructions below.",
+    );
+    expect(inbox).toMatch(
+      /!isFrontDesk \? <div>\s*<dt[^>]*>Clinical review<\/dt>/,
+    );
+    expect(inbox).toContain(
+      "Your 100 highest-priority assigned items are shown.",
+    );
     expect(rls).toContain("'lab_result_events'");
     expect(rls).toContain("REVOKE ALL ON lab_results FROM openpims_app");
-    expect(rls).toContain("GRANT SELECT, INSERT ON lab_results TO openpims_app");
-    expect(rlsTest).toContain("application role cannot rewrite lab result evidence");
-    expect(rlsTest).toContain("lab evidence owner mutation requires the maintenance GUC");
+    expect(rls).toContain(
+      "GRANT SELECT, INSERT ON lab_results TO openpims_app",
+    );
+    expect(rlsTest).toContain(
+      "application role cannot rewrite lab result evidence",
+    );
+    expect(rlsTest).toContain(
+      "lab evidence owner mutation requires the maintenance GUC",
+    );
     expect(rlsTest).toContain("cross-tenant lab evidence actor is blocked");
     expect(migration).toContain("AND current_user = (");
     expect(migration).toContain("class.relname = TG_TABLE_NAME");
     expect(backup).toContain("labResultEvents: labResultEventRows");
-    expect(backup).toContain('restorePracticeRows("labResultEvents", labResultEvents)');
+    expect(backup).toContain(
+      'restorePracticeRows("labResultEvents", labResultEvents)',
+    );
   });
 
   it("seeds a truthful chronological lab evidence chain", () => {
     const seed = read("../../packages/db/seed.ts");
 
-    expect(seed).toContain("await db.insert(labResultEvents).values(labEventValues)");
+    expect(seed).toContain(
+      "await db.insert(labResultEvents).values(labEventValues)",
+    );
     expect(seed).toContain('eventType: "created"');
     expect(seed).toContain('statusAfter: "pending"');
-    expect(seed).toContain('resultValue: null');
+    expect(seed).toContain("resultValue: null");
     expect(seed).toContain('resultFlag: "unknown"');
     expect(seed).toContain('eventType: "completed"');
     expect(seed).toContain('statusBefore: "pending"');
@@ -329,8 +377,10 @@ describe("lab result clinical safety contract", () => {
     expect(rlsTest).toContain(
       "application role cannot delete correction evidence even with bypass GUCs",
     );
-    expect(reset.indexOf('"lab_result_replacements"')).toBeLessThan(
-      reset.indexOf('"clinical_record_corrections"'),
+    expect(reset).toContain("declaredSchema().keys()");
+    expect(reset).toContain("quoteIdentifier(\"public\")");
+    expect(reset).toContain(
+      "TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE",
     );
   });
 

--- a/apps/web/lib/clinic-readiness-evidence-collector.ts
+++ b/apps/web/lib/clinic-readiness-evidence-collector.ts
@@ -64,6 +64,8 @@ export type ClinicReadinessEvidenceCollectionOptions = {
   repository: string;
   ciRunId: number;
   stagingMigrationRunId: number;
+  stagingResetRunId: number;
+  stagingDatabaseFingerprint: string;
   migrationRunId: number;
   stagingHealthUrl: string;
   hostedHealthUrl: string;
@@ -87,11 +89,9 @@ function exactSha(value: string): string {
   return value.toLowerCase();
 }
 
-function exactFingerprint(value: string): string {
+function exactFingerprint(value: string, label = "Clinical database"): string {
   if (!/^[0-9a-f]{64}$/i.test(value)) {
-    throw new Error(
-      "Clinical database fingerprint must be an exact SHA-256 value.",
-    );
+    throw new Error(`${label} fingerprint must be an exact SHA-256 value.`);
   }
   return value.toLowerCase();
 }
@@ -477,6 +477,15 @@ export async function collectClinicReadinessEvidence(
   const clinicalDatabaseFingerprint = exactFingerprint(
     options.clinicalDatabaseFingerprint,
   );
+  const stagingDatabaseFingerprint = exactFingerprint(
+    options.stagingDatabaseFingerprint,
+    "Staging database",
+  );
+  if (stagingDatabaseFingerprint === clinicalDatabaseFingerprint) {
+    throw new Error(
+      "Staging and clinical production database fingerprints must be distinct.",
+    );
+  }
   if (!REPOSITORY_PATTERN.test(options.repository)) {
     throw new Error("GitHub repository must use the owner/name form.");
   }
@@ -484,6 +493,10 @@ export async function collectClinicReadinessEvidence(
   const stagingMigrationRunId = runId(
     options.stagingMigrationRunId,
     "Staging migration run ID",
+  );
+  const stagingResetRunId = runId(
+    options.stagingResetRunId,
+    "Staging reset run ID",
   );
   const migrationRunId = runId(
     options.migrationRunId,
@@ -497,6 +510,7 @@ export async function collectClinicReadinessEvidence(
   const [
     ci,
     stagingMigration,
+    stagingReset,
     migration,
     stagingHealthResponse,
     healthResponse,
@@ -515,6 +529,13 @@ export async function collectClinicReadinessEvidence(
       stagingMigrationRunId,
       options.githubToken,
       "Staging migration",
+    ),
+    githubRunAndJobs(
+      fetchFn,
+      options.repository,
+      stagingResetRunId,
+      options.githubToken,
+      "Staging reset",
     ),
     githubRunAndJobs(
       fetchFn,
@@ -555,6 +576,13 @@ export async function collectClinicReadinessEvidence(
     releaseSha,
     branch: "staging",
   });
+  verifyRun(stagingReset.run, {
+    label: "Staging reset",
+    name: "Reset isolated staging",
+    event: "workflow_dispatch",
+    releaseSha,
+    branch: "staging",
+  });
   verifyRun(migration.run, {
     label: "Production migration",
     name: "Apply migrations",
@@ -575,6 +603,14 @@ export async function collectClinicReadinessEvidence(
     "validate staging request",
   );
   const stagingMigrationJob = successfulJob(stagingMigration.jobs, "staging");
+  const stagingResetValidationJob = successfulJob(
+    stagingReset.jobs,
+    "validate staging reset request",
+  );
+  const stagingResetJob = successfulJob(
+    stagingReset.jobs,
+    "reset isolated staging",
+  );
   const validationJob = successfulJob(
     migration.jobs,
     "validate production request",
@@ -608,6 +644,31 @@ export async function collectClinicReadinessEvidence(
   requireSuccessfulStep(stagingMigrationJob, "Apply migrations");
   requireSuccessfulStep(stagingMigrationJob, "Re-apply row-level security");
   requireSuccessfulStep(stagingMigrationJob, "Verify schema matches the code");
+  requireSuccessfulStep(
+    stagingResetValidationJob,
+    "Require exact staging revision and destructive confirmation",
+  );
+  requireSuccessfulStep(
+    stagingResetJob,
+    "Reject protected or mismatched staging project",
+  );
+  requireSuccessfulStep(stagingResetJob, "Verify database target identity");
+  requireSuccessfulStep(
+    stagingResetJob,
+    "Reset every staging application table",
+  );
+  requireSuccessfulStep(
+    stagingResetJob,
+    "Seed repository-owned synthetic clinic",
+  );
+  requireSuccessfulStep(
+    stagingResetJob,
+    "Verify exact schema and migration history",
+  );
+  requireSuccessfulStep(
+    stagingResetJob,
+    "Prove synthetic-only staging data and contact boundaries",
+  );
   requireSuccessfulStep(validationJob, "Require exact revision confirmation");
   requireSuccessfulStep(productionMigrationJob, "Apply migrations");
   requireSuccessfulStep(productionMigrationJob, "Re-apply row-level security");
@@ -687,7 +748,7 @@ export async function collectClinicReadinessEvidence(
   }
 
   return {
-    evidenceFormatVersion: 6,
+    evidenceFormatVersion: 7,
     releaseSha,
     ci: {
       releaseSha,
@@ -711,11 +772,18 @@ export async function collectClinicReadinessEvidence(
     repositoryGovernance,
     staging: {
       releaseSha,
+      databaseTargetFingerprint: stagingDatabaseFingerprint,
       migrationRunId: stagingMigrationRunId,
       migrationRunUrl:
         typeof stagingMigration.run.html_url === "string"
           ? stagingMigration.run.html_url
           : undefined,
+      resetRunId: stagingResetRunId,
+      resetRunUrl:
+        typeof stagingReset.run.html_url === "string"
+          ? stagingReset.run.html_url
+          : undefined,
+      syntheticDataAudit: "passed",
       hostedHealth: {
         releaseSha,
         checkedAt,

--- a/apps/web/lib/clinic-readiness-release.ts
+++ b/apps/web/lib/clinic-readiness-release.ts
@@ -25,6 +25,7 @@ export const REQUIRED_RELEASE_CI_GATES = [
 
 const REQUIRED_HOSTED_CHECKS = [
   "hostedRelease",
+  "hostedDatabaseIdentity",
   "database",
   "schema",
   "hostedRlsRole",
@@ -84,6 +85,7 @@ function evaluateHostedHealthEvidence(
   label: "Hosted" | "Staging hosted",
   value: unknown,
   releaseSha: string | null,
+  expectedDatabaseFingerprint: string | null,
   nowMs: number,
 ) {
   const hosted = record(value);
@@ -113,6 +115,14 @@ function evaluateHostedHealthEvidence(
   if (releaseSha && body?.releaseSha !== releaseSha) {
     reasons.push(`${label} health body does not identify the release SHA.`);
   }
+  if (
+    !expectedDatabaseFingerprint ||
+    body?.databaseTargetFingerprint !== expectedDatabaseFingerprint
+  ) {
+    reasons.push(
+      `${label} health does not match the expected database target.`,
+    );
+  }
   const checks = record(body?.checks);
   for (const checkName of REQUIRED_HOSTED_CHECKS) {
     const check = record(checks?.[checkName]);
@@ -139,8 +149,8 @@ export function evaluateClinicReadinessRelease(
 ): ClinicReadinessDecision {
   const reasons: string[] = [];
   const root = record(input);
-  if (root?.evidenceFormatVersion !== 6) {
-    reasons.push("Clinic readiness evidence format version must be 6.");
+  if (root?.evidenceFormatVersion !== 7) {
+    reasons.push("Clinic readiness evidence format version must be 7.");
   }
   const releaseSha =
     root &&
@@ -390,11 +400,48 @@ export function evaluateClinicReadinessRelease(
     ) {
       reasons.push("Isolated staging migration run ID is missing or invalid.");
     }
+    if (
+      typeof staging.resetRunId !== "number" ||
+      !Number.isSafeInteger(staging.resetRunId) ||
+      staging.resetRunId <= 0
+    ) {
+      reasons.push("Isolated staging reset run ID is missing or invalid.");
+    }
+    if (staging.syntheticDataAudit !== "passed") {
+      reasons.push(
+        "Isolated staging synthetic-data and contact audit has not passed.",
+      );
+    }
+    const stagingDatabaseFingerprint =
+      typeof staging.databaseTargetFingerprint === "string" &&
+      /^[0-9a-f]{64}$/i.test(staging.databaseTargetFingerprint)
+        ? staging.databaseTargetFingerprint.toLowerCase()
+        : null;
+    if (!stagingDatabaseFingerprint) {
+      reasons.push(
+        "Isolated staging database fingerprint is missing or invalid.",
+      );
+    }
+    const clinicalDatabaseFingerprint =
+      typeof clinicalDataIntegrity?.databaseTargetFingerprint === "string" &&
+      /^[0-9a-f]{64}$/i.test(clinicalDataIntegrity.databaseTargetFingerprint)
+        ? clinicalDataIntegrity.databaseTargetFingerprint.toLowerCase()
+        : null;
+    if (
+      stagingDatabaseFingerprint &&
+      clinicalDatabaseFingerprint &&
+      stagingDatabaseFingerprint === clinicalDatabaseFingerprint
+    ) {
+      reasons.push(
+        "Isolated staging and clinical production use the same database target.",
+      );
+    }
     evaluateHostedHealthEvidence(
       reasons,
       "Staging hosted",
       staging.hostedHealth,
       releaseSha,
+      stagingDatabaseFingerprint,
       nowMs,
     );
   }
@@ -404,6 +451,9 @@ export function evaluateClinicReadinessRelease(
     "Hosted",
     root?.hostedHealth,
     releaseSha,
+    typeof clinicalDataIntegrity?.databaseTargetFingerprint === "string"
+      ? clinicalDataIntegrity.databaseTargetFingerprint.toLowerCase()
+      : null,
     nowMs,
   );
 

--- a/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
+++ b/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  collect: vi.fn(async () => ({ evidenceFormatVersion: 6 })),
+  collect: vi.fn(async () => ({ evidenceFormatVersion: 7 })),
   evaluate: vi.fn(() => ({
     decision: "GO",
     evaluatedAt: "2026-08-29T21:00:00.000Z",
@@ -47,6 +47,10 @@ function argumentsFor(output: string): string[] {
     "101",
     "--staging-migration-run-id",
     "151",
+    "--staging-reset-run-id",
+    "171",
+    "--staging-database-fingerprint",
+    "e".repeat(64),
     "--migration-run-id",
     "202",
     "--staging-health-url",

--- a/apps/web/scripts/collect-clinic-readiness-evidence.ts
+++ b/apps/web/scripts/collect-clinic-readiness-evidence.ts
@@ -11,6 +11,8 @@ const VALUE_ARGS = new Set([
   "--repository",
   "--ci-run-id",
   "--staging-migration-run-id",
+  "--staging-reset-run-id",
+  "--staging-database-fingerprint",
   "--migration-run-id",
   "--staging-health-url",
   "--hosted-health-url",
@@ -33,7 +35,7 @@ function argumentsMap(args: string[]): Map<string, string> {
     const value = normalized[index + 1]?.trim();
     if (!name || !VALUE_ARGS.has(name) || !value || values.has(name)) {
       throw new Error(
-        "Usage: release:clinic-readiness:collect -- --release-sha <sha> --repository <owner/name> --ci-run-id <id> --staging-migration-run-id <id> --migration-run-id <id> --staging-health-url <https-url> --hosted-health-url <https-url> --restore-evidence <path> --incident-evidence <path> --auth-recovery-evidence <path> --clinical-database-fingerprint <sha256> --controlled-substance-audit <path> --prescription-audit <path> --lab-result-audit <path> --vaccination-audit <path> --output <path>",
+        "Usage: release:clinic-readiness:collect -- --release-sha <sha> --repository <owner/name> --ci-run-id <id> --staging-migration-run-id <id> --staging-reset-run-id <id> --staging-database-fingerprint <sha256> --migration-run-id <id> --staging-health-url <https-url> --hosted-health-url <https-url> --restore-evidence <path> --incident-evidence <path> --auth-recovery-evidence <path> --clinical-database-fingerprint <sha256> --controlled-substance-audit <path> --prescription-audit <path> --lab-result-audit <path> --vaccination-audit <path> --output <path>",
       );
     }
     values.set(name, value);
@@ -70,6 +72,11 @@ export async function main(args = process.argv.slice(2)) {
       values.get("--staging-migration-run-id")!,
       "Staging migration run ID",
     ),
+    stagingResetRunId: positiveInteger(
+      values.get("--staging-reset-run-id")!,
+      "Staging reset run ID",
+    ),
+    stagingDatabaseFingerprint: values.get("--staging-database-fingerprint")!,
     migrationRunId: positiveInteger(
       values.get("--migration-run-id")!,
       "Production migration run ID",

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -182,7 +182,7 @@ PLATFORM_ADMIN_EMAILS=...
 
 ### Transitional production release gate
 
-Before production approval, collect one PHI-free, format-version `6` JSON
+Before production approval, collect one PHI-free, format-version `7` JSON
 evidence packet from authoritative sources. Export a read-only `GITHUB_TOKEN`
 in the secure operator environment. Immediately before collection, run all four
 aggregate-only audits against the same intended production database. Each audit
@@ -208,6 +208,8 @@ pnpm --filter @openpims/web release:clinic-readiness:collect -- \
   --repository evangauer/openvpm \
   --ci-run-id "$CI_RUN_ID" \
   --staging-migration-run-id "$STAGING_MIGRATION_RUN_ID" \
+  --staging-reset-run-id "$STAGING_RESET_RUN_ID" \
+  --staging-database-fingerprint "$STAGING_DATABASE_TARGET_FINGERPRINT" \
   --migration-run-id "$PRODUCTION_MIGRATION_RUN_ID" \
   --staging-health-url "$STAGING_HEALTH_URL" \
   --hosted-health-url https://app.openvpm.com/api/health \
@@ -223,8 +225,9 @@ pnpm --filter @openpims/web release:clinic-readiness:collect -- \
 ```
 
 The collector refuses to overwrite an existing packet. It verifies the
-successful exact-SHA `main` CI run, an exact-SHA migration from the canonical
-`staging` branch, and the manually confirmed exact-SHA production migration,
+successful exact-SHA `main` CI run, an exact-SHA migration and protected
+synthetic reset from the canonical `staging` branch, and the manually confirmed
+exact-SHA production migration,
 RLS, and drift steps directly through GitHub. It fetches both isolated staging
 and production HTTPS health, requires both deployments to identify the same
 release SHA, and rejects any required dependency that is unhealthy or advisory.
@@ -249,7 +252,8 @@ pnpm --filter @openpims/web release:clinic-readiness -- \
 
 The command returns `GO` only when migrations, RLS, tests, build, and the
 production dependency audit passed for that exact SHA; isolated staging
-migration and health passed for the same SHA before production; production
+migration, protected reset, synthetic contact audit, and health passed for the
+same SHA before production; production
 health is a fresh HTTP 200 hosted result whose response reports that same
 deployment SHA; backup freshness and 100% independent file coverage are
 affirmative (not advisory) in both hosted environments;
@@ -318,6 +322,16 @@ all committed migrations, full RLS reapplication, and a final exact-schema
 check. Run `pnpm db:seed` only with the documented synthetic seed and route all
 email/SMS/payment destinations to non-delivering or allowlisted sandbox
 providers.
+
+After migrations and before collecting staging health evidence, dispatch
+**Reset isolated staging** from the canonical `staging` branch. Supply its exact
+40-character head commit and type `RESET_STAGING_DATA`. The protected workflow
+shares the staging migration concurrency lock, re-verifies the project ref and
+target fingerprints, truncates every application table in `public`, applies
+the repository-owned seed, reapplies RLS, checks exact schema/history, and
+scans every email/phone/E.164 contact column. An extra fixture or a destination
+outside reserved example domains and the synthetic 555 range fails the run.
+This operation is destructive by design and is never available to Production.
 
 If Resend is configured in Development or Staging, set
 `NONPRODUCTION_EMAIL_RECIPIENT_HASHES` to 1-20 comma-separated SHA-256 hashes of

--- a/packages/db/audit-staging-synthetic-data.ts
+++ b/packages/db/audit-staging-synthetic-data.ts
@@ -1,0 +1,142 @@
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { sql } from "drizzle-orm";
+import { db } from "./client";
+import { assertStagingResetPolicy } from "./reset-policy";
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+type ContactColumn = {
+  table_name: string;
+  column_name: string;
+  contact_kind: "email" | "phone";
+};
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+async function unsafeContactCount(column: ContactColumn): Promise<number> {
+  const table = `${quoteIdentifier("public")}.${quoteIdentifier(column.table_name)}`;
+  const field = quoteIdentifier(column.column_name);
+  const safeExpression =
+    column.contact_kind === "email"
+      ? `lower(${field}::text) ~ '@([a-z0-9-]+\\.)*(example\\.(com|net|org)|invalid)$'`
+      : `regexp_replace(${field}::text, '[^0-9]', '', 'g') ~ '^(1)?555[0-9]*$'`;
+  const rows = await db.execute<{ unsafe_count: number }>(
+    sql.raw(`select count(*)::int as unsafe_count from ${table}
+      where ${field} is not null
+        and btrim(${field}::text) <> ''
+        and not (${safeExpression})`),
+  );
+  return rows[0]?.unsafe_count ?? 0;
+}
+
+async function main(): Promise<number> {
+  try {
+    const target = assertStagingResetPolicy(process.env);
+    const releaseSha = required("STAGING_RELEASE_SHA").toLowerCase();
+    if (!SHA_PATTERN.test(releaseSha)) {
+      throw new Error("STAGING_RELEASE_SHA must be an exact commit SHA.");
+    }
+
+    const [counts] = await db.execute<{
+      practices: number;
+      locations: number;
+      users: number;
+      clients: number;
+      patients: number;
+      known_seed_practices: number;
+    }>(sql`
+      select
+        (select count(*)::int from practices) as practices,
+        (select count(*)::int from locations) as locations,
+        (select count(*)::int from users) as users,
+        (select count(*)::int from clients) as clients,
+        (select count(*)::int from patients) as patients,
+        (select count(*)::int from practices
+          where email = 'hello@neighborhoodvet.example.com'
+            and name = 'Neighborhood Veterinary') as known_seed_practices
+    `);
+    if (!counts) throw new Error("Staging fixture counts are unavailable.");
+
+    const contactColumns = await db.execute<ContactColumn>(sql`
+      select table_name, column_name,
+        case
+          when column_name ~ '(^|_)email$' then 'email'
+          else 'phone'
+        end as contact_kind
+      from information_schema.columns
+      where table_schema = 'public'
+        and data_type in ('character varying', 'text')
+        and (
+          column_name ~ '(^|_)email$'
+          or column_name ~ '(phone|e164)$'
+        )
+      order by table_name, column_name
+    `);
+    const findings: Array<{
+      table: string;
+      column: string;
+      kind: "email" | "phone";
+      unsafeRows: number;
+    }> = [];
+    for (const column of contactColumns) {
+      const unsafeRows = await unsafeContactCount(column);
+      if (unsafeRows > 0) {
+        findings.push({
+          table: column.table_name,
+          column: column.column_name,
+          kind: column.contact_kind,
+          unsafeRows,
+        });
+      }
+    }
+
+    const expectedCounts = {
+      practices: 1,
+      locations: 1,
+      users: 8,
+      clients: 25,
+      patients: 40,
+      known_seed_practices: 1,
+    };
+    const fixtureMatches = Object.entries(expectedCounts).every(
+      ([name, count]) => counts[name as keyof typeof counts] === count,
+    );
+    const releaseSafe = fixtureMatches && findings.length === 0;
+    const evidence = {
+      evidenceFormatVersion: 1,
+      releaseSha,
+      checkedAt: new Date().toISOString(),
+      databaseTargetFingerprint: target.projectRefFingerprint,
+      resetSource: "repository-seed",
+      fixtureCounts: counts,
+      inspectedContactColumns: contactColumns.length,
+      findings,
+      syntheticOnly: releaseSafe,
+      realContactDestinationsFree: findings.length === 0,
+      releaseSafe,
+    };
+    const outputPath = process.env.STAGING_SYNTHETIC_EVIDENCE_PATH?.trim();
+    if (outputPath) writeFileSync(outputPath, `${JSON.stringify(evidence)}\n`);
+    console.log(JSON.stringify(evidence));
+    if (!releaseSafe) throw new Error("Staging synthetic-data audit failed.");
+    return 0;
+  } catch (error) {
+    console.error(
+      error instanceof Error ? error.message : "Staging data audit failed.",
+    );
+    return 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exitCode = await main();
+}

--- a/packages/db/audit-staging-synthetic-data.ts
+++ b/packages/db/audit-staging-synthetic-data.ts
@@ -138,5 +138,5 @@ async function main(): Promise<number> {
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  process.exitCode = await main();
+  process.exit(await main());
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,12 +13,16 @@
     "./rls-preflight": "./rls-preflight.ts"
   },
   "scripts": {
+    "test": "tsx --test reset-policy.test.ts",
     "type-check": "tsc --noEmit",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx seed.ts",
     "db:reset": "tsx reset.ts",
+    "db:reset:staging": "tsx reset-staging.ts",
+    "db:reset:test": "tsx test-reset.ts",
+    "db:staging:synthetic:audit": "tsx audit-staging-synthetic-data.ts",
     "db:rls": "tsx apply-rls.ts",
     "db:rls:preflight": "tsx rls-preflight.ts",
     "db:rls:preflight:test": "tsx test-rls-preflight.ts",

--- a/packages/db/reset-policy.test.ts
+++ b/packages/db/reset-policy.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { databaseTargetFingerprint } from "./deployment-target";
+import {
+  assertLocalResetPolicy,
+  assertStagingResetPolicy,
+} from "./reset-policy";
+
+const isolatedRef = "abcdefghijklmnopqrst";
+const isolatedUrl = `postgresql://owner:secret@db.${isolatedRef}.supabase.co:5432/postgres`;
+const isolatedFingerprint = databaseTargetFingerprint(isolatedRef);
+const forbiddenFingerprint = databaseTargetFingerprint("zyxwvutsrqponmlkjihg");
+
+test("local reset requires loopback, an OpenVPM database, and typed intent", () => {
+  assert.doesNotThrow(() =>
+    assertLocalResetPolicy({
+      DATABASE_URL: "postgresql://openpims:secret@127.0.0.1:5432/openpims_dev",
+      RESET_DATABASE_CONFIRMATION: "RESET_LOCAL_OPENVPM",
+      OPENVPM_ENVIRONMENT: "development",
+    }),
+  );
+  for (const env of [
+    {
+      DATABASE_URL: isolatedUrl,
+      RESET_DATABASE_CONFIRMATION: "RESET_LOCAL_OPENVPM",
+    },
+    {
+      DATABASE_URL: "postgresql://openpims:secret@localhost/openpims",
+      RESET_DATABASE_CONFIRMATION: "yes",
+    },
+    {
+      DATABASE_URL: "postgresql://openpims:secret@localhost/customer_records",
+      RESET_DATABASE_CONFIRMATION: "RESET_LOCAL_OPENVPM",
+    },
+    {
+      DATABASE_URL: "postgresql://openpims:secret@localhost/openpims",
+      RESET_DATABASE_CONFIRMATION: "RESET_LOCAL_OPENVPM",
+      CI: "true",
+    },
+  ]) {
+    assert.throws(() => assertLocalResetPolicy(env));
+  }
+});
+
+test("staging reset binds intent to the isolated environment target", () => {
+  assert.deepEqual(
+    assertStagingResetPolicy({
+      DATABASE_URL: isolatedUrl,
+      STAGING_DATABASE_URL: isolatedUrl,
+      STAGING_PROJECT_REF: isolatedRef,
+      DATABASE_TARGET_FINGERPRINT: isolatedFingerprint,
+      FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: forbiddenFingerprint,
+      OPENVPM_ENVIRONMENT: "staging",
+      STAGING_RESET_CONFIRMATION: "RESET_STAGING_DATA",
+    }),
+    { projectRefFingerprint: isolatedFingerprint },
+  );
+});
+
+test("staging reset fails closed on every identity or intent mismatch", () => {
+  const healthy = {
+    DATABASE_URL: isolatedUrl,
+    STAGING_DATABASE_URL: isolatedUrl,
+    STAGING_PROJECT_REF: isolatedRef,
+    DATABASE_TARGET_FINGERPRINT: isolatedFingerprint,
+    FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: forbiddenFingerprint,
+    OPENVPM_ENVIRONMENT: "staging",
+    STAGING_RESET_CONFIRMATION: "RESET_STAGING_DATA",
+  };
+  for (const override of [
+    { OPENVPM_ENVIRONMENT: "production" },
+    { STAGING_RESET_CONFIRMATION: "RESET_STAGING" },
+    { STAGING_PROJECT_REF: "zyxwvutsrqponmlkjihg" },
+    { DATABASE_TARGET_FINGERPRINT: forbiddenFingerprint },
+    { FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: isolatedFingerprint },
+    {
+      STAGING_DATABASE_URL:
+        "postgresql://owner:secret@db.zyxwvutsrqponmlkjihg.supabase.co/postgres",
+    },
+  ]) {
+    assert.throws(() => assertStagingResetPolicy({ ...healthy, ...override }));
+  }
+});
+
+test("staging reset independently rejects known data-bearing projects", () => {
+  const protectedRef = "pgcbnjctkohehngiyola";
+  const protectedUrl = `postgresql://owner:secret@db.${protectedRef}.supabase.co/postgres`;
+  assert.throws(
+    () =>
+      assertStagingResetPolicy({
+        DATABASE_URL: protectedUrl,
+        STAGING_DATABASE_URL: protectedUrl,
+        STAGING_PROJECT_REF: protectedRef,
+        DATABASE_TARGET_FINGERPRINT: databaseTargetFingerprint(protectedRef),
+        FORBIDDEN_DATABASE_TARGET_FINGERPRINTS: forbiddenFingerprint,
+        OPENVPM_ENVIRONMENT: "staging",
+        STAGING_RESET_CONFIRMATION: "RESET_STAGING_DATA",
+      }),
+    /protected data-bearing target/,
+  );
+});

--- a/packages/db/reset-policy.ts
+++ b/packages/db/reset-policy.ts
@@ -1,0 +1,119 @@
+import {
+  assertDatabaseTarget,
+  databaseTargetFingerprint,
+  supabaseProjectRef,
+} from "./deployment-target";
+
+export type ResetEnvironment = Readonly<Record<string, string | undefined>>;
+
+export type StagingResetEvidence = {
+  projectRefFingerprint: string;
+};
+
+const STAGING_PROJECT_REF_PATTERN = /^[a-z0-9]{20}$/;
+const PROTECTED_DATA_BEARING_FINGERPRINTS = new Set([
+  "475ea002bcfafd75c0becd388af7b396fe918bd3e57d960458b4c912d006212d",
+  "6580350addb8614fe9179d5539b91c298b28e4ebcb613020ac2abff7dbe43289",
+]);
+
+function required(env: ResetEnvironment, name: string): string {
+  const value = env[name]?.trim();
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+function postgresUrl(value: string, label: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid PostgreSQL URL.`);
+  }
+  if (!new Set(["postgres:", "postgresql:"]).has(parsed.protocol)) {
+    throw new Error(`${label} must use PostgreSQL.`);
+  }
+  if (!parsed.username || !parsed.hostname || !parsed.pathname.slice(1)) {
+    throw new Error(`${label} is missing its database identity.`);
+  }
+  return parsed;
+}
+
+/**
+ * The developer reset command is deliberately local-only. A checked-in helper
+ * must never turn an accidentally inherited hosted DATABASE_URL into a remote
+ * destructive operation.
+ */
+export function assertLocalResetPolicy(env: ResetEnvironment): void {
+  if (required(env, "RESET_DATABASE_CONFIRMATION") !== "RESET_LOCAL_OPENVPM") {
+    throw new Error(
+      "RESET_DATABASE_CONFIRMATION must equal RESET_LOCAL_OPENVPM.",
+    );
+  }
+  if (env.VERCEL?.trim() || env.CI?.trim() === "true") {
+    throw new Error("The local reset command cannot run in CI or Vercel.");
+  }
+  const declared = env.OPENVPM_ENVIRONMENT?.trim();
+  if (declared && declared !== "development") {
+    throw new Error("The local reset command only permits development.");
+  }
+  const url = postgresUrl(required(env, "DATABASE_URL"), "DATABASE_URL");
+  const hostname = url.hostname.toLowerCase();
+  if (!new Set(["localhost", "127.0.0.1", "::1"]).has(hostname)) {
+    throw new Error("The local reset command refuses non-loopback databases.");
+  }
+  const databaseName = decodeURIComponent(url.pathname.slice(1));
+  if (!/^openpims(?:_[a-z0-9_]+)?$/.test(databaseName)) {
+    throw new Error(
+      "The local reset command requires an openpims development database name.",
+    );
+  }
+}
+
+/**
+ * Staging resets are a separate, environment-protected operation. Identity is
+ * checked three ways: the URL's Supabase ref, its expected fingerprint, and a
+ * mandatory forbidden-target set. No secret or raw project ref is returned.
+ */
+export function assertStagingResetPolicy(
+  env: ResetEnvironment,
+): StagingResetEvidence {
+  if (required(env, "OPENVPM_ENVIRONMENT") !== "staging") {
+    throw new Error("OPENVPM_ENVIRONMENT must equal staging.");
+  }
+  if (required(env, "STAGING_RESET_CONFIRMATION") !== "RESET_STAGING_DATA") {
+    throw new Error(
+      "STAGING_RESET_CONFIRMATION must equal RESET_STAGING_DATA.",
+    );
+  }
+  const databaseUrl = required(env, "DATABASE_URL");
+  const stagingDatabaseUrl = required(env, "STAGING_DATABASE_URL");
+  if (databaseUrl !== stagingDatabaseUrl) {
+    throw new Error(
+      "DATABASE_URL must be the environment-scoped STAGING_DATABASE_URL.",
+    );
+  }
+  postgresUrl(databaseUrl, "STAGING_DATABASE_URL");
+  const projectRef = supabaseProjectRef(databaseUrl);
+  const expectedProjectRef = required(env, "STAGING_PROJECT_REF").toLowerCase();
+  if (
+    !STAGING_PROJECT_REF_PATTERN.test(expectedProjectRef) ||
+    !projectRef ||
+    projectRef !== expectedProjectRef
+  ) {
+    throw new Error(
+      "STAGING_DATABASE_URL does not identify STAGING_PROJECT_REF.",
+    );
+  }
+  assertDatabaseTarget({
+    databaseUrl,
+    expectedFingerprint: env.DATABASE_TARGET_FINGERPRINT,
+    forbiddenFingerprints: env.FORBIDDEN_DATABASE_TARGET_FINGERPRINTS,
+  });
+  const projectRefFingerprint = databaseTargetFingerprint(projectRef);
+  if (PROTECTED_DATA_BEARING_FINGERPRINTS.has(projectRefFingerprint)) {
+    throw new Error(
+      "The configured database is a protected data-bearing target, not disposable staging.",
+    );
+  }
+  return { projectRefFingerprint };
+}

--- a/packages/db/reset-staging.ts
+++ b/packages/db/reset-staging.ts
@@ -1,0 +1,29 @@
+import { fileURLToPath } from "node:url";
+import { resetDatabase } from "./reset";
+import { assertStagingResetPolicy } from "./reset-policy";
+
+async function main(): Promise<number> {
+  try {
+    const target = assertStagingResetPolicy(process.env);
+    const count = await resetDatabase();
+    console.log(
+      JSON.stringify({
+        status: "passed",
+        resetEnvironment: "staging",
+        projectRefFingerprint: target.projectRefFingerprint,
+        tablesReset: count,
+      }),
+    );
+    return 0;
+  } catch (error) {
+    console.error(
+      "Staging reset refused:",
+      error instanceof Error ? error.message : "invalid reset request",
+    );
+    return 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exitCode = await main();
+}

--- a/packages/db/reset-staging.ts
+++ b/packages/db/reset-staging.ts
@@ -25,5 +25,5 @@ async function main(): Promise<number> {
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  process.exitCode = await main();
+  process.exit(await main());
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -48,5 +48,5 @@ async function main(): Promise<number> {
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  process.exitCode = await main();
+  process.exit(await main());
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -1,96 +1,52 @@
 import { config } from "dotenv";
 config({ path: "../../.env" });
+import { fileURLToPath } from "node:url";
 import { sql } from "drizzle-orm";
 import { db } from "./client";
+import { assertLocalResetPolicy } from "./reset-policy";
+import { declaredSchema } from "./schema-drift";
 
-// Order doesn't matter with CASCADE, but we TRUNCATE every table the seed touches.
-// RESTART IDENTITY resets any serial sequences (none in this schema, but cheap).
-const TABLES = [
-  "historical_documents",
-  "legacy_financial_allocations",
-  "legacy_financial_line_items",
-  "legacy_financial_payments",
-  "legacy_financial_documents",
-  "external_lab_observations",
-  "external_lab_reports",
-  "external_prescription_fills",
-  "external_prescriptions",
-  "historical_appointments",
-  "client_contacts",
-  "sms_provider_event_resolutions",
-  "messaging_registration_events",
-  "sms_provider_event_conflict_reviews",
-  "sms_provider_event_conflicts",
-  "sms_provider_events",
-  // Core / leaf tables first (purely defensive — CASCADE handles it)
-  "audit_log",
-  "rate_limit_buckets",
-  "stripe_events",
-  "subscription_cadence_operations",
-  "subscription_checkout_attempts",
-  "practice_conversion_milestones",
-  "auth_email_webhook_conflicts",
-  "auth_email_provider_identity_conflicts",
-  "auth_email_delivery_events",
-  "auth_email_attempts",
-  "lifecycle_email_attempts",
-  "lifecycle_email_jobs",
-  "usage_records",
-  "controlled_substance_log",
-  "payments",
-  "communications",
-  "care_reminders",
-  "webhooks",
-  "api_keys",
-  "treatment_template_items",
-  "treatment_templates",
-  "sms_delivery_event_history",
-  "sms_delivery_events",
-  "sms_send_attempt_events",
-  "sms_send_attempts",
-  "sms_consent_events",
-  "patient_merge_events",
-  "dispense_charge_queue",
-  "invoice_items",
-  "invoices",
-  "soap_note_replacements",
-  "lab_result_replacements",
-  "clinical_record_corrections",
-  "lab_result_events",
-  "lab_results",
-  "procedures",
-  "visit_closeouts",
-  "prescription_events",
-  "prescriptions",
-  "vaccination_records",
-  "soap_notes",
-  "appointments",
-  "rooms",
-  "appointment_types",
-  "patient_weights",
-  "patient_allergies",
-  "patients",
-  "clients",
-  "products",
-  "services",
-  "users",
-  "locations",
-  "practices",
-];
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
 
-async function reset() {
-  console.log("Truncating all tables...");
-  // Single statement — TRUNCATE ... CASCADE handles FK dependencies.
-  const tableList = TABLES.join(", ");
+/**
+ * Clear every application table declared by the current Drizzle schema,
+ * including tables added after this helper was written. Extension-managed
+ * public tables and the migration ledger remain intact. Callers must enforce a
+ * reset policy before invoking this function.
+ */
+export async function resetDatabase(): Promise<number> {
+  const tableNames = [...declaredSchema().keys()].sort();
+  if (tableNames.length === 0) {
+    throw new Error(
+      "Reset refused because the application schema has no tables.",
+    );
+  }
+  const tableList = tableNames
+    .map((name) => `${quoteIdentifier("public")}.${quoteIdentifier(name)}`)
+    .join(", ");
   await db.execute(
     sql.raw(`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`),
   );
-  console.log(`Truncated ${TABLES.length} tables`);
+  return tableNames.length;
 }
 
-reset()
-  .then(() => process.exit(0))
-  .catch((err) => {
-    console.error("Reset failed:", err);
-    process.exit(1);
-  });
+async function main(): Promise<number> {
+  try {
+    assertLocalResetPolicy(process.env);
+    const count = await resetDatabase();
+    console.log(`Reset ${count} local public tables.`);
+    return 0;
+  } catch (error) {
+    console.error(
+      "Reset refused:",
+      error instanceof Error ? error.message : "invalid reset request",
+    );
+    return 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exitCode = await main();
+}

--- a/packages/db/test-reset.ts
+++ b/packages/db/test-reset.ts
@@ -65,5 +65,5 @@ async function main(): Promise<number> {
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  process.exitCode = await main();
+  process.exit(await main());
 }

--- a/packages/db/test-reset.ts
+++ b/packages/db/test-reset.ts
@@ -1,0 +1,69 @@
+import { fileURLToPath } from "node:url";
+import { sql } from "drizzle-orm";
+import { db } from "./client";
+import { resetDatabase } from "./reset";
+
+function assertDisposableCiTarget(): void {
+  if (process.env.RESET_DB_INTEGRATION !== "1" || process.env.CI !== "true") {
+    throw new Error("Reset integration contract is CI-only.");
+  }
+  const value = process.env.DATABASE_URL;
+  if (!value) throw new Error("DATABASE_URL is required.");
+  const url = new URL(value);
+  if (
+    !new Set(["postgres:", "postgresql:"]).has(url.protocol) ||
+    !new Set(["localhost", "127.0.0.1", "::1"]).has(
+      url.hostname.toLowerCase(),
+    ) ||
+    decodeURIComponent(url.pathname.slice(1)) !== "openpims"
+  ) {
+    throw new Error(
+      "Reset integration contract requires disposable CI Postgres.",
+    );
+  }
+}
+
+async function main(): Promise<number> {
+  try {
+    assertDisposableCiTarget();
+    await db.execute(sql`
+      insert into practices (name, subscription_tier)
+      values ('Reset contract sentinel', 'cloud')
+    `);
+    const tablesReset = await resetDatabase();
+    const [remaining] = await db.execute<{ count: number }>(sql`
+      select count(*)::int as count from practices
+    `);
+    const [migrationLedger] = await db.execute<{ count: number }>(sql`
+      select count(*)::int as count from drizzle.__drizzle_migrations
+    `);
+    if (
+      tablesReset < 1 ||
+      remaining?.count !== 0 ||
+      !migrationLedger ||
+      migrationLedger.count < 1
+    ) {
+      throw new Error(
+        "Reset did not clear application data and retain history.",
+      );
+    }
+    console.log(
+      JSON.stringify({
+        status: "passed",
+        tablesReset,
+        applicationRowsRemaining: remaining.count,
+        migrationHistoryRetained: true,
+      }),
+    );
+    return 0;
+  } catch (error) {
+    console.error(
+      error instanceof Error ? error.message : "Reset integration failed.",
+    );
+    return 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  process.exitCode = await main();
+}

--- a/packages/db/test-sms-provider-event-resolutions.ts
+++ b/packages/db/test-sms-provider-event-resolutions.ts
@@ -162,11 +162,16 @@ for (const contract of [
 ]) {
   requireText(rls, contract, `RLS ${contract}`);
 }
-requireText(
-  reset,
-  '"sms_provider_event_resolutions"',
-  "reset deletes resolution children before evidence parents",
-);
+for (const contract of [
+  "declaredSchema().keys()",
+  "TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE",
+]) {
+  requireText(
+    reset,
+    contract,
+    `schema-derived reset includes SMS resolution evidence: ${contract}`,
+  );
+}
 for (const contract of [
   "sms_provider_event_resolutions_shape_check",
   "sms_provider_event_resolutions_validate_insert",


### PR DESCRIPTION
## Outcome

Makes database reset operations fail closed and adds a protected, exact-SHA workflow for rebuilding isolated staging from repository-owned synthetic data.

This is a stacked draft on #305. It does **not** provision staging, run the hosted reset, merge, deploy, spend, or authorize clinic use.

## Safety changes

- `pnpm db:reset` now requires `RESET_DATABASE_CONFIRMATION=RESET_LOCAL_OPENVPM`, accepts only loopback `openpims*` development databases, and refuses CI/Vercel and non-development environments.
- Reset scope is derived from the current Drizzle application schema, so new application tables cannot be silently omitted and extension-managed public tables remain untouched.
- The separate staging command requires the Staging environment identity, exact Supabase ref, expected database fingerprint, forbidden-target set, typed destructive confirmation, and an independent hard-coded refusal for both known data-bearing OpenVPM projects.
- The manual **Reset isolated staging** workflow is restricted to the canonical `staging` head and exact SHA, runs under the protected `Staging` environment, shares the migration concurrency lock, migrates, resets, seeds, reapplies RLS, and verifies schema/history.
- The post-reset audit checks exact seed identity/counts and every declared email/phone/E.164 contact column without printing values. Only reserved example domains and the synthetic 555 range pass.
- Hosted health now emits a credential-free database target fingerprint.
- Clinic-readiness evidence format v7 requires the exact-SHA staging reset run, passing synthetic/contact audit, staging health bound to that fingerprint, production health bound to the independently collected clinical database fingerprint, and distinct staging/production targets.
- The disposable CI PostgreSQL job now exercises the real schema-driven reset last and proves application rows are cleared while migration history survives.

## Verification

- `pnpm lint`
- `pnpm type-check`
- `pnpm test` — DB 4/4; web 4,613 passed, 31 intentional integration skips
- `pnpm build` — 56 static pages
- focused health/release/reset tests — 85/85 plus 86/86 migration/lab safety checks
- `pnpm audit --prod --audit-level high` — no known vulnerabilities
- `pnpm verify:oss-release` — 1,566 tracked files
- `pnpm verify:secrets` — 9 reviewed synthetic fixture exceptions
- `pnpm verify:secret-artifacts` — 9 structurally classified framework/dependency findings
- `git diff --check`

The workstation PostgreSQL role cannot create a disposable database, so the destructive integration exercise is intentionally confined to the existing ephemeral GitHub PostgreSQL service. Hosted staging remains unavailable because the protected environment has no configured secrets or variables.

## Release boundary

Current status remains `NO_GO`. Do not merge or dispatch the staging reset until an isolated provider project, independently protected reviewer, environment-scoped credentials, and cost authorization exist.
