### PR TITLE
fix(ops): require exact release review provenance

### DIFF
--- a/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
@@ -7,6 +7,7 @@ import { evaluateClinicReadinessRelease } from "../clinic-readiness-release";
 import { CLINICAL_DATA_AUDIT_SCHEMAS } from "../clinical-data-integrity-evidence";
 
 const sha = "a".repeat(40);
+const reviewedHeadSha = "f".repeat(40);
 const clinicalDatabaseFingerprint = "d".repeat(64);
 const stagingDatabaseFingerprint = "e".repeat(64);
 const temporaryDirectories: string[] = [];
@@ -450,6 +451,30 @@ function authoritativeResponses(options: { missingBuildStep?: string } = {}) {
       required_approving_review_count: 1,
     },
   };
+  const releasePullRequest = {
+    number: 88,
+    state: "closed",
+    merged_at: "2026-08-29T20:45:00.000Z",
+    merge_commit_sha: sha,
+    html_url: "https://github.example/pulls/88",
+    user: { login: "release-author" },
+    head: { sha: reviewedHeadSha },
+    base: { ref: "main" },
+  };
+  const releaseReviews = [
+    {
+      state: "APPROVED",
+      submitted_at: "2026-08-29T20:40:00.000Z",
+      commit_id: reviewedHeadSha,
+      user: { login: "reviewer-one" },
+    },
+    {
+      state: "APPROVED",
+      submitted_at: "2026-08-29T20:41:00.000Z",
+      commit_id: reviewedHeadSha,
+      user: { login: "reviewer-two" },
+    },
+  ];
 
   return vi.fn(async (input: string | URL | Request) => {
     const url = String(input);
@@ -488,6 +513,12 @@ function authoritativeResponses(options: { missingBuildStep?: string } = {}) {
     }
     if (url.endsWith("/branches/staging/protection")) {
       return response(stagingProtection);
+    }
+    if (url.endsWith(`/commits/${sha}/pulls?per_page=100`)) {
+      return response([releasePullRequest]);
+    }
+    if (url.endsWith("/pulls/88/reviews?per_page=100")) {
+      return response(releaseReviews);
     }
     if (url === "https://staging.example/api/health") {
       return response({
@@ -532,8 +563,19 @@ describe("clinic readiness evidence collector", () => {
     );
 
     expect(evidence).toMatchObject({
-      evidenceFormatVersion: 7,
+      evidenceFormatVersion: 8,
       releaseSha: sha,
+      releaseApproval: {
+        releaseSha: sha,
+        pullRequestNumber: 88,
+        authorLogin: "release-author",
+        reviewedHeadSha,
+        approvalCount: 2,
+        approvals: [
+          { reviewerLogin: "reviewer-one", reviewedHeadSha },
+          { reviewerLogin: "reviewer-two", reviewedHeadSha },
+        ],
+      },
       ci: {
         releaseSha: sha,
         ciRunId: 101,
@@ -619,6 +661,49 @@ describe("clinic readiness evidence collector", () => {
     await expect(
       collectClinicReadinessEvidence(options(wrapped)),
     ).rejects.toThrow("CI must be a successful exact-SHA CI run from main.");
+  });
+
+  it("rejects a release commit without two exact-head non-author approvals", async () => {
+    const fetchFn = authoritativeResponses();
+    const wrapped = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const result = await fetchFn(input, init);
+        if (String(input).endsWith("/pulls/88/reviews?per_page=100")) {
+          const reviews = (await result.json()) as Array<
+            Record<string, unknown>
+          >;
+          return response([
+            reviews[0],
+            { ...reviews[1], commit_id: "c".repeat(40) },
+          ]);
+        }
+        return result;
+      },
+    ) as unknown as typeof fetch;
+
+    await expect(
+      collectClinicReadinessEvidence(options(wrapped)),
+    ).rejects.toThrow(
+      "Release pull request requires two distinct non-author approvals on its exact head.",
+    );
+  });
+
+  it("rejects a direct-push release SHA with no merged main pull request", async () => {
+    const fetchFn = authoritativeResponses();
+    const wrapped = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        if (String(input).endsWith(`/commits/${sha}/pulls?per_page=100`)) {
+          return response([]);
+        }
+        return fetchFn(input, init);
+      },
+    ) as unknown as typeof fetch;
+
+    await expect(
+      collectClinicReadinessEvidence(options(wrapped)),
+    ).rejects.toThrow(
+      "Release SHA must identify exactly one merged pull request to main.",
+    );
   });
 
   it("rejects a green job whose required dependency audit step is absent", async () => {

--- a/apps/web/lib/__tests__/clinic-readiness-release.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-release.test.ts
@@ -182,8 +182,30 @@ function healthyEvidence() {
       ].map((name) => [name, { ok: true }]),
     );
   return {
-    evidenceFormatVersion: 7,
+    evidenceFormatVersion: 8,
     releaseSha: sha,
+    releaseApproval: {
+      releaseSha: sha,
+      pullRequestNumber: 88,
+      pullRequestUrl: "https://github.example/pulls/88",
+      baseBranch: "main",
+      authorLogin: "release-author",
+      reviewedHeadSha: "f".repeat(40),
+      mergedAt: "2026-08-29T20:45:00.000Z",
+      approvalCount: 2,
+      approvals: [
+        {
+          reviewerLogin: "reviewer-one",
+          submittedAt: "2026-08-29T20:40:00.000Z",
+          reviewedHeadSha: "f".repeat(40),
+        },
+        {
+          reviewerLogin: "reviewer-two",
+          submittedAt: "2026-08-29T20:41:00.000Z",
+          reviewedHeadSha: "f".repeat(40),
+        },
+      ],
+    },
     clinicalDataIntegrity: healthyClinicalDataIntegrityEvidence(),
     ci: {
       releaseSha: sha,
@@ -361,7 +383,22 @@ describe("clinic readiness release decision", () => {
     const evidence = healthyEvidence();
     evidence.evidenceFormatVersion = 5;
     expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
-      "Clinic readiness evidence format version must be 7.",
+      "Clinic readiness evidence format version must be 8.",
+    );
+  });
+
+  it("rejects missing, stale-head, duplicate, or self release approvals", () => {
+    const evidence = healthyEvidence();
+    evidence.releaseApproval.approvals[0]!.reviewerLogin = "release-author";
+    evidence.releaseApproval.approvals[1]!.reviewedHeadSha = "c".repeat(40);
+    expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
+      "Release pull request lacks two distinct non-author exact-head approvals.",
+    );
+
+    delete (evidence as Partial<ReturnType<typeof healthyEvidence>>)
+      .releaseApproval;
+    expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
+      "Exact release pull request approval evidence is missing.",
     );
   });
 

--- a/apps/web/lib/clinic-readiness-evidence-collector.ts
+++ b/apps/web/lib/clinic-readiness-evidence-collector.ts
@@ -59,6 +59,24 @@ type BranchProtectionResponse = {
   allow_deletions?: unknown;
 };
 
+type PullRequestResponse = {
+  number?: unknown;
+  state?: unknown;
+  merged_at?: unknown;
+  merge_commit_sha?: unknown;
+  html_url?: unknown;
+  user?: unknown;
+  head?: unknown;
+  base?: unknown;
+};
+
+type PullReviewResponse = {
+  state?: unknown;
+  submitted_at?: unknown;
+  commit_id?: unknown;
+  user?: unknown;
+};
+
 export type ClinicReadinessEvidenceCollectionOptions = {
   releaseSha: string;
   repository: string;
@@ -249,6 +267,164 @@ async function githubJson(
     throw new Error(`${label} request failed with HTTP ${response.status}.`);
   }
   return boundedJsonResponse(response, label);
+}
+
+function githubLogin(value: unknown, label: string): string {
+  const login = record(value)?.login;
+  if (
+    typeof login !== "string" ||
+    !/^[a-z0-9](?:[a-z0-9-]{0,38})$/i.test(login)
+  ) {
+    throw new Error(`${label} identity is invalid.`);
+  }
+  return login;
+}
+
+export async function releaseApprovalEvidence(
+  fetchFn: typeof fetch,
+  repository: string,
+  releaseSha: string,
+  token: string | undefined,
+) {
+  const root = `https://api.github.com/repos/${repository}`;
+  const associated = await githubJson(
+    fetchFn,
+    `${root}/commits/${releaseSha}/pulls?per_page=100`,
+    token,
+    "Release pull requests",
+  );
+  if (!Array.isArray(associated) || associated.length >= 100) {
+    throw new Error("Release pull request evidence is incomplete.");
+  }
+  const candidates = associated.filter((value) => {
+    const pull = record(value) as PullRequestResponse | null;
+    const base = record(pull?.base);
+    return (
+      pull?.state === "closed" &&
+      typeof pull.merged_at === "string" &&
+      typeof pull.merge_commit_sha === "string" &&
+      pull.merge_commit_sha.toLowerCase() === releaseSha &&
+      base?.ref === "main"
+    );
+  });
+  if (candidates.length !== 1) {
+    throw new Error(
+      "Release SHA must identify exactly one merged pull request to main.",
+    );
+  }
+
+  const pull = candidates[0] as PullRequestResponse;
+  const pullNumber = pull.number;
+  const headSha = record(pull.head)?.sha;
+  const mergedAtMs = Date.parse(String(pull.merged_at));
+  if (
+    !Number.isSafeInteger(pullNumber) ||
+    Number(pullNumber) <= 0 ||
+    typeof headSha !== "string" ||
+    !SHA_PATTERN.test(headSha) ||
+    !Number.isFinite(mergedAtMs) ||
+    typeof pull.html_url !== "string"
+  ) {
+    throw new Error("Release pull request evidence is invalid.");
+  }
+  const authorLogin = githubLogin(pull.user, "Release pull request author");
+  const rawReviews = await githubJson(
+    fetchFn,
+    `${root}/pulls/${pullNumber}/reviews?per_page=100`,
+    token,
+    "Release pull request reviews",
+  );
+  if (!Array.isArray(rawReviews) || rawReviews.length >= 100) {
+    throw new Error("Release pull request review evidence is incomplete.");
+  }
+
+  const latestDecisiveByReviewer = new Map<
+    string,
+    {
+      reviewerLogin: string;
+      state: string;
+      submittedAt: string;
+      submittedAtMs: number;
+      reviewedHeadSha: string;
+    }
+  >();
+  for (const value of rawReviews) {
+    const review = record(value) as PullReviewResponse | null;
+    if (
+      review?.state !== "APPROVED" &&
+      review?.state !== "CHANGES_REQUESTED" &&
+      review?.state !== "DISMISSED"
+    ) {
+      continue;
+    }
+    const reviewerLogin = githubLogin(
+      review.user,
+      "Release pull request reviewer",
+    );
+    const submittedAt = review.submitted_at;
+    const reviewedHeadSha = review.commit_id;
+    const submittedAtMs = Date.parse(String(submittedAt));
+    if (
+      typeof submittedAt !== "string" ||
+      !Number.isFinite(submittedAtMs) ||
+      submittedAtMs > mergedAtMs ||
+      typeof reviewedHeadSha !== "string" ||
+      !SHA_PATTERN.test(reviewedHeadSha)
+    ) {
+      throw new Error("Release pull request review evidence is invalid.");
+    }
+    const key = reviewerLogin.toLowerCase();
+    const current = latestDecisiveByReviewer.get(key);
+    if (!current || current.submittedAtMs < submittedAtMs) {
+      latestDecisiveByReviewer.set(key, {
+        reviewerLogin,
+        state: review.state,
+        submittedAt,
+        submittedAtMs,
+        reviewedHeadSha: reviewedHeadSha.toLowerCase(),
+      });
+    }
+  }
+
+  if (
+    [...latestDecisiveByReviewer.values()].some(
+      (review) => review.state === "CHANGES_REQUESTED",
+    )
+  ) {
+    throw new Error("Release pull request has an unresolved change request.");
+  }
+  const approvals = [...latestDecisiveByReviewer.values()]
+    .filter(
+      (review) =>
+        review.state === "APPROVED" &&
+        review.reviewedHeadSha === headSha.toLowerCase() &&
+        review.reviewerLogin.toLowerCase() !== authorLogin.toLowerCase(),
+    )
+    .sort((left, right) =>
+      left.reviewerLogin.localeCompare(right.reviewerLogin),
+    )
+    .map(({ reviewerLogin, submittedAt, reviewedHeadSha }) => ({
+      reviewerLogin,
+      submittedAt,
+      reviewedHeadSha,
+    }));
+  if (approvals.length < 2) {
+    throw new Error(
+      "Release pull request requires two distinct non-author approvals on its exact head.",
+    );
+  }
+
+  return {
+    releaseSha,
+    pullRequestNumber: pullNumber as number,
+    pullRequestUrl: pull.html_url,
+    baseBranch: "main",
+    authorLogin,
+    reviewedHeadSha: headSha.toLowerCase(),
+    mergedAt: pull.merged_at as string,
+    approvalCount: approvals.length,
+    approvals,
+  };
 }
 
 async function githubRunAndJobs(
@@ -515,6 +691,7 @@ export async function collectClinicReadinessEvidence(
     stagingHealthResponse,
     healthResponse,
     repositoryGovernance,
+    releaseApproval,
   ] = await Promise.all([
     githubRunAndJobs(
       fetchFn,
@@ -559,6 +736,12 @@ export async function collectClinicReadinessEvidence(
       options.repository,
       options.githubToken,
       checkedAt,
+    ),
+    releaseApprovalEvidence(
+      fetchFn,
+      options.repository,
+      releaseSha,
+      options.githubToken,
     ),
   ]);
 
@@ -748,8 +931,9 @@ export async function collectClinicReadinessEvidence(
   }
 
   return {
-    evidenceFormatVersion: 7,
+    evidenceFormatVersion: 8,
     releaseSha,
+    releaseApproval,
     ci: {
       releaseSha,
       repository: options.repository,

--- a/apps/web/lib/clinic-readiness-release.ts
+++ b/apps/web/lib/clinic-readiness-release.ts
@@ -3,6 +3,7 @@ import { evaluateAuthRecoveryEvidence } from "./auth-recovery-evidence";
 import { evaluateClinicalDataIntegrityEvidence } from "./clinical-data-integrity-evidence";
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const GITHUB_LOGIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,38})$/i;
 const HEALTH_MAX_AGE_MS = 15 * 60 * 1000;
 const RESTORE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const REQUIRED_MAIN_CHECKS = [
@@ -149,8 +150,8 @@ export function evaluateClinicReadinessRelease(
 ): ClinicReadinessDecision {
   const reasons: string[] = [];
   const root = record(input);
-  if (root?.evidenceFormatVersion !== 7) {
-    reasons.push("Clinic readiness evidence format version must be 7.");
+  if (root?.evidenceFormatVersion !== 8) {
+    reasons.push("Clinic readiness evidence format version must be 8.");
   }
   const releaseSha =
     root &&
@@ -189,6 +190,65 @@ export function evaluateClinicReadinessRelease(
       if (gates?.[gate] !== "passed") {
         reasons.push(`CI gate ${gate} has not passed.`);
       }
+    }
+  }
+
+  const releaseApproval = record(root?.releaseApproval);
+  if (!releaseApproval) {
+    reasons.push("Exact release pull request approval evidence is missing.");
+  } else {
+    if (releaseSha && releaseApproval.releaseSha !== releaseSha) {
+      reasons.push(
+        "Release pull request approval does not match the release SHA.",
+      );
+    }
+    if (
+      !Number.isSafeInteger(releaseApproval.pullRequestNumber) ||
+      Number(releaseApproval.pullRequestNumber) <= 0 ||
+      releaseApproval.baseBranch !== "main" ||
+      typeof releaseApproval.authorLogin !== "string" ||
+      !GITHUB_LOGIN_PATTERN.test(releaseApproval.authorLogin) ||
+      typeof releaseApproval.reviewedHeadSha !== "string" ||
+      !SHA_PATTERN.test(releaseApproval.reviewedHeadSha)
+    ) {
+      reasons.push("Release pull request provenance is invalid.");
+    }
+    const mergedAtMs = timestamp(releaseApproval.mergedAt);
+    if (mergedAtMs == null || mergedAtMs > nowMs + 60_000) {
+      reasons.push("Release pull request merge timestamp is invalid.");
+    }
+    const approvals = Array.isArray(releaseApproval.approvals)
+      ? releaseApproval.approvals.map(record).filter((item) => item !== null)
+      : [];
+    const reviewerLogins = new Set<string>();
+    let approvalsValid =
+      approvals.length >= 2 &&
+      releaseApproval.approvalCount === approvals.length &&
+      typeof releaseApproval.authorLogin === "string" &&
+      typeof releaseApproval.reviewedHeadSha === "string";
+    for (const approval of approvals) {
+      const reviewerLogin = approval.reviewerLogin;
+      const submittedAtMs = timestamp(approval.submittedAt);
+      if (
+        typeof reviewerLogin !== "string" ||
+        !GITHUB_LOGIN_PATTERN.test(reviewerLogin) ||
+        reviewerLogin.toLowerCase() ===
+          String(releaseApproval.authorLogin).toLowerCase() ||
+        reviewerLogins.has(reviewerLogin.toLowerCase()) ||
+        approval.reviewedHeadSha !== releaseApproval.reviewedHeadSha ||
+        submittedAtMs == null ||
+        (mergedAtMs != null && submittedAtMs > mergedAtMs)
+      ) {
+        approvalsValid = false;
+      }
+      if (typeof reviewerLogin === "string") {
+        reviewerLogins.add(reviewerLogin.toLowerCase());
+      }
+    }
+    if (!approvalsValid) {
+      reasons.push(
+        "Release pull request lacks two distinct non-author exact-head approvals.",
+      );
     }
   }
 

--- a/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
+++ b/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  collect: vi.fn(async () => ({ evidenceFormatVersion: 7 })),
+  collect: vi.fn(async () => ({ evidenceFormatVersion: 8 })),
   evaluate: vi.fn(() => ({
     decision: "GO",
     evaluatedAt: "2026-08-29T21:00:00.000Z",

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -231,11 +231,15 @@ exact-SHA production migration,
 RLS, and drift steps directly through GitHub. It fetches both isolated staging
 and production HTTPS health, requires both deployments to identify the same
 release SHA, and rejects any required dependency that is unhealthy or advisory.
-It also reads the live `Staging` and `Production` environments plus their
-canonical branch protections. A release remains `NO_GO` while administrators
-can bypass either environment, the workflow actor can self-approve, environment
-branch scope is wrong, `staging` lacks independent approval, `main` needs fewer
-than two approvals, code-owner or last-push review is disabled, or any required
+It also resolves the exact release commit to one merged pull request targeting
+`main` and requires two distinct, non-author approvals on that pull request's
+exact final head; current protection settings alone cannot retroactively prove
+review provenance. It reads the live `Staging` and `Production` environments
+plus their canonical branch protections. A release remains `NO_GO` while
+administrators can bypass either environment, the workflow actor can
+self-approve, environment branch scope is wrong, `staging` lacks independent
+approval, `main` needs fewer than two approvals, code-owner or last-push review
+is disabled, the exact merge/review provenance is absent, or any required
 clinic-readiness/security check is optional. It fetches the HTTPS health
 response itself and requires bounded local provider-restore and incident-
 tabletop packets. It also requires fresh, aggregate-only controlled-substance,


### PR DESCRIPTION
## Outcome

Closes a release-governance evidence gap: current branch protection settings cannot prove that a specific release commit actually arrived through reviewed pull-request history.

## Controls

- Resolve the exact release SHA to exactly one merged pull request targeting main.
- Require two distinct non-author approvals on the pull request exact final head.
- Reject stale-head approvals, unresolved change requests, direct-push release SHAs, incomplete API result sets, and malformed reviewer identity or timestamps.
- Carry immutable merge and approval evidence into clinic-readiness packet format v8.
- Keep the release decision fail-closed when provenance is absent or inconsistent.

## Verification

- Focused: 35 tests passed.
- Full: 4,624 tests passed; 31 integration tests skipped by their existing environment gates.
- Lint and TypeScript checks passed.
- Production build passed, including 56 generated static pages.
- Prettier and git diff checks passed.

## Safety boundary

Draft stacked on #307. No merge, deployment, staging provisioning, provider read, production read/write, or release authorization was performed. Release remains NO_GO until exact-head hosted CI and the rest of the clinic-readiness evidence are independently satisfied.