### PR TITLE
fix(ops): require clinic pilot release evidence

### DIFF
--- a/apps/web/lib/__tests__/clinic-pilot-release-evidence.test.ts
+++ b/apps/web/lib/__tests__/clinic-pilot-release-evidence.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLINIC_PILOT_OUTCOMES,
+  evaluateClinicPilotReleaseEvidence,
+} from "../clinic-pilot-release-evidence";
+
+const now = Date.parse("2026-08-30T21:00:00.000Z");
+const releaseSha = "a".repeat(40);
+
+export function healthyClinicPilotReleaseEvidence() {
+  return {
+    evidenceFormatVersion: 1,
+    pilotId: "pilot-2026-08-30-deadbeef",
+    releaseSha,
+    startedAt: "2026-08-25T14:00:00.000Z",
+    completedAt: "2026-08-30T19:00:00.000Z",
+    pilotScope: {
+      workflow: "general_practice",
+      jurisdiction: "US",
+      activeLocationCount: 1,
+      distinctClinicDays: 5,
+    },
+    outcomes: Object.fromEntries(
+      CLINIC_PILOT_OUTCOMES.map((outcome) => [outcome, true]),
+    ) as Record<(typeof CLINIC_PILOT_OUTCOMES)[number], boolean>,
+    sourceEvidence: {
+      clinicUseValidatedHash: "b".repeat(64),
+      pilotProjectionVersion: 7,
+    },
+    approvals: {
+      clinicAdministrator: {
+        actorId: "user:5f55c40b-0e87-4af2-94a8-fbe97ff5ca15",
+        approvedAt: "2026-08-30T19:10:00.000Z",
+      },
+      veterinaryClinicalOwner: {
+        actorId: "github:@clinical-owner",
+        approvedAt: "2026-08-30T19:20:00.000Z",
+      },
+      releaseOwner: {
+        actorId: "github:@release-owner",
+        approvedAt: "2026-08-30T19:30:00.000Z",
+      },
+      securityOwner: {
+        actorId: "github:@security-owner",
+        approvedAt: "2026-08-30T19:40:00.000Z",
+      },
+    },
+    evidenceSafety: {
+      phiFree: true,
+      secretsFree: true,
+      patientIdentifiersFree: true,
+      contactDestinationsFree: true,
+      localPathsFree: true,
+    },
+    findings: {
+      criticalCount: 0,
+      highCount: 0,
+      openReleaseBlockingCount: 0,
+    },
+  };
+}
+
+describe("clinic-pilot release evidence", () => {
+  it("accepts a fresh five-day pilot for one exact release", () => {
+    expect(
+      evaluateClinicPilotReleaseEvidence(
+        healthyClinicPilotReleaseEvidence(),
+        now,
+      ),
+    ).toEqual({
+      ready: true,
+      pilotId: "pilot-2026-08-30-deadbeef",
+      releaseSha,
+      evaluatedAt: "2026-08-30T21:00:00.000Z",
+      reasons: [],
+    });
+  });
+
+  it("rejects automation-only proof without five clinic days or acceptance", () => {
+    const evidence = healthyClinicPilotReleaseEvidence();
+    evidence.pilotScope.distinctClinicDays = 1;
+    evidence.outcomes.clinicUseValidated = false;
+    evidence.outcomes.clinicAcceptanceRecorded = false;
+    const reasons = evaluateClinicPilotReleaseEvidence(evidence, now).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot evidence requires five distinct clinic days.",
+        "Clinic-pilot evidence did not prove clinicUseValidated.",
+        "Clinic-pilot evidence did not prove clinicAcceptanceRecorded.",
+      ]),
+    );
+  });
+
+  it("requires four independent role-appropriate approvals", () => {
+    const evidence = healthyClinicPilotReleaseEvidence();
+    evidence.approvals.clinicAdministrator.actorId = "github:@clinical-owner";
+    evidence.approvals.securityOwner.actorId = "github:@release-owner";
+    const reasons = evaluateClinicPilotReleaseEvidence(evidence, now).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot approval clinicAdministrator is unassigned or not independent.",
+        "Clinic-pilot approval securityOwner is unassigned or not independent.",
+      ]),
+    );
+  });
+
+  it("rejects stale, future, or pre-completion approvals", () => {
+    const evidence = healthyClinicPilotReleaseEvidence();
+    evidence.completedAt = "2026-06-30T19:00:00.000Z";
+    evidence.pilotId = "pilot-2026-06-30-deadbeef";
+    evidence.startedAt = "2026-06-25T14:00:00.000Z";
+    evidence.approvals.releaseOwner.approvedAt = "2026-06-30T18:59:00.000Z";
+    const reasons = evaluateClinicPilotReleaseEvidence(evidence, now).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot evidence is older than 30 days.",
+        "Clinic-pilot approval releaseOwner has an invalid time.",
+      ]),
+    );
+  });
+
+  it("requires zero critical, high, and release-blocking findings", () => {
+    const evidence = healthyClinicPilotReleaseEvidence();
+    evidence.findings.highCount = 1;
+    evidence.findings.openReleaseBlockingCount = 2;
+    const reasons = evaluateClinicPilotReleaseEvidence(evidence, now).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot highCount must be zero for release.",
+        "Clinic-pilot openReleaseBlockingCount must be zero for release.",
+      ]),
+    );
+  });
+
+  it("requires immutable validated-use source linkage", () => {
+    const evidence = healthyClinicPilotReleaseEvidence();
+    evidence.sourceEvidence.clinicUseValidatedHash = "not-a-hash";
+    evidence.sourceEvidence.pilotProjectionVersion = 0;
+    const reasons = evaluateClinicPilotReleaseEvidence(evidence, now).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot validated-use hash is missing or invalid.",
+        "Clinic-pilot projection version is missing or invalid.",
+      ]),
+    );
+  });
+
+  it("rejects free-form or unsafe evidence fields", () => {
+    const evidence = healthyClinicPilotReleaseEvidence() as ReturnType<
+      typeof healthyClinicPilotReleaseEvidence
+    > & { notes?: string };
+    evidence.notes = "patient details must never be copied here";
+    evidence.evidenceSafety.patientIdentifiersFree = false;
+    const reasons = evaluateClinicPilotReleaseEvidence(evidence, now).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot evidence has an unexpected root shape.",
+        "Clinic-pilot evidence is not patientIdentifiersFree.",
+      ]),
+    );
+  });
+});

