### PR TITLE
Keep prescription pagination isolated during search changes

### DIFF
--- a/apps/web/components/records/prescription-inventory-product-picker.tsx
+++ b/apps/web/components/records/prescription-inventory-product-picker.tsx
@@ -91,7 +91,16 @@ export function PrescriptionInventoryProductPicker({
   }
 
   function loadNextPage() {
-    if (!products.data || products.isFetching || !hasMore) {
+    // Scroll events can fire while closing or while the debounced query still
+    // belongs to the previous search. Never save that page into the new list.
+    if (
+      !open ||
+      !searchSettled ||
+      !products.data ||
+      products.error ||
+      products.isFetching ||
+      !hasMore
+    ) {
       return;
     }
 


### PR DESCRIPTION
Reopening the prescription inventory picker immediately after selecting a search result can let a scroll event append the previous search page to the reset catalog. This mixes results and skips the beginning of the next page. Pagination now advances only while the picker is open, the search is settled, and the query is neither failed nor fetching.

Verified the same component change in an isolated release-base checkout: reproduced the mixed 70/125 result, then confirmed retry restores the correct 50/125 result after the fix; checked duplicate names, SKU selection and a 390px mobile viewport. The four targeted suites pass (56 tests), and the production build passes. The rendered fixture uses synthetic tRPC data; authenticated application verification remains outstanding.

GitHub CI also passes on this main-based PR: build/type checks/tests, migration history, RLS tenant isolation and CodeQL. Hosted preview builds were skipped by the existing build policy and do not count as browser verification.

Tracks OPENVPM-92. No schema or dependency changes.
