### PR TITLE
fix(recovery): reject empty restore evidence

### DIFF
--- a/apps/web/lib/__tests__/provider-restore-release-evidence.test.ts
+++ b/apps/web/lib/__tests__/provider-restore-release-evidence.test.ts
@@ -161,6 +161,23 @@ describe("provider-restore release evidence", () => {
     );
   });
 
+  it("rejects empty-object and zero-duration recovery claims", () => {
+    const evidence = healthyProviderRestoreEvidence();
+    evidence.independentObject.fileSizeBytes = 0;
+    evidence.metrics.rtoMs = 0;
+
+    const reasons = evaluateProviderRestoreReleaseEvidence(
+      evidence,
+      now,
+    ).reasons;
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "Independent object restore identity is incomplete.",
+        "Provider-restore RTO evidence is invalid.",
+      ]),
+    );
+  });
+
   it("rejects missing recovery smokes and release-blocking findings", () => {
     const evidence = healthyProviderRestoreEvidence();
     evidence.recoveryHold.releasedAfterChecklistAndDatabaseGate = false;

--- a/apps/web/lib/provider-restore-release-evidence.ts
+++ b/apps/web/lib/provider-restore-release-evidence.ts
@@ -116,6 +116,10 @@ function nonNegativeInteger(value: unknown): value is number {
   return Number.isSafeInteger(value) && Number(value) >= 0;
 }
 
+function positiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) > 0;
+}
+
 /** Strict, identifier-free evidence for a real provider-backed restore drill. */
 export function evaluateProviderRestoreReleaseEvidence(
   input: unknown,
@@ -234,7 +238,7 @@ export function evaluateProviderRestoreReleaseEvidence(
     !VERSION_ID.test(object.objectVersionId) ||
     typeof object.checksumSha256 !== "string" ||
     !SHA256.test(object.checksumSha256) ||
-    !nonNegativeInteger(object.fileSizeBytes) ||
+    !positiveInteger(object.fileSizeBytes) ||
     object.exactVersionVerified !== true
   ) {
     reasons.push("Independent object restore identity is incomplete.");
@@ -289,7 +293,7 @@ export function evaluateProviderRestoreReleaseEvidence(
       reasons.push("Provider-restore RPO evidence is invalid.");
     }
     if (
-      !nonNegativeInteger(metrics.rtoMs) ||
+      !positiveInteger(metrics.rtoMs) ||
       duration == null ||
       metrics.rtoMs > duration ||
       metrics.rtoMs > MAX_DRILL_DURATION_MS

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -294,7 +294,8 @@ non-synthetic restore drill for the same SHA
 proves dual control before execution, an exact database-backup version and
 SHA-256, a fresh backup/RPO, a bounded RTO, the isolated-staging target
 fingerprint, the hold/release workflow, an exact independently replicated
-object version and SHA-256, and authentication, tenant, scheduling, clinical,
+non-empty object version, positive byte size and SHA-256, a positive measured
+RTO, and authentication, tenant, scheduling, clinical,
 invoice, payment, and file smokes. The restore packet has a strict
 identifier-free shape and must attest that it contains no PHI, patient IDs,
 contact destinations, provider payloads, local paths, or secrets; any extra


### PR DESCRIPTION
## Outcome

The provider-restore release evaluator accepted a zero-byte independent object and a zero-millisecond RTO because both fields used the non-negative integer validator. That allowed an empty object and a no-time recovery claim to satisfy otherwise strict provider-backed recovery evidence.

## Change

- Require the independently restored object to have a positive byte size.
- Require the measured RTO to be a positive integer while retaining the existing upper bounds and relationship to drill duration.
- Add a regression test proving both zero-value claims fail closed.
- Align the production runbook with the enforced contract.

## Verification

- Exact hosted run for head `a0e955558198b4faec78980c2cf30672db1c1c39`: https://github.com/evangauer/openvpm/actions/runs/33349594191
- Hosted full suite: 4,651 tests passed; 31 existing environment-gated integrations skipped.
- Hosted 56-page production build, migration history, full RLS/database contracts, real WebAuthn golden-clinic workflow, lint, type checking, dependency audit, OSS verification, and secret scans passed.
- Focused provider/collector/release tests: 47/47 passed.
- Production dependency audit found no known vulnerabilities.

## Safety boundary

Draft stacked on #311. No provider, object, database, secret, environment, deployment, merge, provisioning, spend, or production state was touched. This strengthens the evidence contract; it does not perform the provider-backed drill. Release remains **NO_GO**.