--- a/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -184,6 +184,78 @@ function authRecoveryEvidencePath() {
         criticalCount: 0,
         highCount: 0,
         followUpIssueNumbers: [],
+      },
+    }),
+  );
+  return file;
+}
+
+function clinicPilotEvidencePath() {
+  const directory = mkdtempSync(
+    path.join(tmpdir(), "openvpm-clinic-pilot-evidence-"),
+  );
+  temporaryDirectories.push(directory);
+  const file = path.join(directory, "clinic-pilot.json");
+  writeFileSync(
+    file,
+    JSON.stringify({
+      evidenceFormatVersion: 1,
+      pilotId: "pilot-2026-08-29-deadbeef",
+      releaseSha: sha,
+      startedAt: "2026-08-24T14:00:00.000Z",
+      completedAt: "2026-08-29T20:00:00.000Z",
+      pilotScope: {
+        workflow: "general_practice",
+        jurisdiction: "US",
+        activeLocationCount: 1,
+        distinctClinicDays: 5,
+      },
+      outcomes: {
+        clinicAcceptanceRecorded: true,
+        clinicUseValidated: true,
+        communicationTested: true,
+        exportAndRollbackConfirmed: true,
+        firstVisitValidated: true,
+        hostedFullAccess: true,
+        incidentAndDowntimeProcedureExercised: true,
+        parallelPimsRetained: true,
+        paymentMethodCollected: true,
+        setupComplete: true,
+        verifiedAdministrator: true,
+      },
+      sourceEvidence: {
+        clinicUseValidatedHash: "b".repeat(64),
+        pilotProjectionVersion: 7,
+      },
+      approvals: {
+        clinicAdministrator: {
+          actorId: "user:5f55c40b-0e87-4af2-94a8-fbe97ff5ca15",
+          approvedAt: "2026-08-29T20:01:00.000Z",
+        },
+        veterinaryClinicalOwner: {
+          actorId: "github:@clinical-owner",
+          approvedAt: "2026-08-29T20:02:00.000Z",
+        },
+        releaseOwner: {
+          actorId: "github:@release-owner",
+          approvedAt: "2026-08-29T20:03:00.000Z",
+        },
+        securityOwner: {
+          actorId: "github:@security-owner",
+          approvedAt: "2026-08-29T20:04:00.000Z",
+        },
+      },
+      evidenceSafety: {
+        phiFree: true,
+        secretsFree: true,
+        patientIdentifiersFree: true,
+        contactDestinationsFree: true,
+        localPathsFree: true,
+      },
+      findings: {
+        criticalCount: 0,
+        highCount: 0,
+        openReleaseBlockingCount: 0,
       },
     }),
   );
@@ -549,6 +621,7 @@ function options(fetchFn: typeof fetch) {
     restoreEvidencePath: restoreEvidencePath(),
     incidentEvidencePath: incidentEvidencePath(),
     authRecoveryEvidencePath: authRecoveryEvidencePath(),
+    clinicPilotEvidencePath: clinicPilotEvidencePath(),
     clinicalDatabaseFingerprint,
     ...clinicalAuditPaths(),
     now: new Date("2026-08-29T21:00:00.000Z"),
@@ -563,7 +636,7 @@ describe("clinic readiness evidence collector", () => {
     );
 
     expect(evidence).toMatchObject({
-      evidenceFormatVersion: 8,
+      evidenceFormatVersion: 9,
       releaseSha: sha,
       releaseApproval: {
         releaseSha: sha,
@@ -704,6 +777,22 @@ describe("clinic readiness evidence collector", () => {
     ).rejects.toThrow(
       "Release SHA must identify exactly one merged pull request to main.",
     );
+  });
+
+  it("rejects clinic-pilot evidence from a different release", async () => {
+    const collectionOptions = options(authoritativeResponses());
+    const pilot = JSON.parse(
+      readFileSync(collectionOptions.clinicPilotEvidencePath, "utf8"),
+    ) as Record<string, unknown>;
+    pilot.releaseSha = "c".repeat(40);
+    writeFileSync(
+      collectionOptions.clinicPilotEvidencePath,
+      JSON.stringify(pilot),
+    );
+
+    await expect(
+      collectClinicReadinessEvidence(collectionOptions),
+    ).rejects.toThrow("Clinic-pilot evidence does not match the release SHA.");
   });
 
   it("rejects a green job whose required dependency audit step is absent", async () => {

--- a/apps/web/lib/__tests__/clinic-readiness-release.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-release.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { evaluateClinicReadinessRelease } from "../clinic-readiness-release";
 import { CLINICAL_DATA_AUDIT_SCHEMAS } from "../clinical-data-integrity-evidence";
+import { CLINIC_PILOT_OUTCOMES } from "../clinic-pilot-release-evidence";
 
 const now = Date.parse("2026-08-29T21:00:00.000Z");
 const sha = "a".repeat(40);
@@ -161,6 +162,59 @@ function healthyAuthRecoveryEvidence() {
   };
 }
 
+function healthyClinicPilotEvidence() {
+  return {
+    evidenceFormatVersion: 1,
+    pilotId: "pilot-2026-08-29-deadbeef",
+    releaseSha: sha,
+    startedAt: "2026-08-24T14:00:00.000Z",
+    completedAt: "2026-08-29T20:00:00.000Z",
+    pilotScope: {
+      workflow: "general_practice",
+      jurisdiction: "US",
+      activeLocationCount: 1,
+      distinctClinicDays: 5,
+    },
+    outcomes: Object.fromEntries(
+      CLINIC_PILOT_OUTCOMES.map((outcome) => [outcome, true]),
+    ) as Record<(typeof CLINIC_PILOT_OUTCOMES)[number], boolean>,
+    sourceEvidence: {
+      clinicUseValidatedHash: "b".repeat(64),
+      pilotProjectionVersion: 7,
+    },
+    approvals: {
+      clinicAdministrator: {
+        actorId: "user:5f55c40b-0e87-4af2-94a8-fbe97ff5ca15",
+        approvedAt: "2026-08-29T20:01:00.000Z",
+      },
+      veterinaryClinicalOwner: {
+        actorId: "github:@clinical-owner",
+        approvedAt: "2026-08-29T20:02:00.000Z",
+      },
+      releaseOwner: {
+        actorId: "github:@release-owner",
+        approvedAt: "2026-08-29T20:03:00.000Z",
+      },
+      securityOwner: {
+        actorId: "github:@security-owner",
+        approvedAt: "2026-08-29T20:04:00.000Z",
+      },
+    },
+    evidenceSafety: {
+      phiFree: true,
+      secretsFree: true,
+      patientIdentifiersFree: true,
+      contactDestinationsFree: true,
+      localPathsFree: true,
+    },
+    findings: {
+      criticalCount: 0,
+      highCount: 0,
+      openReleaseBlockingCount: 0,
+    },
+  };
+}
+
 function healthyEvidence() {
   const checks: Record<string, { ok: boolean; advisory?: boolean }> =
     Object.fromEntries(
@@ -182,7 +236,7 @@ function healthyEvidence() {
       ].map((name) => [name, { ok: true }]),
     );
   return {
-    evidenceFormatVersion: 8,
+    evidenceFormatVersion: 9,
     releaseSha: sha,
     releaseApproval: {
       releaseSha: sha,
@@ -219,6 +273,7 @@ function healthyEvidence() {
     },
     incidentResponse: healthyIncidentResponseEvidence(),
     authRecovery: healthyAuthRecoveryEvidence(),
+    clinicPilot: healthyClinicPilotEvidence(),
     repositoryGovernance: {
       checkedAt: "2026-08-29T20:55:00.000Z",
       productionEnvironment: {
@@ -383,7 +438,7 @@ describe("clinic readiness release decision", () => {
     const evidence = healthyEvidence();
     evidence.evidenceFormatVersion = 5;
     expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
-      "Clinic readiness evidence format version must be 8.",
+      "Clinic readiness evidence format version must be 9.",
     );
   });
 
@@ -430,6 +485,24 @@ describe("clinic readiness release decision", () => {
         "Account-recovery request and approval require distinct named authorities.",
         "Account-recovery drill did not prove priorSessionsRevoked.",
       ]),
+    );
+  });
+
+  it("rejects missing, cross-SHA, or incomplete clinic-pilot evidence", () => {
+    const evidence = healthyEvidence();
+    evidence.clinicPilot.releaseSha = "c".repeat(40);
+    evidence.clinicPilot.outcomes.clinicAcceptanceRecorded = false;
+    expect(evaluateClinicReadinessRelease(evidence, now).reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot evidence does not match the release SHA.",
+        "Clinic-pilot evidence did not prove clinicAcceptanceRecorded.",
+      ]),
+    );
+
+    delete (evidence as Partial<ReturnType<typeof healthyEvidence>>)
+      .clinicPilot;
+    expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
+      "Controlled clinic-pilot evidence is missing.",
     );
   });
 

--- a/apps/web/lib/clinic-pilot-release-evidence.ts
+++ b/apps/web/lib/clinic-pilot-release-evidence.ts
@@ -1,0 +1,279 @@
+const MAX_EVIDENCE_AGE_MS = 30 * 24 * 60 * 60 * 1_000;
+const MIN_PILOT_DURATION_MS = 4 * 24 * 60 * 60 * 1_000;
+const MAX_PILOT_DURATION_MS = 45 * 24 * 60 * 60 * 1_000;
+const MAX_APPROVAL_LAG_MS = 7 * 24 * 60 * 60 * 1_000;
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const PILOT_ID = /^pilot-(\d{4}-\d{2}-\d{2})-[a-f0-9]{8}$/;
+const SHA = /^[0-9a-f]{40}$/i;
+const USER_ACTOR =
+  /^user:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const GITHUB_ACTOR = /^github:@[A-Za-z0-9](?:[A-Za-z0-9-]{0,36}[A-Za-z0-9])?$/;
+const SHA256 = /^[0-9a-f]{64}$/i;
+
+export const CLINIC_PILOT_APPROVAL_ROLES = [
+  "clinicAdministrator",
+  "veterinaryClinicalOwner",
+  "releaseOwner",
+  "securityOwner",
+] as const;
+
+export const CLINIC_PILOT_OUTCOMES = [
+  "clinicAcceptanceRecorded",
+  "clinicUseValidated",
+  "communicationTested",
+  "exportAndRollbackConfirmed",
+  "firstVisitValidated",
+  "hostedFullAccess",
+  "incidentAndDowntimeProcedureExercised",
+  "parallelPimsRetained",
+  "paymentMethodCollected",
+  "setupComplete",
+  "verifiedAdministrator",
+] as const;
+
+const ROOT_KEYS = [
+  "approvals",
+  "completedAt",
+  "evidenceFormatVersion",
+  "evidenceSafety",
+  "findings",
+  "outcomes",
+  "pilotId",
+  "pilotScope",
+  "releaseSha",
+  "sourceEvidence",
+  "startedAt",
+] as const;
+const PILOT_SCOPE_KEYS = [
+  "activeLocationCount",
+  "distinctClinicDays",
+  "jurisdiction",
+  "workflow",
+] as const;
+const APPROVAL_KEYS = ["actorId", "approvedAt"] as const;
+const SAFETY_KEYS = [
+  "contactDestinationsFree",
+  "localPathsFree",
+  "patientIdentifiersFree",
+  "phiFree",
+  "secretsFree",
+] as const;
+const FINDING_KEYS = [
+  "criticalCount",
+  "highCount",
+  "openReleaseBlockingCount",
+] as const;
+const SOURCE_EVIDENCE_KEYS = [
+  "clinicUseValidatedHash",
+  "pilotProjectionVersion",
+] as const;
+
+type RecordValue = Record<string, unknown>;
+
+export type ClinicPilotReleaseEvidenceDecision = {
+  ready: boolean;
+  pilotId: string | null;
+  releaseSha: string | null;
+  evaluatedAt: string;
+  reasons: string[];
+};
+
+function record(value: unknown): RecordValue | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as RecordValue)
+    : null;
+}
+
+function exactKeys(value: RecordValue, expected: readonly string[]): boolean {
+  return (
+    JSON.stringify(Object.keys(value).sort()) ===
+    JSON.stringify([...expected].sort())
+  );
+}
+
+function timestamp(value: unknown): number | null {
+  if (typeof value !== "string" || !ISO_TIMESTAMP.test(value)) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value
+    ? parsed
+    : null;
+}
+
+function actorId(value: unknown, role: string): string | null {
+  if (typeof value !== "string") return null;
+  if (role === "clinicAdministrator") {
+    return USER_ACTOR.test(value) ? value.toLowerCase() : null;
+  }
+  return GITHUB_ACTOR.test(value) &&
+    !/^github:@(?:unassigned|unknown|replace|todo|tbd)(?:-|$)/i.test(value)
+    ? value.toLowerCase()
+    : null;
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+/** Strict, free-form-text-free evidence for a completed controlled clinic pilot. */
+export function evaluateClinicPilotReleaseEvidence(
+  input: unknown,
+  nowMs = Date.now(),
+): ClinicPilotReleaseEvidenceDecision {
+  const reasons: string[] = [];
+  const root = record(input);
+  if (!root || !exactKeys(root, ROOT_KEYS)) {
+    reasons.push("Clinic-pilot evidence has an unexpected root shape.");
+  }
+  if (root?.evidenceFormatVersion !== 1) {
+    reasons.push("Clinic-pilot evidence format version must be 1.");
+  }
+
+  const pilotMatch =
+    typeof root?.pilotId === "string" ? PILOT_ID.exec(root.pilotId) : null;
+  const pilotId = pilotMatch ? (root?.pilotId as string) : null;
+  if (!pilotId) reasons.push("Clinic-pilot evidence ID is invalid.");
+
+  const releaseSha =
+    typeof root?.releaseSha === "string" && SHA.test(root.releaseSha)
+      ? root.releaseSha.toLowerCase()
+      : null;
+  if (!releaseSha) {
+    reasons.push("Clinic-pilot release SHA must be an exact commit.");
+  }
+
+  const startedAt = timestamp(root?.startedAt);
+  const completedAt = timestamp(root?.completedAt);
+  if (startedAt == null || completedAt == null) {
+    reasons.push("Clinic-pilot timestamps are missing or invalid.");
+  } else {
+    const duration = completedAt - startedAt;
+    if (duration < MIN_PILOT_DURATION_MS || duration > MAX_PILOT_DURATION_MS) {
+      reasons.push("Clinic-pilot duration is outside policy.");
+    }
+    if (completedAt > nowMs + 60_000) {
+      reasons.push("Clinic-pilot evidence is dated in the future.");
+    } else if (nowMs - completedAt > MAX_EVIDENCE_AGE_MS) {
+      reasons.push("Clinic-pilot evidence is older than 30 days.");
+    }
+    if (
+      pilotMatch &&
+      pilotMatch[1] !== new Date(completedAt).toISOString().slice(0, 10)
+    ) {
+      reasons.push("Clinic-pilot evidence ID date does not match completion.");
+    }
+  }
+
+  const scope = record(root?.pilotScope);
+  if (!scope || !exactKeys(scope, PILOT_SCOPE_KEYS)) {
+    reasons.push("Clinic-pilot scope is missing or malformed.");
+  } else {
+    if (!["general_practice", "house_call"].includes(String(scope.workflow))) {
+      reasons.push("Clinic-pilot workflow is outside the supported cohort.");
+    }
+    if (scope.jurisdiction !== "US") {
+      reasons.push("Clinic-pilot jurisdiction is outside the first cohort.");
+    }
+    if (scope.activeLocationCount !== 1) {
+      reasons.push("Clinic-pilot scope must contain exactly one location.");
+    }
+    if (
+      !Number.isSafeInteger(scope.distinctClinicDays) ||
+      Number(scope.distinctClinicDays) < 5
+    ) {
+      reasons.push("Clinic-pilot evidence requires five distinct clinic days.");
+    }
+  }
+
+  const outcomes = record(root?.outcomes);
+  if (!outcomes || !exactKeys(outcomes, CLINIC_PILOT_OUTCOMES)) {
+    reasons.push("Clinic-pilot outcomes are missing or malformed.");
+  } else {
+    for (const outcome of CLINIC_PILOT_OUTCOMES) {
+      if (outcomes[outcome] !== true) {
+        reasons.push(`Clinic-pilot evidence did not prove ${outcome}.`);
+      }
+    }
+  }
+
+  const sourceEvidence = record(root?.sourceEvidence);
+  if (!sourceEvidence || !exactKeys(sourceEvidence, SOURCE_EVIDENCE_KEYS)) {
+    reasons.push("Clinic-pilot source evidence is missing or malformed.");
+  } else {
+    if (
+      typeof sourceEvidence.clinicUseValidatedHash !== "string" ||
+      !SHA256.test(sourceEvidence.clinicUseValidatedHash)
+    ) {
+      reasons.push("Clinic-pilot validated-use hash is missing or invalid.");
+    }
+    if (
+      !Number.isSafeInteger(sourceEvidence.pilotProjectionVersion) ||
+      Number(sourceEvidence.pilotProjectionVersion) <= 0
+    ) {
+      reasons.push("Clinic-pilot projection version is missing or invalid.");
+    }
+  }
+
+  const approvals = record(root?.approvals);
+  const assignedActors = new Set<string>();
+  if (!approvals || !exactKeys(approvals, CLINIC_PILOT_APPROVAL_ROLES)) {
+    reasons.push("Clinic-pilot approvals are missing or malformed.");
+  } else {
+    for (const role of CLINIC_PILOT_APPROVAL_ROLES) {
+      const approval = record(approvals[role]);
+      if (!approval || !exactKeys(approval, APPROVAL_KEYS)) {
+        reasons.push(`Clinic-pilot approval ${role} is malformed.`);
+        continue;
+      }
+      const assigned = actorId(approval.actorId, role);
+      if (!assigned || assignedActors.has(assigned)) {
+        reasons.push(
+          `Clinic-pilot approval ${role} is unassigned or not independent.`,
+        );
+      } else {
+        assignedActors.add(assigned);
+      }
+      const approvedAt = timestamp(approval.approvedAt);
+      if (
+        approvedAt == null ||
+        completedAt == null ||
+        approvedAt < completedAt ||
+        approvedAt > completedAt + MAX_APPROVAL_LAG_MS ||
+        approvedAt > nowMs + 60_000
+      ) {
+        reasons.push(`Clinic-pilot approval ${role} has an invalid time.`);
+      }
+    }
+  }
+
+  const safety = record(root?.evidenceSafety);
+  if (!safety || !exactKeys(safety, SAFETY_KEYS)) {
+    reasons.push("Clinic-pilot evidence safety attestation is malformed.");
+  } else {
+    for (const field of SAFETY_KEYS) {
+      if (safety[field] !== true) {
+        reasons.push(`Clinic-pilot evidence is not ${field}.`);
+      }
+    }
+  }
+
+  const findings = record(root?.findings);
+  if (!findings || !exactKeys(findings, FINDING_KEYS)) {
+    reasons.push("Clinic-pilot finding summary is malformed.");
+  } else {
+    for (const field of FINDING_KEYS) {
+      if (!nonNegativeInteger(findings[field])) {
+        reasons.push(`Clinic-pilot ${field} is invalid.`);
+      } else if (findings[field] !== 0) {
+        reasons.push(`Clinic-pilot ${field} must be zero for release.`);
+      }
+    }
+  }
+
+  return {
+    ready: reasons.length === 0,
+    pilotId,
+    releaseSha,
+    evaluatedAt: new Date(nowMs).toISOString(),
+    reasons,
+  };
+}

--- a/apps/web/lib/clinic-readiness-evidence-collector.ts
+++ b/apps/web/lib/clinic-readiness-evidence-collector.ts
@@ -2,6 +2,7 @@ import { readFileSync, statSync } from "node:fs";
 import { evaluateIncidentResponseEvidence } from "./incident-response-evidence";
 import { evaluateAuthRecoveryEvidence } from "./auth-recovery-evidence";
 import { evaluateClinicalDataIntegrityEvidence } from "./clinical-data-integrity-evidence";
+import { evaluateClinicPilotReleaseEvidence } from "./clinic-pilot-release-evidence";
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const REPOSITORY_PATTERN = /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/i;
@@ -90,6 +91,7 @@ export type ClinicReadinessEvidenceCollectionOptions = {
   restoreEvidencePath: string;
   incidentEvidencePath: string;
   authRecoveryEvidencePath: string;
+  clinicPilotEvidencePath: string;
   clinicalDatabaseFingerprint: string;
   controlledSubstanceAuditPath: string;
   prescriptionAuditPath: string;
@@ -880,6 +882,10 @@ export async function collectClinicReadinessEvidence(
     options.authRecoveryEvidencePath,
     "Account-recovery evidence",
   );
+  const clinicPilot = regularBoundedJsonFile(
+    options.clinicPilotEvidencePath,
+    "Clinic-pilot evidence",
+  );
   const clinicalDataIntegrity = {
     evidenceFormatVersion: 1,
     releaseSha,
@@ -919,6 +925,16 @@ export async function collectClinicReadinessEvidence(
       "Account-recovery evidence is incomplete, stale, or unsafe.",
     );
   }
+  const clinicPilotDecision = evaluateClinicPilotReleaseEvidence(
+    clinicPilot,
+    Date.parse(checkedAt),
+  );
+  if (!clinicPilotDecision.ready) {
+    throw new Error("Clinic-pilot evidence is incomplete, stale, or unsafe.");
+  }
+  if (clinicPilotDecision.releaseSha !== releaseSha) {
+    throw new Error("Clinic-pilot evidence does not match the release SHA.");
+  }
   if (
     !evaluateClinicalDataIntegrityEvidence(
       clinicalDataIntegrity,
@@ -931,7 +947,7 @@ export async function collectClinicReadinessEvidence(
   }
 
   return {
-    evidenceFormatVersion: 8,
+    evidenceFormatVersion: 9,
     releaseSha,
     releaseApproval,
     ci: {
@@ -985,6 +1001,7 @@ export async function collectClinicReadinessEvidence(
     },
     incidentResponse,
     authRecovery,
+    clinicPilot,
     clinicalDataIntegrity,
     restoreDrill,
   };

--- a/apps/web/lib/clinic-readiness-release.ts
+++ b/apps/web/lib/clinic-readiness-release.ts
@@ -1,6 +1,7 @@
 import { evaluateIncidentResponseEvidence } from "./incident-response-evidence";
 import { evaluateAuthRecoveryEvidence } from "./auth-recovery-evidence";
 import { evaluateClinicalDataIntegrityEvidence } from "./clinical-data-integrity-evidence";
+import { evaluateClinicPilotReleaseEvidence } from "./clinic-pilot-release-evidence";
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const GITHUB_LOGIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,38})$/i;
@@ -150,8 +151,8 @@ export function evaluateClinicReadinessRelease(
 ): ClinicReadinessDecision {
   const reasons: string[] = [];
   const root = record(input);
-  if (root?.evidenceFormatVersion !== 8) {
-    reasons.push("Clinic readiness evidence format version must be 8.");
+  if (root?.evidenceFormatVersion !== 9) {
+    reasons.push("Clinic readiness evidence format version must be 9.");
   }
   const releaseSha =
     root &&
@@ -272,6 +273,20 @@ export function evaluateClinicReadinessRelease(
       nowMs,
     );
     reasons.push(...authRecoveryDecision.reasons);
+  }
+
+  const clinicPilot = record(root?.clinicPilot);
+  if (!clinicPilot) {
+    reasons.push("Controlled clinic-pilot evidence is missing.");
+  } else {
+    const clinicPilotDecision = evaluateClinicPilotReleaseEvidence(
+      clinicPilot,
+      nowMs,
+    );
+    reasons.push(...clinicPilotDecision.reasons);
+    if (releaseSha && clinicPilotDecision.releaseSha !== releaseSha) {
+      reasons.push("Clinic-pilot evidence does not match the release SHA.");
+    }
   }
 
   const governance = record(root?.repositoryGovernance);

--- a/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
+++ b/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  collect: vi.fn(async () => ({ evidenceFormatVersion: 8 })),
+  collect: vi.fn(async () => ({ evidenceFormatVersion: 9 })),
   evaluate: vi.fn(() => ({
     decision: "GO",
     evaluatedAt: "2026-08-29T21:00:00.000Z",
@@ -63,6 +63,8 @@ function argumentsFor(output: string): string[] {
     "private/incident.json",
     "--auth-recovery-evidence",
     "private/auth-recovery.json",
+    "--clinic-pilot-evidence",
+    "private/clinic-pilot.json",
     "--clinical-database-fingerprint",
     "d".repeat(64),
     "--controlled-substance-audit",
@@ -97,6 +99,10 @@ describe("clinic readiness evidence collector CLI", () => {
         authRecoveryEvidencePath: path.join(
           directory,
           "private/auth-recovery.json",
+        ),
+        clinicPilotEvidencePath: path.join(
+          directory,
+          "private/clinic-pilot.json",
         ),
         clinicalDatabaseFingerprint: "d".repeat(64),
         controlledSubstanceAuditPath: path.join(

--- a/apps/web/scripts/collect-clinic-readiness-evidence.ts
+++ b/apps/web/scripts/collect-clinic-readiness-evidence.ts
@@ -19,6 +19,7 @@ const VALUE_ARGS = new Set([
   "--restore-evidence",
   "--incident-evidence",
   "--auth-recovery-evidence",
+  "--clinic-pilot-evidence",
   "--clinical-database-fingerprint",
   "--controlled-substance-audit",
   "--prescription-audit",
@@ -35,7 +36,7 @@ function argumentsMap(args: string[]): Map<string, string> {
     const value = normalized[index + 1]?.trim();
     if (!name || !VALUE_ARGS.has(name) || !value || values.has(name)) {
       throw new Error(
-        "Usage: release:clinic-readiness:collect -- --release-sha <sha> --repository <owner/name> --ci-run-id <id> --staging-migration-run-id <id> --staging-reset-run-id <id> --staging-database-fingerprint <sha256> --migration-run-id <id> --staging-health-url <https-url> --hosted-health-url <https-url> --restore-evidence <path> --incident-evidence <path> --auth-recovery-evidence <path> --clinical-database-fingerprint <sha256> --controlled-substance-audit <path> --prescription-audit <path> --lab-result-audit <path> --vaccination-audit <path> --output <path>",
+        "Usage: release:clinic-readiness:collect -- --release-sha <sha> --repository <owner/name> --ci-run-id <id> --staging-migration-run-id <id> --staging-reset-run-id <id> --staging-database-fingerprint <sha256> --migration-run-id <id> --staging-health-url <https-url> --hosted-health-url <https-url> --restore-evidence <path> --incident-evidence <path> --auth-recovery-evidence <path> --clinic-pilot-evidence <path> --clinical-database-fingerprint <sha256> --controlled-substance-audit <path> --prescription-audit <path> --lab-result-audit <path> --vaccination-audit <path> --output <path>",
       );
     }
     values.set(name, value);
@@ -87,6 +88,9 @@ export async function main(args = process.argv.slice(2)) {
     incidentEvidencePath: operatorPath(values.get("--incident-evidence")!),
     authRecoveryEvidencePath: operatorPath(
       values.get("--auth-recovery-evidence")!,
+    ),
+    clinicPilotEvidencePath: operatorPath(
+      values.get("--clinic-pilot-evidence")!,
     ),
     clinicalDatabaseFingerprint: values.get("--clinical-database-fingerprint")!,
     controlledSubstanceAuditPath: operatorPath(

--- a/docs/clinic-pilot-operations.md
+++ b/docs/clinic-pilot-operations.md
@@ -176,3 +176,82 @@ sessions cannot read any pilot-cohort state.
 No dashboard can replace clinic sign-off. Graduation is a documented operating
 decision supported by exact product evidence, an accepted workflow, recoverable
 data, and a team that knows the fallback.
+
+Graduation in the pilot workspace is not by itself a production release. The
+clinic-readiness collector also requires a bounded, PHI-free pilot evidence
+packet for the exact release SHA. That packet records only the supported
+workflow/jurisdiction, counts and boolean outcomes, opaque clinic-admin user ID,
+the validated clinic-use hash and pilot projection version, named
+clinical/release/security approvers, timestamps, and zero release-blocking
+finding counts. Free-form notes, clinic or patient names, contact destinations,
+provider payloads, credentials, and local paths are prohibited.
+
+The evidence JSON has no optional or free-form fields. Use this exact shape,
+substituting reviewed values from the immutable pilot projection and the exact
+release candidate:
+
+```json
+{
+  "evidenceFormatVersion": 1,
+  "pilotId": "pilot-2026-08-30-deadbeef",
+  "releaseSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "startedAt": "2026-08-25T14:00:00.000Z",
+  "completedAt": "2026-08-30T19:00:00.000Z",
+  "pilotScope": {
+    "workflow": "general_practice",
+    "jurisdiction": "US",
+    "activeLocationCount": 1,
+    "distinctClinicDays": 5
+  },
+  "outcomes": {
+    "clinicAcceptanceRecorded": true,
+    "clinicUseValidated": true,
+    "communicationTested": true,
+    "exportAndRollbackConfirmed": true,
+    "firstVisitValidated": true,
+    "hostedFullAccess": true,
+    "incidentAndDowntimeProcedureExercised": true,
+    "parallelPimsRetained": true,
+    "paymentMethodCollected": true,
+    "setupComplete": true,
+    "verifiedAdministrator": true
+  },
+  "sourceEvidence": {
+    "clinicUseValidatedHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "pilotProjectionVersion": 7
+  },
+  "approvals": {
+    "clinicAdministrator": {
+      "actorId": "user:5f55c40b-0e87-4af2-94a8-fbe97ff5ca15",
+      "approvedAt": "2026-08-30T19:10:00.000Z"
+    },
+    "veterinaryClinicalOwner": {
+      "actorId": "github:@clinical-owner",
+      "approvedAt": "2026-08-30T19:20:00.000Z"
+    },
+    "releaseOwner": {
+      "actorId": "github:@release-owner",
+      "approvedAt": "2026-08-30T19:30:00.000Z"
+    },
+    "securityOwner": {
+      "actorId": "github:@security-owner",
+      "approvedAt": "2026-08-30T19:40:00.000Z"
+    }
+  },
+  "evidenceSafety": {
+    "contactDestinationsFree": true,
+    "localPathsFree": true,
+    "patientIdentifiersFree": true,
+    "phiFree": true,
+    "secretsFree": true
+  },
+  "findings": {
+    "criticalCount": 0,
+    "highCount": 0,
+    "openReleaseBlockingCount": 0
+  }
+}
+```
+
+The example identifiers and hashes are synthetic placeholders and are not valid
+release evidence.

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -216,6 +216,7 @@ pnpm --filter @openpims/web release:clinic-readiness:collect -- \
   --restore-evidence /secure/path/provider-restore-evidence.json \
   --incident-evidence /secure/path/incident-tabletop-evidence.json \
   --auth-recovery-evidence /secure/path/auth-recovery-drill-evidence.json \
+  --clinic-pilot-evidence /secure/path/clinic-pilot-release-evidence.json \
   --clinical-database-fingerprint "$DATABASE_TARGET_FINGERPRINT" \
   --controlled-substance-audit /secure/path/controlled-substances.json \
   --prescription-audit /secure/path/prescriptions.json \
@@ -241,8 +242,16 @@ self-approve, environment branch scope is wrong, `staging` lacks independent
 approval, `main` needs fewer than two approvals, code-owner or last-push review
 is disabled, the exact merge/review provenance is absent, or any required
 clinic-readiness/security check is optional. It fetches the HTTPS health
-response itself and requires bounded local provider-restore and incident-
-tabletop packets. It also requires fresh, aggregate-only controlled-substance,
+response itself and requires bounded local provider-restore, incident-tabletop,
+account-recovery, and controlled clinic-pilot packets. Clinic-pilot evidence is
+bound to the exact release SHA and must prove five distinct clinic days, one
+supported US location, validated clinic use and acceptance, retained parallel
+PIMS/rollback paths, communications, billing access, four independent
+role-appropriate approvals, an immutable validated-use hash plus pilot
+projection version, and zero critical, high, or release-blocking open
+findings. The strict packet shape rejects free-form fields that could carry PHI,
+contact destinations, local paths, or secrets. It also requires fresh,
+aggregate-only controlled-substance,
 prescription, lab-result, and vaccination reports from the same independently
 configured database fingerprint; every report must have valid counts, empty
 finding lists, and `releaseSafe: true`. It writes the combined packet with
@@ -266,8 +275,9 @@ proves the hold/release workflow, exact object version, and authentication,
 tenant, scheduling, clinical, invoice, payment, and file smokes; and a fresh,
 approved incident tabletop covers all five required scenarios with three
 distinct named authorities. Missing, stale, cross-SHA, synthetic-only,
-unhealthy, incomplete-incident, cross-database, unsafe-clinical-data, or
-weak-governance evidence returns `NO_GO` and a nonzero exit. The synthetic CI
+unhealthy, incomplete-incident, absent clinic acceptance, cross-database,
+unsafe-clinical-data, or weak-governance evidence returns `NO_GO` and a nonzero
+exit. The synthetic CI
 drill is necessary regression proof, but it
 cannot authorize production. Keep the packet access-controlled; it contains
 only bounded status evidence and safe role handles, never credentials, private


### PR DESCRIPTION
## Outcome

Closes a clinic-readiness fail-open gap: automated golden-clinic CI could previously coexist with a theoretical GO decision even when no supervised clinic pilot or clinic acceptance existed.

## Controls

- Add strict clinic-pilot evidence format v1 and require it in clinic-readiness format v9.
- Bind pilot evidence to the exact release SHA, five distinct clinic days, the immutable validated-use hash, and pilot projection version.
- Require one supported US single-location workflow, retained parallel-PIMS and rollback paths, validated first visit and clinic use, communications, payment method, hosted access, incident/downtime exercise, and explicit clinic acceptance.
- Require four distinct role-appropriate approvals: opaque verified clinic-admin user ID plus named veterinary clinical, release, and security owners.
- Require zero critical, high, or open release-blocking findings.
- Reject stale, cross-SHA, malformed, free-form, PHI-bearing, patient-identifier, contact-destination, secret, or local-path evidence.

## Verification

- Focused: 44 tests passed.
- Full: 4,633 tests passed; 31 existing environment-gated integrations skipped.
- Lint, TypeScript, formatting, and diff checks passed.
- Production build passed with 56 generated static pages.
- Production dependency audit found no known vulnerabilities.
- OSS release verification passed 1,566 tracked files.
- Source and artifact secret scans passed with only reviewed/classified fixtures and framework findings.

## Safety boundary

This PR adds a gate; it does not claim a clinic pilot occurred. It is draft and stacked on #308. No merge, deployment, staging provisioning, provider contact, clinic data read/write, production read/write, or release authorization was performed. Release remains NO_GO.