### PR TITLE
fix(recovery): require exact legacy file evidence

### DIFF
--- a/apps/web/lib/__tests__/legacy-file-recovery.test.ts
+++ b/apps/web/lib/__tests__/legacy-file-recovery.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertLegacyRecoveryStorageSeparation,
   bytesMatch,
   inspectLegacyFileBytes,
   parseLegacyFileRecoveryArgs,
@@ -13,6 +14,42 @@ const FILE_ID = "123e4567-e89b-42d3-a456-426614174000";
 const CHECKSUM = "a".repeat(64);
 
 describe("legacy file recovery", () => {
+  it("rejects a legacy source that is also the primary or replica target", () => {
+    expect(() =>
+      assertLegacyRecoveryStorageSeparation({
+        legacyEndpoint: "https://s3.example.test/",
+        legacyBucket: "Clinic-Objects",
+        primaryProvider: "s3",
+        primaryEndpoint: "https://S3.EXAMPLE.TEST",
+        primaryBucket: "clinic-objects",
+      }),
+    ).toThrow("distinct from primary storage");
+
+    expect(() =>
+      assertLegacyRecoveryStorageSeparation({
+        legacyEndpoint: "https://legacy.example.test",
+        legacyBucket: "legacy-files",
+        primaryProvider: "vercel_blob",
+        replicaProvider: "s3",
+        replicaEndpoint: "https://legacy.example.test/",
+        replicaBucket: "LEGACY-FILES",
+      }),
+    ).toThrow("distinct from independent replica storage");
+  });
+
+  it("accepts distinct legacy, primary, and replica targets", () => {
+    expect(() =>
+      assertLegacyRecoveryStorageSeparation({
+        legacyEndpoint: "https://legacy.example.test",
+        legacyBucket: "legacy-files",
+        primaryProvider: "vercel_blob",
+        replicaProvider: "s3",
+        replicaEndpoint: "https://replica.example.test",
+        replicaBucket: "recovery-files",
+      }),
+    ).not.toThrow();
+  });
+
   it("checks exact-byte authorization before reading legacy provider bytes", () => {
     const script = readFileSync(
       resolve("scripts/recover-legacy-file.ts"),

--- a/apps/web/lib/__tests__/legacy-file-recovery.test.ts
+++ b/apps/web/lib/__tests__/legacy-file-recovery.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertLegacyRecoveryDatabaseIdentity,
   assertLegacyRecoveryStorageSeparation,
   bytesMatch,
   inspectLegacyFileBytes,
@@ -14,6 +15,32 @@ const FILE_ID = "123e4567-e89b-42d3-a456-426614174000";
 const CHECKSUM = "a".repeat(64);
 
 describe("legacy file recovery", () => {
+  it("binds executed recovery to an independently expected database identity", () => {
+    const databaseUrl =
+      "postgresql://recovery_owner:secret@db.example.test:5432/openpims";
+    const expectedFingerprint =
+      "ce8185206ff644bc44614a3f67020bac52693e7244daa62c350a0b423df3a722";
+
+    expect(
+      assertLegacyRecoveryDatabaseIdentity({
+        databaseUrl,
+        expectedFingerprint,
+      }),
+    ).toBe(expectedFingerprint);
+    expect(() =>
+      assertLegacyRecoveryDatabaseIdentity({
+        databaseUrl,
+        expectedFingerprint: "b".repeat(64),
+      }),
+    ).toThrow("does not match");
+    expect(() =>
+      assertLegacyRecoveryDatabaseIdentity({
+        databaseUrl,
+        expectedFingerprint: undefined,
+      }),
+    ).toThrow("not configured");
+  });
+
   it("rejects a legacy source that is also the primary or replica target", () => {
     expect(() =>
       assertLegacyRecoveryStorageSeparation({
@@ -59,9 +86,11 @@ describe("legacy file recovery", () => {
       "const expectedChecksumSha256 = resolveLegacyRecoveryChecksum",
     );
     const providerRead = script.indexOf("const legacy = legacyClient()");
+    const cleanExit = script.indexOf(".then(() => process.exit(0))");
 
     expect(evidenceGate).toBeGreaterThan(0);
     expect(providerRead).toBeGreaterThan(evidenceGate);
+    expect(cleanExit).toBeGreaterThan(providerRead);
   });
 
   it("keeps audit read-only and scoped to one UUID", () => {

--- a/apps/web/lib/__tests__/legacy-file-recovery.test.ts
+++ b/apps/web/lib/__tests__/legacy-file-recovery.test.ts
@@ -1,13 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   bytesMatch,
   inspectLegacyFileBytes,
   parseLegacyFileRecoveryArgs,
+  resolveLegacyRecoveryChecksum,
+  sha256Hex,
 } from "../legacy-file-recovery";
 
 const FILE_ID = "123e4567-e89b-42d3-a456-426614174000";
+const CHECKSUM = "a".repeat(64);
 
 describe("legacy file recovery", () => {
+  it("checks exact-byte authorization before reading legacy provider bytes", () => {
+    const script = readFileSync(
+      resolve("scripts/recover-legacy-file.ts"),
+      "utf8",
+    );
+    const evidenceGate = script.indexOf(
+      "const expectedChecksumSha256 = resolveLegacyRecoveryChecksum",
+    );
+    const providerRead = script.indexOf("const legacy = legacyClient()");
+
+    expect(evidenceGate).toBeGreaterThan(0);
+    expect(providerRead).toBeGreaterThan(evidenceGate);
+  });
+
   it("keeps audit read-only and scoped to one UUID", () => {
     expect(
       parseLegacyFileRecoveryArgs(["audit", "--file-id", FILE_ID]),
@@ -16,6 +35,7 @@ describe("legacy file recovery", () => {
       fileId: FILE_ID,
       execute: false,
       confirmation: undefined,
+      expectedChecksumSha256: undefined,
     });
     expect(() =>
       parseLegacyFileRecoveryArgs(["audit", "--file-id", FILE_ID, "--execute"]),
@@ -47,6 +67,76 @@ describe("legacy file recovery", () => {
         `RESTORE-LEGACY-FILE:${FILE_ID}`,
       ]).execute,
     ).toBe(true);
+
+    expect(() =>
+      parseLegacyFileRecoveryArgs([
+        "restore",
+        "--file-id",
+        FILE_ID,
+        "--execute",
+        "--expected-sha256",
+        CHECKSUM,
+        "--confirmation",
+        `RESTORE-LEGACY-FILE:${FILE_ID}`,
+      ]),
+    ).toThrow(`RESTORE-LEGACY-FILE:${FILE_ID}:${CHECKSUM}`);
+
+    expect(
+      parseLegacyFileRecoveryArgs([
+        "restore",
+        "--file-id",
+        FILE_ID,
+        "--execute",
+        "--expected-sha256",
+        CHECKSUM,
+        "--confirmation",
+        `RESTORE-LEGACY-FILE:${FILE_ID}:${CHECKSUM}`,
+      ]).expectedChecksumSha256,
+    ).toBe(CHECKSUM);
+  });
+
+  it("rejects malformed reviewed checksum evidence", () => {
+    expect(() =>
+      parseLegacyFileRecoveryArgs([
+        "audit",
+        "--file-id",
+        FILE_ID,
+        "--expected-sha256",
+        "ABC123",
+      ]),
+    ).toThrow("lowercase SHA-256 digest");
+  });
+
+  it("requires reviewed exact-byte evidence before executing a checksum-less restore", () => {
+    expect(
+      resolveLegacyRecoveryChecksum({
+        recordedChecksumSha256: null,
+        execute: false,
+      }),
+    ).toBeNull();
+    expect(() =>
+      resolveLegacyRecoveryChecksum({
+        recordedChecksumSha256: null,
+        execute: true,
+      }),
+    ).toThrow("separately reviewed --expected-sha256");
+    expect(
+      resolveLegacyRecoveryChecksum({
+        recordedChecksumSha256: null,
+        reviewedChecksumSha256: CHECKSUM,
+        execute: true,
+      }),
+    ).toBe(CHECKSUM);
+  });
+
+  it("rejects reviewed evidence that conflicts with the recorded checksum", () => {
+    expect(() =>
+      resolveLegacyRecoveryChecksum({
+        recordedChecksumSha256: "b".repeat(64),
+        reviewedChecksumSha256: CHECKSUM,
+        execute: true,
+      }),
+    ).toThrow("does not match the recorded manifest checksum");
   });
 
   it("verifies legacy bytes without exposing their contents", () => {
@@ -54,7 +144,7 @@ describe("legacy file recovery", () => {
     const inspected = inspectLegacyFileBytes({
       body,
       expectedFileSizeBytes: body.byteLength,
-      expectedChecksumSha256: null,
+      expectedChecksumSha256: sha256Hex(body),
     });
 
     expect(inspected.sizeMatches).toBe(true);
@@ -80,5 +170,16 @@ describe("legacy file recovery", () => {
         expectedChecksumSha256: null,
       }).sizeMatches,
     ).toBe(false);
+  });
+
+  it("does not treat a missing expected checksum as a successful match", () => {
+    const inspected = inspectLegacyFileBytes({
+      body: new Uint8Array([1, 2, 3]),
+      expectedFileSizeBytes: 3,
+      expectedChecksumSha256: null,
+    });
+
+    expect(inspected.sizeMatches).toBe(true);
+    expect(inspected.checksumMatches).toBe(false);
   });
 });

--- a/apps/web/lib/legacy-file-recovery.ts
+++ b/apps/web/lib/legacy-file-recovery.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { databaseConnectionIdentityFingerprint } from "@openpims/db/deployment-target";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -52,6 +53,21 @@ export function assertLegacyRecoveryStorageSeparation(input: {
       );
     }
   }
+}
+
+export function assertLegacyRecoveryDatabaseIdentity(input: {
+  databaseUrl: string;
+  expectedFingerprint: string | undefined;
+}): string {
+  const expected = input.expectedFingerprint?.trim().toLowerCase() ?? "";
+  if (!SHA256_PATTERN.test(expected)) {
+    throw new Error("Owner recovery database fingerprint is not configured.");
+  }
+  const actual = databaseConnectionIdentityFingerprint(input.databaseUrl);
+  if (actual !== expected) {
+    throw new Error("Owner recovery database fingerprint does not match.");
+  }
+  return actual;
 }
 
 export type LegacyFileRecoveryArgs = {

--- a/apps/web/lib/legacy-file-recovery.ts
+++ b/apps/web/lib/legacy-file-recovery.ts
@@ -6,6 +6,54 @@ const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 
 export const LEGACY_FILE_RECOVERY_CONFIRMATION = "RESTORE-LEGACY-FILE";
 
+function canonicalS3Target(
+  endpoint: string | undefined,
+  bucket: string | undefined,
+): string | null {
+  const normalizedBucket = bucket?.trim().toLowerCase();
+  if (!normalizedBucket) return null;
+  const normalizedEndpoint = (endpoint?.trim() || "https://s3.amazonaws.com")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+  return `${normalizedEndpoint}/${normalizedBucket}`;
+}
+
+export function assertLegacyRecoveryStorageSeparation(input: {
+  legacyEndpoint: string;
+  legacyBucket: string;
+  primaryProvider?: string;
+  primaryEndpoint?: string;
+  primaryBucket?: string;
+  replicaProvider?: string;
+  replicaEndpoint?: string;
+  replicaBucket?: string;
+}): void {
+  const legacy = canonicalS3Target(input.legacyEndpoint, input.legacyBucket);
+  if (!legacy) throw new Error("Legacy source target is invalid.");
+
+  if (input.primaryProvider?.trim() !== "vercel_blob") {
+    const primary = canonicalS3Target(
+      input.primaryEndpoint,
+      input.primaryBucket ?? "openpims",
+    );
+    if (primary === legacy) {
+      throw new Error("Legacy source must be distinct from primary storage.");
+    }
+  }
+
+  if ((input.replicaProvider?.trim() || "s3") === "s3") {
+    const replica = canonicalS3Target(
+      input.replicaEndpoint,
+      input.replicaBucket,
+    );
+    if (replica === legacy) {
+      throw new Error(
+        "Legacy source must be distinct from independent replica storage.",
+      );
+    }
+  }
+}
+
 export type LegacyFileRecoveryArgs = {
   command: "audit" | "restore";
   fileId: string;

--- a/apps/web/lib/legacy-file-recovery.ts
+++ b/apps/web/lib/legacy-file-recovery.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 
 export const LEGACY_FILE_RECOVERY_CONFIRMATION = "RESTORE-LEGACY-FILE";
 
@@ -10,6 +11,7 @@ export type LegacyFileRecoveryArgs = {
   fileId: string;
   execute: boolean;
   confirmation?: string;
+  expectedChecksumSha256?: string;
 };
 
 function flagValue(args: string[], name: string): string | undefined {
@@ -33,21 +35,79 @@ export function parseLegacyFileRecoveryArgs(
 
   const execute = normalizedArgs.includes("--execute");
   const confirmation = flagValue(normalizedArgs, "confirmation")?.trim();
+  const expectedChecksumSha256 = flagValue(
+    normalizedArgs,
+    "expected-sha256",
+  )?.trim();
+  if (
+    expectedChecksumSha256 !== undefined &&
+    !SHA256_PATTERN.test(expectedChecksumSha256)
+  ) {
+    throw new Error("--expected-sha256 must be a lowercase SHA-256 digest.");
+  }
   if (command === "audit" && execute) {
     throw new Error("audit is always read-only and does not accept --execute.");
   }
   if (command === "restore" && execute) {
-    const expected = `${LEGACY_FILE_RECOVERY_CONFIRMATION}:${fileId}`;
+    const expected = [
+      LEGACY_FILE_RECOVERY_CONFIRMATION,
+      fileId,
+      expectedChecksumSha256,
+    ]
+      .filter(Boolean)
+      .join(":");
     if (confirmation !== expected) {
       throw new Error(`--confirmation must exactly equal ${expected}.`);
     }
   }
 
-  return { command, fileId, execute, confirmation };
+  return {
+    command,
+    fileId,
+    execute,
+    confirmation,
+    expectedChecksumSha256,
+  };
 }
 
 export function sha256Hex(body: Uint8Array): string {
   return createHash("sha256").update(body).digest("hex");
+}
+
+export function resolveLegacyRecoveryChecksum(input: {
+  recordedChecksumSha256: string | null;
+  reviewedChecksumSha256?: string;
+  execute: boolean;
+}): string | null {
+  if (
+    input.recordedChecksumSha256 !== null &&
+    !SHA256_PATTERN.test(input.recordedChecksumSha256)
+  ) {
+    throw new Error("Recorded manifest checksum is invalid.");
+  }
+  if (
+    input.reviewedChecksumSha256 !== undefined &&
+    !SHA256_PATTERN.test(input.reviewedChecksumSha256)
+  ) {
+    throw new Error("Reviewed checksum is invalid.");
+  }
+  if (
+    input.recordedChecksumSha256 &&
+    input.reviewedChecksumSha256 &&
+    input.recordedChecksumSha256 !== input.reviewedChecksumSha256
+  ) {
+    throw new Error(
+      "Reviewed checksum does not match the recorded manifest checksum.",
+    );
+  }
+  const expected =
+    input.recordedChecksumSha256 ?? input.reviewedChecksumSha256 ?? null;
+  if (input.execute && expected === null) {
+    throw new Error(
+      "Checksum-less manifests require a separately reviewed --expected-sha256 before restore.",
+    );
+  }
+  return expected;
 }
 
 export function inspectLegacyFileBytes(input: {
@@ -69,7 +129,7 @@ export function inspectLegacyFileBytes(input: {
       input.expectedFileSizeBytes === null ||
       input.expectedFileSizeBytes === fileSizeBytes,
     checksumMatches:
-      input.expectedChecksumSha256 === null ||
+      input.expectedChecksumSha256 !== null &&
       input.expectedChecksumSha256 === checksumSha256,
   };
 }

--- a/apps/web/scripts/recover-legacy-file.ts
+++ b/apps/web/scripts/recover-legacy-file.ts
@@ -5,6 +5,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { files } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import {
+  assertLegacyRecoveryStorageSeparation,
   bytesMatch,
   inspectLegacyFileBytes,
   parseLegacyFileRecoveryArgs,
@@ -40,14 +41,20 @@ function legacyClient(): { client: S3Client; bucket: string } {
   const secretAccessKey = requiredEnv("LEGACY_FILE_S3_SECRET_KEY");
   const bucket = requiredEnv("LEGACY_FILE_S3_BUCKET");
 
-  if (
-    process.env.FILE_STORAGE_PROVIDER?.trim() !== "vercel_blob" &&
-    process.env.S3_ENDPOINT?.trim().replace(/\/+$/, "") ===
-      endpoint.replace(/\/+$/, "") &&
-    process.env.S3_BUCKET?.trim() === bucket
-  ) {
+  try {
+    assertLegacyRecoveryStorageSeparation({
+      legacyEndpoint: endpoint,
+      legacyBucket: bucket,
+      primaryProvider: process.env.FILE_STORAGE_PROVIDER,
+      primaryEndpoint: process.env.S3_ENDPOINT,
+      primaryBucket: process.env.S3_BUCKET,
+      replicaProvider: process.env.FILE_REPLICA_PROVIDER,
+      replicaEndpoint: process.env.FILE_REPLICA_S3_ENDPOINT,
+      replicaBucket: process.env.FILE_REPLICA_S3_BUCKET,
+    });
+  } catch (error) {
     throw new OperatorSafeError(
-      "Legacy source must be distinct from primary storage.",
+      error instanceof Error ? error.message : "Storage targets are invalid.",
     );
   }
 

--- a/apps/web/scripts/recover-legacy-file.ts
+++ b/apps/web/scripts/recover-legacy-file.ts
@@ -5,6 +5,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { files } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import {
+  assertLegacyRecoveryDatabaseIdentity,
   assertLegacyRecoveryStorageSeparation,
   bytesMatch,
   inspectLegacyFileBytes,
@@ -223,7 +224,12 @@ async function putAndVerifyPrimary(input: {
 async function main() {
   const args = parseLegacyFileRecoveryArgs(process.argv.slice(2));
   if (args.execute) {
-    process.env.DATABASE_URL = requiredEnv("OWNER_RECOVERY_DATABASE_URL");
+    const ownerDatabaseUrl = requiredEnv("OWNER_RECOVERY_DATABASE_URL");
+    assertLegacyRecoveryDatabaseIdentity({
+      databaseUrl: ownerDatabaseUrl,
+      expectedFingerprint: process.env.OWNER_RECOVERY_DATABASE_FINGERPRINT,
+    });
+    process.env.DATABASE_URL = ownerDatabaseUrl;
   }
 
   const [{ db }, storage, replication] = await Promise.all([
@@ -385,15 +391,17 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  const safeMessage =
-    error instanceof OperatorSafeError ||
-    (error instanceof Error &&
-      /^(First argument|--file-id|--confirmation|--expected-sha256|audit is always|Recorded manifest checksum|Reviewed checksum|Checksum-less manifests)/.test(
-        error.message,
-      ))
-      ? error.message
-      : "Legacy file recovery failed; inspect provider access privately.";
-  console.error(JSON.stringify({ ok: false, error: safeMessage }));
-  process.exit(1);
-});
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    const safeMessage =
+      error instanceof OperatorSafeError ||
+      (error instanceof Error &&
+        /^(First argument|--file-id|--confirmation|--expected-sha256|audit is always|Recorded manifest checksum|Reviewed checksum|Checksum-less manifests|Owner recovery database)/.test(
+          error.message,
+        ))
+        ? error.message
+        : "Legacy file recovery failed; inspect provider access privately.";
+    console.error(JSON.stringify({ ok: false, error: safeMessage }));
+    process.exit(1);
+  });

--- a/apps/web/scripts/recover-legacy-file.ts
+++ b/apps/web/scripts/recover-legacy-file.ts
@@ -8,6 +8,7 @@ import {
   bytesMatch,
   inspectLegacyFileBytes,
   parseLegacyFileRecoveryArgs,
+  resolveLegacyRecoveryChecksum,
 } from "../lib/legacy-file-recovery";
 import { UPLOAD_FILE_MAX_BYTES } from "../lib/upload-limits";
 import { isAllowedUploadCategory } from "../lib/upload-security";
@@ -224,6 +225,11 @@ async function main() {
     import("../lib/file-replication"),
   ]);
   const candidate = await loadCandidate(db, args.fileId);
+  const expectedChecksumSha256 = resolveLegacyRecoveryChecksum({
+    recordedChecksumSha256: candidate.checksumSha256,
+    reviewedChecksumSha256: args.expectedChecksumSha256,
+    execute: args.execute,
+  });
   const legacy = legacyClient();
   const body = await readLegacyObject({
     client: legacy.client,
@@ -233,9 +239,12 @@ async function main() {
   const inspected = inspectLegacyFileBytes({
     body,
     expectedFileSizeBytes: candidate.fileSizeBytes,
-    expectedChecksumSha256: candidate.checksumSha256,
+    expectedChecksumSha256,
   });
-  if (!inspected.sizeMatches || !inspected.checksumMatches) {
+  if (
+    !inspected.sizeMatches ||
+    (expectedChecksumSha256 !== null && !inspected.checksumMatches)
+  ) {
     throw new OperatorSafeError(
       "Legacy object does not match the recorded manifest.",
     );
@@ -270,7 +279,10 @@ async function main() {
         mode: "dry_run",
         sourceAvailable: true,
         manifestSizeMatches: inspected.sizeMatches,
-        manifestChecksumMatches: inspected.checksumMatches,
+        recordedChecksumPresent: candidate.checksumSha256 !== null,
+        reviewedChecksumProvided: args.expectedChecksumSha256 !== undefined,
+        exactChecksumVerified: inspected.checksumMatches,
+        observedChecksumSha256: inspected.checksumSha256,
         primaryState:
           primary.status === "available"
             ? primaryExact
@@ -285,12 +297,17 @@ async function main() {
             : replica.status,
         replicaConfigured: storage.replicaStorageReadiness().ready,
         readyToExecute:
+          inspected.checksumMatches &&
           storage.replicaStorageReadiness().ready &&
           (primary.status === "missing" || primaryExact) &&
           (replica.status === "missing" || replicaExact),
       }),
     );
     return;
+  }
+
+  if (!inspected.checksumMatches) {
+    throw new OperatorSafeError("Legacy object checksum is not verified.");
   }
 
   if (!storage.replicaStorageReadiness().ready) {
@@ -365,7 +382,7 @@ main().catch((error) => {
   const safeMessage =
     error instanceof OperatorSafeError ||
     (error instanceof Error &&
-      /^(First argument|--file-id|--confirmation|audit is always)/.test(
+      /^(First argument|--file-id|--confirmation|--expected-sha256|audit is always|Recorded manifest checksum|Reviewed checksum|Checksum-less manifests)/.test(
         error.message,
       ))
       ? error.message

--- a/docs/file-object-recovery-runbook.md
+++ b/docs/file-object-recovery-runbook.md
@@ -148,8 +148,12 @@ that exact digest. Do not manufacture approval by copying the observed digest
 without reviewing the artifact, and do not paste the digest or file identifier
 into a public issue.
 
-An executed restore requires the owner database URL, the reviewed exact
-SHA-256, and a confirmation bound to both the manifest and checksum:
+An executed restore requires `OWNER_RECOVERY_DATABASE_URL` plus an independently
+recorded credential-free `OWNER_RECOVERY_DATABASE_FINGERPRINT`, the reviewed
+exact SHA-256, and a confirmation bound to both the manifest and checksum. Use
+the database fingerprint from the approved health/audit evidence for the target
+environment; do not derive and approve it from the same ad hoc command that
+will perform recovery.
 
 ```bash
 pnpm --filter @openpims/web files:recover-legacy -- \
@@ -168,13 +172,15 @@ canonicalizes endpoint/bucket identity and refuses if the legacy source is the
 same target as either current primary or independent replica storage. Different
 buckets or endpoints are not proof of different provider accounts; retain the
 provider-console account, IAM, versioning, retention, and deletion-denial
-evidence required above. The command writes and reads back the independent
-replica first, then writes and reads back the primary key, performs a
-compare-and-set manifest transition, and queues append-only recovery evidence.
-A retry converges on already-written exact bytes. After every restore, run the
-normal replica reconciler so it writes the immutable recovery catalog and
-require the release-gate metrics to return to 100% coverage with no missing,
-corrupt, failed, or backlog rows.
+evidence required above. Before importing the database client, execute mode
+verifies that the owner URL resolves to the independently expected database
+fingerprint. The command writes and reads back the independent replica first,
+then writes and reads back the primary key, performs a compare-and-set manifest
+transition, and queues append-only recovery evidence. A retry converges on
+already-written exact bytes. After every restore, run the normal replica
+reconciler so it writes the immutable recovery catalog and require the
+release-gate metrics to return to 100% coverage with no missing, corrupt,
+failed, or backlog rows.
 
 ### Database healthy, primary provider unavailable
 

--- a/docs/file-object-recovery-runbook.md
+++ b/docs/file-object-recovery-runbook.md
@@ -163,13 +163,18 @@ existing checksum, computes SHA-256 in memory, and refuses missing or
 conflicting exact-byte evidence. For a checksum-less manifest it refuses the
 restore before reading provider bytes unless `--expected-sha256` is present.
 Supplying that flag also extends the typed confirmation, preventing a reviewed
-digest from being accidentally applied to another invocation. The command
-writes and reads back the independent replica first, then writes and reads back
-the primary key, performs a compare-and-set manifest transition, and queues
-append-only recovery evidence. A retry converges on already-written exact
-bytes. After every restore, run the normal replica reconciler so it writes the
-immutable recovery catalog and require the release-gate metrics to return to
-100% coverage with no missing, corrupt, failed, or backlog rows.
+digest from being accidentally applied to another invocation. It also
+canonicalizes endpoint/bucket identity and refuses if the legacy source is the
+same target as either current primary or independent replica storage. Different
+buckets or endpoints are not proof of different provider accounts; retain the
+provider-console account, IAM, versioning, retention, and deletion-denial
+evidence required above. The command writes and reads back the independent
+replica first, then writes and reads back the primary key, performs a
+compare-and-set manifest transition, and queues append-only recovery evidence.
+A retry converges on already-written exact bytes. After every restore, run the
+normal replica reconciler so it writes the immutable recovery catalog and
+require the release-gate metrics to return to 100% coverage with no missing,
+corrupt, failed, or backlog rows.
 
 ### Database healthy, primary provider unavailable
 

--- a/docs/file-object-recovery-runbook.md
+++ b/docs/file-object-recovery-runbook.md
@@ -140,23 +140,36 @@ pnpm --filter @openpims/web files:recover-legacy -- \
   audit --file-id <file-uuid>
 ```
 
-An executed restore requires the owner database URL and an exact, per-file
-confirmation:
+The audit emits the observed SHA-256 for the authorized private recovery
+record. If the legacy manifest has no recorded checksum, byte length alone is
+not identity evidence: an authorized reviewer must compare the source against
+an approved export or privately inspect the clinical artifact, then approve
+that exact digest. Do not manufacture approval by copying the observed digest
+without reviewing the artifact, and do not paste the digest or file identifier
+into a public issue.
+
+An executed restore requires the owner database URL, the reviewed exact
+SHA-256, and a confirmation bound to both the manifest and checksum:
 
 ```bash
 pnpm --filter @openpims/web files:recover-legacy -- \
   restore --file-id <file-uuid> --execute \
-  --confirmation RESTORE-LEGACY-FILE:<file-uuid>
+  --expected-sha256 <reviewed-lowercase-sha256> \
+  --confirmation RESTORE-LEGACY-FILE:<file-uuid>:<reviewed-lowercase-sha256>
 ```
 
 The command reads only that manifest key, checks the recorded length and any
-existing checksum, computes SHA-256 in memory, and refuses conflicting bytes.
-It writes and reads back the independent replica first, then writes and reads
-back the primary key, performs a compare-and-set manifest transition, and
-queues append-only recovery evidence. A retry converges on already-written
-exact bytes. After every restore, run the normal replica reconciler so it writes
-the immutable recovery catalog and require the release-gate metrics to return
-to 100% coverage with no missing, corrupt, failed, or backlog rows.
+existing checksum, computes SHA-256 in memory, and refuses missing or
+conflicting exact-byte evidence. For a checksum-less manifest it refuses the
+restore before reading provider bytes unless `--expected-sha256` is present.
+Supplying that flag also extends the typed confirmation, preventing a reviewed
+digest from being accidentally applied to another invocation. The command
+writes and reads back the independent replica first, then writes and reads back
+the primary key, performs a compare-and-set manifest transition, and queues
+append-only recovery evidence. A retry converges on already-written exact
+bytes. After every restore, run the normal replica reconciler so it writes the
+immutable recovery catalog and require the release-gate metrics to return to
+100% coverage with no missing, corrupt, failed, or backlog rows.
 
 ### Database healthy, primary provider unavailable
 


### PR DESCRIPTION
## Outcome

Closes multiple fail-open patient-file recovery paths: a legacy manifest without a recorded checksum can no longer treat same-length bytes as exact recovery evidence, a recovery write cannot trust an unverified owner database URL, and the legacy source cannot also be the primary or supposed independent replica target.

This is a stacked draft on #306. It does **not** access the legacy provider, inspect or restore patient objects, change a database, merge, deploy, provision resources, or authorize clinic use.

## Safety changes

- A missing expected checksum is no longer reported as a successful checksum match.
- Executing recovery for a checksum-less manifest requires a separately reviewed lowercase SHA-256 before any legacy-provider bytes are read.
- Supplying `--expected-sha256` changes the exact typed confirmation to `RESTORE-LEGACY-FILE:<file-id>:<sha256>`, binding approval to both manifest and reviewed bytes.
- Existing recorded manifest checksums remain authoritative; conflicting reviewed evidence is refused.
- Execute mode verifies `OWNER_RECOVERY_DATABASE_URL` against an independently recorded credential-free `OWNER_RECOVERY_DATABASE_FINGERPRINT` before importing the database client.
- Canonical endpoint/bucket checks reject a legacy source that is also the current primary or independent replica target, including case and trailing-slash variants. Provider-account/IAM independence remains a required human console check.
- Read-only audit output distinguishes recorded, reviewed, and unverified checksum states and emits the observed digest only for the authorized private recovery record.
- Successful CLI execution now terminates after its awaited work instead of retaining the shared database pool.
- The runbook requires authorized private artifact/export review; copying the observed digest without reviewing the artifact is explicitly not approval.

## Verification

Authoritative hosted exact-head run at `40ad451e61344e33732c7059e14cf7fdf0cd9b3c`: https://github.com/evangauer/openvpm/actions/runs/33343996252

- build, secret scans, dependency audit, lint, type-check, full tests, production build, and OSS verification: passed;
- migration history integrity: passed;
- full ordered RLS/PostgreSQL contract suite, including safe disposable reset: passed;
- browser clinic workflow and real WebAuthn ceremonies: passed;
- focused exact-head recovery/database/storage controls: 68/68 passed; and
- formatting and `git diff --check`: passed.

The full local gate earlier in this same PR passed database 4/4, web 4,618 with 31 intentional environment-gated skips, lint, type checks, the 56-page production build, dependency audit, OSS verification, and both secret scans.

## Release boundary

Issue #277 remains unresolved until an authorized provider/account owner locates the four objects, an independent human reviews each exact artifact and tenant classification, bytes are recovered through the guarded path, reconciliation returns to 100%, and evidence is reviewed. Current release status remains **NO_GO**.
