### PR TITLE
fix(ops): bind clinic pilot release to database evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,26 @@ jobs:
           MIGRATION_CONFORMANCE_MODE: exact
         run: pnpm --filter @openpims/db db:migrations:conformance
 
+      # Compile and execute the real projection audit against the fully
+      # migrated disposable schema. A nonexistent opaque selector must produce
+      # bounded JSON, releaseSafe=false, and the documented refusal exit code.
+      - name: Execute clinic-pilot release audit refusal contract
+        env:
+          CLINIC_PILOT_RELEASE_READ_ONLY_CONFIRMATION: OPENVPM_CLINIC_PILOT_RELEASE_READ_ONLY
+        run: |
+          set +e
+          pnpm --filter @openpims/db exec tsx audit-clinic-pilot-release.ts \
+            --allow-live-read-only \
+            --clinic-use-hash aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+            --projection-version 1 \
+            > "$RUNNER_TEMP/clinic-pilot-projection-refusal.json"
+          audit_status=$?
+          set -e
+          test "$audit_status" -eq 2
+          jq --exit-status \
+            '.releaseSafe == false and .projection.matchedPilotCount == 0 and .clinicAdministratorActorHash == null' \
+            "$RUNNER_TEMP/clinic-pilot-projection-refusal.json" > /dev/null
+
       - name: Execute RLS ownership preflight contract
         run: pnpm --filter @openpims/db db:rls:preflight:test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
           CLINIC_PILOT_RELEASE_READ_ONLY_CONFIRMATION: OPENVPM_CLINIC_PILOT_RELEASE_READ_ONLY
         run: |
           set +e
-          pnpm --filter @openpims/db exec tsx audit-clinic-pilot-release.ts \
+          packages/db/node_modules/.bin/tsx packages/db/audit-clinic-pilot-release.ts \
             --allow-live-read-only \
             --clinic-use-hash aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
             --projection-version 1 \

--- a/apps/web/lib/__tests__/clinic-pilot-projection-audit-source.test.ts
+++ b/apps/web/lib/__tests__/clinic-pilot-projection-audit-source.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../../../../packages/db/audit-clinic-pilot-release.ts",
+      import.meta.url,
+    ),
+  ),
+  "utf8",
+);
+
+describe("clinic-pilot projection audit source", () => {
+  it("requires explicit read-only authority and a narrow evidence selector", () => {
+    expect(source).toContain("--allow-live-read-only");
+    expect(source).toContain("CLINIC_PILOT_RELEASE_READ_ONLY_CONFIRMATION");
+    expect(source).toContain("--clinic-use-hash");
+    expect(source).toContain("--projection-version");
+    expect(source).toContain("isolation level repeatable read read only");
+  });
+
+  it("binds the projection to one immutable event without emitting identities", () => {
+    expect(source).toContain("join clinic_pilot_events event");
+    expect(source).toContain("event.projection_version = cp.version");
+    expect(source).toContain("event.next_action = cp.next_action");
+    expect(source).toContain(
+      "event.next_review_at is not distinct from cp.next_review_at",
+    );
+    expect(source).toContain("recomputedClinicUseHash");
+    expect(source).toContain("clinicAdministratorActorHash");
+    expect(source).not.toContain("practiceName");
+    expect(source).not.toContain("patient_id");
+    expect(source).not.toContain("email");
+  });
+});

--- a/apps/web/lib/__tests__/clinic-pilot-projection-audit-source.test.ts
+++ b/apps/web/lib/__tests__/clinic-pilot-projection-audit-source.test.ts
@@ -35,10 +35,15 @@ describe("clinic-pilot projection audit source", () => {
       "event.next_review_at is not distinct from cp.next_review_at",
     );
     expect(source).toContain("recomputedClinicUseHash");
+    expect(source).toContain("join visit_closeouts closeout");
+    expect(source).toContain("from users administrator");
+    expect(source).toContain("from locations location");
+    expect(source).toContain("from practice_conversion_milestones milestone");
     expect(source).toContain("clinicAdministratorActorHash");
     expect(source).not.toContain("practiceName");
     expect(source).not.toContain("patient_id");
-    expect(source).not.toContain("email");
+    expect(source).not.toContain('as "email"');
+    expect(source).not.toContain("administrator.email,");
   });
 
   it("executes a fail-closed query against the fully migrated CI schema", () => {

--- a/apps/web/lib/__tests__/clinic-pilot-projection-audit-source.test.ts
+++ b/apps/web/lib/__tests__/clinic-pilot-projection-audit-source.test.ts
@@ -11,6 +11,12 @@ const source = readFileSync(
   ),
   "utf8",
 );
+const ci = readFileSync(
+  fileURLToPath(
+    new URL("../../../../.github/workflows/ci.yml", import.meta.url),
+  ),
+  "utf8",
+);
 
 describe("clinic-pilot projection audit source", () => {
   it("requires explicit read-only authority and a narrow evidence selector", () => {
@@ -33,5 +39,13 @@ describe("clinic-pilot projection audit source", () => {
     expect(source).not.toContain("practiceName");
     expect(source).not.toContain("patient_id");
     expect(source).not.toContain("email");
+  });
+
+  it("executes a fail-closed query against the fully migrated CI schema", () => {
+    expect(ci).toContain("Execute clinic-pilot release audit refusal contract");
+    expect(ci).toContain(
+      "CLINIC_PILOT_RELEASE_READ_ONLY_CONFIRMATION: OPENVPM_CLINIC_PILOT_RELEASE_READ_ONLY",
+    );
+    expect(ci).toContain(".projection.matchedPilotCount == 0");
   });
 });

--- a/apps/web/lib/__tests__/clinic-pilot-projection-evidence.test.ts
+++ b/apps/web/lib/__tests__/clinic-pilot-projection-evidence.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  clinicPilotActorHash,
+  evaluateClinicPilotProjectionEvidence,
+} from "../clinic-pilot-projection-evidence";
+
+const now = Date.parse("2026-08-30T21:00:00.000Z");
+
+export function healthyClinicPilotProjectionEvidence() {
+  return {
+    evidenceFormatVersion: 1,
+    mode: "read_only_aggregate",
+    checkedAt: "2026-08-30T20:55:00.000Z",
+    databaseTargetFingerprint: "d".repeat(64),
+    clinicUseValidatedHash: "b".repeat(64),
+    pilotProjectionVersion: 7,
+    clinicAdministratorActorHash: clinicPilotActorHash(
+      "user:5f55c40b-0e87-4af2-94a8-fbe97ff5ca15",
+    ),
+    projection: {
+      matchedPilotCount: 1,
+      immutableEventMatch: true,
+      workflow: "general_practice",
+      stage: "completed",
+      decision: "graduated",
+      blockerCount: 0,
+      qualificationComplete: true,
+      readinessComplete: true,
+    },
+    outcomes: {
+      verifiedAdministrator: true,
+      activeLocationCount: 1,
+      setupComplete: true,
+      communicationTested: true,
+      firstVisitValidated: true,
+      distinctClinicDays: 5,
+      clinicUseValidated: true,
+      paymentMethodCollected: true,
+      positivePaymentRecorded: true,
+      hostedFullAccess: true,
+      jurisdictionConfirmed: true,
+      clinicAcceptanceRecorded: true,
+    },
+    evidenceSafety: {
+      phiFree: true,
+      secretsFree: true,
+      patientIdentifiersFree: true,
+      contactDestinationsFree: true,
+      localPathsFree: true,
+    },
+    releaseSafe: true,
+  };
+}
+
+describe("clinic-pilot projection evidence", () => {
+  it("accepts a fresh exact immutable projection", () => {
+    expect(
+      evaluateClinicPilotProjectionEvidence(
+        healthyClinicPilotProjectionEvidence(),
+        now,
+      ),
+    ).toMatchObject({
+      ready: true,
+      clinicUseValidatedHash: "b".repeat(64),
+      pilotProjectionVersion: 7,
+      databaseTargetFingerprint: "d".repeat(64),
+      reasons: [],
+    });
+  });
+
+  it("rejects a missing immutable event, blockers, and incomplete outcomes", () => {
+    const evidence = healthyClinicPilotProjectionEvidence();
+    evidence.projection.immutableEventMatch = false;
+    evidence.projection.blockerCount = 1;
+    evidence.outcomes.firstVisitValidated = false;
+
+    expect(
+      evaluateClinicPilotProjectionEvidence(evidence, now).reasons,
+    ).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot projection lacks an exact immutable event.",
+        "Clinic-pilot projection still has blockers.",
+        "Clinic-pilot projection did not prove firstVisitValidated.",
+      ]),
+    );
+  });
+
+  it("rejects stale, cross-shape, unsafe evidence", () => {
+    const evidence = healthyClinicPilotProjectionEvidence() as ReturnType<
+      typeof healthyClinicPilotProjectionEvidence
+    > & { clinicName?: string };
+    evidence.checkedAt = "2026-08-30T20:00:00.000Z";
+    evidence.clinicName = "must not be copied";
+    evidence.evidenceSafety.phiFree = false;
+
+    expect(
+      evaluateClinicPilotProjectionEvidence(evidence, now).reasons,
+    ).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot projection evidence has an unexpected root shape.",
+        "Clinic-pilot projection evidence is stale.",
+        "Clinic-pilot projection evidence is not phiFree.",
+      ]),
+    );
+  });
+
+  it("normalizes administrator actor IDs before hashing", () => {
+    expect(clinicPilotActorHash("USER:ABC")).toBe(
+      clinicPilotActorHash("user:abc"),
+    );
+  });
+});

