### PR TITLE
Harden prescription inventory pagination safety

### DIFF
--- a/apps/web/components/records/prescription-inventory-product-picker.tsx
+++ b/apps/web/components/records/prescription-inventory-product-picker.tsx
@@ -7,6 +7,12 @@ import { Command } from "cmdk";
 import type { AppRouter } from "@/server/routers/_app";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
+import {
+  advancePrescriptionProductPagination,
+  createPrescriptionProductPaginationState,
+  mergePrescriptionProductPages,
+  resetPrescriptionProductPagination,
+} from "@/lib/inventory/prescription-product-pagination";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -43,11 +49,18 @@ export function PrescriptionInventoryProductPicker({
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const [pageOffset, setPageOffset] = useState(0);
-  const [loadedProducts, setLoadedProducts] = useState<
-    PrescriptionInventoryProduct[]
-  >([]);
-  const [resultTotal, setResultTotal] = useState(0);
+  const trpcUtils = trpc.useUtils();
+  const [pagination, setPagination] = useState(() =>
+    createPrescriptionProductPaginationState<PrescriptionInventoryProduct>(),
+  );
+  const {
+    catalogChanged,
+    exhausted,
+    loadedProducts,
+    pageOffset,
+    resultTotal,
+    revision,
+  } = pagination;
   const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
   const normalizedSearch = debouncedSearch.trim();
   const searchSettled = search.trim() === normalizedSearch;
@@ -61,52 +74,48 @@ export function PrescriptionInventoryProductPicker({
   );
 
   const visibleProducts = useMemo(() => {
-    const productsById = new Map(
-      loadedProducts.map((product) => [product.id, product]),
+    return mergePrescriptionProductPages(
+      loadedProducts,
+      searchSettled ? (products.data?.items ?? []) : [],
     );
-    if (searchSettled) {
-      for (const product of products.data?.items ?? []) {
-        productsById.set(product.id, product);
-      }
-    }
-    return [...productsById.values()];
   }, [loadedProducts, products.data?.items, searchSettled]);
 
-  const total = products.data?.total ?? resultTotal;
-  const hasMore = visibleProducts.length < total;
+  const total = exhausted
+    ? visibleProducts.length
+    : (products.data?.total ?? resultTotal);
+  const hasMore = !exhausted && visibleProducts.length < total;
 
   function changeSearch(nextSearch: string) {
     setSearch(nextSearch);
-    setPageOffset(0);
-    setLoadedProducts([]);
-    setResultTotal(0);
+    setPagination(resetPrescriptionProductPagination);
   }
 
   function loadNextPage() {
-    if (
-      !products.data ||
-      products.isFetching ||
-      !hasMore ||
-      products.data.items.length === 0
-    ) {
+    if (!products.data || products.isFetching || !hasMore) {
       return;
     }
 
-    setLoadedProducts(visibleProducts);
-    setResultTotal(products.data.total);
-    // A native scroll and a synthetic scroll can arrive before React renders
-    // again. Set this render's absolute next page so duplicate events cannot
-    // increment twice and skip an entire page.
-    setPageOffset(pageOffset + products.data.items.length);
+    const currentPage = {
+      revision,
+      offset: pageOffset,
+      items: products.data.items,
+      total: products.data.total,
+    };
+    setPagination((current) =>
+      advancePrescriptionProductPagination(current, currentPage),
+    );
+  }
+
+  function refreshProducts() {
+    setPagination(resetPrescriptionProductPagination);
+    void trpcUtils.inventory.list.invalidate();
   }
 
   function changeOpen(nextOpen: boolean) {
     setOpen(nextOpen);
     if (!nextOpen) {
       setSearch("");
-      setPageOffset(0);
-      setLoadedProducts([]);
-      setResultTotal(0);
+      setPagination(resetPrescriptionProductPagination);
     }
   }
 
@@ -158,6 +167,7 @@ export function PrescriptionInventoryProductPicker({
           </div>
           <Command.List
             className="max-h-64 overflow-y-auto p-1"
+            aria-busy={products.isFetching}
             onScroll={(event) => {
               const list = event.currentTarget;
               if (
@@ -202,32 +212,59 @@ export function PrescriptionInventoryProductPicker({
                 No inventory items found.
               </div>
             ) : null}
-            {!products.error
-              ? visibleProducts.map((product) => (
-                  <Command.Item
-                    key={product.id}
-                    value={product.id}
-                    onSelect={() => selectProduct(product)}
-                    className="flex cursor-pointer items-start rounded-sm px-2 py-2 text-sm aria-selected:bg-accent"
-                  >
-                    <Check
-                      className={cn(
-                        "mr-2 mt-0.5 h-4 w-4 shrink-0",
-                        value === product.id ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                    <span className="min-w-0">
-                      <span className="block truncate">{product.name}</span>
-                      <span className="block text-xs text-muted-foreground">
-                        {product.stockQuantity} units on hand ·{" "}
-                        {product.unitPrice} each
-                        {product.sku ? ` · SKU ${product.sku}` : ""}
-                      </span>
-                    </span>
-                  </Command.Item>
-                ))
-              : null}
+            {visibleProducts.map((product) => (
+              <Command.Item
+                key={product.id}
+                value={product.id}
+                onSelect={() => selectProduct(product)}
+                className="flex cursor-pointer items-start rounded-sm px-2 py-2 text-sm aria-selected:bg-accent"
+                style={{
+                  contentVisibility: "auto",
+                  containIntrinsicSize: "auto 48px",
+                }}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 mt-0.5 h-4 w-4 shrink-0",
+                    value === product.id ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                <span className="min-w-0">
+                  <span className="block truncate">{product.name}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {product.stockQuantity} units on hand · {product.unitPrice}{" "}
+                    each
+                    {product.sku ? ` · SKU ${product.sku}` : ""}
+                  </span>
+                </span>
+              </Command.Item>
+            ))}
           </Command.List>
+          <div className="sr-only" role="status" aria-live="polite">
+            {catalogChanged
+              ? "Inventory changed while loading. Refresh inventory items."
+              : products.error
+                ? "Inventory items could not be loaded."
+                : products.isFetching || !searchSettled
+                  ? "Loading inventory items."
+                  : `${visibleProducts.length} of ${total} inventory items loaded.`}
+          </div>
+          {catalogChanged ? (
+            <div className="border-t border-border px-3 py-2 text-center">
+              <p className="text-xs text-muted-foreground">
+                Inventory changed while this list was loading.
+              </p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="mt-1 h-auto py-1 text-xs"
+                onClick={refreshProducts}
+              >
+                Refresh inventory items
+              </Button>
+            </div>
+          ) : null}
           {!products.error && hasMore ? (
             <div className="border-t border-border px-3 py-2">
               <Button

--- a/apps/web/lib/__tests__/soap-editor-ui.test.ts
+++ b/apps/web/lib/__tests__/soap-editor-ui.test.ts
@@ -318,16 +318,25 @@ describe("records prescription form UX", () => {
     expect(inventoryPicker).toContain("onScroll={(event) => {");
     expect(inventoryPicker).toContain("loadNextPage();");
     expect(inventoryPicker).toContain(
-      "setPageOffset(pageOffset + products.data.items.length)"
+      "advancePrescriptionProductPagination(current, currentPage)"
     );
     expect(inventoryPicker).toContain("Load more inventory items");
     expect(inventoryPicker).toMatch(/Scroll for more or\s+use search/);
     expect(inventoryPicker).toContain("Inventory unavailable. Please retry.");
+    expect(inventoryPicker).toContain('role="status"');
+    expect(inventoryPicker).toContain('aria-live="polite"');
+    expect(inventoryPicker).toContain("Refresh inventory items");
+    expect(inventoryPicker).toContain(
+      "trpcUtils.inventory.list.invalidate()"
+    );
+    expect(inventoryPicker).toContain('contentVisibility: "auto"');
     expect(source).not.toContain("{ limit: 100, offset: 0 }");
     expect(source).toContain("prescriptionQuantity <= linkedPrescriptionProduct.stockQuantity");
     expect(source).toContain("Quantity (inventory units)");
     expect(inventoryPicker).toContain("{product.stockQuantity} units on hand");
-    expect(inventoryPicker).toContain("{product.unitPrice} each");
+    expect(inventoryPicker).toMatch(
+      /\{product\.unitPrice\}\s*(?:\{" "\})?\s*each/
+    );
     expect(source).toContain("The prescription quantity will be");
     expect(source).toContain("charged in that same unit.");
     expect(source).toContain("isPrescriptionOptionalPositiveIntegerInputValid");

--- a/apps/web/lib/inventory/__tests__/prescription-product-pagination.test.ts
+++ b/apps/web/lib/inventory/__tests__/prescription-product-pagination.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  advancePrescriptionProductPagination,
+  createPrescriptionProductPaginationState,
+  mergePrescriptionProductPages,
+  resetPrescriptionProductPagination,
+} from "../prescription-product-pagination";
+
+type Product = { id: string; name: string };
+
+function products(start: number, count: number): Product[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `product-${start + index}`,
+    name: "Same display name",
+  }));
+}
+
+describe("prescription product pagination", () => {
+  it("coalesces duplicate requests while advancing through more than one page", () => {
+    const initial = createPrescriptionProductPaginationState<Product>();
+    const firstPage = {
+      revision: initial.revision,
+      offset: 0,
+      items: products(0, 50),
+      total: 60,
+    };
+
+    const afterFirstPage = advancePrescriptionProductPagination(
+      initial,
+      firstPage,
+    );
+    const afterDuplicateEvent = advancePrescriptionProductPagination(
+      afterFirstPage,
+      firstPage,
+    );
+
+    expect(afterFirstPage.pageOffset).toBe(50);
+    expect(afterFirstPage.loadedProducts).toHaveLength(50);
+    expect(afterDuplicateEvent).toBe(afterFirstPage);
+
+    const afterFinalPage = advancePrescriptionProductPagination(
+      afterFirstPage,
+      {
+        revision: afterFirstPage.revision,
+        offset: 50,
+        items: products(50, 10),
+        total: 60,
+      },
+    );
+
+    expect(afterFinalPage.pageOffset).toBe(60);
+    expect(afterFinalPage.loadedProducts.map((product) => product.id)).toEqual(
+      products(0, 60).map((product) => product.id),
+    );
+  });
+
+  it("rejects a stale page after search reset, even when both use offset zero", () => {
+    const initial = createPrescriptionProductPaginationState<Product>();
+    const reset = resetPrescriptionProductPagination(initial);
+    const stalePage = advancePrescriptionProductPagination(reset, {
+      revision: initial.revision,
+      offset: 0,
+      items: products(0, 50),
+      total: 50,
+    });
+
+    expect(reset.revision).toBe(1);
+    expect(stalePage).toBe(reset);
+    expect(stalePage.loadedProducts).toEqual([]);
+  });
+
+  it("deduplicates product IDs while preserving the complete page order", () => {
+    const merged = mergePrescriptionProductPages(products(0, 50), [
+      { id: "product-49", name: "Updated name" },
+      ...products(50, 10),
+    ]);
+
+    expect(merged).toHaveLength(60);
+    expect(merged[49]).toEqual({ id: "product-49", name: "Updated name" });
+    expect(merged.at(-1)?.id).toBe("product-59");
+  });
+
+  it("terminates an inconsistent empty page and allows a clean refresh", () => {
+    const initial = createPrescriptionProductPaginationState<Product>();
+    const afterFirstPage = advancePrescriptionProductPagination(initial, {
+      revision: initial.revision,
+      offset: 0,
+      items: products(0, 50),
+      total: 60,
+    });
+    const emptyPage = advancePrescriptionProductPagination(afterFirstPage, {
+      revision: afterFirstPage.revision,
+      offset: 50,
+      items: [],
+      total: 60,
+    });
+
+    expect(emptyPage.pageOffset).toBe(50);
+    expect(emptyPage.loadedProducts).toHaveLength(50);
+    expect(emptyPage.resultTotal).toBe(50);
+    expect(emptyPage.exhausted).toBe(true);
+    expect(emptyPage.catalogChanged).toBe(true);
+
+    const refreshed = resetPrescriptionProductPagination(emptyPage);
+    expect(refreshed.pageOffset).toBe(0);
+    expect(refreshed.loadedProducts).toEqual([]);
+    expect(refreshed.exhausted).toBe(false);
+    expect(refreshed.catalogChanged).toBe(false);
+  });
+
+  it("does not advance an out-of-order page", () => {
+    const initial = createPrescriptionProductPaginationState<Product>();
+
+    expect(
+      advancePrescriptionProductPagination(initial, {
+        revision: initial.revision,
+        offset: 50,
+        items: products(50, 10),
+        total: 60,
+      }),
+    ).toBe(initial);
+  });
+});

--- a/apps/web/lib/inventory/__tests__/prescription-product-query-refresh.test.ts
+++ b/apps/web/lib/inventory/__tests__/prescription-product-query-refresh.test.ts
@@ -1,0 +1,100 @@
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+
+type PageResult = {
+  offset: number;
+  version: number;
+};
+
+const inventoryListKey = (offset: number) => [
+  ["inventory", "list"],
+  { input: { limit: 50, offset }, type: "query" },
+];
+
+const inventoryListFamilyKey = [["inventory", "list"]];
+
+function waitForResult(
+  observer: QueryObserver<PageResult>,
+  predicate: (result: PageResult | undefined) => boolean,
+): Promise<PageResult> {
+  const current = observer.getCurrentResult().data;
+  if (predicate(current)) return Promise.resolve(current as PageResult);
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error("Timed out waiting for query result"));
+    }, 2_000);
+    const unsubscribe = observer.subscribe((result) => {
+      if (!predicate(result.data)) return;
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(result.data as PageResult);
+    });
+  });
+}
+
+describe("prescription product query refresh", () => {
+  it("invalidates cached page zero and isolates a late obsolete page result", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: 30_000 },
+      },
+    });
+    let offset0Fetches = 0;
+    let offset50Fetches = 0;
+    let resolveLateOffset50: ((result: PageResult) => void) | undefined;
+    const fetchOffset0 = async () => ({
+      offset: 0,
+      version: ++offset0Fetches,
+    });
+    const fetchOffset50 = async () => {
+      offset50Fetches += 1;
+      if (offset50Fetches === 1) {
+        return { offset: 50, version: 1 };
+      }
+      return new Promise<PageResult>((resolve) => {
+        resolveLateOffset50 = resolve;
+      });
+    };
+
+    await queryClient.fetchQuery({
+      queryKey: inventoryListKey(0),
+      queryFn: fetchOffset0,
+    });
+    await queryClient.fetchQuery({
+      queryKey: inventoryListKey(50),
+      queryFn: fetchOffset50,
+    });
+    const observer = new QueryObserver<PageResult>(queryClient, {
+      queryKey: inventoryListKey(50),
+      queryFn: fetchOffset50,
+    });
+    const keepActive = observer.subscribe(() => undefined);
+
+    const invalidation = queryClient.invalidateQueries({
+      queryKey: inventoryListFamilyKey,
+    });
+    observer.setOptions({
+      queryKey: inventoryListKey(0),
+      queryFn: fetchOffset0,
+    });
+
+    const refreshed = await waitForResult(
+      observer,
+      (result) => result?.offset === 0 && result.version === 2,
+    );
+    expect(refreshed).toEqual({ offset: 0, version: 2 });
+    expect(offset0Fetches).toBe(2);
+
+    resolveLateOffset50?.({ offset: 50, version: 2 });
+    await invalidation;
+    expect(observer.getCurrentResult().data).toEqual({
+      offset: 0,
+      version: 2,
+    });
+
+    keepActive();
+    queryClient.clear();
+  });
+});

--- a/apps/web/lib/inventory/prescription-product-pagination.ts
+++ b/apps/web/lib/inventory/prescription-product-pagination.ts
@@ -1,0 +1,97 @@
+export type PrescriptionProductPageItem = {
+  id: string;
+};
+
+export type PrescriptionProductPaginationState<
+  Product extends PrescriptionProductPageItem,
+> = {
+  pageOffset: number;
+  loadedProducts: Product[];
+  resultTotal: number;
+  revision: number;
+  exhausted: boolean;
+  catalogChanged: boolean;
+};
+
+export type PrescriptionProductPage<
+  Product extends PrescriptionProductPageItem,
+> = {
+  revision: number;
+  offset: number;
+  items: Product[];
+  total: number;
+};
+
+export function createPrescriptionProductPaginationState<
+  Product extends PrescriptionProductPageItem,
+>(): PrescriptionProductPaginationState<Product> {
+  return {
+    pageOffset: 0,
+    loadedProducts: [],
+    resultTotal: 0,
+    revision: 0,
+    exhausted: false,
+    catalogChanged: false,
+  };
+}
+
+export function resetPrescriptionProductPagination<
+  Product extends PrescriptionProductPageItem,
+>(
+  state: PrescriptionProductPaginationState<Product>,
+): PrescriptionProductPaginationState<Product> {
+  return {
+    pageOffset: 0,
+    loadedProducts: [],
+    resultTotal: 0,
+    revision: state.revision + 1,
+    exhausted: false,
+    catalogChanged: false,
+  };
+}
+
+export function mergePrescriptionProductPages<
+  Product extends PrescriptionProductPageItem,
+>(loadedProducts: Product[], currentPage: Product[]): Product[] {
+  const productsById = new Map(
+    loadedProducts.map((product) => [product.id, product]),
+  );
+  for (const product of currentPage) {
+    productsById.set(product.id, product);
+  }
+  return [...productsById.values()];
+}
+
+export function advancePrescriptionProductPagination<
+  Product extends PrescriptionProductPageItem,
+>(
+  state: PrescriptionProductPaginationState<Product>,
+  page: PrescriptionProductPage<Product>,
+): PrescriptionProductPaginationState<Product> {
+  // A response belongs to the exact search revision and offset that requested
+  // it. This also coalesces duplicate scroll/button events from one render.
+  if (page.revision !== state.revision || page.offset !== state.pageOffset) {
+    return state;
+  }
+
+  if (page.items.length === 0) {
+    return {
+      ...state,
+      resultTotal: state.loadedProducts.length,
+      exhausted: true,
+      catalogChanged: page.total > state.loadedProducts.length,
+    };
+  }
+
+  return {
+    ...state,
+    pageOffset: page.offset + page.items.length,
+    loadedProducts: mergePrescriptionProductPages(
+      state.loadedProducts,
+      page.items,
+    ),
+    resultTotal: page.total,
+    exhausted: false,
+    catalogChanged: false,
+  };
+}

--- a/apps/web/server/__tests__/inventory-safety.test.ts
+++ b/apps/web/server/__tests__/inventory-safety.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { products } from "@openpims/db";
 
 const mocks = vi.hoisted(() => ({
   recordAuditLog: vi.fn(async () => undefined),
@@ -49,21 +50,22 @@ function createDb(opts?: {
   updatedRows?: unknown[];
 }) {
   const selectResults = [...(opts?.selectResults ?? [])];
+  const orderBy = vi.fn();
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
-    const afterWhere = {
-      limit: vi.fn(async () => result),
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      orderBy: vi.fn((...columns: unknown[]) => {
+        orderBy(...columns);
+        return builder;
+      }),
+      limit: vi.fn(() => builder),
+      offset: vi.fn(() => builder),
       then: (
         resolve: (value: unknown[]) => unknown,
         reject?: (error: unknown) => unknown
       ) => Promise.resolve(result).then(resolve, reject),
-    };
-    const builder = {
-      from: vi.fn(() => builder),
-      where: vi.fn(() => afterWhere),
-      orderBy: vi.fn(() => builder),
-      limit: vi.fn(async () => result),
-      offset: vi.fn(() => builder),
     };
     return builder;
   });
@@ -89,7 +91,7 @@ function createDb(opts?: {
     update,
   };
 
-  return { db, select, insertValues, updateSet };
+  return { db, select, orderBy, insertValues, updateSet };
 }
 
 afterEach(() => {
@@ -223,6 +225,40 @@ describe("inventory mutation safety", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
+  });
+
+  it("uses a total product order across duplicate names and multiple pages", async () => {
+    const catalog = Array.from({ length: 60 }, (_, index) => ({
+      id: `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`,
+      name: "Carprofen",
+      inventoryTracked: false,
+      stockQuantity: 0,
+      reorderPoint: null,
+      expirationDate: null,
+    }));
+    const countRows = Array.from({ length: 5 }, () => [{ count: 60 }]);
+    const { db, orderBy } = createDb({
+      selectResults: [
+        [{ timezone: "UTC" }],
+        catalog.slice(0, 50),
+        ...countRows,
+        [{ timezone: "UTC" }],
+        catalog.slice(50),
+        ...countRows,
+      ],
+    });
+    const caller = callerWithDb(db);
+
+    const firstPage = await caller.list({ limit: 50, offset: 0 });
+    const secondPage = await caller.list({ limit: 50, offset: 50 });
+
+    expect(orderBy).toHaveBeenCalledTimes(2);
+    expect(orderBy).toHaveBeenNthCalledWith(1, products.name, products.id);
+    expect(orderBy).toHaveBeenNthCalledWith(2, products.name, products.id);
+    expect(
+      new Set([...firstPage.items, ...secondPage.items].map((item) => item.id))
+        .size
+    ).toBe(60);
   });
 
   it("rejects invalid product list filters before DB work", async () => {

--- a/apps/web/server/routers/inventory.ts
+++ b/apps/web/server/routers/inventory.ts
@@ -262,7 +262,7 @@ export const inventoryRouter = createRouter({
           .select()
           .from(products)
           .where(and(...conditions))
-          .orderBy(products.name)
+          .orderBy(products.name, products.id)
           .limit(input.limit)
           .offset(input.offset),
         countWhere(alertCondition ?? undefined),


### PR DESCRIPTION
## Executive remediation

This follow-up closes correctness and recovery gaps found during the exact-SHA audit of #325.

- orders offset pages by product name plus immutable product ID so duplicate names cannot skip/repeat rows
- coalesces duplicate load events and rejects stale search/offset responses using revision-bound functional state
- terminates count/item snapshot mismatches without a permanent Load More deadlock and provides a family-invalidating refresh
- preserves already loaded/selectable products when a later page fails
- adds accessible loading/catalog-change announcements and content-visibility for large lists
- adds executable 60-row duplicate-name, pagination state, and TanStack Query cache-race regressions

## Exact evidence

- reviewed head: `cc8877b9eff1267f994b5e993edaeed84d1956b4`
- exact parent/main: `396c1cc43f683025c4f3f3058b315b5b2c7bbbbd`
- independent audit: GO; no P0/P1/P2 findings
- full suite: 4,372 passed; 22 expected integration skips
- production build: passed
- web typecheck: passed
- open-source verification: 1,457 tracked files passed
- secret scan: no leaks
- migrations/dependencies/tenant boundaries: unchanged

Production remains pinned; this PR does not deploy or migrate production.