### PR TITLE
fix(security): patch fflate ZIP denial of service

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "dompurify": "3.4.13",
       "fast-xml-builder": "1.1.7",
       "fast-xml-parser": "5.10.1",
+      "fflate": "0.8.3",
       "form-data": "4.0.6",
       "@tiptap/extension-bubble-menu": "3.30.5",
       "@tiptap/extension-floating-menu": "3.30.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   dompurify: 3.4.13
   fast-xml-builder: 1.1.7
   fast-xml-parser: 5.10.1
+  fflate: 0.8.3
   form-data: 4.0.6
   '@tiptap/extension-bubble-menu': 3.30.5
   '@tiptap/extension-floating-menu': 3.30.5
@@ -2683,8 +2684,8 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -5939,7 +5940,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -6163,7 +6164,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       fast-png: 6.4.0
-      fflate: 0.8.2
+      fflate: 0.8.3
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0


### PR DESCRIPTION
## Summary

- override transitive `fflate` from 0.8.2 to patched 0.8.3
- remove newly published GHSA-px8p-9vwx-vf98 / CVE-2026-45820 from both production and full dependency graphs
- keep `jspdf` unchanged while applying the upstream compatible patch

## Verification

- `pnpm audit --prod --json`: zero vulnerabilities
- `pnpm audit --json`: zero vulnerabilities
- installed tree resolves `jspdf 4.2.1 -> fflate 0.8.3`
- PDF generation and consent PDF tests: 13 passed
- web and database TypeScript checks passed
- open-source release verification passed across 1,404 tracked files
- `git diff --check` passed