--- a/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-evidence-collector.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectClinicReadinessEvidence } from "../clinic-readiness-evidence-collector";
 import { evaluateClinicReadinessRelease } from "../clinic-readiness-release";
 import { CLINICAL_DATA_AUDIT_SCHEMAS } from "../clinical-data-integrity-evidence";
+import { clinicPilotActorHash } from "../clinic-pilot-projection-evidence";
 
 const sha = "a".repeat(40);
 const reviewedHeadSha = "f".repeat(40);
@@ -285,6 +286,61 @@ function clinicPilotEvidencePath() {
         highCount: 0,
         openReleaseBlockingCount: 0,
       },
+    }),
+  );
+  return file;
+}
+
+function clinicPilotProjectionAuditPath() {
+  const directory = mkdtempSync(
+    path.join(tmpdir(), "openvpm-clinic-pilot-projection-evidence-"),
+  );
+  temporaryDirectories.push(directory);
+  const file = path.join(directory, "clinic-pilot-projection.json");
+  writeFileSync(
+    file,
+    JSON.stringify({
+      evidenceFormatVersion: 1,
+      mode: "read_only_aggregate",
+      checkedAt: "2026-08-29T20:58:00.000Z",
+      databaseTargetFingerprint: clinicalDatabaseFingerprint,
+      clinicUseValidatedHash: "b".repeat(64),
+      pilotProjectionVersion: 7,
+      clinicAdministratorActorHash: clinicPilotActorHash(
+        "user:5f55c40b-0e87-4af2-94a8-fbe97ff5ca15",
+      ),
+      projection: {
+        matchedPilotCount: 1,
+        immutableEventMatch: true,
+        workflow: "general_practice",
+        stage: "completed",
+        decision: "graduated",
+        blockerCount: 0,
+        qualificationComplete: true,
+        readinessComplete: true,
+      },
+      outcomes: {
+        verifiedAdministrator: true,
+        activeLocationCount: 1,
+        setupComplete: true,
+        communicationTested: true,
+        firstVisitValidated: true,
+        distinctClinicDays: 5,
+        clinicUseValidated: true,
+        paymentMethodCollected: true,
+        positivePaymentRecorded: true,
+        hostedFullAccess: true,
+        jurisdictionConfirmed: true,
+        clinicAcceptanceRecorded: true,
+      },
+      evidenceSafety: {
+        phiFree: true,
+        secretsFree: true,
+        patientIdentifiersFree: true,
+        contactDestinationsFree: true,
+        localPathsFree: true,
+      },
+      releaseSafe: true,
     }),
   );
   return file;
@@ -650,6 +706,7 @@ function options(fetchFn: typeof fetch) {
     incidentEvidencePath: incidentEvidencePath(),
     authRecoveryEvidencePath: authRecoveryEvidencePath(),
     clinicPilotEvidencePath: clinicPilotEvidencePath(),
+    clinicPilotProjectionAuditPath: clinicPilotProjectionAuditPath(),
     clinicalDatabaseFingerprint,
     ...clinicalAuditPaths(),
     now: new Date("2026-08-29T21:00:00.000Z"),
@@ -664,7 +721,7 @@ describe("clinic readiness evidence collector", () => {
     );
 
     expect(evidence).toMatchObject({
-      evidenceFormatVersion: 10,
+      evidenceFormatVersion: 11,
       releaseSha: sha,
       releaseApproval: {
         releaseSha: sha,
@@ -725,6 +782,11 @@ describe("clinic readiness evidence collector", () => {
       },
       authRecovery: {
         drillId: "auth-recovery-2026-08-29-deadbeef",
+      },
+      clinicPilotProjection: {
+        clinicUseValidatedHash: "b".repeat(64),
+        pilotProjectionVersion: 7,
+        releaseSafe: true,
       },
       clinicalDataIntegrity: {
         releaseSha: sha,
@@ -821,6 +883,24 @@ describe("clinic readiness evidence collector", () => {
     await expect(
       collectClinicReadinessEvidence(collectionOptions),
     ).rejects.toThrow("Clinic-pilot evidence does not match the release SHA.");
+  });
+
+  it("rejects a clinic-pilot packet detached from its database projection", async () => {
+    const collectionOptions = options(authoritativeResponses());
+    const projection = JSON.parse(
+      readFileSync(collectionOptions.clinicPilotProjectionAuditPath, "utf8"),
+    ) as Record<string, unknown>;
+    projection.clinicUseValidatedHash = "c".repeat(64);
+    writeFileSync(
+      collectionOptions.clinicPilotProjectionAuditPath,
+      JSON.stringify(projection),
+    );
+
+    await expect(
+      collectClinicReadinessEvidence(collectionOptions),
+    ).rejects.toThrow(
+      "Clinic-pilot packet does not match the configured immutable projection.",
+    );
   });
 
   it("rejects a green job whose required dependency audit step is absent", async () => {

--- a/apps/web/lib/__tests__/clinic-readiness-release.test.ts
+++ b/apps/web/lib/__tests__/clinic-readiness-release.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { evaluateClinicReadinessRelease } from "../clinic-readiness-release";
 import { CLINICAL_DATA_AUDIT_SCHEMAS } from "../clinical-data-integrity-evidence";
 import { CLINIC_PILOT_OUTCOMES } from "../clinic-pilot-release-evidence";
+import { clinicPilotActorHash } from "../clinic-pilot-projection-evidence";
 
 const now = Date.parse("2026-08-29T21:00:00.000Z");
 const sha = "a".repeat(40);
@@ -236,7 +237,7 @@ function healthyEvidence() {
       ].map((name) => [name, { ok: true }]),
     );
   return {
-    evidenceFormatVersion: 10,
+    evidenceFormatVersion: 11,
     releaseSha: sha,
     releaseApproval: {
       releaseSha: sha,
@@ -274,6 +275,49 @@ function healthyEvidence() {
     incidentResponse: healthyIncidentResponseEvidence(),
     authRecovery: healthyAuthRecoveryEvidence(),
     clinicPilot: healthyClinicPilotEvidence(),
+    clinicPilotProjection: {
+      evidenceFormatVersion: 1,
+      mode: "read_only_aggregate",
+      checkedAt: "2026-08-29T20:55:00.000Z",
+      databaseTargetFingerprint: clinicalDatabaseFingerprint,
+      clinicUseValidatedHash: "b".repeat(64),
+      pilotProjectionVersion: 7,
+      clinicAdministratorActorHash: clinicPilotActorHash(
+        "user:5f55c40b-0e87-4af2-94a8-fbe97ff5ca15",
+      ),
+      projection: {
+        matchedPilotCount: 1,
+        immutableEventMatch: true,
+        workflow: "general_practice",
+        stage: "completed",
+        decision: "graduated",
+        blockerCount: 0,
+        qualificationComplete: true,
+        readinessComplete: true,
+      },
+      outcomes: {
+        verifiedAdministrator: true,
+        activeLocationCount: 1,
+        setupComplete: true,
+        communicationTested: true,
+        firstVisitValidated: true,
+        distinctClinicDays: 5,
+        clinicUseValidated: true,
+        paymentMethodCollected: true,
+        positivePaymentRecorded: true,
+        hostedFullAccess: true,
+        jurisdictionConfirmed: true,
+        clinicAcceptanceRecorded: true,
+      },
+      evidenceSafety: {
+        phiFree: true,
+        secretsFree: true,
+        patientIdentifiersFree: true,
+        contactDestinationsFree: true,
+        localPathsFree: true,
+      },
+      releaseSafe: true,
+    },
     repositoryGovernance: {
       checkedAt: "2026-08-29T20:55:00.000Z",
       productionEnvironment: {
@@ -467,7 +511,7 @@ describe("clinic readiness release decision", () => {
     const evidence = healthyEvidence();
     evidence.evidenceFormatVersion = 5;
     expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
-      "Clinic readiness evidence format version must be 10.",
+      "Clinic readiness evidence format version must be 11.",
     );
   });
 
@@ -532,6 +576,23 @@ describe("clinic readiness release decision", () => {
       .clinicPilot;
     expect(evaluateClinicReadinessRelease(evidence, now).reasons).toContain(
       "Controlled clinic-pilot evidence is missing.",
+    );
+  });
+
+  it("binds clinic-pilot assertions to the configured immutable projection", () => {
+    const evidence = healthyEvidence();
+    evidence.clinicPilotProjection.clinicUseValidatedHash = "c".repeat(64);
+    evidence.clinicPilotProjection.clinicAdministratorActorHash = "e".repeat(
+      64,
+    );
+    evidence.clinicPilotProjection.databaseTargetFingerprint = "f".repeat(64);
+
+    expect(evaluateClinicReadinessRelease(evidence, now).reasons).toEqual(
+      expect.arrayContaining([
+        "Clinic-pilot packet does not match the immutable projection version.",
+        "Clinic-pilot administrator approval does not match the projection.",
+        "Clinic-pilot projection does not match the clinical database.",
+      ]),
     );
   });
 

--- a/apps/web/lib/clinic-pilot-projection-evidence.ts
+++ b/apps/web/lib/clinic-pilot-projection-evidence.ts
@@ -1,0 +1,229 @@
+import { createHash } from "node:crypto";
+
+const MAX_EVIDENCE_AGE_MS = 15 * 60 * 1_000;
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const SHA256 = /^[0-9a-f]{64}$/i;
+
+const ROOT_KEYS = [
+  "checkedAt",
+  "clinicAdministratorActorHash",
+  "clinicUseValidatedHash",
+  "databaseTargetFingerprint",
+  "evidenceFormatVersion",
+  "evidenceSafety",
+  "mode",
+  "outcomes",
+  "pilotProjectionVersion",
+  "projection",
+  "releaseSafe",
+] as const;
+const PROJECTION_KEYS = [
+  "blockerCount",
+  "decision",
+  "immutableEventMatch",
+  "matchedPilotCount",
+  "qualificationComplete",
+  "readinessComplete",
+  "stage",
+  "workflow",
+] as const;
+const OUTCOME_KEYS = [
+  "activeLocationCount",
+  "clinicAcceptanceRecorded",
+  "clinicUseValidated",
+  "communicationTested",
+  "distinctClinicDays",
+  "firstVisitValidated",
+  "hostedFullAccess",
+  "jurisdictionConfirmed",
+  "paymentMethodCollected",
+  "positivePaymentRecorded",
+  "setupComplete",
+  "verifiedAdministrator",
+] as const;
+const SAFETY_KEYS = [
+  "contactDestinationsFree",
+  "localPathsFree",
+  "patientIdentifiersFree",
+  "phiFree",
+  "secretsFree",
+] as const;
+
+type RecordValue = Record<string, unknown>;
+
+export type ClinicPilotProjectionEvidenceDecision = {
+  ready: boolean;
+  clinicUseValidatedHash: string | null;
+  pilotProjectionVersion: number | null;
+  databaseTargetFingerprint: string | null;
+  clinicAdministratorActorHash: string | null;
+  evaluatedAt: string;
+  reasons: string[];
+};
+
+function record(value: unknown): RecordValue | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as RecordValue)
+    : null;
+}
+
+function exactKeys(value: RecordValue, expected: readonly string[]): boolean {
+  return (
+    JSON.stringify(Object.keys(value).sort()) ===
+    JSON.stringify([...expected].sort())
+  );
+}
+
+function timestamp(value: unknown): number | null {
+  if (typeof value !== "string" || !ISO_TIMESTAMP.test(value)) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value
+    ? parsed
+    : null;
+}
+
+export function clinicPilotActorHash(actorId: string): string {
+  return createHash("sha256").update(actorId.toLowerCase()).digest("hex");
+}
+
+/** Strict, PHI-free proof derived from the immutable clinic-pilot projection. */
+export function evaluateClinicPilotProjectionEvidence(
+  input: unknown,
+  nowMs = Date.now(),
+): ClinicPilotProjectionEvidenceDecision {
+  const reasons: string[] = [];
+  const root = record(input);
+  if (!root || !exactKeys(root, ROOT_KEYS)) {
+    reasons.push(
+      "Clinic-pilot projection evidence has an unexpected root shape.",
+    );
+  }
+  if (
+    root?.evidenceFormatVersion !== 1 ||
+    root?.mode !== "read_only_aggregate"
+  ) {
+    reasons.push("Clinic-pilot projection evidence format is invalid.");
+  }
+
+  const checkedAt = timestamp(root?.checkedAt);
+  if (checkedAt == null) {
+    reasons.push("Clinic-pilot projection timestamp is missing or invalid.");
+  } else if (checkedAt > nowMs + 60_000) {
+    reasons.push("Clinic-pilot projection evidence is dated in the future.");
+  } else if (nowMs - checkedAt > MAX_EVIDENCE_AGE_MS) {
+    reasons.push("Clinic-pilot projection evidence is stale.");
+  }
+
+  const clinicUseValidatedHash =
+    typeof root?.clinicUseValidatedHash === "string" &&
+    SHA256.test(root.clinicUseValidatedHash)
+      ? root.clinicUseValidatedHash.toLowerCase()
+      : null;
+  if (!clinicUseValidatedHash) {
+    reasons.push("Clinic-pilot projection validated-use hash is invalid.");
+  }
+  const pilotProjectionVersion =
+    Number.isSafeInteger(root?.pilotProjectionVersion) &&
+    Number(root?.pilotProjectionVersion) > 0
+      ? Number(root?.pilotProjectionVersion)
+      : null;
+  if (!pilotProjectionVersion) {
+    reasons.push("Clinic-pilot projection version is invalid.");
+  }
+  const databaseTargetFingerprint =
+    typeof root?.databaseTargetFingerprint === "string" &&
+    SHA256.test(root.databaseTargetFingerprint)
+      ? root.databaseTargetFingerprint.toLowerCase()
+      : null;
+  if (!databaseTargetFingerprint) {
+    reasons.push("Clinic-pilot projection database fingerprint is invalid.");
+  }
+  const clinicAdministratorActorHash =
+    typeof root?.clinicAdministratorActorHash === "string" &&
+    SHA256.test(root.clinicAdministratorActorHash)
+      ? root.clinicAdministratorActorHash.toLowerCase()
+      : null;
+  if (!clinicAdministratorActorHash) {
+    reasons.push("Clinic-pilot projection administrator binding is invalid.");
+  }
+
+  const projection = record(root?.projection);
+  if (!projection || !exactKeys(projection, PROJECTION_KEYS)) {
+    reasons.push("Clinic-pilot projection summary is malformed.");
+  } else {
+    if (projection.matchedPilotCount !== 1) {
+      reasons.push("Clinic-pilot projection must match exactly one pilot.");
+    }
+    if (projection.immutableEventMatch !== true) {
+      reasons.push("Clinic-pilot projection lacks an exact immutable event.");
+    }
+    if (
+      !["general_practice", "house_call"].includes(String(projection.workflow))
+    ) {
+      reasons.push("Clinic-pilot projection workflow is unsupported.");
+    }
+    if (
+      projection.stage !== "completed" ||
+      projection.decision !== "graduated"
+    ) {
+      reasons.push("Clinic-pilot projection is not graduated.");
+    }
+    if (projection.blockerCount !== 0) {
+      reasons.push("Clinic-pilot projection still has blockers.");
+    }
+    if (
+      projection.qualificationComplete !== true ||
+      projection.readinessComplete !== true
+    ) {
+      reasons.push("Clinic-pilot projection checklists are incomplete.");
+    }
+  }
+
+  const outcomes = record(root?.outcomes);
+  if (!outcomes || !exactKeys(outcomes, OUTCOME_KEYS)) {
+    reasons.push("Clinic-pilot projection outcomes are malformed.");
+  } else {
+    for (const outcome of OUTCOME_KEYS.filter(
+      (field) => !["activeLocationCount", "distinctClinicDays"].includes(field),
+    )) {
+      if (outcomes[outcome] !== true) {
+        reasons.push(`Clinic-pilot projection did not prove ${outcome}.`);
+      }
+    }
+    if (outcomes.activeLocationCount !== 1) {
+      reasons.push(
+        "Clinic-pilot projection must contain exactly one location.",
+      );
+    }
+    if (
+      !Number.isSafeInteger(outcomes.distinctClinicDays) ||
+      Number(outcomes.distinctClinicDays) < 5
+    ) {
+      reasons.push("Clinic-pilot projection requires five clinic days.");
+    }
+  }
+
+  const safety = record(root?.evidenceSafety);
+  if (!safety || !exactKeys(safety, SAFETY_KEYS)) {
+    reasons.push("Clinic-pilot projection safety attestation is malformed.");
+  } else {
+    for (const field of SAFETY_KEYS) {
+      if (safety[field] !== true) {
+        reasons.push(`Clinic-pilot projection evidence is not ${field}.`);
+      }
+    }
+  }
+  if (root?.releaseSafe !== true) {
+    reasons.push("Clinic-pilot projection is not release-safe.");
+  }
+
+  return {
+    ready: reasons.length === 0,
+    clinicUseValidatedHash,
+    pilotProjectionVersion,
+    databaseTargetFingerprint,
+    clinicAdministratorActorHash,
+    evaluatedAt: new Date(nowMs).toISOString(),
+    reasons,
+  };
+}

--- a/apps/web/lib/clinic-readiness-evidence-collector.ts
+++ b/apps/web/lib/clinic-readiness-evidence-collector.ts
@@ -3,6 +3,10 @@ import { evaluateIncidentResponseEvidence } from "./incident-response-evidence";
 import { evaluateAuthRecoveryEvidence } from "./auth-recovery-evidence";
 import { evaluateClinicalDataIntegrityEvidence } from "./clinical-data-integrity-evidence";
 import { evaluateClinicPilotReleaseEvidence } from "./clinic-pilot-release-evidence";
+import {
+  clinicPilotActorHash,
+  evaluateClinicPilotProjectionEvidence,
+} from "./clinic-pilot-projection-evidence";
 import { evaluateProviderRestoreReleaseEvidence } from "./provider-restore-release-evidence";
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
@@ -93,6 +97,7 @@ export type ClinicReadinessEvidenceCollectionOptions = {
   incidentEvidencePath: string;
   authRecoveryEvidencePath: string;
   clinicPilotEvidencePath: string;
+  clinicPilotProjectionAuditPath: string;
   clinicalDatabaseFingerprint: string;
   controlledSubstanceAuditPath: string;
   prescriptionAuditPath: string;
@@ -906,6 +911,10 @@ export async function collectClinicReadinessEvidence(
     options.clinicPilotEvidencePath,
     "Clinic-pilot evidence",
   );
+  const clinicPilotProjection = regularBoundedJsonFile(
+    options.clinicPilotProjectionAuditPath,
+    "Clinic-pilot projection audit",
+  );
   const clinicalDataIntegrity = {
     evidenceFormatVersion: 1,
     releaseSha,
@@ -955,6 +964,40 @@ export async function collectClinicReadinessEvidence(
   if (clinicPilotDecision.releaseSha !== releaseSha) {
     throw new Error("Clinic-pilot evidence does not match the release SHA.");
   }
+  const clinicPilotProjectionDecision = evaluateClinicPilotProjectionEvidence(
+    clinicPilotProjection,
+    Date.parse(checkedAt),
+  );
+  if (!clinicPilotProjectionDecision.ready) {
+    throw new Error(
+      "Clinic-pilot projection audit is incomplete, stale, or unsafe.",
+    );
+  }
+  const clinicPilotRecord = record(clinicPilot);
+  const clinicPilotSource = record(clinicPilotRecord?.sourceEvidence);
+  const clinicPilotApprovals = record(clinicPilotRecord?.approvals);
+  const clinicAdministratorApproval = record(
+    clinicPilotApprovals?.clinicAdministrator,
+  );
+  const clinicAdministratorActorId =
+    typeof clinicAdministratorApproval?.actorId === "string"
+      ? clinicAdministratorApproval.actorId
+      : null;
+  if (
+    clinicPilotProjectionDecision.clinicUseValidatedHash !==
+      clinicPilotSource?.clinicUseValidatedHash ||
+    clinicPilotProjectionDecision.pilotProjectionVersion !==
+      clinicPilotSource?.pilotProjectionVersion ||
+    clinicPilotProjectionDecision.databaseTargetFingerprint !==
+      clinicalDatabaseFingerprint ||
+    !clinicAdministratorActorId ||
+    clinicPilotProjectionDecision.clinicAdministratorActorHash !==
+      clinicPilotActorHash(clinicAdministratorActorId)
+  ) {
+    throw new Error(
+      "Clinic-pilot packet does not match the configured immutable projection.",
+    );
+  }
   if (
     !evaluateClinicalDataIntegrityEvidence(
       clinicalDataIntegrity,
@@ -967,7 +1010,7 @@ export async function collectClinicReadinessEvidence(
   }
 
   return {
-    evidenceFormatVersion: 10,
+    evidenceFormatVersion: 11,
     releaseSha,
     releaseApproval,
     ci: {
@@ -1022,6 +1065,7 @@ export async function collectClinicReadinessEvidence(
     incidentResponse,
     authRecovery,
     clinicPilot,
+    clinicPilotProjection,
     clinicalDataIntegrity,
     restoreDrill,
   };

--- a/apps/web/lib/clinic-readiness-release.ts
+++ b/apps/web/lib/clinic-readiness-release.ts
@@ -2,6 +2,10 @@ import { evaluateIncidentResponseEvidence } from "./incident-response-evidence";
 import { evaluateAuthRecoveryEvidence } from "./auth-recovery-evidence";
 import { evaluateClinicalDataIntegrityEvidence } from "./clinical-data-integrity-evidence";
 import { evaluateClinicPilotReleaseEvidence } from "./clinic-pilot-release-evidence";
+import {
+  clinicPilotActorHash,
+  evaluateClinicPilotProjectionEvidence,
+} from "./clinic-pilot-projection-evidence";
 import { evaluateProviderRestoreReleaseEvidence } from "./provider-restore-release-evidence";
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
@@ -151,8 +155,8 @@ export function evaluateClinicReadinessRelease(
 ): ClinicReadinessDecision {
   const reasons: string[] = [];
   const root = record(input);
-  if (root?.evidenceFormatVersion !== 10) {
-    reasons.push("Clinic readiness evidence format version must be 10.");
+  if (root?.evidenceFormatVersion !== 11) {
+    reasons.push("Clinic readiness evidence format version must be 11.");
   }
   const releaseSha =
     root &&
@@ -286,6 +290,56 @@ export function evaluateClinicReadinessRelease(
     reasons.push(...clinicPilotDecision.reasons);
     if (releaseSha && clinicPilotDecision.releaseSha !== releaseSha) {
       reasons.push("Clinic-pilot evidence does not match the release SHA.");
+    }
+  }
+
+  const clinicPilotProjection = record(root?.clinicPilotProjection);
+  if (!clinicPilotProjection) {
+    reasons.push("Clinic-pilot projection evidence is missing.");
+  } else {
+    const projectionDecision = evaluateClinicPilotProjectionEvidence(
+      clinicPilotProjection,
+      nowMs,
+    );
+    reasons.push(...projectionDecision.reasons);
+    const pilotSource = record(clinicPilot?.sourceEvidence);
+    const pilotApprovals = record(clinicPilot?.approvals);
+    const clinicAdministrator = record(pilotApprovals?.clinicAdministrator);
+    const administratorActorId =
+      typeof clinicAdministrator?.actorId === "string"
+        ? clinicAdministrator.actorId
+        : null;
+    if (
+      projectionDecision.clinicUseValidatedHash !==
+        pilotSource?.clinicUseValidatedHash ||
+      projectionDecision.pilotProjectionVersion !==
+        pilotSource?.pilotProjectionVersion
+    ) {
+      reasons.push(
+        "Clinic-pilot packet does not match the immutable projection version.",
+      );
+    }
+    if (
+      !administratorActorId ||
+      projectionDecision.clinicAdministratorActorHash !==
+        clinicPilotActorHash(administratorActorId)
+    ) {
+      reasons.push(
+        "Clinic-pilot administrator approval does not match the projection.",
+      );
+    }
+    const clinicalDatabaseFingerprint =
+      typeof clinicalDataIntegrity?.databaseTargetFingerprint === "string" &&
+      /^[0-9a-f]{64}$/i.test(clinicalDataIntegrity.databaseTargetFingerprint)
+        ? clinicalDataIntegrity.databaseTargetFingerprint.toLowerCase()
+        : null;
+    if (
+      projectionDecision.databaseTargetFingerprint !==
+      clinicalDatabaseFingerprint
+    ) {
+      reasons.push(
+        "Clinic-pilot projection does not match the clinical database.",
+      );
     }
   }
 

--- a/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
+++ b/apps/web/scripts/__tests__/collect-clinic-readiness-evidence.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  collect: vi.fn(async () => ({ evidenceFormatVersion: 10 })),
+  collect: vi.fn(async () => ({ evidenceFormatVersion: 11 })),
   evaluate: vi.fn(() => ({
     decision: "GO",
     evaluatedAt: "2026-08-29T21:00:00.000Z",
@@ -65,6 +65,8 @@ function argumentsFor(output: string): string[] {
     "private/auth-recovery.json",
     "--clinic-pilot-evidence",
     "private/clinic-pilot.json",
+    "--clinic-pilot-projection-audit",
+    "private/clinic-pilot-projection.json",
     "--clinical-database-fingerprint",
     "d".repeat(64),
     "--controlled-substance-audit",
@@ -103,6 +105,10 @@ describe("clinic readiness evidence collector CLI", () => {
         clinicPilotEvidencePath: path.join(
           directory,
           "private/clinic-pilot.json",
+        ),
+        clinicPilotProjectionAuditPath: path.join(
+          directory,
+          "private/clinic-pilot-projection.json",
         ),
         clinicalDatabaseFingerprint: "d".repeat(64),
         controlledSubstanceAuditPath: path.join(

--- a/apps/web/scripts/collect-clinic-readiness-evidence.ts
+++ b/apps/web/scripts/collect-clinic-readiness-evidence.ts
@@ -20,6 +20,7 @@ const VALUE_ARGS = new Set([
   "--incident-evidence",
   "--auth-recovery-evidence",
   "--clinic-pilot-evidence",
+  "--clinic-pilot-projection-audit",
   "--clinical-database-fingerprint",
   "--controlled-substance-audit",
   "--prescription-audit",
@@ -36,7 +37,7 @@ function argumentsMap(args: string[]): Map<string, string> {
     const value = normalized[index + 1]?.trim();
     if (!name || !VALUE_ARGS.has(name) || !value || values.has(name)) {
       throw new Error(
-        "Usage: release:clinic-readiness:collect -- --release-sha <sha> --repository <owner/name> --ci-run-id <id> --staging-migration-run-id <id> --staging-reset-run-id <id> --staging-database-fingerprint <sha256> --migration-run-id <id> --staging-health-url <https-url> --hosted-health-url <https-url> --restore-evidence <path> --incident-evidence <path> --auth-recovery-evidence <path> --clinic-pilot-evidence <path> --clinical-database-fingerprint <sha256> --controlled-substance-audit <path> --prescription-audit <path> --lab-result-audit <path> --vaccination-audit <path> --output <path>",
+        "Usage: release:clinic-readiness:collect -- --release-sha <sha> --repository <owner/name> --ci-run-id <id> --staging-migration-run-id <id> --staging-reset-run-id <id> --staging-database-fingerprint <sha256> --migration-run-id <id> --staging-health-url <https-url> --hosted-health-url <https-url> --restore-evidence <path> --incident-evidence <path> --auth-recovery-evidence <path> --clinic-pilot-evidence <path> --clinic-pilot-projection-audit <path> --clinical-database-fingerprint <sha256> --controlled-substance-audit <path> --prescription-audit <path> --lab-result-audit <path> --vaccination-audit <path> --output <path>",
       );
     }
     values.set(name, value);
@@ -91,6 +92,9 @@ export async function main(args = process.argv.slice(2)) {
     ),
     clinicPilotEvidencePath: operatorPath(
       values.get("--clinic-pilot-evidence")!,
+    ),
+    clinicPilotProjectionAuditPath: operatorPath(
+      values.get("--clinic-pilot-projection-audit")!,
     ),
     clinicalDatabaseFingerprint: values.get("--clinical-database-fingerprint")!,
     controlledSubstanceAuditPath: operatorPath(

--- a/docs/clinic-pilot-operations.md
+++ b/docs/clinic-pilot-operations.md
@@ -188,7 +188,12 @@ provider payloads, credentials, and local paths are prohibited.
 
 The evidence JSON has no optional or free-form fields. Use this exact shape,
 substituting reviewed values from the immutable pilot projection and the exact
-release candidate:
+release candidate. Immediately before final collection, run the read-only
+`db:clinic-pilot-release:audit` command documented in
+`hosted-cloud-production.md` with this packet's `clinicUseValidatedHash` and
+`pilotProjectionVersion`. Release format v11 requires that fresh audit to match
+the packet, the accepting clinic administrator, and the configured clinical
+database; a hand-authored hash alone cannot produce `GO`.
 
 ```json
 {

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -182,9 +182,9 @@ PLATFORM_ADMIN_EMAILS=...
 
 ### Transitional production release gate
 
-Before production approval, collect one PHI-free, format-version `7` JSON
+Before production approval, collect one PHI-free, format-version `11` JSON
 evidence packet from authoritative sources. Export a read-only `GITHUB_TOKEN`
-in the secure operator environment. Immediately before collection, run all four
+in the secure operator environment. Immediately before collection, run all five
 aggregate-only audits against the same intended production database. Each audit
 requires its explicit read-only confirmation and writes no database data:
 
@@ -194,10 +194,16 @@ export CONTROLLED_SUBSTANCE_LEDGER_READ_ONLY_CONFIRMATION=OPENVPM_CONTROLLED_SUB
 export PRESCRIPTION_INTEGRITY_READ_ONLY_CONFIRMATION=OPENVPM_PRESCRIPTION_INTEGRITY_READ_ONLY
 export LAB_RESULT_INTEGRITY_READ_ONLY_CONFIRMATION=OPENVPM_LAB_RESULT_INTEGRITY_READ_ONLY
 export VACCINATION_INTEGRITY_READ_ONLY_CONFIRMATION=OPENVPM_VACCINATION_INTEGRITY_READ_ONLY
+export CLINIC_PILOT_RELEASE_READ_ONLY_CONFIRMATION=OPENVPM_CLINIC_PILOT_RELEASE_READ_ONLY
 pnpm --filter @openpims/db db:controlled-substance-ledger:audit -- --allow-live-read-only > /secure/path/controlled-substances.json
 pnpm --filter @openpims/db db:prescription-integrity:audit -- --allow-live-read-only > /secure/path/prescriptions.json
 pnpm --filter @openpims/db db:lab-result-integrity:audit -- --allow-live-read-only > /secure/path/lab-results.json
 pnpm --filter @openpims/db db:vaccination-integrity:audit -- --allow-live-read-only > /secure/path/vaccinations.json
+pnpm --filter @openpims/db db:clinic-pilot-release:audit -- \
+  --allow-live-read-only \
+  --clinic-use-hash "$CLINIC_USE_VALIDATED_HASH" \
+  --projection-version "$PILOT_PROJECTION_VERSION" \
+  > /secure/path/clinic-pilot-projection.json
 ```
 
 Then assemble the release packet while those reports are still fresh:
@@ -217,6 +223,7 @@ pnpm --filter @openpims/web release:clinic-readiness:collect -- \
   --incident-evidence /secure/path/incident-tabletop-evidence.json \
   --auth-recovery-evidence /secure/path/auth-recovery-drill-evidence.json \
   --clinic-pilot-evidence /secure/path/clinic-pilot-release-evidence.json \
+  --clinic-pilot-projection-audit /secure/path/clinic-pilot-projection.json \
   --clinical-database-fingerprint "$DATABASE_TARGET_FINGERPRINT" \
   --controlled-substance-audit /secure/path/controlled-substances.json \
   --prescription-audit /secure/path/prescriptions.json \
@@ -224,6 +231,15 @@ pnpm --filter @openpims/web release:clinic-readiness:collect -- \
   --vaccination-audit /secure/path/vaccinations.json \
   --output /secure/path/clinic-readiness-evidence.json
 ```
+
+The clinic-pilot projection audit selects only the packet's validated-use hash
+and projection version, recomputes the first five clinic-day evidence hash,
+requires one matching graduated projection plus its exact immutable event, and
+emits only aggregate booleans, counts, a database fingerprint, and a one-way
+hash of the accepting administrator ID. It never emits a clinic, staff, client,
+patient, contact, or visit identifier. The collector binds that database output
+to the packet's source hash/version, accepting administrator, and independently
+configured clinical database fingerprint.
 
 The collector refuses to overwrite an existing packet. It verifies the
 successful exact-SHA `main` CI run, an exact-SHA migration and protected
@@ -270,7 +286,8 @@ same SHA before production; production
 health is a fresh HTTP 200 hosted result whose response reports that same
 deployment SHA; backup freshness and 100% independent file coverage are
 affirmative (not advisory) in both hosted environments;
-and a recent provider-backed, non-synthetic restore drill for the same SHA
+the fresh immutable clinic-pilot projection audit; and a recent provider-backed,
+non-synthetic restore drill for the same SHA
 proves dual control before execution, an exact database-backup version and
 SHA-256, a fresh backup/RPO, a bounded RTO, the isolated-staging target
 fingerprint, the hold/release workflow, an exact independently replicated

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -233,13 +233,16 @@ pnpm --filter @openpims/web release:clinic-readiness:collect -- \
 ```
 
 The clinic-pilot projection audit selects only the packet's validated-use hash
-and projection version, recomputes the first five clinic-day evidence hash,
-requires one matching graduated projection plus its exact immutable event, and
-emits only aggregate booleans, counts, a database fingerprint, and a one-way
-hash of the accepting administrator ID. It never emits a clinic, staff, client,
-patient, contact, or visit identifier. The collector binds that database output
-to the packet's source hash/version, accepting administrator, and independently
-configured clinical database fingerprint.
+and projection version, recomputes the first five clinic-day evidence hash from
+current non-demo closeouts, and requires one matching graduated projection plus
+its exact immutable event. It also rechecks the accepting administrator,
+location count, setup, conversion milestones, billing access, and jurisdiction
+against current rows. It emits only aggregate booleans, counts, a database
+fingerprint, and a one-way hash of the accepting administrator ID. It never
+emits a clinic, staff, client, patient, contact, or visit identifier. The
+collector binds that database output to the packet's source hash/version,
+accepting administrator, and independently configured clinical database
+fingerprint.
 
 The collector refuses to overwrite an existing packet. It verifies the
 successful exact-SHA `main` CI run, an exact-SHA migration and protected

--- a/packages/db/audit-clinic-pilot-release.ts
+++ b/packages/db/audit-clinic-pilot-release.ts
@@ -76,6 +76,63 @@ try {
     "isolation level repeatable read read only",
     async (tx) =>
       tx.unsafe<PilotRow[]>(`
+        with eligible_closeouts as (
+          select
+            cp.id as clinic_pilot_id,
+            closeout.id as closeout_id,
+            closeout.completed_at,
+            (closeout.completed_at at time zone practice.timezone)::date as local_date
+          from clinic_pilots cp
+          join practices practice
+            on practice.id = cp.practice_id
+           and practice.deleted_at is null
+           and practice.settings ->> 'analyticsExcluded' is distinct from 'true'
+          join visit_closeouts closeout
+            on closeout.practice_id = cp.practice_id
+           and closeout.status = 'completed'
+           and closeout.completed_at is not null
+           and closeout.completed_at >= cp.created_at
+           and closeout.deleted_at is null
+          join appointments appointment
+            on appointment.id = closeout.appointment_id
+           and appointment.practice_id = cp.practice_id
+           and appointment.deleted_at is null
+          where cp.clinic_use_validated_hash = '${clinicUseValidatedHash}'
+            and cp.version = ${pilotProjectionVersion}
+            and not (
+              coalesce(
+                practice.settings -> 'demoData' -> 'appointmentIds',
+                '[]'::jsonb
+              ) @> to_jsonb(appointment.id::text)
+            )
+        ), clinic_use_days as (
+          select distinct on (clinic_pilot_id, local_date)
+            clinic_pilot_id, closeout_id, completed_at, local_date
+          from eligible_closeouts
+          order by clinic_pilot_id, local_date, completed_at, closeout_id
+        ), ranked_clinic_use_days as (
+          select
+            clinic_use_days.*,
+            row_number() over (
+              partition by clinic_pilot_id order by completed_at, closeout_id
+            ) as day_rank
+          from clinic_use_days
+        ), current_use as (
+          select
+            clinic_pilot_id,
+            (array_agg(closeout_id order by completed_at, closeout_id))[1]
+              as first_visit_closeout_id,
+            count(*)::int as distinct_clinic_days,
+            jsonb_agg(
+              jsonb_build_object(
+                'closeoutId', closeout_id,
+                'completedAt', completed_at,
+                'localDate', local_date
+              ) order by completed_at, closeout_id
+            ) filter (where day_rank <= 5) as clinic_use_days
+          from ranked_clinic_use_days
+          group by clinic_pilot_id
+        )
         select
           cp.workflow::text as workflow,
           cp.stage::text as stage,
@@ -93,7 +150,7 @@ try {
           cp.first_visit_validated_at is not null
             and cp.first_visit_validated_closeout_id is not null
             and cp.first_visit_validated_closeout_id =
-              nullif(event.evidence_snapshot ->> 'firstVisitCloseoutId', '')::uuid
+              current_use.first_visit_closeout_id
             as "firstVisitValidated",
           cp.clinic_use_validated_at is not null
             and cp.clinic_use_validated_hash = '${clinicUseValidatedHash}'
@@ -103,28 +160,66 @@ try {
             as "clinicAcceptanceRecorded",
           cp.clinic_acceptance_by_user_id::text as "clinicAdministratorUserId",
           cp.clinic_acceptance_by_user_id is not null
-            and jsonb_typeof(event.evidence_snapshot -> 'verifiedAdminUserIds') = 'array'
-            and event.evidence_snapshot -> 'verifiedAdminUserIds'
-              @> jsonb_build_array(cp.clinic_acceptance_by_user_id::text)
+            and exists (
+              select 1 from users administrator
+              where administrator.practice_id = cp.practice_id
+                and administrator.id = cp.clinic_acceptance_by_user_id
+                and administrator.role = 'admin'
+                and administrator.email_verified_at is not null
+                and administrator.deleted_at is null
+            )
             as "verifiedAdministrator",
-          jsonb_array_length(event.evidence_snapshot -> 'activeLocationIds')::int
-            as "activeLocationCount",
-          nullif(event.evidence_snapshot ->> 'setupCompletedAt', '') is not null
-            and nullif(event.evidence_snapshot ->> 'activatedAt', '') is not null
+          (
+            select count(*)::int from locations location
+            where location.practice_id = cp.practice_id
+              and location.deleted_at is null
+          ) as "activeLocationCount",
+          nullif(practice.settings ->> 'onboardingCompletedAt', '') is not null
+            and exists (
+              select 1 from practice_conversion_milestones milestone
+              where milestone.practice_id = cp.practice_id
+                and milestone.milestone = 'activated'
+            )
             as "setupComplete",
-          jsonb_array_length(event.evidence_snapshot -> 'clinicUseDays')::int
+          coalesce(current_use.distinct_clinic_days, 0)::int
             as "distinctClinicDays",
-          event.evidence_snapshot -> 'clinicUseDays' as "clinicUseDays",
-          nullif(event.evidence_snapshot ->> 'paymentMethodCollectedAt', '') is not null
+          coalesce(current_use.clinic_use_days, '[]'::jsonb)
+            as "clinicUseDays",
+          exists (
+            select 1 from practice_conversion_milestones milestone
+            where milestone.practice_id = cp.practice_id
+              and milestone.milestone = 'payment_method_collected'
+          )
             as "paymentMethodCollected",
-          nullif(event.evidence_snapshot ->> 'firstPositivePaymentAt', '') is not null
+          exists (
+            select 1 from practice_conversion_milestones milestone
+            where milestone.practice_id = cp.practice_id
+              and milestone.milestone = 'first_positive_payment'
+          )
             as "positivePaymentRecorded",
-          (event.evidence_snapshot ->> 'hostedFullAccess')::boolean
+          (
+            (practice.billing_status = 'trialing'
+              and practice.trial_ends_at > now())
+            or (
+              practice.billing_status in ('active', 'past_due')
+              and practice.subscription_tier in (
+                'cloud', 'enterprise', 'starter', 'pro', 'professional'
+              )
+            )
+          )
             as "hostedFullAccess",
-          (event.evidence_snapshot ->> 'jurisdictionConfirmed')::boolean
-            and event.evidence_snapshot ->> 'country' = 'US'
+          practice.country = 'US'
+            and practice.settings -> 'onboardingState' ->> 'jurisdictionCountry' = 'US'
+            and length(btrim(coalesce(
+              practice.settings -> 'onboardingState' ->> 'jurisdictionSelectedAt',
+              ''
+            ))) > 0
             as "jurisdictionConfirmed"
         from clinic_pilots cp
+        join practices practice
+          on practice.id = cp.practice_id
+         and practice.deleted_at is null
+         and practice.settings ->> 'analyticsExcluded' is distinct from 'true'
         join clinic_pilot_events event
           on event.clinic_pilot_id = cp.id
          and event.practice_id = cp.practice_id
@@ -150,6 +245,7 @@ try {
          and event.last_contact_outcome is not distinct from cp.last_contact_outcome
          and event.target_start_on is not distinct from cp.target_start_on
          and event.next_review_at is not distinct from cp.next_review_at
+        left join current_use on current_use.clinic_pilot_id = cp.id
         where cp.clinic_use_validated_hash = '${clinicUseValidatedHash}'
           and cp.version = ${pilotProjectionVersion}
       `),

--- a/packages/db/audit-clinic-pilot-release.ts
+++ b/packages/db/audit-clinic-pilot-release.ts
@@ -1,0 +1,250 @@
+/** PHI-free, read-only proof that a release packet matches one pilot projection. */
+import { createHash } from "node:crypto";
+import { config } from "dotenv";
+config({ path: process.env.OPENPIMS_ENV_FILE?.trim() || "../../.env" });
+
+import postgres from "postgres";
+import { databaseConnectionIdentityFingerprint } from "./deployment-target";
+
+const CONFIRMATION = "OPENVPM_CLINIC_PILOT_RELEASE_READ_ONLY";
+const SHA256 = /^[0-9a-f]{64}$/i;
+
+function argument(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1]?.trim() : undefined;
+}
+
+const clinicUseValidatedHash = argument("--clinic-use-hash")?.toLowerCase();
+const rawProjectionVersion = argument("--projection-version");
+const pilotProjectionVersion = rawProjectionVersion
+  ? Number(rawProjectionVersion)
+  : Number.NaN;
+if (
+  !process.argv.includes("--allow-live-read-only") ||
+  process.env.CLINIC_PILOT_RELEASE_READ_ONLY_CONFIRMATION !== CONFIRMATION ||
+  !clinicUseValidatedHash ||
+  !SHA256.test(clinicUseValidatedHash) ||
+  !Number.isSafeInteger(pilotProjectionVersion) ||
+  pilotProjectionVersion <= 0
+) {
+  console.error(
+    `Refusing database access. Pass --allow-live-read-only --clinic-use-hash <sha256> --projection-version <positive integer> and set CLINIC_PILOT_RELEASE_READ_ONLY_CONFIRMATION=${CONFIRMATION}.`,
+  );
+  process.exit(1);
+}
+
+const databaseUrl = process.env.DATABASE_URL?.trim();
+if (!databaseUrl) {
+  console.error("DATABASE_URL is required.");
+  process.exit(1);
+}
+const sql = postgres(databaseUrl, {
+  max: 1,
+  connect_timeout: 10,
+  idle_timeout: 2,
+});
+
+type PilotRow = {
+  workflow: string;
+  stage: string;
+  decision: string;
+  blockerCount: number;
+  qualificationComplete: boolean;
+  readinessComplete: boolean;
+  communicationTested: boolean;
+  firstVisitValidated: boolean;
+  clinicUseValidated: boolean;
+  clinicAcceptanceRecorded: boolean;
+  clinicAdministratorUserId: string | null;
+  verifiedAdministrator: boolean;
+  activeLocationCount: number;
+  setupComplete: boolean;
+  distinctClinicDays: number;
+  clinicUseDays: Array<{
+    closeoutId: string;
+    completedAt: string;
+    localDate: string;
+  }>;
+  paymentMethodCollected: boolean;
+  positivePaymentRecorded: boolean;
+  hostedFullAccess: boolean;
+  jurisdictionConfirmed: boolean;
+};
+
+try {
+  const rows = await sql.begin(
+    "isolation level repeatable read read only",
+    async (tx) =>
+      tx.unsafe<PilotRow[]>(`
+        select
+          cp.workflow::text as workflow,
+          cp.stage::text as stage,
+          cp.decision::text as decision,
+          cardinality(cp.blocker_codes)::int as "blockerCount",
+          not exists (
+            select 1 from jsonb_each(cp.qualification_checklist) item
+            where item.value is distinct from 'true'::jsonb
+          ) as "qualificationComplete",
+          not exists (
+            select 1 from jsonb_each(cp.readiness_checklist) item
+            where item.value is distinct from 'true'::jsonb
+          ) as "readinessComplete",
+          cp.communication_tested_at is not null as "communicationTested",
+          cp.first_visit_validated_at is not null
+            and cp.first_visit_validated_closeout_id is not null
+            and cp.first_visit_validated_closeout_id =
+              nullif(event.evidence_snapshot ->> 'firstVisitCloseoutId', '')::uuid
+            as "firstVisitValidated",
+          cp.clinic_use_validated_at is not null
+            and cp.clinic_use_validated_hash = '${clinicUseValidatedHash}'
+            as "clinicUseValidated",
+          cp.clinic_acceptance_at is not null
+            and cp.clinic_acceptance_by_user_id is not null
+            as "clinicAcceptanceRecorded",
+          cp.clinic_acceptance_by_user_id::text as "clinicAdministratorUserId",
+          cp.clinic_acceptance_by_user_id is not null
+            and jsonb_typeof(event.evidence_snapshot -> 'verifiedAdminUserIds') = 'array'
+            and event.evidence_snapshot -> 'verifiedAdminUserIds'
+              @> jsonb_build_array(cp.clinic_acceptance_by_user_id::text)
+            as "verifiedAdministrator",
+          jsonb_array_length(event.evidence_snapshot -> 'activeLocationIds')::int
+            as "activeLocationCount",
+          nullif(event.evidence_snapshot ->> 'setupCompletedAt', '') is not null
+            and nullif(event.evidence_snapshot ->> 'activatedAt', '') is not null
+            as "setupComplete",
+          jsonb_array_length(event.evidence_snapshot -> 'clinicUseDays')::int
+            as "distinctClinicDays",
+          event.evidence_snapshot -> 'clinicUseDays' as "clinicUseDays",
+          nullif(event.evidence_snapshot ->> 'paymentMethodCollectedAt', '') is not null
+            as "paymentMethodCollected",
+          nullif(event.evidence_snapshot ->> 'firstPositivePaymentAt', '') is not null
+            as "positivePaymentRecorded",
+          (event.evidence_snapshot ->> 'hostedFullAccess')::boolean
+            as "hostedFullAccess",
+          (event.evidence_snapshot ->> 'jurisdictionConfirmed')::boolean
+            and event.evidence_snapshot ->> 'country' = 'US'
+            as "jurisdictionConfirmed"
+        from clinic_pilots cp
+        join clinic_pilot_events event
+          on event.clinic_pilot_id = cp.id
+         and event.practice_id = cp.practice_id
+         and event.projection_version = cp.version
+         and event.workflow = cp.workflow
+         and event.stage = cp.stage
+         and event.decision = cp.decision
+         and event.qualification_checklist = cp.qualification_checklist
+         and event.readiness_checklist = cp.readiness_checklist
+         and event.blocker_codes = cp.blocker_codes
+         and event.next_action = cp.next_action
+         and event.support_cadence = cp.support_cadence
+         and event.owner_identity = cp.owner_identity
+         and event.communication_mode = cp.communication_mode
+         and event.communication_tested_at is not distinct from cp.communication_tested_at
+         and event.first_visit_validated_at is not distinct from cp.first_visit_validated_at
+         and event.first_visit_validated_closeout_id is not distinct from cp.first_visit_validated_closeout_id
+         and event.clinic_use_validated_at is not distinct from cp.clinic_use_validated_at
+         and event.clinic_use_validated_hash is not distinct from cp.clinic_use_validated_hash
+         and event.clinic_acceptance_at is not distinct from cp.clinic_acceptance_at
+         and event.clinic_acceptance_by_user_id is not distinct from cp.clinic_acceptance_by_user_id
+         and event.last_contact_at is not distinct from cp.last_contact_at
+         and event.last_contact_outcome is not distinct from cp.last_contact_outcome
+         and event.target_start_on is not distinct from cp.target_start_on
+         and event.next_review_at is not distinct from cp.next_review_at
+        where cp.clinic_use_validated_hash = '${clinicUseValidatedHash}'
+          and cp.version = ${pilotProjectionVersion}
+      `),
+  );
+
+  const row = rows.length === 1 ? rows[0] : undefined;
+  const recomputedClinicUseHash = row
+    ? createHash("sha256")
+        .update(JSON.stringify(row.clinicUseDays.slice(0, 5)))
+        .digest("hex")
+    : null;
+  const clinicUseValidated = Boolean(
+    row?.clinicUseValidated &&
+    recomputedClinicUseHash === clinicUseValidatedHash &&
+    row.distinctClinicDays >= 5,
+  );
+  const clinicAdministratorActorHash = row?.clinicAdministratorUserId
+    ? createHash("sha256")
+        .update(`user:${row.clinicAdministratorUserId}`.toLowerCase())
+        .digest("hex")
+    : null;
+  const projection = {
+    matchedPilotCount: rows.length,
+    immutableEventMatch: rows.length === 1,
+    workflow: row?.workflow ?? null,
+    stage: row?.stage ?? null,
+    decision: row?.decision ?? null,
+    blockerCount: row?.blockerCount ?? -1,
+    qualificationComplete: row?.qualificationComplete ?? false,
+    readinessComplete: row?.readinessComplete ?? false,
+  };
+  const outcomes = {
+    verifiedAdministrator: row?.verifiedAdministrator ?? false,
+    activeLocationCount: row?.activeLocationCount ?? 0,
+    setupComplete: row?.setupComplete ?? false,
+    communicationTested: row?.communicationTested ?? false,
+    firstVisitValidated: row?.firstVisitValidated ?? false,
+    distinctClinicDays: row?.distinctClinicDays ?? 0,
+    clinicUseValidated,
+    paymentMethodCollected: row?.paymentMethodCollected ?? false,
+    positivePaymentRecorded: row?.positivePaymentRecorded ?? false,
+    hostedFullAccess: row?.hostedFullAccess ?? false,
+    jurisdictionConfirmed: row?.jurisdictionConfirmed ?? false,
+    clinicAcceptanceRecorded: row?.clinicAcceptanceRecorded ?? false,
+  };
+  const releaseSafe =
+    projection.matchedPilotCount === 1 &&
+    projection.immutableEventMatch &&
+    projection.stage === "completed" &&
+    projection.decision === "graduated" &&
+    projection.blockerCount === 0 &&
+    projection.qualificationComplete &&
+    projection.readinessComplete &&
+    projection.workflow !== null &&
+    ["general_practice", "house_call"].includes(projection.workflow) &&
+    Object.entries(outcomes).every(([field, value]) =>
+      field === "activeLocationCount"
+        ? value === 1
+        : field === "distinctClinicDays"
+          ? Number(value) >= 5
+          : value === true,
+    );
+
+  console.log(
+    JSON.stringify(
+      {
+        evidenceFormatVersion: 1,
+        mode: "read_only_aggregate",
+        checkedAt: new Date().toISOString(),
+        databaseTargetFingerprint:
+          databaseConnectionIdentityFingerprint(databaseUrl),
+        clinicUseValidatedHash,
+        pilotProjectionVersion,
+        clinicAdministratorActorHash,
+        projection,
+        outcomes,
+        evidenceSafety: {
+          phiFree: true,
+          secretsFree: true,
+          patientIdentifiersFree: true,
+          contactDestinationsFree: true,
+          localPathsFree: true,
+        },
+        releaseSafe,
+      },
+      null,
+      2,
+    ),
+  );
+  if (!releaseSafe) process.exitCode = 2;
+} catch {
+  console.error(
+    "Clinic-pilot release read-only audit failed; details redacted.",
+  );
+  process.exitCode = 1;
+} finally {
+  await sql.end();
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -46,6 +46,7 @@
     "db:lab-result-integrity:audit": "tsx audit-lab-result-integrity.ts",
     "db:lab-result-integrity:test": "tsx test-lab-result-integrity.ts",
     "db:vaccination-integrity:audit": "tsx audit-vaccination-integrity.ts",
+    "db:clinic-pilot-release:audit": "tsx audit-clinic-pilot-release.ts",
     "db:vaccination-integrity:test": "tsx test-vaccination-integrity.ts",
     "db:migrations:check": "pnpm --filter @openpims/web exec vitest run lib/__tests__/migration-journal-integrity.test.ts lib/__tests__/db-migrations.test.ts",
     "db:migrations:conformance": "tsx migration-conformance.ts",


### PR DESCRIPTION
## Outcome

Closes a release-integrity gap left after #309: the pilot packet required a syntactically valid clinic-use hash and projection version, but the final collector did not independently prove those values came from the immutable clinic-pilot projection. A well-shaped hand-authored packet could theoretically assert clinic use and acceptance without matching configured database evidence.

## Controls

- Add a guarded, repeatable-read, read-only clinic-pilot release audit selected only by validated-use SHA-256 and projection version.
- Recompute the first five clinic-day evidence hash from current, non-demo, completed clinic-day closeouts and require an exact immutable event projection.
- Require exactly one graduated single-pilot projection, zero blockers, completed qualification/readiness checklists, and matching current workflow state.
- Revalidate current database rows for the accepting clinic administrator, one active location, setup and activation, communications, first visit, five clinic days, payment method plus positive payment, hosted access, US jurisdiction, and clinic acceptance.
- Emit only aggregate booleans and counts, hashes, version, workflow/state, and the credential-free database fingerprint; hash the clinic administrator actor rather than outputting its UUID.
- Bind release format v11 to the packet source hash/version, accepting administrator, and independently configured clinical database fingerprint.
- Reject stale, extra-field, unsafe, cross-database, cross-projection, or hand-authored detached evidence.

## Verification

- Exact hosted run for head `11a29d0846f85acf24e67648212aaf7437879f24`: https://github.com/evangauer/openvpm/actions/runs/33348863191
- Hosted full suite: 4,650 tests passed; 31 existing environment-gated integrations skipped.
- Hosted 56-page production build, lint, type checking, migration history, RLS/database contracts, real WebAuthn golden-clinic workflow, dependency audit, OSS verification, and secret scans passed.
- The permanent migrated-schema refusal check ran the exact final audit, required exit 2, and verified bounded `releaseSafe:false` output with zero matches and no administrator hash.
- Focused release/projection controls: 45/45 passed.
- Local full serial suite before the final additional source contract: 4,649 tests passed; 31 existing environment-gated integrations skipped.
- The exact final query also passed against the full 114-migration disposable schema and failed closed for a nonexistent selector.
- Production dependency audit found no known vulnerabilities.
- OSS verification passed 1,574 tracked files; source and artifact secret scans passed.

## Safety boundary

Draft stacked on #310. Database exercises used disposable local PostgreSQL clusters only; both were stopped and moved to Trash. No configured database, provider, patient object, merge, deployment, provisioning, spend, or production state was touched. This proves the evidence path, not that a clinic pilot occurred. Release remains NO_GO.